### PR TITLE
Correct MERRA-2 layer depth metadata in catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,8 @@ See `catalog/sources.yml` `status:` and `notes:` fields for per-source gaps.
 - Recharge normalization window — confirmed **2000-2009** from TM 6-B10 body text
 - MOD16A2 / MOD10C1 v006 → v061: both decommissioned; use v061 in all new runs
 - MERRA-2 variable — use `GWETTOP` (0-0.05m, dimensionless); product M2TMNXLND
-- NLDAS-2 MOSAIC / NOAH variable names — confirmed: SoilM_0_10cm, SoilM_10_40cm, SoilM_40_200cm
+- MERRA-2 layer depths — dzsf=0.05m (constant globally), dzrz=1.00m (per GMAO FAQ), dzpr=spatially varying (surface to bedrock, ~1.3-8.5m). Thicknesses in M2CONXLND collection.
+- NLDAS NOAH variable names — confirmed from file inspection: SoilM_0_10cm, SoilM_10_40cm, SoilM_40_100cm, SoilM_100_200cm
 
 **Still open:**
 - WaterGAP 2.2a — registration-gated; substitute candidate is WaterGAP 2.2d on PANGAEA (doi:10.1594/PANGAEA.918447)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See `catalog/sources.yml` `status:` and `notes:` fields for per-source details.
 - Recharge normalization window — confirmed 2000–2009 from TM 6-B10 body text
 - MOD16A2 / MOD10C1 v006 → v061: both decommissioned; use v061 in new runs
 - MERRA-2 variable — use `GWETTOP` (0–0.05m, dimensionless); product M2TMNXLND
+- MERRA-2 layer depths — `dzsf`=0.05m (constant), `dzrz`=1.00m, `dzpr`=spatially varying (surface to bedrock). Thicknesses in M2CONXLND.
 - NLDAS NOAH variable names — confirmed from file inspection: `SoilM_0_10cm`, `SoilM_10_40cm`, `SoilM_40_100cm`, `SoilM_100_200cm`
 
 **Still open:**

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -223,6 +223,7 @@ sources:
       - name: GWETTOP
         long_name: surface_soil_wetness
         layer_depth_m: "0.00-0.05"
+        layer_depth_source: "dzsf in M2CONXLND; constant globally at 0.05m"
         units: dimensionless (fraction of saturation, 0-1)
         preferred: true
         notes: >
@@ -231,18 +232,26 @@ sources:
       - name: GWETROOT
         long_name: root_zone_soil_wetness
         layer_depth_m: "0.00-1.00"
+        layer_depth_source: "dzrz in M2CONXLND; described as 0-100cm in GMAO FAQ"
         units: dimensionless (fraction of saturation, 0-1)
         notes: Root zone integrated wetness.
       - name: GWETPROF
         long_name: ave_prof_soil_moisture
-        layer_depth_m: "0.00-3.50"
+        layer_depth_m: spatially varying (surface to bedrock)
+        layer_depth_source: "dzpr in M2CONXLND; varies ~1.3-8.5m globally"
         units: dimensionless (fraction of saturation, 0-1)
-        notes: Full profile average soil moisture.
+        notes: >
+          Full profile average soil moisture. Depth extends from surface
+          to bedrock and varies spatially per Catchment LSM parameterization.
+          Actual thickness available in dzpr variable of M2CONXLND collection.
     layer_depth_notes: >
-      Three nested depth intervals (0-5cm, 0-100cm, 0-350cm) allow weighted
-      interpolation to any target depth. TM 6-B10 notes magnitudes are not
-      expected to equate across sources — normalization makes depth difference
-      irrelevant for calibration.
+      Layer thicknesses from NASA Catchment Land Surface Model. Surface layer
+      (dzsf) is constant at 0.05m globally. Root zone (dzrz) is 1.00m per
+      GMAO FAQ. Profile layer (dzpr) varies spatially (surface to bedrock,
+      ~1.3-8.5m range). All thickness fields available in M2CONXLND.
+      TM 6-B10 notes magnitudes are not expected to equate across sources —
+      normalization makes depth difference irrelevant for calibration.
+      References: GMAO MERRA-2 FAQ, Earthdata Forum topic 6156.
     time_step: monthly
     period: "1980/present"
     spatial_extent: global


### PR DESCRIPTION
## Summary

Closes #11

- Fix GWETPROF `layer_depth_m` from fixed `"0.00-3.50"` to `spatially varying (surface to bedrock)`
- Add `layer_depth_source` fields to all three MERRA-2 variables documenting provenance:
  - GWETTOP: `dzsf` in M2CONXLND, constant globally at 0.05m
  - GWETROOT: `dzrz` in M2CONXLND, 0-100cm per GMAO FAQ
  - GWETPROF: `dzpr` in M2CONXLND, varies ~1.3-8.5m globally
- Update `layer_depth_notes` with corrected info and references
- Update CLAUDE.md and README.md known gaps

## References

- [GMAO MERRA-2 FAQ](https://gmao.gsfc.nasa.gov/gmao-products/merra-2/faq_merra-2/)
- [Earthdata Forum topic 6156](https://forum.earthdata.nasa.gov/viewtopic.php?t=6156)

## Test plan

- [x] All 109 tests pass
- [x] Catalog loads correctly (test_catalog.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)