### PR TITLE
Add fetch-all CLI command and QAQC notebooks

### DIFF
--- a/notebooks/inspect_consolidated.ipynb
+++ b/notebooks/inspect_consolidated.ipynb
@@ -16,14 +16,7 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import xarray as xr\n",
-    "\n",
-    "RUN_DIR = Path.home() / \"data\" / \"test1\" / \"2026-03-12_test1_v0.1.0\"\n"
-   ]
+   "source": "from pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport xarray as xr\n\nRUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\""
   },
   {
    "cell_type": "markdown",

--- a/notebooks/visualize_merra2.ipynb
+++ b/notebooks/visualize_merra2.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "z0dpo4fe9c",
+   "metadata": {},
+   "source": [
+    "# MERRA-2 — Surface Soil Wetness (GWETTOP)\n",
+    "\n",
+    "Visualize the consolidated MERRA-2 `GWETTOP` (surface soil wetness, 0–0.05 m)\n",
+    "dataset from NASA GES DISC (M2TMNXLND v5.12.4).\n",
+    "\n",
+    "- **Variable:** `GWETTOP` — surface soil wetness (fraction of saturation, 0–1)\n",
+    "- **Resolution:** 0.5° × 0.625° global grid\n",
+    "- **Period:** 1980–present (monthly)\n",
+    "- **Additional variables:** `GWETROOT` (root zone, 0–1 m), `GWETPROF` (full profile, variable depth)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "393byp2vi9g",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
+    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"merra2\" / \"merra2_consolidated.nc\"\n",
+    "PRIMARY_VAR = \"GWETTOP\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2gwat8zxrt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(NC_PATH)\n",
+    "print(ds)\n",
+    "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
+    "print(f\"Time steps: {ds.time.size}\")\n",
+    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
+    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nx3ccxyaqjr",
+   "metadata": {},
+   "source": [
+    "## Single-month soil wetness map (global)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "caj62zpw0vh",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_TIME = \"2000-01-15\"\n",
+    "\n",
+    "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "actual_time = str(da.time.values)[:10]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 6))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", vmin=0, vmax=1, cbar_kwargs={\"label\": \"fraction of saturation\"})\n",
+    "ax.set_title(f\"MERRA-2 Surface Soil Wetness (GWETTOP, 0–0.05 m) — {actual_time}\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Stats for {actual_time}:\")\n",
+    "print(f\"  min:  {float(da.min()):.4f}\")\n",
+    "print(f\"  max:  {float(da.max()):.4f}\")\n",
+    "print(f\"  mean: {float(da.mean()):.4f}\")\n",
+    "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "126sc9voz8v",
+   "metadata": {},
+   "source": [
+    "## All three soil wetness variables — single timestep comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1w7l0h77zg2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soil_vars = {\n",
+    "    \"GWETTOP\": \"Surface (0–0.05 m)\",\n",
+    "    \"GWETROOT\": \"Root zone (0–1.0 m)\",\n",
+    "    \"GWETPROF\": \"Full profile (to bedrock)\",\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(20, 5))\n",
+    "\n",
+    "for ax, (var, label) in zip(axes, soil_vars.items()):\n",
+    "    if var not in ds.data_vars:\n",
+    "        ax.set_title(f\"{label}\\n(not in dataset)\")\n",
+    "        ax.set_visible(False)\n",
+    "        continue\n",
+    "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", vmin=0, vmax=1, cbar_kwargs={\"label\": \"fraction\"})\n",
+    "    ax.set_title(f\"{var}\\n{label}\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(f\"MERRA-2 Soil Wetness Variables — {actual_time}\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7djqn4isryo",
+   "metadata": {},
+   "source": [
+    "## CONUS subset — calibration period mean (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "xv3ybl14dhs",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conus = ds[PRIMARY_VAR].sel(\n",
+    "    lat=slice(23.9, 50.1),\n",
+    "    lon=slice(-125.1, -65.9),\n",
+    "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
+    ")\n",
+    "\n",
+    "mean_wetness = conus.mean(dim=\"time\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "mean_wetness.plot(ax=ax, cmap=\"YlGnBu\", vmin=0, vmax=1, cbar_kwargs={\"label\": \"fraction of saturation\"})\n",
+    "ax.set_title(\"Mean Surface Soil Wetness (GWETTOP) — CONUS 2000–2009\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"CONUS 2000-2009 mean stats:\")\n",
+    "print(f\"  min:  {float(mean_wetness.min()):.4f}\")\n",
+    "print(f\"  max:  {float(mean_wetness.max()):.4f}\")\n",
+    "print(f\"  mean: {float(mean_wetness.mean()):.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2707j5v7kx3",
+   "metadata": {},
+   "source": [
+    "## Seasonal comparison (CONUS, 2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hy926e1m0q",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seasons = {\n",
+    "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
+    "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
+    "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
+    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
+    "\n",
+    "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
+    "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", vmin=0, vmax=1, cbar_kwargs={\"label\": \"fraction\"})\n",
+    "    ax.set_title(f\"{label} mean\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(\"Seasonal Mean Surface Soil Wetness — CONUS 2000–2009\", fontsize=14, y=1.01)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "z51hnu5o57h",
+   "metadata": {},
+   "source": [
+    "## Monthly time series (CONUS spatial mean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hu366nfkn6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conus_full = ds[PRIMARY_VAR].sel(\n",
+    "    lat=slice(23.9, 50.1),\n",
+    "    lon=slice(-125.1, -65.9),\n",
+    ")\n",
+    "monthly_mean = conus_full.mean(dim=[\"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 4))\n",
+    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
+    "ax.set_ylabel(\"Mean Soil Wetness (fraction)\")\n",
+    "ax.set_title(\"CONUS-mean monthly surface soil wetness (GWETTOP)\")\n",
+    "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
+    "ax.set_ylim(0, 1)\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dwl79qy1jhb",
+   "metadata": {},
+   "source": [
+    "## Monthly climatology (CONUS, 2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aazzhre030m",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_clim = conus.groupby(\"time.month\").mean(dim=[\"time\", \"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Mean Soil Wetness (fraction)\")\n",
+    "ax.set_title(\"Monthly Climatology — CONUS 2000–2009 (GWETTOP)\")\n",
+    "ax.set_xticks(range(1, 13))\n",
+    "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "ax.set_ylim(0, 1)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cu4438gg8gf",
+   "metadata": {},
+   "source": [
+    "## CF compliance verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9gksc7t2py9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"CF Compliance Checks:\")\n",
+    "print(f\"  Conventions attr:  {ds.attrs.get('Conventions', 'MISSING')}\")\n",
+    "print(f\"  Time dtype:        {ds.time.dtype}\")\n",
+    "print(f\"  Time first:        {ds.time.values[0]}\")\n",
+    "print(f\"  Time last:         {ds.time.values[-1]}\")\n",
+    "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
+    "if \"crs\" in ds.data_vars:\n",
+    "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
+    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
+    "for var in [\"GWETTOP\", \"GWETROOT\", \"GWETPROF\"]:\n",
+    "    if var in ds.data_vars:\n",
+    "        print(f\"  {var}:\")\n",
+    "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
+    "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35xmixfmz6l",
+   "metadata": {},
+   "source": [
+    "## Manifest provenance check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jd8b4t1zomr",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "if manifest_path.exists():\n",
+    "    manifest = json.loads(manifest_path.read_text())\n",
+    "    entry = manifest[\"sources\"].get(\"merra2\", {})\n",
+    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
+    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
+    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
+    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "else:\n",
+    "    print(f\"manifest.json not found at {manifest_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1s12bq2n18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nhf-spatial-targets\n  (dev)",
+   "language": "python",
+   "name": "nhf-spatial-targets"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/visualize_ncep_ncar.ipynb
+++ b/notebooks/visualize_ncep_ncar.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NCEP/NCAR Reanalysis — Soil Moisture\n",
+    "\n",
+    "Visualize the consolidated NCEP/NCAR Reanalysis 1 soil moisture\n",
+    "from NOAA PSL (daily files resampled to monthly means).\n",
+    "\n",
+    "- **Variables:** `soilw_0_10cm` (0–10 cm), `soilw_10_200cm` (10–200 cm) — kg/m²\n",
+    "- **Resolution:** T62 Gaussian grid (~1.875°) global\n",
+    "- **Period:** 1948–present (monthly, derived from daily)\n",
+    "- **Note:** Coarsest resolution among the four soil moisture sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d97ab85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
+    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"ncep_ncar\" / \"ncep_ncar_consolidated.nc\"\n",
+    "PRIMARY_VAR = \"soilw_0_10cm\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a5f5da7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(NC_PATH)\n",
+    "print(ds)\n",
+    "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
+    "print(f\"Time steps: {ds.time.size}\")\n",
+    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
+    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66ea2af7",
+   "metadata": {},
+   "source": [
+    "## Single-month soil moisture map (global)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425d091e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_TIME = \"2000-01-15\"\n",
+    "\n",
+    "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "actual_time = str(da.time.values)[:10]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 6))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(f\"NCEP/NCAR Soil Moisture (0–10 cm) — {actual_time}\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Stats for {actual_time}:\")\n",
+    "print(f\"  min:  {float(da.min()):.2f}\")\n",
+    "print(f\"  max:  {float(da.max()):.2f}\")\n",
+    "print(f\"  mean: {float(da.mean()):.2f}\")\n",
+    "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ace80ec",
+   "metadata": {},
+   "source": [
+    "## Both soil layers — single timestep comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "373eb62f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer_vars = {\n",
+    "    \"soilw_0_10cm\": \"0–10 cm\",\n",
+    "    \"soilw_10_200cm\": \"10–200 cm\",\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(18, 6))\n",
+    "\n",
+    "for ax, (var, label) in zip(axes, layer_vars.items()):\n",
+    "    if var not in ds.data_vars:\n",
+    "        ax.set_visible(False)\n",
+    "        continue\n",
+    "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{var}\\n{label}\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(f\"NCEP/NCAR Soil Moisture Layers — {actual_time}\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ad0cc38",
+   "metadata": {},
+   "source": [
+    "## CONUS subset — calibration period mean (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bf94f1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NCEP/NCAR uses 0–360 longitudes; convert CONUS bounds accordingly\n",
+    "conus = ds[PRIMARY_VAR].sel(\n",
+    "    lat=slice(50.1, 23.9),\n",
+    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
+    "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
+    ")\n",
+    "\n",
+    "mean_sm = conus.mean(dim=\"time\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "mean_sm.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(\"Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"CONUS 2000-2009 mean stats:\")\n",
+    "print(f\"  min:  {float(mean_sm.min()):.2f}\")\n",
+    "print(f\"  max:  {float(mean_sm.max()):.2f}\")\n",
+    "print(f\"  mean: {float(mean_sm.mean()):.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seasonal comparison (CONUS, 2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seasons = {\n",
+    "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
+    "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
+    "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
+    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
+    "\n",
+    "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
+    "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{label} mean\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(\"Seasonal Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\", fontsize=14, y=1.01)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly time series (CONUS spatial mean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f06b949",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conus_full = ds[PRIMARY_VAR].sel(\n",
+    "    lat=slice(50.1, 23.9),\n",
+    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
+    ")\n",
+    "monthly_mean = conus_full.mean(dim=[\"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 4))\n",
+    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"CONUS-mean monthly soil moisture (NCEP/NCAR, 0–10 cm)\")\n",
+    "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly climatology (CONUS, 2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_clim = conus.groupby(\"time.month\").mean(dim=[\"time\", \"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"Monthly Climatology — NCEP/NCAR CONUS 2000–2009 (0–10 cm)\")\n",
+    "ax.set_xticks(range(1, 13))\n",
+    "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CF compliance verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"CF Compliance Checks:\")\n",
+    "print(f\"  Conventions attr:  {ds.attrs.get('Conventions', 'MISSING')}\")\n",
+    "print(f\"  Time dtype:        {ds.time.dtype}\")\n",
+    "print(f\"  Time first:        {ds.time.values[0]}\")\n",
+    "print(f\"  Time last:         {ds.time.values[-1]}\")\n",
+    "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
+    "if \"crs\" in ds.data_vars:\n",
+    "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
+    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
+    "for var in [\"soilw_0_10cm\", \"soilw_10_200cm\"]:\n",
+    "    if var in ds.data_vars:\n",
+    "        print(f\"  {var}:\")\n",
+    "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
+    "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifest provenance check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "if manifest_path.exists():\n",
+    "    manifest = json.loads(manifest_path.read_text())\n",
+    "    entry = manifest[\"sources\"].get(\"ncep_ncar\", {})\n",
+    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
+    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
+    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
+    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "else:\n",
+    "    print(f\"manifest.json not found at {manifest_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nhf-spatial-targets\n  (dev)",
+   "language": "python",
+   "name": "nhf-spatial-targets"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/visualize_nldas_mosaic.ipynb
+++ b/notebooks/visualize_nldas_mosaic.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NLDAS-2 MOSAIC — Soil Moisture\n",
+    "\n",
+    "Visualize the consolidated NLDAS-2 MOSAIC land surface model soil moisture\n",
+    "from NASA GES DISC (NLDAS_MOS0125_M v2.0).\n",
+    "\n",
+    "- **Variables:** `SoilM_0_10cm`, `SoilM_10_40cm`, `SoilM_40_200cm` (kg/m²)\n",
+    "- **Resolution:** 0.125° CONUS grid\n",
+    "- **Period:** 1979–present (monthly)\n",
+    "- **Note:** MOSAIC uses three soil layers; NOAH uses four (different layer boundaries)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
+    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
+    "PRIMARY_VAR = \"SoilM_0_10cm\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(NC_PATH)\n",
+    "print(ds)\n",
+    "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
+    "print(f\"Time steps: {ds.time.size}\")\n",
+    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
+    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single-month soil moisture map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_TIME = \"2000-01-15\"\n",
+    "\n",
+    "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "actual_time = str(da.time.values)[:10]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(f\"NLDAS-2 MOSAIC Soil Moisture (0–10 cm) — {actual_time}\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Stats for {actual_time}:\")\n",
+    "print(f\"  min:  {float(da.min()):.2f}\")\n",
+    "print(f\"  max:  {float(da.max()):.2f}\")\n",
+    "print(f\"  mean: {float(da.mean()):.2f}\")\n",
+    "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## All soil layers — single timestep comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer_vars = {\n",
+    "    \"SoilM_0_10cm\": \"0–10 cm\",\n",
+    "    \"SoilM_10_40cm\": \"10–40 cm\",\n",
+    "    \"SoilM_40_200cm\": \"40–200 cm\",\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(20, 6))\n",
+    "\n",
+    "for ax, (var, label) in zip(axes, layer_vars.items()):\n",
+    "    if var not in ds.data_vars:\n",
+    "        ax.set_visible(False)\n",
+    "        continue\n",
+    "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{var}\\n{label}\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(f\"NLDAS-2 MOSAIC Soil Moisture Layers — {actual_time}\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration period mean (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conus = ds[PRIMARY_VAR].sel(\n",
+    "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
+    ")\n",
+    "\n",
+    "mean_sm = conus.mean(dim=\"time\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "mean_sm.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(\"Mean Soil Moisture (0–10 cm) — NLDAS MOSAIC 2000–2009\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"2000-2009 mean stats:\")\n",
+    "print(f\"  min:  {float(mean_sm.min()):.2f}\")\n",
+    "print(f\"  max:  {float(mean_sm.max()):.2f}\")\n",
+    "print(f\"  mean: {float(mean_sm.mean()):.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seasonal comparison (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seasons = {\n",
+    "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
+    "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
+    "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
+    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
+    "\n",
+    "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
+    "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{label} mean\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(\"Seasonal Mean Soil Moisture (0–10 cm) — NLDAS MOSAIC 2000–2009\", fontsize=14, y=1.01)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly time series (spatial mean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_mean = ds[PRIMARY_VAR].mean(dim=[\"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 4))\n",
+    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"NLDAS-2 MOSAIC spatial-mean monthly soil moisture (0–10 cm)\")\n",
+    "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly climatology (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_clim = conus.groupby(\"time.month\").mean(dim=[\"time\", \"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"Monthly Climatology — NLDAS MOSAIC 2000–2009 (0–10 cm)\")\n",
+    "ax.set_xticks(range(1, 13))\n",
+    "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CF compliance verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"CF Compliance Checks:\")\n",
+    "print(f\"  Conventions attr:  {ds.attrs.get('Conventions', 'MISSING')}\")\n",
+    "print(f\"  Time dtype:        {ds.time.dtype}\")\n",
+    "print(f\"  Time first:        {ds.time.values[0]}\")\n",
+    "print(f\"  Time last:         {ds.time.values[-1]}\")\n",
+    "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
+    "if \"crs\" in ds.data_vars:\n",
+    "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
+    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
+    "for var in [\"SoilM_0_10cm\", \"SoilM_10_40cm\", \"SoilM_40_200cm\"]:\n",
+    "    if var in ds.data_vars:\n",
+    "        print(f\"  {var}:\")\n",
+    "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
+    "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifest provenance check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "if manifest_path.exists():\n",
+    "    manifest = json.loads(manifest_path.read_text())\n",
+    "    entry = manifest[\"sources\"].get(\"nldas_mosaic\", {})\n",
+    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
+    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
+    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
+    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "else:\n",
+    "    print(f\"manifest.json not found at {manifest_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nhf-spatial-targets\n  (dev)",
+   "language": "python",
+   "name": "nhf-spatial-targets"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/visualize_nldas_noah.ipynb
+++ b/notebooks/visualize_nldas_noah.ipynb
@@ -1,0 +1,365 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NLDAS-2 NOAH — Soil Moisture\n",
+    "\n",
+    "Visualize the consolidated NLDAS-2 NOAH land surface model soil moisture\n",
+    "from NASA GES DISC (NLDAS_NOAH0125_M v2.0).\n",
+    "\n",
+    "- **Variables:** `SoilM_0_10cm`, `SoilM_10_40cm`, `SoilM_40_100cm`, `SoilM_100_200cm` (kg/m²)\n",
+    "- **Resolution:** 0.125° CONUS grid\n",
+    "- **Period:** 1979–present (monthly)\n",
+    "- **Note:** NOAH uses four soil layers; MOSAIC uses three (different layer boundaries)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
+    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"nldas_noah\" / \"nldas_noah_consolidated.nc\"\n",
+    "PRIMARY_VAR = \"SoilM_0_10cm\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(NC_PATH)\n",
+    "print(ds)\n",
+    "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
+    "print(f\"Time steps: {ds.time.size}\")\n",
+    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
+    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single-month soil moisture map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_TIME = \"2000-01-15\"\n",
+    "\n",
+    "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "actual_time = str(da.time.values)[:10]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(f\"NLDAS-2 NOAH Soil Moisture (0–10 cm) — {actual_time}\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Stats for {actual_time}:\")\n",
+    "print(f\"  min:  {float(da.min()):.2f}\")\n",
+    "print(f\"  max:  {float(da.max()):.2f}\")\n",
+    "print(f\"  mean: {float(da.mean()):.2f}\")\n",
+    "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## All soil layers — single timestep comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer_vars = {\n",
+    "    \"SoilM_0_10cm\": \"0–10 cm\",\n",
+    "    \"SoilM_10_40cm\": \"10–40 cm\",\n",
+    "    \"SoilM_40_100cm\": \"40–100 cm\",\n",
+    "    \"SoilM_100_200cm\": \"100–200 cm\",\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
+    "\n",
+    "for ax, (var, label) in zip(axes.flatten(), layer_vars.items()):\n",
+    "    if var not in ds.data_vars:\n",
+    "        ax.set_visible(False)\n",
+    "        continue\n",
+    "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{var}\\n{label}\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(f\"NLDAS-2 NOAH Soil Moisture Layers — {actual_time}\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calibration period mean (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conus = ds[PRIMARY_VAR].sel(\n",
+    "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
+    ")\n",
+    "\n",
+    "mean_sm = conus.mean(dim=\"time\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "mean_sm.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "ax.set_title(\"Mean Soil Moisture (0–10 cm) — NLDAS NOAH 2000–2009\")\n",
+    "ax.set_xlabel(\"Longitude\")\n",
+    "ax.set_ylabel(\"Latitude\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"2000-2009 mean stats:\")\n",
+    "print(f\"  min:  {float(mean_sm.min()):.2f}\")\n",
+    "print(f\"  max:  {float(mean_sm.max()):.2f}\")\n",
+    "print(f\"  mean: {float(mean_sm.mean()):.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seasonal comparison (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seasons = {\n",
+    "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
+    "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
+    "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
+    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
+    "\n",
+    "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
+    "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    ax.set_title(f\"{label} mean\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "\n",
+    "fig.suptitle(\"Seasonal Mean Soil Moisture (0–10 cm) — NLDAS NOAH 2000–2009\", fontsize=14, y=1.01)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly time series (spatial mean)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_mean = ds[PRIMARY_VAR].mean(dim=[\"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16, 4))\n",
+    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"NLDAS-2 NOAH spatial-mean monthly soil moisture (0–10 cm)\")\n",
+    "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monthly climatology (2000–2009)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_clim = conus.groupby(\"time.month\").mean(dim=[\"time\", \"lat\", \"lon\"])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "ax.set_title(\"Monthly Climatology — NLDAS NOAH 2000–2009 (0–10 cm)\")\n",
+    "ax.set_xticks(range(1, 13))\n",
+    "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## NOAH vs MOSAIC comparison (0–10 cm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic_path = RUN_DIR / \"data\" / \"raw\" / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
+    "\n",
+    "if mosaic_path.exists():\n",
+    "    ds_mosaic = xr.open_dataset(mosaic_path)\n",
+    "    noah_ts = ds[PRIMARY_VAR].sel(time=slice(\"2000-01-01\", \"2009-12-31\")).mean(dim=[\"lat\", \"lon\"])\n",
+    "    mosaic_ts = ds_mosaic[PRIMARY_VAR].sel(time=slice(\"2000-01-01\", \"2009-12-31\")).mean(dim=[\"lat\", \"lon\"])\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(16, 4))\n",
+    "    noah_ts.plot(ax=ax, color=\"#2980b9\", linewidth=0.8, label=\"NOAH\")\n",
+    "    mosaic_ts.plot(ax=ax, color=\"#e74c3c\", linewidth=0.8, label=\"MOSAIC\")\n",
+    "    ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
+    "    ax.set_title(\"NOAH vs MOSAIC — 0–10 cm soil moisture (2000–2009)\")\n",
+    "    ax.legend()\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "    ds_mosaic.close()\n",
+    "else:\n",
+    "    print(f\"MOSAIC consolidated file not found at {mosaic_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CF compliance verification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"CF Compliance Checks:\")\n",
+    "print(f\"  Conventions attr:  {ds.attrs.get('Conventions', 'MISSING')}\")\n",
+    "print(f\"  Time dtype:        {ds.time.dtype}\")\n",
+    "print(f\"  Time first:        {ds.time.values[0]}\")\n",
+    "print(f\"  Time last:         {ds.time.values[-1]}\")\n",
+    "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
+    "if \"crs\" in ds.data_vars:\n",
+    "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
+    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
+    "for var in [\"SoilM_0_10cm\", \"SoilM_10_40cm\", \"SoilM_40_100cm\", \"SoilM_100_200cm\"]:\n",
+    "    if var in ds.data_vars:\n",
+    "        print(f\"  {var}:\")\n",
+    "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
+    "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manifest provenance check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "if manifest_path.exists():\n",
+    "    manifest = json.loads(manifest_path.read_text())\n",
+    "    entry = manifest[\"sources\"].get(\"nldas_noah\", {})\n",
+    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
+    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
+    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
+    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "else:\n",
+    "    print(f\"manifest.json not found at {manifest_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.close()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "nhf-spatial-targets\n  (dev)",
+   "language": "python",
+   "name": "nhf-spatial-targets"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -220,6 +220,99 @@ def init(
     console.print(Panel(msg, title="nhf-targets init", border_style="green"))
 
 
+@fetch_app.command(name="all")
+def fetch_all_cmd(
+    run_dir: Annotated[
+        Path,
+        Parameter(
+            name=["--run-dir", "-r"],
+            help="Run workspace created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ],
+):
+    """Download all source datasets into the run workspace.
+
+    Iterates through every registered fetch module in sequence.
+    Stops on the first failure.
+    """
+    from rich.console import Console
+
+    if not run_dir.exists():
+        print(f"Error: Run directory not found: {run_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+
+    # Import all fetch functions
+    import nhf_spatial_targets.catalog as _catalog
+    from nhf_spatial_targets.fetch._period import clamp_period
+    from nhf_spatial_targets.fetch.merra2 import fetch_merra2
+    from nhf_spatial_targets.fetch.modis import fetch_mod10c1, fetch_mod16a2
+    from nhf_spatial_targets.fetch.ncep_ncar import fetch_ncep_ncar
+    from nhf_spatial_targets.fetch.nldas import fetch_nldas_mosaic, fetch_nldas_noah
+    from nhf_spatial_targets.fetch.pangaea import fetch_watergap22d
+    from nhf_spatial_targets.fetch.reitz2017 import fetch_reitz2017
+
+    # (display name, catalog source key, fetch function)
+    sources = [
+        ("merra2", "merra2", fetch_merra2),
+        ("nldas-mosaic", "nldas_mosaic", fetch_nldas_mosaic),
+        ("nldas-noah", "nldas_noah", fetch_nldas_noah),
+        ("ncep-ncar", "ncep_ncar", fetch_ncep_ncar),
+        ("mod16a2", "mod16a2_v061", fetch_mod16a2),
+        ("mod10c1", "mod10c1_v061", fetch_mod10c1),
+        ("watergap22d", "watergap22d", fetch_watergap22d),
+        ("reitz2017", "reitz2017", fetch_reitz2017),
+    ]
+
+    results = {}
+    for name, source_key, fetch_fn in sources:
+        console.print(f"\n[bold]{'─' * 60}[/bold]")
+
+        # Clamp requested period to the source's available range
+        meta = _catalog.source(source_key)
+        available = meta.get("period", "")
+        clamped = clamp_period(period, available) if available else period
+
+        if clamped is None:
+            console.print(
+                f"[yellow]{name}: skipped (no overlap between "
+                f"requested {period} and available {available})[/yellow]"
+            )
+            continue
+
+        if clamped != period:
+            console.print(
+                f"[bold]Fetching {name} for period {clamped} "
+                f"(clamped from {period} to available {available})...[/bold]"
+            )
+        else:
+            console.print(f"[bold]Fetching {name} for period {period}...[/bold]")
+
+        try:
+            result = fetch_fn(run_dir=run_dir, period=clamped)
+            results[name] = result
+            console.print(f"[green]{name}: done[/green]")
+        except (ValueError, FileNotFoundError, RuntimeError) as exc:
+            print(f"Error fetching {name}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as exc:
+            _logger.exception("Unexpected error during %s fetch", name)
+            print(
+                f"Unexpected error fetching {name} ({type(exc).__name__}): {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    console.print(
+        f"\n[bold green]All {len(results)} sources fetched successfully.[/bold green]"
+    )
+
+
 @fetch_app.command(name="merra2")
 def fetch_merra2_cmd(
     run_dir: Annotated[

--- a/src/nhf_spatial_targets/fetch/_period.py
+++ b/src/nhf_spatial_targets/fetch/_period.py
@@ -42,3 +42,41 @@ def years_in_period(period: str) -> list[int]:
     parts = period.split("/")
     start_year, end_year = int(parts[0]), int(parts[1])
     return list(range(start_year, end_year + 1))
+
+
+def clamp_period(requested: str, available: str) -> str | None:
+    """Clamp *requested* period to the *available* range from the catalog.
+
+    Parameters
+    ----------
+    requested : str
+        User-requested period as ``"YYYY/YYYY"``.
+    available : str
+        Catalog period, e.g. ``"2000/2013"`` or ``"1980/present"``.
+        ``"present"`` is treated as year 9999 (no upper bound).
+
+    Returns
+    -------
+    str or None
+        Clamped period as ``"YYYY/YYYY"``, or ``None`` if there is no
+        overlap between the requested and available ranges.
+    """
+    parse_period(requested)
+    req_parts = requested.split("/")
+    req_start, req_end = int(req_parts[0]), int(req_parts[1])
+
+    avail_parts = available.split("/")
+    if len(avail_parts) != 2:
+        raise ValueError(f"available period must be 'YYYY/YYYY', got: {available!r}")
+    avail_start = int(avail_parts[0])
+    avail_end = (
+        9999 if avail_parts[1] == "present" else int(avail_parts[1].split("-")[0])
+    )
+
+    clamped_start = max(req_start, avail_start)
+    clamped_end = min(req_end, avail_end)
+
+    if clamped_start > clamped_end:
+        return None
+
+    return f"{clamped_start}/{clamped_end}"

--- a/tests/test_period.py
+++ b/tests/test_period.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from nhf_spatial_targets.fetch._period import (
+    clamp_period,
     months_in_period,
     parse_period,
     years_in_period,
@@ -56,3 +57,36 @@ def test_years_in_period():
 def test_years_in_period_single():
     years = years_in_period("2010/2010")
     assert years == [2010]
+
+
+def test_clamp_period_within_range():
+    assert clamp_period("2000/2010", "1980/2020") == "2000/2010"
+
+
+def test_clamp_period_clamps_end():
+    assert clamp_period("2000/2020", "2000/2013") == "2000/2013"
+
+
+def test_clamp_period_clamps_start():
+    assert clamp_period("1990/2010", "2000/2013") == "2000/2010"
+
+
+def test_clamp_period_clamps_both():
+    assert clamp_period("1990/2020", "2000/2013") == "2000/2013"
+
+
+def test_clamp_period_no_overlap():
+    assert clamp_period("1990/1995", "2000/2013") is None
+
+
+def test_clamp_period_present():
+    assert clamp_period("2000/2025", "1980/present") == "2000/2025"
+
+
+def test_clamp_period_present_clamps_start():
+    assert clamp_period("1970/2010", "1980/present") == "1980/2010"
+
+
+def test_clamp_period_handles_date_suffix():
+    """Available period like '1980/2016-02-29' uses the year portion."""
+    assert clamp_period("2000/2020", "1980/2016-02-29") == "2000/2016"


### PR DESCRIPTION
## Summary
- Add `nhf-targets fetch all` CLI command that runs all 8 fetch sources in sequence with automatic per-source period clamping via catalog metadata
- Add `clamp_period()` utility to `_period.py` (handles "present", date suffixes, no-overlap skip)
- Add QAQC visualization notebooks for MERRA-2, NLDAS MOSAIC, NLDAS NOAH, and NCEP/NCAR (the 4 soil moisture sources that were missing individual notebooks)
- Update `inspect_consolidated.ipynb` run directory path

## Test plan
- [x] `clamp_period` unit tests (8 cases: within range, clamp start/end/both, no overlap, present, date suffix)
- [x] Full test suite passes (218 tests)
- [ ] Run `nhf-targets fetch all --run-dir <dir> --period 2000/2010` end-to-end
- [ ] Execute each new notebook against fetched data

🤖 Generated with [Claude Code](https://claude.com/claude-code)