### PR TITLE
Implement MODIS consolidation (MOD16A2 + MOD10C1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,19 @@
       "Bash(git config --global --add safe.directory '%\\(prefix\\)///wsl.localhost/Ubuntu/home/rmcd/projects/usgs/nhf-spatial-targets')",
       "Bash(.pixi/envs/dev/bin/pytest tests/test_nldas.py -v -m \"not integration\" 2>&1)",
       "Bash(git stash:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "WebFetch(domain:www.sciencebase.gov)",
+      "WebFetch(domain:labs.waterdata.usgs.gov)",
+      "WebFetch(domain:planetarycomputer.microsoft.com)",
+      "WebFetch(domain:data.usgs.gov)",
+      "WebSearch",
+      "WebFetch(domain:api.water.usgs.gov)",
+      "WebFetch(domain:www.usgs.gov)",
+      "WebFetch(domain:doi.org)",
+      "WebFetch(domain:waterdata.usgs.gov)",
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs"
     ]
   }
 }

--- a/docs/plans/2026-03-14-modis-consolidation-design.md
+++ b/docs/plans/2026-03-14-modis-consolidation-design.md
@@ -1,0 +1,58 @@
+# MODIS Consolidation Design
+
+**Goal:** Implement `consolidate_mod16a2` and `consolidate_mod10c1` — the two stubs in `fetch/consolidate.py` — to merge per-granule downloads into single consolidated NetCDF files per year.
+
+## MOD16A2 (AET)
+
+**Input:** `data/raw/mod16a2_v061/*.hdf` — sinusoidal-projected 500m tiles, multiple tiles per 8-day composite, ~46 composites/year.
+
+**Pipeline per year:**
+
+1. Glob HDF files, filter to requested year via `AYYYYDDD` filename pattern.
+2. Group tiles by time step (same AYYYYDDD token = same 8-day composite).
+3. For each time step:
+   - Open tiles with rioxarray.
+   - Mosaic into a single raster using `rasterio.merge`.
+   - Reproject to EPSG:4326 at 0.04° resolution (~4km).
+   - Resampling: **average** for `ET_500m`, **nearest neighbor** for `ET_QC_500m`.
+4. Stack all time steps along a `time` dimension.
+5. Select requested variables.
+6. Write to `data/raw/mod16a2_v061/mod16a2_v061_{year}_consolidated.nc`.
+
+**Output size:** ~500 MB/year (vs ~30 GB at native 500m).
+
+**Rationale for 0.04° / ~4km:** Matches the typical scale of climate forcing used in NHM. 500m is overkill for area-weighted HRU aggregation. gdptools handles CRS reprojection internally via `to_crs()`, but clean 1D lat/lon coordinates make the consolidated files directly inspectable.
+
+## MOD10C1 (Snow Cover)
+
+**Input:** `data/raw/mod10c1_v061/*.conus.nc` — already subsetted to CONUS at 0.05° lat/lon, one file per day, ~365 files/year.
+
+**Pipeline per year:**
+
+1. Glob `.conus.nc` files, filter to requested year.
+2. Open all files, concat along time, sort by time.
+3. Select requested variables (`Day_CMG_Snow_Cover`, `Snow_Spatial_QA`).
+4. Write to `data/raw/mod10c1_v061/mod10c1_v061_{year}_consolidated.nc`.
+
+No mosaicking or reprojection needed. Daily resolution preserved (no temporal aggregation).
+
+## Error Handling
+
+- **Missing tiles for a time step:** Log warning, mosaic available tiles (partial coverage preferred over skipping).
+- **Corrupt HDF files:** Use existing `_open_datasets` pattern — clean up and raise with clear message.
+- **Existing consolidated file:** Overwrite (reconsolidation is idempotent).
+- **No files for requested year:** Raise `FileNotFoundError`.
+- **Empty year after filtering:** Return `None` so caller skips gracefully.
+
+## Testing
+
+- **MOD16A2:** Synthetic sinusoidal-projected arrays, verify grouping by time step, verify output has 1D lat/lon coords at 0.04°.
+- **MOD10C1:** Synthetic `.conus.nc` files with time/lat/lon, verify concat and variable selection.
+- **Both:** Provenance dict structure, overwrite behavior, error cases.
+- **Integration tests:** Deferred to full integration test session with real data.
+
+## Dependencies
+
+- `rioxarray` — CRS-aware xarray operations
+- `rasterio.merge` — tile mosaicking
+- Both available via gdptools dependency chain (no new dependencies needed).

--- a/docs/plans/2026-03-14-modis-consolidation-plan.md
+++ b/docs/plans/2026-03-14-modis-consolidation-plan.md
@@ -1,0 +1,910 @@
+# MODIS Consolidation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the `consolidate_mod16a2` and `consolidate_mod10c1` stubs in `fetch/consolidate.py` with working implementations that merge per-granule downloads into single consolidated NetCDF files per year.
+
+**Architecture:** MOD16A2 requires mosaicking sinusoidal tiles per time step, reprojecting to EPSG:4326 at 0.04° (~4km), then stacking along time. MOD10C1 is simpler — concat daily `.conus.nc` files along time. Both produce one consolidated NetCDF per year.
+
+**Tech Stack:** rioxarray (open_rasterio, merge_arrays, rio.reproject), rasterio.enums.Resampling, xarray, numpy
+
+---
+
+### Task 1: MOD10C1 consolidation (the simpler one)
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py:293-300`
+- Create: `tests/test_consolidate_modis.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_consolidate_modis.py`:
+
+```python
+"""Tests for MODIS consolidation functions."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+
+@pytest.fixture()
+def mod10c1_run_dir(tmp_path: Path) -> Path:
+    """Create a run workspace with synthetic MOD10C1 .conus.nc files."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    source_dir = rd / "data" / "raw" / "mod10c1_v061"
+    source_dir.mkdir(parents=True)
+
+    # Create 3 synthetic daily files for year 2010
+    for doy in [1, 2, 3]:
+        fname = f"MOD10C1.A2010{doy:03d}.061.2020345123456.conus.nc"
+        ds = xr.Dataset(
+            {
+                "Day_CMG_Snow_Cover": (
+                    ["lat", "lon"],
+                    np.random.randint(0, 100, (4, 6), dtype=np.int16),
+                ),
+                "Snow_Spatial_QA": (
+                    ["lat", "lon"],
+                    np.random.randint(0, 100, (4, 6), dtype=np.int16),
+                ),
+            },
+            coords={
+                "lat": [50.0, 49.95, 49.90, 49.85],
+                "lon": [-125.0, -124.95, -124.90, -124.85, -124.80, -124.75],
+            },
+        )
+        ds.to_netcdf(source_dir / fname)
+    return rd
+
+
+def test_consolidate_mod10c1_basic(mod10c1_run_dir):
+    """Consolidation merges daily files into one NetCDF with time dim."""
+    result = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key="mod10c1_v061",
+        variables=["Day_CMG_Snow_Cover", "Snow_Spatial_QA"],
+        year=2010,
+    )
+
+    assert "consolidated_nc" in result
+    assert "last_consolidated_utc" in result
+    assert result["n_files"] == 3
+    assert result["variables"] == ["Day_CMG_Snow_Cover", "Snow_Spatial_QA"]
+
+    nc_path = mod10c1_run_dir / result["consolidated_nc"]
+    assert nc_path.exists()
+
+    ds = xr.open_dataset(nc_path)
+    assert "time" in ds.dims
+    assert ds.sizes["time"] == 3
+    assert "Day_CMG_Snow_Cover" in ds.data_vars
+    assert "Snow_Spatial_QA" in ds.data_vars
+    ds.close()
+
+
+def test_consolidate_mod10c1_no_files(tmp_path):
+    """Raises FileNotFoundError when no .conus.nc files exist for year."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    (rd / "data" / "raw" / "mod10c1_v061").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        consolidate_mod10c1(rd, "mod10c1_v061", ["Day_CMG_Snow_Cover"], year=2010)
+
+
+def test_consolidate_mod10c1_overwrites_existing(mod10c1_run_dir):
+    """Re-running consolidation overwrites the previous file."""
+    result1 = consolidate_mod10c1(
+        mod10c1_run_dir, "mod10c1_v061",
+        ["Day_CMG_Snow_Cover", "Snow_Spatial_QA"], year=2010,
+    )
+    result2 = consolidate_mod10c1(
+        mod10c1_run_dir, "mod10c1_v061",
+        ["Day_CMG_Snow_Cover", "Snow_Spatial_QA"], year=2010,
+    )
+    assert result1["consolidated_nc"] == result2["consolidated_nc"]
+    assert (mod10c1_run_dir / result2["consolidated_nc"]).exists()
+
+
+def test_consolidate_mod10c1_filters_year(mod10c1_run_dir):
+    """Only files matching the requested year are included."""
+    # Add a file for a different year
+    source_dir = mod10c1_run_dir / "data" / "raw" / "mod10c1_v061"
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (["lat", "lon"], np.zeros((4, 6), dtype=np.int16)),
+            "Snow_Spatial_QA": (["lat", "lon"], np.zeros((4, 6), dtype=np.int16)),
+        },
+        coords={
+            "lat": [50.0, 49.95, 49.90, 49.85],
+            "lon": [-125.0, -124.95, -124.90, -124.85, -124.80, -124.75],
+        },
+    )
+    ds.to_netcdf(source_dir / "MOD10C1.A2011001.061.2021345123456.conus.nc")
+
+    result = consolidate_mod10c1(
+        mod10c1_run_dir, "mod10c1_v061",
+        ["Day_CMG_Snow_Cover", "Snow_Spatial_QA"], year=2010,
+    )
+    assert result["n_files"] == 3  # only 2010 files
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py -v`
+Expected: FAIL with `NotImplementedError`
+
+**Step 3: Write minimal implementation**
+
+In `src/nhf_spatial_targets/fetch/consolidate.py`, replace the `consolidate_mod10c1` stub (lines 293-300) with:
+
+```python
+def consolidate_mod10c1(
+    run_dir: Path,
+    source_key: str,
+    variables: list[str],
+    year: int,
+) -> dict:
+    """Merge daily MOD10C1 CONUS subsets for a single year into one NetCDF.
+
+    Parameters
+    ----------
+    run_dir : Path
+        Run workspace directory containing ``data/raw/<source_key>/*.conus.nc``.
+    source_key : str
+        Source key (e.g. ``"mod10c1_v061"``).
+    variables : list[str]
+        Variable names to include.
+    year : int
+        Year to consolidate.
+
+    Returns
+    -------
+    dict
+        Provenance record.
+    """
+    import re
+
+    source_dir = run_dir / "data" / "raw" / source_key
+    year_re = re.compile(rf"\.A{year}\d{{3}}\.")
+    nc_files = sorted(
+        f for f in source_dir.glob("*.conus.nc") if year_re.search(f.name)
+    )
+
+    if not nc_files:
+        raise FileNotFoundError(
+            f"No .conus.nc files found for year {year} in {source_dir}. "
+            f"Run 'nhf-targets fetch {source_key.replace('_', '-')}' first."
+        )
+
+    logger.info("Merging %d daily files for %s year %d", len(nc_files), source_key, year)
+
+    datasets = _open_datasets(nc_files, f"Reading {source_key} {year}")
+    try:
+        ds = xr.concat(datasets, dim="time", data_vars="minimal", coords="minimal")
+        ds = ds.sortby("time")
+        _validate_variables(ds, variables)
+        ds = ds[variables]
+
+        out_path = source_dir / f"{source_key}_{year}_consolidated.nc"
+        logger.info("Writing consolidated file: %s", out_path)
+        _write_netcdf(ds, out_path)
+        logger.info("Wrote %s", out_path)
+    finally:
+        for d in datasets:
+            d.close()
+
+    return {
+        "consolidated_nc": str(out_path.relative_to(run_dir)),
+        "last_consolidated_utc": datetime.now(timezone.utc).isoformat(),
+        "n_files": len(nc_files),
+        "variables": variables,
+    }
+```
+
+**Important:** The `.conus.nc` files created by `_subset_to_conus` in `modis.py` use `xr.open_dataset` + `to_netcdf`, so they have lat/lon coordinates but no `time` dimension. The files are one-per-day. We need to infer time from the filename. Add this helper before `consolidate_mod10c1`:
+
+```python
+def _time_from_modis_filename(path: Path) -> pd.Timestamp:
+    """Extract time from MODIS ``AYYYYDDD`` filename pattern."""
+    m = re.search(r"\.A(\d{4})(\d{3})\.", path.name)
+    if not m:
+        raise ValueError(f"Cannot extract date from MODIS filename: {path.name}")
+    year, doy = int(m.group(1)), int(m.group(2))
+    return pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
+```
+
+And update `_open_datasets` call to assign time coordinates. Actually, it's cleaner to assign time after opening. Revise the implementation to:
+
+```python
+    datasets = []
+    for f in tqdm(nc_files, desc=f"Reading {source_key} {year}"):
+        try:
+            ds_i = xr.open_dataset(f, chunks={})
+            t = _time_from_modis_filename(f)
+            ds_i = ds_i.expand_dims(time=[t])
+            datasets.append(ds_i)
+        except Exception as exc:
+            for d in datasets:
+                d.close()
+            raise RuntimeError(
+                f"Failed to open {f.name} during consolidation. "
+                f"The file may be corrupt or truncated. "
+                f"Delete it and re-run the fetch. Detail: {exc}"
+            ) from exc
+    try:
+        ds = xr.concat(datasets, dim="time", data_vars="minimal", coords="minimal")
+        ds = ds.sortby("time")
+        _validate_variables(ds, variables)
+        ds = ds[variables]
+
+        out_path = source_dir / f"{source_key}_{year}_consolidated.nc"
+        logger.info("Writing consolidated file: %s", out_path)
+        _write_netcdf(ds, out_path)
+        logger.info("Wrote %s", out_path)
+    finally:
+        for d in datasets:
+            d.close()
+```
+
+Also update the test fixture to NOT include a time dimension in the synthetic files (matching real `_subset_to_conus` output which has only lat/lon).
+
+**Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py -v`
+Expected: PASS (all 4 tests)
+
+**Step 5: Run full test suite**
+
+Run: `pixi run -e dev test`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+git add tests/test_consolidate_modis.py src/nhf_spatial_targets/fetch/consolidate.py
+git commit -m "feat: implement consolidate_mod10c1"
+```
+
+---
+
+### Task 2: MOD16A2 tile grouping and time extraction tests
+
+**Files:**
+- Modify: `tests/test_consolidate_modis.py`
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py`
+
+**Step 1: Write the failing tests**
+
+Add to `tests/test_consolidate_modis.py`:
+
+```python
+from nhf_spatial_targets.fetch.consolidate import _time_from_modis_filename
+
+
+def test_time_from_modis_filename():
+    """Extract date from MODIS AYYYYDDD filename."""
+    t = _time_from_modis_filename(Path("MOD16A2GF.A2010001.h08v04.061.hdf"))
+    assert t == pd.Timestamp("2010-01-01")
+
+    t = _time_from_modis_filename(Path("MOD16A2GF.A2010009.h08v04.061.hdf"))
+    assert t == pd.Timestamp("2010-01-09")
+
+    t = _time_from_modis_filename(Path("MOD10C1.A2010032.061.conus.nc"))
+    assert t == pd.Timestamp("2010-02-01")
+
+
+def test_time_from_modis_filename_bad():
+    """Raises ValueError for non-MODIS filename."""
+    with pytest.raises(ValueError, match="Cannot extract date"):
+        _time_from_modis_filename(Path("random_file.nc"))
+```
+
+Import `pd` at top of test file:
+
+```python
+import pandas as pd
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py::test_time_from_modis_filename -v`
+Expected: FAIL with ImportError (function doesn't exist yet or was added in Task 1)
+
+**Step 3: Verify `_time_from_modis_filename` works**
+
+If already added in Task 1, tests should pass. If not, add the helper now.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_consolidate_modis.py src/nhf_spatial_targets/fetch/consolidate.py
+git commit -m "test: add time extraction tests for MODIS filenames"
+```
+
+---
+
+### Task 3: MOD16A2 consolidation — mosaic, reproject, stack
+
+This is the most complex task. MOD16A2 HDF tiles are in sinusoidal projection with multiple tiles per 8-day composite.
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py:303-327`
+- Modify: `tests/test_consolidate_modis.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_consolidate_modis.py`:
+
+```python
+import rioxarray  # noqa: F401 — registers rio accessor
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
+
+from nhf_spatial_targets.fetch.consolidate import consolidate_mod16a2
+
+
+def _make_sinusoidal_tile(
+    path: Path,
+    variable: str,
+    h: int,
+    v: int,
+    year: int,
+    doy: int,
+) -> None:
+    """Create a tiny synthetic sinusoidal-projected HDF-like NetCDF tile.
+
+    We use NetCDF instead of real HDF4 for testability. The consolidation
+    code uses rioxarray.open_rasterio which can handle NetCDF with CRS.
+    """
+    # Sinusoidal CRS (MODIS)
+    srs = CRS.from_proj4(
+        "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +R=6371007.181 +units=m +no_defs"
+    )
+    # Small 4x4 grid in sinusoidal coords (arbitrary tile location)
+    nx, ny = 4, 4
+    # Use h/v to offset the tile position
+    x0 = -10_000_000 + h * 100_000
+    y0 = 6_000_000 - v * 100_000
+    res = 500.0  # 500m
+    transform = from_bounds(x0, y0 - ny * res, x0 + nx * res, y0, nx, ny)
+
+    data = np.random.randint(0, 1000, (1, ny, nx), dtype=np.int16)
+    da = xr.DataArray(
+        data,
+        dims=["band", "y", "x"],
+        coords={"band": [1]},
+    )
+    da.rio.write_crs(srs, inplace=True)
+    da.rio.write_transform(transform, inplace=True)
+    da.rio.write_nodata(-1, inplace=True)
+    da.name = variable
+    da.rio.to_raster(path)
+
+
+@pytest.fixture()
+def mod16a2_run_dir(tmp_path: Path) -> Path:
+    """Create run workspace with synthetic MOD16A2 sinusoidal tiles."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    source_dir = rd / "data" / "raw" / "mod16a2_v061"
+    source_dir.mkdir(parents=True)
+
+    # 2 time steps (DOY 001, 009), 2 tiles each (h08v04, h09v04)
+    for doy in [1, 9]:
+        for h, v in [(8, 4), (9, 4)]:
+            for var in ["ET_500m", "ET_QC_500m"]:
+                fname = f"MOD16A2GF.A2010{doy:03d}.h{h:02d}v{v:02d}.061.{var}.tif"
+                _make_sinusoidal_tile(
+                    source_dir / fname, var, h, v, 2010, doy,
+                )
+    return rd
+
+
+def test_consolidate_mod16a2_basic(mod16a2_run_dir):
+    """Consolidation mosaics tiles, reprojects to 4326, stacks along time."""
+    result = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key="mod16a2_v061",
+        variables=["ET_500m", "ET_QC_500m"],
+        year=2010,
+    )
+
+    assert "consolidated_nc" in result
+    assert "last_consolidated_utc" in result
+    assert result["variables"] == ["ET_500m", "ET_QC_500m"]
+
+    nc_path = mod16a2_run_dir / result["consolidated_nc"]
+    assert nc_path.exists()
+
+    ds = xr.open_dataset(nc_path)
+    assert "time" in ds.dims
+    assert ds.sizes["time"] == 2  # 2 time steps
+    assert "ET_500m" in ds.data_vars
+    assert "ET_QC_500m" in ds.data_vars
+    # Verify reprojected to EPSG:4326 (1D lat/lon coords)
+    assert "lat" in ds.coords or "y" in ds.coords
+    assert "lon" in ds.coords or "x" in ds.coords
+    ds.close()
+
+
+def test_consolidate_mod16a2_no_files(tmp_path):
+    """Raises FileNotFoundError when no HDF files exist for year."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    (rd / "data" / "raw" / "mod16a2_v061").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        consolidate_mod16a2(rd, "mod16a2_v061", ["ET_500m"], year=2010)
+```
+
+**Note on test design:** Real MOD16A2 files are HDF4 with subdatasets. For testing, we create GeoTIFF tiles with sinusoidal CRS using rioxarray. The consolidation code must handle both real HDF and test GeoTIFF — we use `rioxarray.open_rasterio()` which handles both formats.
+
+The actual file glob pattern in the implementation needs to handle `.hdf` files (production) and `.tif` files (tests). Alternatively, the test fixture can create `.hdf`-named files that are actually NetCDF/GeoTIFF — rioxarray doesn't care about the extension. **Use `.hdf` extension in tests for realism.**
+
+Update `_make_sinusoidal_tile` to use `.hdf` extension in the fixture:
+
+```python
+                fname = f"MOD16A2GF.A2010{doy:03d}.h{h:02d}v{v:02d}.061.2020256154955.hdf"
+```
+
+And create one file per tile (not per variable) — the real HDF has multiple subdatasets. For testing simplicity, store just `ET_500m` in each tile. The implementation will need to handle extracting variables from HDF subdatasets.
+
+**Actually, let's simplify the test approach:** Real MODIS HDF4 files have subdatasets like `HDF4_EOS:EOS_GRID:"file.hdf":MOD_Grid_MOD16A2:ET_500m`. This is complex to mock. Instead:
+
+1. The test creates small GeoTIFF files with `.tif` extension
+2. The implementation groups files by time step and variable, mosaics per variable per time step
+3. The glob pattern is configurable or we glob for both `.hdf` and `.tif`
+
+**Revised simpler approach for implementation:** Since MODIS HDF4 files require GDAL HDF4 driver and have subdataset structure that's hard to mock, the implementation should:
+
+1. Glob `.hdf` files
+2. For each HDF, list subdatasets via `rioxarray.open_rasterio(f, variable=var_name)` to extract each variable
+3. Group by (time_step, variable)
+4. Mosaic tiles per group, reproject each mosaic
+5. Combine variables into a Dataset, stack along time
+
+For testing, we'll mock the rioxarray operations or create simple raster files.
+
+**Revised test — mock-based approach:**
+
+```python
+from unittest.mock import patch, MagicMock
+
+def test_consolidate_mod16a2_no_files(tmp_path):
+    """Raises FileNotFoundError when no HDF files exist for year."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    (rd / "data" / "raw" / "mod16a2_v061").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        consolidate_mod16a2(rd, "mod16a2_v061", ["ET_500m"], year=2010)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py::test_consolidate_mod16a2_no_files -v`
+Expected: FAIL with NotImplementedError
+
+**Step 3: Write the implementation**
+
+Replace `consolidate_mod16a2` stub in `consolidate.py`:
+
+```python
+def _mosaic_and_reproject_timestep(
+    tile_paths: list[Path],
+    variable: str,
+    resolution: float = 0.04,
+) -> xr.DataArray:
+    """Mosaic tiles for one variable/timestep, reproject to EPSG:4326.
+
+    Parameters
+    ----------
+    tile_paths : list[Path]
+        Paths to HDF tiles for a single time step.
+    variable : str
+        Subdataset variable name to extract from each tile.
+    resolution : float
+        Target resolution in degrees (default 0.04° ≈ 4km).
+
+    Returns
+    -------
+    xr.DataArray
+        Mosaicked and reprojected array with y/x dimensions.
+    """
+    from rasterio.enums import Resampling
+    from rioxarray.merge import merge_arrays
+
+    arrays = []
+    for p in tile_paths:
+        da = rioxarray.open_rasterio(p, variable=variable, masked=True)
+        if isinstance(da, list):
+            da = da[0]
+        arrays.append(da)
+
+    if len(arrays) == 1:
+        mosaic = arrays[0]
+    else:
+        mosaic = merge_arrays(arrays)
+
+    # Choose resampling: average for continuous data, nearest for QC
+    if "QC" in variable or "qa" in variable.lower():
+        resampling = Resampling.nearest
+    else:
+        resampling = Resampling.average
+
+    reprojected = mosaic.rio.reproject(
+        "EPSG:4326",
+        resolution=resolution,
+        resampling=resampling,
+    )
+
+    for a in arrays:
+        a.close()
+
+    return reprojected
+
+
+def consolidate_mod16a2(
+    run_dir: Path,
+    source_key: str,
+    variables: list[str],
+    year: int,
+    resolution: float = 0.04,
+) -> dict:
+    """Merge per-granule MOD16A2 HDF files into a consolidated NetCDF.
+
+    For each 8-day composite (identified by AYYYYDDD filename pattern):
+    1. Mosaic tiles into a single raster per variable
+    2. Reproject from sinusoidal to EPSG:4326 at *resolution* degrees
+    3. Stack all time steps along a time dimension
+
+    Parameters
+    ----------
+    run_dir : Path
+        Run workspace directory.
+    source_key : str
+        Source key (e.g. ``"mod16a2_v061"``).
+    variables : list[str]
+        Variable names to extract from each HDF (e.g. ``["ET_500m"]``).
+    year : int
+        Year to consolidate.
+    resolution : float
+        Target resolution in degrees (default 0.04° ≈ 4km).
+
+    Returns
+    -------
+    dict
+        Provenance record.
+    """
+    import re
+    from collections import defaultdict
+
+    import rioxarray  # noqa: F401 — registers rio accessor
+
+    source_dir = run_dir / "data" / "raw" / source_key
+    year_re = re.compile(rf"\.A{year}\d{{3}}\.")
+    # Match the AYYYYDDD token to group by time step
+    timestep_re = re.compile(r"\.(A\d{7})\.")
+
+    hdf_files = sorted(
+        f for f in source_dir.glob("*.hdf") if year_re.search(f.name)
+    )
+
+    if not hdf_files:
+        raise FileNotFoundError(
+            f"No .hdf files found for year {year} in {source_dir}. "
+            f"Run 'nhf-targets fetch {source_key.replace('_', '-')}' first."
+        )
+
+    # Group tiles by time step (AYYYYDDD token)
+    groups: dict[str, list[Path]] = defaultdict(list)
+    for f in hdf_files:
+        m = timestep_re.search(f.name)
+        if m:
+            groups[m.group(1)].append(f)
+        else:
+            logger.warning("Skipping file without AYYYYDDD token: %s", f.name)
+
+    logger.info(
+        "Processing %d time steps (%d tiles) for %s year %d",
+        len(groups), len(hdf_files), source_key, year,
+    )
+
+    # Process each time step: mosaic tiles, reproject, build dataset
+    time_slices: list[xr.Dataset] = []
+    for ts_key in sorted(groups):
+        tile_paths = groups[ts_key]
+        t = _time_from_modis_filename(tile_paths[0])
+
+        var_arrays = {}
+        for var in variables:
+            try:
+                da = _mosaic_and_reproject_timestep(
+                    tile_paths, var, resolution=resolution,
+                )
+                # Drop band dim if present (single band)
+                if "band" in da.dims:
+                    da = da.squeeze("band", drop=True)
+                var_arrays[var] = da
+            except Exception as exc:
+                logger.warning(
+                    "Failed to process variable %s for %s: %s",
+                    var, ts_key, exc,
+                )
+                raise
+
+        # Build dataset for this time step
+        ds_t = xr.Dataset(var_arrays)
+        ds_t = ds_t.expand_dims(time=[t])
+
+        # Rename x/y to lon/lat for clean 1D coordinates
+        if "x" in ds_t.dims:
+            ds_t = ds_t.rename({"x": "lon", "y": "lat"})
+
+        time_slices.append(ds_t)
+
+    try:
+        ds = xr.concat(time_slices, dim="time", data_vars="minimal", coords="minimal")
+        ds = ds.sortby("time")
+
+        out_path = source_dir / f"{source_key}_{year}_consolidated.nc"
+        logger.info("Writing consolidated file: %s", out_path)
+        _write_netcdf(ds, out_path)
+        logger.info("Wrote %s", out_path)
+    finally:
+        for s in time_slices:
+            s.close()
+
+    return {
+        "consolidated_nc": str(out_path.relative_to(run_dir)),
+        "last_consolidated_utc": datetime.now(timezone.utc).isoformat(),
+        "n_files": len(hdf_files),
+        "variables": variables,
+    }
+```
+
+Add `import rioxarray` to the top-level imports in `consolidate.py`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `pixi run -e dev test`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/consolidate.py tests/test_consolidate_modis.py
+git commit -m "feat: implement consolidate_mod16a2 with mosaic and reproject"
+```
+
+---
+
+### Task 4: MOD16A2 integration test with synthetic rasters
+
+**Files:**
+- Modify: `tests/test_consolidate_modis.py`
+
+**Step 1: Write the test using real rioxarray operations**
+
+This test creates actual sinusoidal-projected GeoTIFF files (named `.hdf`) and verifies end-to-end mosaicking, reprojection, and time stacking.
+
+Add to `tests/test_consolidate_modis.py`:
+
+```python
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
+
+
+def _make_sinusoidal_tile(path: Path, h: int, v: int, value: int = 42) -> None:
+    """Create a small sinusoidal-projected GeoTIFF (named .hdf for testing)."""
+    srs = CRS.from_proj4(
+        "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +R=6371007.181 +units=m +no_defs"
+    )
+    nx, ny = 4, 4
+    x0 = -10_000_000 + h * 200_000
+    y0 = 6_000_000 - v * 200_000
+    res = 500.0
+    transform = from_bounds(x0, y0 - ny * res, x0 + nx * res, y0, nx, ny)
+
+    data = np.full((1, ny, nx), value, dtype=np.int16)
+    da = xr.DataArray(data, dims=["band", "y", "x"], coords={"band": [1]})
+    da.rio.write_crs(srs, inplace=True)
+    da.rio.write_transform(transform, inplace=True)
+    da.rio.write_nodata(-1, inplace=True)
+    da.rio.to_raster(path)
+
+
+@pytest.fixture()
+def mod16a2_run_dir(tmp_path: Path) -> Path:
+    """Create run workspace with synthetic MOD16A2 tiles."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    source_dir = rd / "data" / "raw" / "mod16a2_v061"
+    source_dir.mkdir(parents=True)
+
+    # 2 time steps (DOY 001, 009), 2 tiles each (h08v04, h09v04)
+    for doy in [1, 9]:
+        for h, v in [(8, 4), (9, 4)]:
+            fname = (
+                f"MOD16A2GF.A2010{doy:03d}.h{h:02d}v{v:02d}"
+                f".061.2020256154955.hdf"
+            )
+            _make_sinusoidal_tile(source_dir / fname, h, v, value=doy * 10)
+
+    return rd
+
+
+def test_consolidate_mod16a2_synthetic(mod16a2_run_dir):
+    """End-to-end: mosaic sinusoidal tiles, reproject to 4326, stack time."""
+    result = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key="mod16a2_v061",
+        variables=["ET_500m"],
+        year=2010,
+    )
+
+    assert result["n_files"] == 4  # 2 timesteps × 2 tiles
+    nc_path = mod16a2_run_dir / result["consolidated_nc"]
+    assert nc_path.exists()
+
+    ds = xr.open_dataset(nc_path)
+    assert "time" in ds.dims
+    assert ds.sizes["time"] == 2
+    assert "ET_500m" in ds.data_vars
+    # Verify 1D lat/lon coordinates (EPSG:4326)
+    assert "lat" in ds.dims or "lat" in ds.coords
+    assert "lon" in ds.dims or "lon" in ds.coords
+    ds.close()
+
+
+def test_consolidate_mod16a2_partial_tiles(mod16a2_run_dir):
+    """Consolidation succeeds even if a time step has fewer tiles."""
+    # Remove one tile from DOY 009
+    source_dir = mod16a2_run_dir / "data" / "raw" / "mod16a2_v061"
+    for f in source_dir.glob("*A2010009*h09v04*"):
+        f.unlink()
+
+    result = consolidate_mod16a2(
+        mod16a2_run_dir, "mod16a2_v061", ["ET_500m"], year=2010,
+    )
+    assert result["n_files"] == 3  # 2 + 1
+    nc_path = mod16a2_run_dir / result["consolidated_nc"]
+    ds = xr.open_dataset(nc_path)
+    assert ds.sizes["time"] == 2  # still 2 time steps
+    ds.close()
+```
+
+**Note:** The `_mosaic_and_reproject_timestep` function uses `rioxarray.open_rasterio(p, variable=variable)`. For real MODIS HDF4 files, the `variable` parameter selects the subdataset. For GeoTIFF test files, there's only one band (no subdatasets), so the `variable` parameter may not apply. The implementation needs to handle both cases:
+- If `variable` parameter works (HDF4 with subdatasets) — use it
+- If it fails or file has no subdatasets (GeoTIFF) — open directly
+
+Update `_mosaic_and_reproject_timestep` to try `variable=` first, fall back to plain open:
+
+```python
+    for p in tile_paths:
+        try:
+            da = rioxarray.open_rasterio(p, variable=variable, masked=True)
+        except Exception:
+            da = rioxarray.open_rasterio(p, masked=True)
+        if isinstance(da, list):
+            da = da[0]
+        arrays.append(da)
+```
+
+**Step 2: Run tests**
+
+Run: `pixi run -e dev pytest tests/test_consolidate_modis.py -v`
+Expected: PASS
+
+**Step 3: Run full test suite**
+
+Run: `pixi run -e dev test`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add tests/test_consolidate_modis.py src/nhf_spatial_targets/fetch/consolidate.py
+git commit -m "test: add synthetic raster tests for MOD16A2 consolidation"
+```
+
+---
+
+### Task 5: Update fetch modules to remove NotImplementedError catch
+
+Now that consolidation is implemented, the `try/except NotImplementedError` wrappers in `modis.py` (added during PR review) should be removed — consolidation should run normally.
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/modis.py`
+
+**Step 1: Update modis.py**
+
+In `fetch_mod16a2` (around line 342), change:
+
+```python
+    for year in years_on_disk:
+        try:
+            result = consolidate_mod16a2(run_dir, source_key, variables, year)
+        except NotImplementedError:
+            logger.warning(
+                "Consolidation for %s year %d not yet implemented; skipping",
+                source_key,
+                year,
+            )
+            continue
+        if result and "consolidated_nc" in result:
+            consolidated_ncs[str(year)] = result["consolidated_nc"]
+```
+
+Back to:
+
+```python
+    for year in years_on_disk:
+        result = consolidate_mod16a2(run_dir, source_key, variables, year)
+        if result and "consolidated_nc" in result:
+            consolidated_ncs[str(year)] = result["consolidated_nc"]
+```
+
+Do the same for `fetch_mod10c1` (around line 562).
+
+**Step 2: Update test mocks in test_modis.py**
+
+The existing tests in `test_modis.py` mock consolidation. Verify they still work — the mocks return dicts, not raise NotImplementedError, so they should be fine.
+
+**Step 3: Run full test suite**
+
+Run: `pixi run -e dev test`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/modis.py
+git commit -m "refactor: remove NotImplementedError catch now that consolidation is implemented"
+```
+
+---
+
+### Task 6: Format, lint, final verification
+
+**Step 1: Format and lint**
+
+```bash
+pixi run -e dev fmt && pixi run -e dev lint
+```
+
+Fix any issues.
+
+**Step 2: Run full test suite**
+
+```bash
+pixi run -e dev test
+```
+
+Expected: All tests pass.
+
+**Step 3: Final commit (if any formatting changes)**
+
+```bash
+git add -u
+git commit -m "style: format and lint fixes"
+```

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -502,7 +502,7 @@ def consolidate_mod16a2(
         time_datasets.append(ds_step)
 
     try:
-        ds = xr.concat(time_datasets, dim="time")
+        ds = xr.concat(time_datasets, dim="time", join="outer")
         ds = ds.sortby("time")
         _validate_variables(ds, variables)
 

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -290,14 +291,83 @@ def consolidate_nldas(
     }
 
 
+def _time_from_modis_filename(path: Path) -> pd.Timestamp:
+    """Extract a timestamp from a MODIS ``AYYYYDDD`` filename pattern."""
+    m = re.search(r"\.A(\d{4})(\d{3})\.", path.name)
+    if not m:
+        raise ValueError(f"Cannot extract date from MODIS filename: {path.name}")
+    year, doy = int(m.group(1)), int(m.group(2))
+    return pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
+
+
 def consolidate_mod10c1(
     run_dir: Path,
     source_key: str,
     variables: list[str],
     year: int,
 ) -> dict:
-    """Merge daily MOD10C1 CONUS subsets for a single year into one NetCDF."""
-    raise NotImplementedError("consolidate_mod10c1 not yet implemented")
+    """Merge daily MOD10C1 CONUS subsets for a single year into one NetCDF.
+
+    Parameters
+    ----------
+    run_dir : Path
+        Run workspace directory.
+    source_key : str
+        Source key (e.g. ``"mod10c1_v061"``).
+    variables : list[str]
+        Variable names to include.
+    year : int
+        Year to consolidate.
+
+    Returns
+    -------
+    dict
+        Provenance record.
+    """
+    source_dir = run_dir / "data" / "raw" / source_key
+    year_pattern = re.compile(rf"\.A{year}\d{{3}}\.")
+    nc_files = sorted(
+        f for f in source_dir.glob("*.conus.nc") if year_pattern.search(f.name)
+    )
+
+    if not nc_files:
+        raise FileNotFoundError(
+            f"No .conus.nc files for year {year} found in {source_dir}. "
+            f"Run 'nhf-targets fetch {source_key.replace('_', '-')}' first."
+        )
+
+    logger.info(
+        "Merging %d MOD10C1 files for %s year %d", len(nc_files), source_key, year
+    )
+
+    datasets = _open_datasets(nc_files, f"Reading {source_key} {year} files")
+    datasets = [
+        ds.expand_dims(time=[_time_from_modis_filename(f)])
+        for ds, f in zip(datasets, nc_files)
+    ]
+
+    try:
+        ds_merged = xr.concat(
+            datasets, dim="time", data_vars="minimal", coords="minimal"
+        )
+        ds_merged = ds_merged.sortby("time")
+        _validate_variables(ds_merged, variables)
+        ds_merged = ds_merged[variables]
+
+        out_path = source_dir / f"{source_key}_{year}_consolidated.nc"
+        logger.info("Writing consolidated file: %s", out_path)
+        _write_netcdf(ds_merged, out_path)
+        logger.info("Wrote %s", out_path)
+    finally:
+        for d in datasets:
+            d.close()
+
+    return {
+        "consolidated_nc": str(out_path.relative_to(run_dir)),
+        "last_consolidated_utc": datetime.now(timezone.utc).isoformat(),
+        "n_files": len(nc_files),
+        "variables": variables,
+    }
 
 
 def consolidate_mod16a2(

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -340,13 +340,13 @@ def consolidate_mod10c1(
         "Merging %d MOD10C1 files for %s year %d", len(nc_files), source_key, year
     )
 
-    datasets = _open_datasets(nc_files, f"Reading {source_key} {year} files")
-    datasets = [
-        ds.expand_dims(time=[_time_from_modis_filename(f)])
-        for ds, f in zip(datasets, nc_files)
-    ]
-
+    opened = _open_datasets(nc_files, f"Reading {source_key} {year} files")
     try:
+        datasets = [
+            ds.expand_dims(time=[_time_from_modis_filename(f)])
+            for ds, f in zip(opened, nc_files)
+        ]
+
         ds_merged = xr.concat(
             datasets, dim="time", data_vars="minimal", coords="minimal"
         )
@@ -359,7 +359,7 @@ def consolidate_mod10c1(
         _write_netcdf(ds_merged, out_path)
         logger.info("Wrote %s", out_path)
     finally:
-        for d in datasets:
+        for d in opened:
             d.close()
 
     return {
@@ -384,9 +384,10 @@ def _mosaic_and_reproject_timestep(
     for p in tile_paths:
         try:
             da = rioxarray.open_rasterio(p, variable=variable, masked=True)
-        except Exception:
-            logger.debug(
-                "variable= kwarg failed for %s; opening without subdataset selection",
+        except TypeError:
+            logger.warning(
+                "variable= kwarg not supported for %s; "
+                "opening without subdataset selection",
                 p.name,
             )
             da = rioxarray.open_rasterio(p, masked=True)
@@ -394,24 +395,31 @@ def _mosaic_and_reproject_timestep(
             da = da[0]
         arrays.append(da)
 
-    if len(arrays) == 1:
-        mosaic = arrays[0]
-    else:
-        mosaic = merge_arrays(arrays)
-
     if "QC" in variable or "qa" in variable.lower():
         resampling = Resampling.nearest
     else:
         resampling = Resampling.average
 
-    reprojected = mosaic.rio.reproject(
-        "EPSG:4326",
-        resolution=resolution,
-        resampling=resampling,
-    )
+    try:
+        if len(arrays) == 1:
+            mosaic = arrays[0]
+        else:
+            mosaic = merge_arrays(arrays)
 
-    for a in arrays:
-        a.close()
+        reprojected = mosaic.rio.reproject(
+            "EPSG:4326",
+            resolution=resolution,
+            resampling=resampling,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to mosaic/reproject {len(arrays)} tiles for "
+            f"variable '{variable}'. "
+            f"Tiles: {[p.name for p in tile_paths]}. Detail: {exc}"
+        ) from exc
+    finally:
+        for a in arrays:
+            a.close()
 
     return reprojected
 

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -370,13 +370,64 @@ def consolidate_mod10c1(
     }
 
 
+def _mosaic_and_reproject_timestep(
+    tile_paths: list[Path],
+    variable: str,
+    resolution: float = 0.04,
+) -> xr.DataArray:
+    """Mosaic tiles for one variable/timestep, reproject to EPSG:4326."""
+    import rioxarray  # noqa: F401
+    from rasterio.enums import Resampling
+    from rioxarray.merge import merge_arrays
+
+    arrays = []
+    for p in tile_paths:
+        try:
+            da = rioxarray.open_rasterio(p, variable=variable, masked=True)
+        except Exception:
+            logger.debug(
+                "variable= kwarg failed for %s; opening without subdataset selection",
+                p.name,
+            )
+            da = rioxarray.open_rasterio(p, masked=True)
+        if isinstance(da, list):
+            da = da[0]
+        arrays.append(da)
+
+    if len(arrays) == 1:
+        mosaic = arrays[0]
+    else:
+        mosaic = merge_arrays(arrays)
+
+    if "QC" in variable or "qa" in variable.lower():
+        resampling = Resampling.nearest
+    else:
+        resampling = Resampling.average
+
+    reprojected = mosaic.rio.reproject(
+        "EPSG:4326",
+        resolution=resolution,
+        resampling=resampling,
+    )
+
+    for a in arrays:
+        a.close()
+
+    return reprojected
+
+
 def consolidate_mod16a2(
     run_dir: Path,
     source_key: str,
     variables: list[str],
     year: int,
+    resolution: float = 0.04,
 ) -> dict:
     """Merge per-granule MOD16A2 HDF files into a consolidated NetCDF.
+
+    Globs ``*.hdf`` files, groups tiles by time step (AYYYYDDD token),
+    mosaics and reprojects each time step to EPSG:4326, and writes a
+    single consolidated NetCDF per year.
 
     Parameters
     ----------
@@ -388,13 +439,87 @@ def consolidate_mod16a2(
         Variable names to include.
     year : int
         Year to consolidate.
+    resolution : float
+        Output resolution in degrees (default 0.04 ≈ 4 km).
 
     Returns
     -------
     dict
         Provenance record.
     """
-    raise NotImplementedError("consolidate_mod16a2 not yet implemented")
+    from collections import defaultdict
+
+    source_dir = run_dir / "data" / "raw" / source_key
+    year_pattern = re.compile(rf"\.A({year}\d{{3}})\.")
+    hdf_files = sorted(
+        f for f in source_dir.glob("*.hdf") if year_pattern.search(f.name)
+    )
+
+    if not hdf_files:
+        raise FileNotFoundError(
+            f"No .hdf files for year {year} found in {source_dir}. "
+            f"Run 'nhf-targets fetch {source_key.replace('_', '-')}' first."
+        )
+
+    # Group tiles by time step (AYYYYDDD token)
+    timestep_groups: dict[str, list[Path]] = defaultdict(list)
+    for f in hdf_files:
+        m = year_pattern.search(f.name)
+        if m:
+            timestep_groups[m.group(1)].append(f)
+
+    logger.info(
+        "Processing %d HDF files across %d time steps for %s year %d",
+        len(hdf_files),
+        len(timestep_groups),
+        source_key,
+        year,
+    )
+
+    time_datasets: list[xr.Dataset] = []
+    for ydoy in tqdm(sorted(timestep_groups), desc=f"Mosaicking {source_key} {year}"):
+        tile_paths = timestep_groups[ydoy]
+        timestamp = _time_from_modis_filename(tile_paths[0])
+
+        var_arrays: dict[str, xr.DataArray] = {}
+        for var in variables:
+            da = _mosaic_and_reproject_timestep(tile_paths, var, resolution)
+            # Squeeze band dimension if present
+            if "band" in da.dims:
+                da = da.squeeze("band", drop=True)
+            # Rename spatial dims to lat/lon
+            rename_map = {}
+            if "y" in da.dims:
+                rename_map["y"] = "lat"
+            if "x" in da.dims:
+                rename_map["x"] = "lon"
+            if rename_map:
+                da = da.rename(rename_map)
+            var_arrays[var] = da
+
+        ds_step = xr.Dataset(var_arrays)
+        ds_step = ds_step.expand_dims(time=[timestamp])
+        time_datasets.append(ds_step)
+
+    try:
+        ds = xr.concat(time_datasets, dim="time")
+        ds = ds.sortby("time")
+        _validate_variables(ds, variables)
+
+        out_path = source_dir / f"{source_key}_{year}_consolidated.nc"
+        logger.info("Writing consolidated file: %s", out_path)
+        _write_netcdf(ds, out_path)
+        logger.info("Wrote %s", out_path)
+    finally:
+        for ts in time_datasets:
+            ts.close()
+
+    return {
+        "consolidated_nc": str(out_path.relative_to(run_dir)),
+        "last_consolidated_utc": datetime.now(timezone.utc).isoformat(),
+        "n_files": len(hdf_files),
+        "variables": variables,
+    }
 
 
 def consolidate_ncep_ncar(

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -344,9 +344,9 @@ def fetch_mod16a2(run_dir: Path, period: str) -> dict:
     consolidated_ncs: dict[str, str] = {}
     years_on_disk = sorted({f["year"] for f in files})
     for year in years_on_disk:
+        logger.info("Consolidating %s year %d", source_key, year)
         result = consolidate_mod16a2(run_dir, source_key, variables, year)
-        if result and "consolidated_nc" in result:
-            consolidated_ncs[str(year)] = result["consolidated_nc"]
+        consolidated_ncs[str(year)] = result["consolidated_nc"]
 
     # Compute effective period from actual files on disk
     if years_on_disk:
@@ -552,9 +552,9 @@ def fetch_mod10c1(run_dir: Path, period: str) -> dict:
     consolidated_ncs: dict[str, str] = {}
     years_on_disk = sorted({f["year"] for f in files})
     for year in years_on_disk:
+        logger.info("Consolidating %s year %d", source_key, year)
         result = consolidate_mod10c1(run_dir, source_key, variables, year)
-        if result and "consolidated_nc" in result:
-            consolidated_ncs[str(year)] = result["consolidated_nc"]
+        consolidated_ncs[str(year)] = result["consolidated_nc"]
 
     # Compute effective period from actual files on disk
     if years_on_disk:

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -344,15 +344,7 @@ def fetch_mod16a2(run_dir: Path, period: str) -> dict:
     consolidated_ncs: dict[str, str] = {}
     years_on_disk = sorted({f["year"] for f in files})
     for year in years_on_disk:
-        try:
-            result = consolidate_mod16a2(run_dir, source_key, variables, year)
-        except NotImplementedError:
-            logger.warning(
-                "Consolidation for %s year %d not yet implemented; skipping",
-                source_key,
-                year,
-            )
-            continue
+        result = consolidate_mod16a2(run_dir, source_key, variables, year)
         if result and "consolidated_nc" in result:
             consolidated_ncs[str(year)] = result["consolidated_nc"]
 
@@ -560,15 +552,7 @@ def fetch_mod10c1(run_dir: Path, period: str) -> dict:
     consolidated_ncs: dict[str, str] = {}
     years_on_disk = sorted({f["year"] for f in files})
     for year in years_on_disk:
-        try:
-            result = consolidate_mod10c1(run_dir, source_key, variables, year)
-        except NotImplementedError:
-            logger.warning(
-                "Consolidation for %s year %d not yet implemented; skipping",
-                source_key,
-                year,
-            )
-            continue
+        result = consolidate_mod10c1(run_dir, source_key, variables, year)
         if result and "consolidated_nc" in result:
             consolidated_ncs[str(year)] = result["consolidated_nc"]
 

--- a/tests/test_consolidate_modis.py
+++ b/tests/test_consolidate_modis.py
@@ -26,6 +26,14 @@ def test_time_from_modis_filename():
     t = _time_from_modis_filename(Path("MOD10C1.A2010032.061.conus.nc"))
     assert t == pd.Timestamp("2010-02-01")
 
+    # DOY 365 in a non-leap year → Dec 31
+    t = _time_from_modis_filename(Path("MOD10C1.A2010365.061.conus.nc"))
+    assert t == pd.Timestamp("2010-12-31")
+
+    # DOY 366 in leap year 2000 → Dec 31
+    t = _time_from_modis_filename(Path("MOD10C1.A2000366.061.conus.nc"))
+    assert t == pd.Timestamp("2000-12-31")
+
 
 def test_time_from_modis_filename_bad():
     """Raises ValueError for non-MODIS filename."""
@@ -146,6 +154,78 @@ def test_consolidate_mod10c1_overwrites_existing(mod10c1_run_dir: Path) -> None:
     assert result1["consolidated_nc"] == result2["consolidated_nc"]
     out_path = mod10c1_run_dir / result2["consolidated_nc"]
     assert out_path.exists()
+
+
+def test_consolidate_mod10c1_missing_variable_raises(mod10c1_run_dir: Path) -> None:
+    """ValueError raised when requesting a nonexistent variable."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    with pytest.raises(ValueError, match="NONEXISTENT"):
+        consolidate_mod10c1(
+            run_dir=mod10c1_run_dir,
+            source_key="mod10c1_v061",
+            variables=["NONEXISTENT"],
+            year=2010,
+        )
+
+
+def test_consolidate_mod10c1_filters_variables(tmp_path: Path) -> None:
+    """Only requested variables appear in consolidated output."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    source_key = "mod10c1_v061"
+    out = tmp_path / "data" / "raw" / source_key
+    out.mkdir(parents=True)
+
+    lat = np.linspace(25.0, 50.0, 4)
+    lon = np.linspace(-125.0, -65.0, 6)
+
+    for doy in range(1, 3):
+        ds = xr.Dataset(
+            {
+                "Day_CMG_Snow_Cover": (
+                    ["lat", "lon"],
+                    np.random.rand(len(lat), len(lon)).astype(np.float32),
+                ),
+                "ExtraVar": (
+                    ["lat", "lon"],
+                    np.random.rand(len(lat), len(lon)).astype(np.float32),
+                ),
+            },
+            coords={"lat": lat, "lon": lon},
+        )
+        fname = f"MOD10C1.A2010{doy:03d}.061.conus.nc"
+        ds.to_netcdf(out / fname)
+
+    result = consolidate_mod10c1(
+        run_dir=tmp_path,
+        source_key=source_key,
+        variables=["Day_CMG_Snow_Cover"],
+        year=2010,
+    )
+
+    out_path = tmp_path / result["consolidated_nc"]
+    ds_out = xr.open_dataset(out_path)
+    assert "Day_CMG_Snow_Cover" in ds_out.data_vars
+    assert "ExtraVar" not in ds_out.data_vars
+    ds_out.close()
+
+
+def test_consolidate_mod10c1_sorts_time(mod10c1_run_dir: Path) -> None:
+    """Consolidated time dimension is monotonically increasing."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    result = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key="mod10c1_v061",
+        variables=["Day_CMG_Snow_Cover"],
+        year=2010,
+    )
+
+    out_path = mod10c1_run_dir / result["consolidated_nc"]
+    ds = xr.open_dataset(out_path)
+    assert pd.DatetimeIndex(ds.time.values).is_monotonic_increasing
+    ds.close()
 
 
 def test_consolidate_mod10c1_filters_year(mod10c1_run_dir: Path) -> None:

--- a/tests/test_consolidate_modis.py
+++ b/tests/test_consolidate_modis.py
@@ -281,3 +281,57 @@ def test_consolidate_mod16a2_synthetic(mod16a2_run_dir: Path) -> None:
         result["consolidated_nc"]
         == f"data/raw/{source_key}/{source_key}_2010_consolidated.nc"
     )
+
+
+def test_consolidate_mod16a2_partial_tiles(mod16a2_run_dir: Path) -> None:
+    """Consolidation succeeds when one tile is missing from a timestep."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod16a2
+
+    source_key = "mod16a2_v061"
+    source_dir = mod16a2_run_dir / "data" / "raw" / source_key
+
+    # Delete the h09v04 tile from DOY 009
+    doy9_h09 = list(source_dir.glob("MOD16A2GF.A2010009.h09v04.*"))
+    assert len(doy9_h09) == 1, "Expected exactly one h09v04 tile for DOY 009"
+    doy9_h09[0].unlink()
+
+    result = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key=source_key,
+        variables=["ET_500m"],
+        year=2010,
+    )
+
+    # 3 remaining HDF files (2 for DOY 001, 1 for DOY 009)
+    assert result["n_files"] == 3
+
+    out_path = mod16a2_run_dir / result["consolidated_nc"]
+    ds = xr.open_dataset(out_path)
+    # Both timesteps should still be present
+    assert ds.sizes["time"] == 2
+    ds.close()
+
+
+def test_consolidate_mod16a2_overwrites_existing(mod16a2_run_dir: Path) -> None:
+    """Re-running consolidation is idempotent and produces the same file."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod16a2
+
+    source_key = "mod16a2_v061"
+    variables = ["ET_500m"]
+
+    result1 = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+    result2 = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+
+    assert result1["consolidated_nc"] == result2["consolidated_nc"]
+    out_path = mod16a2_run_dir / result2["consolidated_nc"]
+    assert out_path.exists()

--- a/tests/test_consolidate_modis.py
+++ b/tests/test_consolidate_modis.py
@@ -1,4 +1,4 @@
-"""Tests for MOD10C1 consolidation."""
+"""Tests for MODIS consolidation (MOD10C1 and MOD16A2)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import rioxarray  # noqa: F401
 import xarray as xr
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
 
 from nhf_spatial_targets.fetch.consolidate import _time_from_modis_filename
 
@@ -183,3 +186,98 @@ def test_consolidate_mod10c1_filters_year(mod10c1_run_dir: Path) -> None:
     ds_out = xr.open_dataset(out_path)
     assert len(ds_out.time) == 3
     ds_out.close()
+
+
+# ---------------------------------------------------------------------------
+# MOD16A2 consolidation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sinusoidal_tile(path: Path, h: int, v: int, value: int = 42) -> None:
+    """Write a small sinusoidal-projected GeoTIFF (with .hdf extension)."""
+    srs = CRS.from_proj4(
+        "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +R=6371007.181 +units=m +no_defs"
+    )
+    nx, ny = 4, 4
+    x0 = -10_000_000 + h * 200_000
+    y0 = 6_000_000 - v * 200_000
+    res = 500.0
+    transform = from_bounds(x0, y0 - ny * res, x0 + nx * res, y0, nx, ny)
+    data = np.full((1, ny, nx), value, dtype=np.int16)
+    da = xr.DataArray(data, dims=["band", "y", "x"], coords={"band": [1]})
+    da.rio.write_crs(srs, inplace=True)
+    da.rio.write_transform(transform, inplace=True)
+    da.rio.write_nodata(-1, inplace=True)
+    da.rio.to_raster(path, driver="GTiff")
+
+
+@pytest.fixture()
+def mod16a2_run_dir(tmp_path):
+    """Create a run workspace with 2 timesteps × 2 tiles of synthetic HDF files."""
+    rd = tmp_path / "run"
+    rd.mkdir()
+    source_dir = rd / "data" / "raw" / "mod16a2_v061"
+    source_dir.mkdir(parents=True)
+    for doy in [1, 9]:
+        for h, v in [(8, 4), (9, 4)]:
+            fname = f"MOD16A2GF.A2010{doy:03d}.h{h:02d}v{v:02d}.061.2020256154955.hdf"
+            _make_sinusoidal_tile(source_dir / fname, h, v, value=doy * 10)
+    return rd
+
+
+def test_consolidate_mod16a2_no_files(tmp_path: Path) -> None:
+    """FileNotFoundError raised for empty directory."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod16a2
+
+    source_key = "mod16a2_v061"
+    (tmp_path / "data" / "raw" / source_key).mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError, match="No .hdf files"):
+        consolidate_mod16a2(
+            run_dir=tmp_path,
+            source_key=source_key,
+            variables=["ET_500m"],
+            year=2010,
+        )
+
+
+def test_consolidate_mod16a2_synthetic(mod16a2_run_dir: Path) -> None:
+    """Full pipeline: mosaic, reproject, stack along time."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod16a2
+
+    source_key = "mod16a2_v061"
+    variables = ["ET_500m"]
+
+    result = consolidate_mod16a2(
+        run_dir=mod16a2_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+
+    out_path = mod16a2_run_dir / result["consolidated_nc"]
+    assert out_path.exists()
+
+    ds = xr.open_dataset(out_path)
+
+    # Should have 2 time steps (DOY 1 and DOY 9)
+    assert "time" in ds.dims
+    assert len(ds.time) == 2
+
+    # Should have lat/lon coordinates in EPSG:4326
+    assert "lat" in ds.dims or "lat" in ds.coords
+    assert "lon" in ds.dims or "lon" in ds.coords
+
+    # Variable is present
+    assert "ET_500m" in ds.data_vars
+
+    ds.close()
+
+    # Provenance checks
+    assert result["n_files"] == 4
+    assert result["variables"] == variables
+    assert "last_consolidated_utc" in result
+    assert (
+        result["consolidated_nc"]
+        == f"data/raw/{source_key}/{source_key}_2010_consolidated.nc"
+    )

--- a/tests/test_consolidate_modis.py
+++ b/tests/test_consolidate_modis.py
@@ -5,8 +5,29 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
+
+from nhf_spatial_targets.fetch.consolidate import _time_from_modis_filename
+
+
+def test_time_from_modis_filename():
+    """Extract date from MODIS AYYYYDDD filename."""
+    t = _time_from_modis_filename(Path("MOD16A2GF.A2010001.h08v04.061.hdf"))
+    assert t == pd.Timestamp("2010-01-01")
+
+    t = _time_from_modis_filename(Path("MOD16A2GF.A2010009.h08v04.061.hdf"))
+    assert t == pd.Timestamp("2010-01-09")
+
+    t = _time_from_modis_filename(Path("MOD10C1.A2010032.061.conus.nc"))
+    assert t == pd.Timestamp("2010-02-01")
+
+
+def test_time_from_modis_filename_bad():
+    """Raises ValueError for non-MODIS filename."""
+    with pytest.raises(ValueError, match="Cannot extract date"):
+        _time_from_modis_filename(Path("random_file.nc"))
 
 
 @pytest.fixture()

--- a/tests/test_consolidate_modis.py
+++ b/tests/test_consolidate_modis.py
@@ -1,0 +1,164 @@
+"""Tests for MOD10C1 consolidation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+@pytest.fixture()
+def mod10c1_run_dir(tmp_path: Path) -> Path:
+    """Create a run workspace with 3 synthetic MOD10C1 .conus.nc files.
+
+    Files simulate DOY 1, 2, 3 of year 2010.  Each has Day_CMG_Snow_Cover
+    and Snow_Spatial_QA on a small lat/lon grid (4x6) with NO time dimension,
+    matching real ``_subset_to_conus`` output.
+    """
+    source_key = "mod10c1_v061"
+    out = tmp_path / "data" / "raw" / source_key
+    out.mkdir(parents=True)
+
+    lat = np.linspace(25.0, 50.0, 4)
+    lon = np.linspace(-125.0, -65.0, 6)
+
+    for doy in range(1, 4):
+        ds = xr.Dataset(
+            {
+                "Day_CMG_Snow_Cover": (
+                    ["lat", "lon"],
+                    np.random.rand(len(lat), len(lon)).astype(np.float32),
+                ),
+                "Snow_Spatial_QA": (
+                    ["lat", "lon"],
+                    np.random.randint(0, 4, (len(lat), len(lon)), dtype=np.int8),
+                ),
+            },
+            coords={"lat": lat, "lon": lon},
+        )
+        fname = f"MOD10C1.A2010{doy:03d}.061.conus.nc"
+        ds.to_netcdf(out / fname)
+
+    return tmp_path
+
+
+def test_consolidate_mod10c1_basic(mod10c1_run_dir: Path) -> None:
+    """Output has time dim with 3 steps, both variables, correct provenance."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    source_key = "mod10c1_v061"
+    variables = ["Day_CMG_Snow_Cover", "Snow_Spatial_QA"]
+
+    result = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+
+    out_path = (
+        mod10c1_run_dir
+        / "data"
+        / "raw"
+        / source_key
+        / f"{source_key}_2010_consolidated.nc"
+    )
+    assert out_path.exists()
+
+    ds = xr.open_dataset(out_path)
+    assert "time" in ds.dims
+    assert len(ds.time) == 3
+    assert "Day_CMG_Snow_Cover" in ds.data_vars
+    assert "Snow_Spatial_QA" in ds.data_vars
+    ds.close()
+
+    assert (
+        result["consolidated_nc"]
+        == f"data/raw/{source_key}/{source_key}_2010_consolidated.nc"
+    )
+    assert "last_consolidated_utc" in result
+    assert result["n_files"] == 3
+    assert result["variables"] == variables
+
+
+def test_consolidate_mod10c1_no_files(tmp_path: Path) -> None:
+    """FileNotFoundError raised for empty directory."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    source_key = "mod10c1_v061"
+    (tmp_path / "data" / "raw" / source_key).mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError, match="No .conus.nc files"):
+        consolidate_mod10c1(
+            run_dir=tmp_path,
+            source_key=source_key,
+            variables=["Day_CMG_Snow_Cover"],
+            year=2010,
+        )
+
+
+def test_consolidate_mod10c1_overwrites_existing(mod10c1_run_dir: Path) -> None:
+    """Re-running consolidation produces the same file path."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    source_key = "mod10c1_v061"
+    variables = ["Day_CMG_Snow_Cover"]
+
+    result1 = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+    result2 = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key=source_key,
+        variables=variables,
+        year=2010,
+    )
+
+    assert result1["consolidated_nc"] == result2["consolidated_nc"]
+    out_path = mod10c1_run_dir / result2["consolidated_nc"]
+    assert out_path.exists()
+
+
+def test_consolidate_mod10c1_filters_year(mod10c1_run_dir: Path) -> None:
+    """Adding a 2011 file does not affect 2010 consolidation."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_mod10c1
+
+    source_key = "mod10c1_v061"
+    source_dir = mod10c1_run_dir / "data" / "raw" / source_key
+
+    # Add a file for 2011 DOY 1
+    lat = np.linspace(25.0, 50.0, 4)
+    lon = np.linspace(-125.0, -65.0, 6)
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (
+                ["lat", "lon"],
+                np.random.rand(len(lat), len(lon)).astype(np.float32),
+            ),
+            "Snow_Spatial_QA": (
+                ["lat", "lon"],
+                np.random.randint(0, 4, (len(lat), len(lon)), dtype=np.int8),
+            ),
+        },
+        coords={"lat": lat, "lon": lon},
+    )
+    ds.to_netcdf(source_dir / "MOD10C1.A2011001.061.conus.nc")
+
+    result = consolidate_mod10c1(
+        run_dir=mod10c1_run_dir,
+        source_key=source_key,
+        variables=["Day_CMG_Snow_Cover", "Snow_Spatial_QA"],
+        year=2010,
+    )
+
+    assert result["n_files"] == 3
+
+    out_path = mod10c1_run_dir / result["consolidated_nc"]
+    ds_out = xr.open_dataset(out_path)
+    assert len(ds_out.time) == 3
+    ds_out.close()


### PR DESCRIPTION
## Summary

- Implement `consolidate_mod10c1`: concat daily `.conus.nc` files along time per year
- Implement `consolidate_mod16a2`: mosaic sinusoidal tiles per 8-day composite, reproject to EPSG:4326 at 0.04° (~4km), stack along time per year
- Add `_time_from_modis_filename` helper for extracting timestamps from MODIS AYYYYDDD filenames
- Add `_mosaic_and_reproject_timestep` helper for tile mosaicking and reprojection
- Remove `NotImplementedError` safety wrappers from `modis.py` fetch functions
- 10 new tests (141 total passing)

Closes #16

## Test plan

- [x] `test_consolidate_mod10c1_basic` — verifies time concat, variable selection, provenance dict
- [x] `test_consolidate_mod10c1_no_files` — FileNotFoundError for empty directory
- [x] `test_consolidate_mod10c1_overwrites_existing` — idempotent reconsolidation
- [x] `test_consolidate_mod10c1_filters_year` — year filtering excludes other years
- [x] `test_time_from_modis_filename` — DOY-to-date conversion
- [x] `test_time_from_modis_filename_bad` — ValueError for non-MODIS names
- [x] `test_consolidate_mod16a2_no_files` — FileNotFoundError for empty directory
- [x] `test_consolidate_mod16a2_synthetic` — end-to-end with sinusoidal GeoTIFF tiles
- [x] `test_consolidate_mod16a2_partial_tiles` — handles missing tiles gracefully
- [x] `test_consolidate_mod16a2_overwrites_existing` — idempotent reconsolidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)