### PR TITLE
Replace NHM-MWBM runoff source with ERA5-Land + GLDAS-2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,8 +137,8 @@ The pipeline separates **projects** (fabric-specific) from the **datastore** (sh
 See `catalog/sources.yml` `status:` and `notes:` fields for per-source gaps.
 
 **Resolved:**
-- MWBM ScienceBase item ID — confirmed: `55fc3f98e4b05d6c4e5029a1`, doi:10.5066/F7VD6WJQ
 - Reitz 2017 ScienceBase item ID — confirmed: `56c49126e4b0946c65219231`, doi:10.5066/F7PN93P0
+- Runoff source replacement — NHM-MWBM removed; replaced by ERA5-Land (CDS) + GLDAS-2.1 NOAH monthly. ERA5-Land ssro also added as third recharge source. Closes issue #41.
 - Recharge normalization window — confirmed **2000-2009** from TM 6-B10 body text
 - MOD16A2 / MOD10C1 v006 → v061: both decommissioned; use v061 in all new runs
 - MERRA-2 variable — use `GWETTOP` (0-0.05m, dimensionless); product M2TMNXLND

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Builds the five baseline calibration targets documented in [Hay and others (2022
 
 | Target | PRMS Variable | Sources | Method | Time Step |
 |---|---|---|---|---|
-| Runoff | `basin_cfs` | NHM-MWBM | MWBM uncertainty | Monthly |
+| Runoff | `basin_cfs` | ERA5-Land (`ro`) + GLDAS-2.1 NOAH (`Qs_acc + Qsb_acc`) | Multi-source min/max | Monthly |
 | AET | `hru_actet` | MWBM + MOD16A2 v061 + SSEBop | Multi-source min/max | Monthly |
 | Recharge | `recharge` | Reitz 2017 + WaterGAP 2.2d | Normalized min/max | Annual |
 | Soil Moisture | `soil_rechr` | MERRA-2 + NCEP/NCAR + NLDAS-MOSAIC + NLDAS-NOAH | Normalized min/max | Monthly + Annual |
@@ -252,7 +252,7 @@ Pixi supports **linux-64**, **osx-arm64**, and **win-64** (see `pixi.toml`).
 | Spatial batching for large fabrics | Done |
 | Visualization notebooks (all sources + SSEBop agg) | Done |
 | `fetch all` command (sequential, all 8 sources) | Done |
-| MWBM fetch (ScienceBase) | Not started |
+| ERA5-Land + GLDAS-2.1 NOAH runoff fetch | Not started |
 | Generic gdptools aggregation module | Not started |
 | Normalization and range-bound methods | Not started |
 | Target builders (runoff, AET, recharge, soil moisture, SCA) | Not started |
@@ -262,8 +262,8 @@ Pixi supports **linux-64**, **osx-arm64**, and **win-64** (see `pixi.toml`).
 See `catalog/sources.yml` `status:` and `notes:` fields for per-source details.
 
 **Resolved:**
-- MWBM ScienceBase item ID — confirmed: `55fc3f98e4b05d6c4e5029a1`
 - Reitz 2017 ScienceBase item ID — confirmed: `56c49126e4b0946c65219231`
+- Runoff source replacement — NHM-MWBM removed; replaced by ERA5-Land (CDS) + GLDAS-2.1 NOAH monthly. ERA5-Land ssro also added as third recharge source. Closes issue #41.
 - Recharge normalization window — confirmed 2000-2009 from TM 6-B10 body text
 - MOD16A2 / MOD10C1 v006 &rarr; v061: both decommissioned; use v061 in new runs
 - MERRA-2 variable — use `GWETTOP` (0-0.05m, dimensionless); product M2TMNXLND
@@ -280,6 +280,5 @@ See `catalog/sources.yml` `status:` and `notes:` fields for per-source details.
 ## References
 
 - Hay, L.E., and others, 2022, USGS TM 6-B10
-- Bock, A.R., and others, 2016/2018 — NHM-MWBM
 - Reitz, M., and others, 2017 — Recharge estimates
 - Xia, Y., and others, 2012 — NLDAS-2

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -8,34 +8,6 @@ sources:
   # ---------------------------------------------------------------------------
   # RUNOFF
   # ---------------------------------------------------------------------------
-  nhm_mwbm:
-    name: NHM Monthly Water Balance Model (MWBM)
-    description: >
-      Monthly runoff and uncertainty bounds for CONUS HRUs from the USGS
-      National Hydrologic Model application of the Monthly Water Balance Model.
-      Uncertainty bounds from Bock et al. (2018) stochastic post-processing
-      framework applied at 1,575 streamgages and 109,951 HRUs.
-    citations:
-      - "Bock, A.R., Hay, L.E., Markstrom, S.L., and Atkinson, R.D., 2016, doi:10.5066/F7VD6WJQ"
-      - "Bock, A.R., Farmer, W.H., and Hay, L.E., 2018, doi:10.1016/j.advwatres.2018.10.005"
-      - "Bock, A.R., Hay, L.E., Markstrom, S.L., Emmerich, C., and Talbert, M., 2016, doi:10.5194/hess-20-2861-2016"
-    access:
-      type: sciencebase
-      item_id: "55fc3f98e4b05d6c4e5029a1"
-      doi: "10.5066/F7VD6WJQ"
-      url: https://www.sciencebase.gov/catalog/item/55fc3f98e4b05d6c4e5029a1
-      notes: >
-        Main MWBM data release (ver. 4.0). Variables include AET, PET, runoff,
-        streamflow, soil moisture, SWE; 109,951 HRUs, 1950-2099. The uncertainty
-        child item (Bock et al. 2018) is nested under this same parent item.
-    variables:
-      - basin_cfs
-    time_step: monthly
-    period: "1982/2010"
-    spatial_extent: CONUS
-    spatial_resolution: HRU (109,951 NHM HRUs)
-    units: cfs
-    status: current
 
   # ---------------------------------------------------------------------------
   # ACTUAL EVAPOTRANSPIRATION

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -9,6 +9,95 @@ sources:
   # RUNOFF
   # ---------------------------------------------------------------------------
 
+  era5_land:
+    name: ECMWF ERA5-Land Reanalysis
+    description: >
+      ECMWF ERA5-Land hourly reanalysis. Total runoff (ro), surface runoff
+      (sro), and sub-surface runoff (ssro) downloaded for CONUS plus
+      contributing watersheds (Canada/Mexico). Used as a source for the
+      runoff calibration target (ro) and the recharge calibration target
+      (ssro, as drainage proxy).
+    citations:
+      - "Muñoz-Sabater, J., and others, 2021, doi:10.5194/essd-13-4349-2021"
+    access:
+      type: copernicus_cds
+      dataset: reanalysis-era5-land
+      url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      bbox_notes: >
+        Encompasses CONUS contributing watersheds (Canada/Mexico) with
+        ~10 km buffer, snapped to the 0.1° ERA5-Land grid.
+      notes: >
+        Access via cdsapi (Copernicus CDS account required). Hourly
+        accumulated fields reset at 00 UTC. Pipeline aggregates
+        hourly→daily (via .diff('time') + resample sum) and daily→monthly.
+        Both daily and monthly consolidated NCs are stored in the datastore.
+    variables:
+      - name: ro
+        long_name: total runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Used for runoff target.
+      - name: sro
+        long_name: surface runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Stored for future use.
+      - name: ssro
+        long_name: sub-surface runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Used as recharge proxy in recharge target.
+    time_step: hourly (aggregated to daily and monthly)
+    period: "1979/present"
+    spatial_extent: CONUS+contributing-watersheds
+    spatial_resolution: 0.1 degree
+    units: m of water equivalent
+    license: Copernicus license (free, attribution)
+    status: current
+
+  gldas_noah_v21_monthly:
+    name: GLDAS-2.1 NOAH Monthly Land Surface Runoff
+    description: >
+      Global Land Data Assimilation System version 2.1, NOAH land
+      surface model, monthly product. Storm surface runoff (Qs_acc)
+      and baseflow-groundwater runoff (Qsb_acc) summed at consolidation
+      time to derived total runoff (runoff_total). Used as second source
+      for the runoff calibration target.
+    citations:
+      - "Rodell, M., and others, 2004, doi:10.1175/BAMS-85-3-381"
+    access:
+      type: nasa_gesdisc
+      short_name: GLDAS_NOAH025_M
+      version: "2.1"
+      url: https://disc.gsfc.nasa.gov/datasets/GLDAS_NOAH025_M_2.1/summary
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      notes: >
+        Access via earthaccess (NASA Earthdata login required). Granules
+        are global (~few MB monthly); downloaded full and clipped to bbox
+        at consolidation time, mirroring the merra2 pattern.
+    variables:
+      - name: Qs_acc
+        long_name: storm surface runoff
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+      - name: Qsb_acc
+        long_name: baseflow-groundwater runoff
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+      - name: runoff_total
+        long_name: total runoff (Qs_acc + Qsb_acc, derived)
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+        derived: true
+    time_step: monthly
+    period: "2000/present"
+    spatial_extent: global (clipped to CONUS+contributing-watersheds)
+    spatial_resolution: 0.25 degree
+    units: kg m-2 (equivalent to mm over the month)
+    license: public domain (NASA)
+    status: current
+
   # ---------------------------------------------------------------------------
   # ACTUAL EVAPOTRANSPIRATION
   # ---------------------------------------------------------------------------

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -29,9 +29,12 @@ sources:
         ~10 km buffer, snapped to the 0.1° ERA5-Land grid.
       notes: >
         Access via cdsapi (Copernicus CDS account required). Hourly
-        accumulated fields reset at 00 UTC. Pipeline aggregates
-        hourly→daily (via .diff('time') + resample sum) and daily→monthly.
-        Both daily and monthly consolidated NCs are stored in the datastore.
+        accumulated fields reset at 00 UTC; the midnight-reset is handled by
+        substituting the raw accumulated value where the diff is negative, then
+        shifting timestamps back 1 h before resampling. Pipeline aggregates
+        hourly→daily and daily→monthly. Both consolidated NCs are stored in
+        the datastore; the daily NC is re-aggregated if any hourly input is
+        newer (mtime comparison).
     variables:
       - name: ro
         long_name: total runoff

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -15,18 +15,24 @@ variables:
   runoff:
     prms_variable: basin_cfs
     description: >
-      Monthly basin mean runoff. Uncertainty bounds pre-computed by MWBM
-      post-processing — single source with built-in uncertainty envelope.
+      Monthly basin mean runoff. Range is min/max across two reanalysis
+      sources per HRU and time step.
     prms_reference: "TM 6-B7 (Markstrom et al. 2015)"
     time_step: monthly
-    period: "1982/2010"
+    period: "2000/2023"
     units: cfs
-    sources: []
-    range_method: mwbm_uncertainty
+    sources:
+      - era5_land
+      - gldas_noah_v21_monthly
+    range_method: multi_source_minmax
     range_notes: >
-      Upper/lower bounds from Bock et al. (2018) stochastic post-processing
-      framework applied at 1,575 streamgages and 109,951 HRUs. Not a
-      multi-source min/max — bounds come from within-model uncertainty.
+      ERA5-Land 'ro' (m water equivalent) and GLDAS-2.1 NOAH
+      'Qs_acc + Qsb_acc' (kg/m² ≡ mm) are aggregated to HRU polygons
+      via gdptools, harmonized to mm/month, then converted to cfs using
+      HRU area and days-in-month. Per-HRU per-month:
+        lower_bound = min(era5, gldas), upper_bound = max(era5, gldas).
+      Replaces the original NHM-MWBM source which had pre-computed
+      uncertainty bounds (Bock et al. 2018) but no public fetch path.
     normalize: false
     output_format: netcdf
 
@@ -66,6 +72,7 @@ variables:
     sources:
       - reitz2017
       - watergap22d
+      - era5_land    # ssro (sub-surface runoff) as recharge proxy
     range_method: normalized_minmax
     range_notes: >
       Normalization confirmed as 2000-2009 per TM 6-B10 text.
@@ -75,6 +82,9 @@ variables:
       upper_bound = max(norm_src1, norm_src2).
       NOTE: PRMSobjfun.f is not publicly available; normalization period
       2000-2009 is confirmed from TM 6-B10 body text (not Appendix 1).
+      ERA5-Land contribution: ssro is summed monthly→annual in mm,
+      then normalized 0-1 over 2000-2009 alongside the other sources
+      before the multi-source min/max.
     normalize: true
     normalize_period: "2000/2009"
     output_format: netcdf

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -21,8 +21,7 @@ variables:
     time_step: monthly
     period: "1982/2010"
     units: cfs
-    sources:
-      - nhm_mwbm
+    sources: []
     range_method: mwbm_uncertainty
     range_notes: >
       Upper/lower bounds from Bock et al. (2018) stochastic post-processing
@@ -42,7 +41,6 @@ variables:
     period: "2000/2010"
     units: inches/day
     sources:
-      - nhm_mwbm
       - mod16a2_v061   # v006 used in original TM 6-B10; v061 for new runs
       - ssebop
     range_method: multi_source_minmax

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -19,7 +19,7 @@ variables:
       sources per HRU and time step.
     prms_reference: "TM 6-B7 (Markstrom et al. 2015)"
     time_step: monthly
-    period: "2000/2023"
+    period: "2000/present"
     units: cfs
     sources:
       - era5_land

--- a/config/pipeline.yml
+++ b/config/pipeline.yml
@@ -39,17 +39,17 @@ targets:
   runoff:
     enabled: true
     sources:
-      - nhm_mwbm
+      - era5_land
+      - gldas_noah_v21_monthly
     time_step: monthly
-    period: "1982-01-01/2010-12-31"
+    period: "2000-01-01/2010-12-31"
     prms_variable: basin_cfs
-    range_method: mwbm_uncertainty
+    range_method: multi_source_minmax
     output_file: runoff_targets.nc
 
   aet:
     enabled: true
     sources:
-      - nhm_mwbm
       - mod16a2_v061
       - ssebop
     time_step: monthly

--- a/docs/superpowers/plans/2026-04-13-era5-land-gldas-runoff.md
+++ b/docs/superpowers/plans/2026-04-13-era5-land-gldas-runoff.md
@@ -1,0 +1,1854 @@
+# ERA5-Land + GLDAS Runoff Replacement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unimplemented `nhm_mwbm` source and replace the runoff target with a `multi_source_minmax` over ERA5-Land (Copernicus CDS) + GLDAS-2.1 NOAH monthly (NASA GES DISC); add ERA5-Land `ssro` as a third recharge source; remove MWBM from the AET source list.
+
+**Architecture:** Two new fetch modules follow the existing pattern (`pangaea.py`, `merra2.py`): per-source download → CF-compliant consolidation in the shared datastore → manifest update. ERA5-Land is unique in needing hourly→daily→monthly aggregation; daily and monthly NCs are both persisted. Targets reuse existing `aggregate/gdptools_agg.py` and `multi_source_minmax` machinery.
+
+**Tech Stack:** Python 3.11+, `cdsapi`, `earthaccess`, `xarray`, `gdptools`, `cyclopts`, `pixi`, `pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-era5-land-gldas-runoff-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/nhf_spatial_targets/fetch/era5_land.py` — CDS download, hourly→daily→monthly aggregation
+- `src/nhf_spatial_targets/fetch/gldas.py` — earthaccess download, bbox-clip, derive `runoff_total`
+- `tests/test_era5_land.py`
+- `tests/test_gldas.py`
+- `tests/test_run_target.py`
+
+**Modify:**
+- `catalog/sources.yml` — drop `nhm_mwbm`, add `era5_land` and `gldas_noah_v21_monthly`
+- `catalog/variables.yml` — runoff sources/method, drop MWBM from aet, add era5_land to recharge
+- `src/nhf_spatial_targets/targets/run.py` — implement multi-source minmax
+- `src/nhf_spatial_targets/targets/aet.py` — drop MWBM source reference
+- `src/nhf_spatial_targets/targets/rch.py` — add ERA5-Land source
+- `src/nhf_spatial_targets/validate.py` — CDS credential check
+- `src/nhf_spatial_targets/cli.py` — register `fetch era5-land` and `fetch gldas` commands
+- `src/nhf_spatial_targets/fetch/consolidate.py` — extend `apply_cf_metadata` if new sources need entries
+- `pixi.toml` — add `cdsapi` dependency
+- `tests/test_catalog.py` — replace MWBM assertions with new sources
+- `CLAUDE.md` — Known Gaps update
+- `README.md` — runoff source description
+
+**Constants module (inline in `fetch/era5_land.py`):**
+- `BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]` (CDS area parameter, snapped to 0.1°)
+
+---
+
+## Task 1: Drop `nhm_mwbm` from catalog and update `tests/test_catalog.py`
+
+**Files:**
+- Modify: `catalog/sources.yml` (remove `nhm_mwbm:` block, lines 11-38)
+- Modify: `catalog/variables.yml` (remove `nhm_mwbm` from `aet.sources`, line 45)
+- Modify: `tests/test_catalog.py`
+
+- [ ] **Step 1: Read existing test to understand assertions**
+
+Run: `cat tests/test_catalog.py | head -60`
+
+- [ ] **Step 2: Write failing test for MWBM removal**
+
+In `tests/test_catalog.py`, add:
+
+```python
+def test_nhm_mwbm_removed():
+    """nhm_mwbm has been replaced by ERA5-Land + GLDAS."""
+    from nhf_spatial_targets import catalog
+    sources = catalog.sources()
+    assert "nhm_mwbm" not in sources, (
+        "nhm_mwbm should be removed; replaced by era5_land + gldas_noah_v21_monthly"
+    )
+    aet = catalog.variable("aet")
+    assert "nhm_mwbm" not in aet["sources"]
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py::test_nhm_mwbm_removed -v`
+Expected: FAIL (`nhm_mwbm` still in sources)
+
+- [ ] **Step 4: Remove the `nhm_mwbm:` block from `catalog/sources.yml`**
+
+Delete lines 11-38 inclusive (the whole block including the `# RUNOFF` comment header — keep the divider comment but remove the source). The runoff section will be repopulated in Task 2.
+
+- [ ] **Step 5: Remove `nhm_mwbm` from `catalog/variables.yml` `aet.sources`**
+
+In the `aet:` block, change:
+```yaml
+    sources:
+      - nhm_mwbm
+      - mod16a2_v061
+      - ssebop
+```
+to:
+```yaml
+    sources:
+      - mod16a2_v061
+      - ssebop
+```
+
+- [ ] **Step 6: Run all catalog tests**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py -v`
+Expected: PASS (test from Step 2 passes; pre-existing tests still pass — if any pre-existing test references `nhm_mwbm`, update it to drop the reference)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add catalog/sources.yml catalog/variables.yml tests/test_catalog.py
+git commit -m "refactor: drop unimplemented nhm_mwbm source from catalog"
+```
+
+---
+
+## Task 2: Add `era5_land` and `gldas_noah_v21_monthly` to `catalog/sources.yml`
+
+**Files:**
+- Modify: `catalog/sources.yml`
+- Modify: `tests/test_catalog.py`
+
+- [ ] **Step 1: Write failing tests for new sources**
+
+Append to `tests/test_catalog.py`:
+
+```python
+def test_era5_land_source_present():
+    from nhf_spatial_targets import catalog
+    s = catalog.source("era5_land")
+    assert s["access"]["type"] == "copernicus_cds"
+    assert s["access"]["dataset"] == "reanalysis-era5-land"
+    var_names = [v["name"] for v in s["variables"]]
+    assert var_names == ["ro", "sro", "ssro"]
+    assert s["time_step"] == "hourly (aggregated to daily and monthly)"
+    assert s["status"] == "current"
+
+
+def test_gldas_source_present():
+    from nhf_spatial_targets import catalog
+    s = catalog.source("gldas_noah_v21_monthly")
+    assert s["access"]["short_name"] == "GLDAS_NOAH025_M"
+    assert s["access"]["version"] == "2.1"
+    var_names = [v["name"] for v in s["variables"]]
+    assert "Qs_acc" in var_names
+    assert "Qsb_acc" in var_names
+    assert "runoff_total" in var_names  # derived
+    assert s["status"] == "current"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py::test_era5_land_source_present tests/test_catalog.py::test_gldas_source_present -v`
+Expected: FAIL (KeyError)
+
+- [ ] **Step 3: Add `era5_land` block under the RUNOFF divider in `catalog/sources.yml`**
+
+```yaml
+  era5_land:
+    name: ECMWF ERA5-Land Reanalysis
+    description: >
+      ECMWF ERA5-Land hourly reanalysis. Total runoff (ro), surface runoff
+      (sro), and sub-surface runoff (ssro) downloaded for CONUS plus
+      contributing watersheds (Canada/Mexico). Used as a source for the
+      runoff calibration target (ro) and the recharge calibration target
+      (ssro, as drainage proxy).
+    citations:
+      - "Muñoz-Sabater, J., and others, 2021, doi:10.5194/essd-13-4349-2021"
+    access:
+      type: copernicus_cds
+      dataset: reanalysis-era5-land
+      url: https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      bbox_notes: >
+        Encompasses CONUS contributing watersheds (Canada/Mexico) with
+        ~10 km buffer, snapped to the 0.1° ERA5-Land grid.
+      notes: >
+        Access via cdsapi (Copernicus CDS account required). Hourly
+        accumulated fields reset at 00 UTC. Pipeline aggregates
+        hourly→daily (via .diff('time') + resample sum) and daily→monthly.
+        Both daily and monthly consolidated NCs are stored in the datastore.
+    variables:
+      - name: ro
+        long_name: total runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Used for runoff target.
+      - name: sro
+        long_name: surface runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Stored for future use.
+      - name: ssro
+        long_name: sub-surface runoff
+        cf_units: "m"
+        cell_methods: "time: sum"
+        notes: Used as recharge proxy in recharge target.
+    time_step: hourly (aggregated to daily and monthly)
+    period: "1979/present"
+    spatial_extent: CONUS+contributing-watersheds
+    spatial_resolution: 0.1 degree
+    units: m of water equivalent
+    license: Copernicus license (free, attribution)
+    status: current
+```
+
+- [ ] **Step 4: Add `gldas_noah_v21_monthly` block under the RUNOFF divider**
+
+```yaml
+  gldas_noah_v21_monthly:
+    name: GLDAS-2.1 NOAH Monthly Land Surface Runoff
+    description: >
+      Global Land Data Assimilation System version 2.1, NOAH land
+      surface model, monthly product. Storm surface runoff (Qs_acc)
+      and baseflow-groundwater runoff (Qsb_acc) summed at consolidation
+      time to derived total runoff (runoff_total). Used as second source
+      for the runoff calibration target.
+    citations:
+      - "Rodell, M., and others, 2004, doi:10.1175/BAMS-85-3-381"
+    access:
+      type: nasa_gesdisc
+      short_name: GLDAS_NOAH025_M
+      version: "2.1"
+      url: https://disc.gsfc.nasa.gov/datasets/GLDAS_NOAH025_M_2.1/summary
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      notes: >
+        Access via earthaccess (NASA Earthdata login required). Granules
+        are global (~few MB monthly); downloaded full and clipped to bbox
+        at consolidation time, mirroring the merra2 pattern.
+    variables:
+      - name: Qs_acc
+        long_name: storm surface runoff
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+      - name: Qsb_acc
+        long_name: baseflow-groundwater runoff
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+      - name: runoff_total
+        long_name: total runoff (Qs_acc + Qsb_acc, derived)
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+        derived: true
+    time_step: monthly
+    period: "2000/present"
+    spatial_extent: global (clipped to CONUS+contributing-watersheds)
+    spatial_resolution: 0.25 degree
+    units: kg m-2 (equivalent to mm over the month)
+    license: public domain (NASA)
+    status: current
+```
+
+- [ ] **Step 5: Run catalog tests**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add catalog/sources.yml tests/test_catalog.py
+git commit -m "feat(catalog): add era5_land and gldas_noah_v21_monthly sources"
+```
+
+---
+
+## Task 3: Update `catalog/variables.yml` runoff and recharge
+
+**Files:**
+- Modify: `catalog/variables.yml`
+- Modify: `tests/test_catalog.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_catalog.py`:
+
+```python
+def test_runoff_uses_era5_and_gldas():
+    from nhf_spatial_targets import catalog
+    v = catalog.variable("runoff")
+    assert v["sources"] == ["era5_land", "gldas_noah_v21_monthly"]
+    assert v["range_method"] == "multi_source_minmax"
+
+
+def test_recharge_includes_era5_land():
+    from nhf_spatial_targets import catalog
+    v = catalog.variable("recharge")
+    assert "era5_land" in v["sources"]
+    assert v["range_method"] == "normalized_minmax"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py -k "runoff_uses or recharge_includes" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Replace the `runoff:` block in `catalog/variables.yml`**
+
+Replace the entire `runoff:` block (currently lines 15-32 referencing `basin_cfs`, `nhm_mwbm`, `mwbm_uncertainty`) with:
+
+```yaml
+  runoff:
+    prms_variable: basin_cfs
+    description: >
+      Monthly basin mean runoff. Range is min/max across two reanalysis
+      sources per HRU and time step.
+    prms_reference: "TM 6-B7 (Markstrom et al. 2015)"
+    time_step: monthly
+    period: "2000/2023"
+    units: cfs
+    sources:
+      - era5_land
+      - gldas_noah_v21_monthly
+    range_method: multi_source_minmax
+    range_notes: >
+      ERA5-Land 'ro' (m water equivalent) and GLDAS-2.1 NOAH
+      'Qs_acc + Qsb_acc' (kg/m² ≡ mm) are aggregated to HRU polygons
+      via gdptools, harmonized to mm/month, then converted to cfs using
+      HRU area and days-in-month. Per-HRU per-month:
+        lower_bound = min(era5, gldas), upper_bound = max(era5, gldas).
+      Replaces the original NHM-MWBM source which had pre-computed
+      uncertainty bounds (Bock et al. 2018) but no public fetch path.
+    normalize: false
+    output_format: netcdf
+```
+
+- [ ] **Step 4: Update the `recharge:` block sources list**
+
+In `catalog/variables.yml` change:
+```yaml
+    sources:
+      - reitz2017
+      - watergap22d
+```
+to:
+```yaml
+    sources:
+      - reitz2017
+      - watergap22d
+      - era5_land    # ssro (sub-surface runoff) as recharge proxy
+```
+
+Also extend `range_notes` with this paragraph (append at end of the block):
+```
+      ERA5-Land contribution: ssro is summed monthly→annual in mm,
+      then normalized 0-1 over 2000-2009 alongside the other sources
+      before the multi-source min/max.
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_catalog.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add catalog/variables.yml tests/test_catalog.py
+git commit -m "feat(catalog): switch runoff to era5/gldas, add era5 to recharge"
+```
+
+---
+
+## Task 4: Add `cdsapi` dependency and CDS credential validation
+
+**Files:**
+- Modify: `pixi.toml`
+- Modify: `src/nhf_spatial_targets/validate.py`
+- Test: `tests/test_validate.py` (create or extend)
+
+- [ ] **Step 1: Read current `validate.py` to find credential check pattern**
+
+Run: `grep -n "credentials\|earthdata" src/nhf_spatial_targets/validate.py`
+
+- [ ] **Step 2: Add `cdsapi` to `pixi.toml`**
+
+Open `pixi.toml`. Under `[pypi-dependencies]` (or `[dependencies]` if `cdsapi` is in conda-forge — prefer conda-forge), add:
+
+```toml
+cdsapi = "*"
+```
+
+- [ ] **Step 3: Run pixi install**
+
+Run: `pixi install`
+Expected: cdsapi resolved and installed.
+
+- [ ] **Step 4: Write failing test for CDS credential validation**
+
+Add to `tests/test_validate.py` (create file if missing):
+
+```python
+from pathlib import Path
+import pytest
+import yaml
+from nhf_spatial_targets.validate import validate_credentials
+
+
+def test_validate_credentials_missing_cds(tmp_path):
+    creds = tmp_path / ".credentials.yml"
+    creds.write_text(yaml.safe_dump({"earthdata": {"username": "u", "password": "p"}}))
+    with pytest.raises(ValueError, match="cds"):
+        validate_credentials(creds, required=["earthdata", "cds"])
+
+
+def test_validate_credentials_with_cds(tmp_path):
+    creds = tmp_path / ".credentials.yml"
+    creds.write_text(yaml.safe_dump({
+        "earthdata": {"username": "u", "password": "p"},
+        "cds": {"url": "https://cds.climate.copernicus.eu/api", "key": "uid:abc"},
+    }))
+    validate_credentials(creds, required=["earthdata", "cds"])  # no raise
+```
+
+- [ ] **Step 5: Run test to verify failure**
+
+Run: `pixi run -e dev test -- tests/test_validate.py -v`
+Expected: FAIL (function may not exist or signature differs).
+
+- [ ] **Step 6: Update `validate.py`**
+
+Locate the existing credential-check logic. Refactor (or add) so that `validate_credentials(path, required=[...])`:
+- Reads YAML at `path`
+- For each name in `required`:
+  - `earthdata`: requires keys `username` and `password`, both non-empty
+  - `cds`: requires keys `url` and `key`, both non-empty
+- Raises `ValueError` with the missing section name in the message
+
+Wire it into the existing `validate` CLI command so that, if any catalog source's `access.type` is `copernicus_cds`, `cds` is added to the required list. Use the catalog API (`catalog.sources()`) to determine this — do not hard-code.
+
+- [ ] **Step 7: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_validate.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pixi.toml pixi.lock src/nhf_spatial_targets/validate.py tests/test_validate.py
+git commit -m "feat(validate): add cdsapi dep and CDS credential check"
+```
+
+---
+
+## Task 5: ERA5-Land hourly→daily aggregation function (pure, testable)
+
+**Files:**
+- Create: `src/nhf_spatial_targets/fetch/era5_land.py`
+- Test: `tests/test_era5_land.py`
+
+This task isolates the aggregation math so it can be tested without the network.
+
+- [ ] **Step 1: Write failing test for hourly→daily**
+
+Create `tests/test_era5_land.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import pytest
+
+from nhf_spatial_targets.fetch.era5_land import hourly_to_daily
+
+
+def _make_hourly(start: str, hours: int, value_per_hour: float = 1.0) -> xr.DataArray:
+    """Synthetic ERA5-Land accumulated field.
+
+    ERA5-Land accumulates from 00 UTC: at hour H, value = H * per_hour
+    (resetting to 0 at the next 00 UTC, where it then represents the
+    accumulation step from 23->00 of the prior day).
+    """
+    times = pd.date_range(start, periods=hours, freq="1h")
+    vals = np.zeros(hours)
+    for i, t in enumerate(times):
+        # value at time t = accumulation since 00 UTC of t's date
+        hours_since_midnight = t.hour if t.hour != 0 else (24 if i > 0 else 0)
+        vals[i] = hours_since_midnight * value_per_hour
+    da = xr.DataArray(
+        vals.reshape(-1, 1, 1),
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+    )
+    return da
+
+
+def test_hourly_to_daily_full_24h():
+    # 48 hours starting 2020-01-01 00:00 → two full days of accumulation
+    da = _make_hourly("2020-01-01 00:00", hours=49, value_per_hour=0.001)
+    daily = hourly_to_daily(da)
+    # Two complete days should each show 24 * 0.001 = 0.024 m
+    assert daily.sizes["time"] == 2
+    np.testing.assert_allclose(daily.isel(time=0).values, 0.024, rtol=1e-6)
+    np.testing.assert_allclose(daily.isel(time=1).values, 0.024, rtol=1e-6)
+
+
+def test_hourly_to_daily_preserves_units_attr():
+    da = _make_hourly("2020-01-01 00:00", hours=49, value_per_hour=0.001)
+    da.attrs["units"] = "m"
+    daily = hourly_to_daily(da)
+    assert daily.attrs["units"] == "m"
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -v`
+Expected: FAIL (module/function does not exist).
+
+- [ ] **Step 3: Create `fetch/era5_land.py` with aggregation helpers**
+
+```python
+"""Fetch ERA5-Land hourly runoff from Copernicus CDS.
+
+Downloads hourly accumulated runoff variables (ro, sro, ssro) for the
+CONUS+contributing-watersheds bbox, then aggregates hourly→daily and
+daily→monthly. Both daily and monthly consolidated NetCDFs are written
+to the shared datastore.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# CDS area parameter [N, W, S, E], snapped to ERA5-Land 0.1° grid.
+# Encompasses CONUS contributing watersheds (Canada/Mexico) + ~10 km buffer.
+BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
+
+VARIABLES = ("ro", "sro", "ssro")
+
+
+def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
+    """Aggregate ERA5-Land hourly accumulated runoff to daily totals.
+
+    ERA5-Land accumulated fields (ro, sro, ssro) reset at 00 UTC each day
+    and represent meters of water equivalent accumulated since 00 UTC.
+    Daily total = sum of hourly increments computed via .diff('time'),
+    then resampled to daily sums. The diff approach is robust to the
+    midnight-reset boundary and to missing hours within a day.
+
+    The first hourly step of each day, after the 00 UTC reset, equals the
+    accumulation over the 23->00 hour of the prior day. We discard the
+    pre-first-midnight increment (which is meaningless without a prior
+    23 UTC value) by requiring the result to come from `.diff` with
+    matching valid timestamps.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Hourly accumulated runoff with a 'time' dimension. Time stamps
+        must be regular hourly.
+
+    Returns
+    -------
+    xr.DataArray
+        Daily-summed runoff. Time coordinate is the date (00:00) of each
+        complete day. Original attrs are preserved.
+    """
+    # Hourly increment: value(t) - value(t-1). Negative jumps occur at the
+    # 00 UTC reset; clip them to 0 because the post-midnight value is the
+    # accumulation 23→00 of the prior day, which we attribute to the prior
+    # day via resampling.
+    incr = da.diff("time", label="upper")
+    # The 00 UTC sample's diff is from 23->00, an increment that belongs
+    # to the prior day. Resampling by day-of-timestamp is right because
+    # the timestamp is 00 UTC of the new day; we instead want it credited
+    # to the prior day. Shift the time coord back by 1 hour so that the
+    # 00 UTC increment lands inside the prior day.
+    incr = incr.assign_coords(time=incr.time - pd.Timedelta(hours=1))
+    daily = incr.resample(time="1D").sum()
+    daily.attrs = dict(da.attrs)
+    return daily
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -v`
+Expected: PASS for both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/era5_land.py tests/test_era5_land.py
+git commit -m "feat(fetch): add ERA5-Land hourly→daily aggregation"
+```
+
+---
+
+## Task 6: ERA5-Land daily→monthly aggregation
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/era5_land.py`
+- Modify: `tests/test_era5_land.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_era5_land.py`:
+
+```python
+from nhf_spatial_targets.fetch.era5_land import daily_to_monthly
+
+
+def test_daily_to_monthly_sum():
+    times = pd.date_range("2020-01-01", periods=60, freq="1D")
+    vals = np.full((60, 1, 1), 0.001)
+    da = xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+        attrs={"units": "m"},
+    )
+    monthly = daily_to_monthly(da)
+    # January (31 days) and February 2020 (29 days, leap year)
+    assert monthly.sizes["time"] == 2
+    np.testing.assert_allclose(monthly.isel(time=0).values, 0.031, rtol=1e-6)
+    np.testing.assert_allclose(monthly.isel(time=1).values, 0.029, rtol=1e-6)
+    assert monthly.attrs["units"] == "m"
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py::test_daily_to_monthly_sum -v`
+Expected: FAIL (function not defined).
+
+- [ ] **Step 3: Add `daily_to_monthly` to `fetch/era5_land.py`**
+
+Append:
+
+```python
+def daily_to_monthly(da: xr.DataArray) -> xr.DataArray:
+    """Sum daily totals to monthly totals.
+
+    Uses month-end frequency ('1ME') so the time coordinate marks the
+    last day of each month — consistent with other monthly products in
+    this codebase. Original attrs are preserved.
+    """
+    monthly = da.resample(time="1ME").sum()
+    monthly.attrs = dict(da.attrs)
+    return monthly
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/era5_land.py tests/test_era5_land.py
+git commit -m "feat(fetch): add ERA5-Land daily→monthly aggregation"
+```
+
+---
+
+## Task 7: ERA5-Land CDS download wrapper
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/era5_land.py`
+- Modify: `tests/test_era5_land.py`
+
+- [ ] **Step 1: Write failing test using a mock CDS client**
+
+Append to `tests/test_era5_land.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+
+def test_download_year_calls_cds_client(tmp_path, monkeypatch):
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock()
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    out = tmp_path / "era5_land_ro_2020.nc"
+    download_year_variable(year=2020, variable="ro", output_path=out)
+
+    fake_client.retrieve.assert_called_once()
+    args, kwargs = fake_client.retrieve.call_args
+    assert args[0] == "reanalysis-era5-land"
+    request = args[1]
+    assert request["variable"] == "runoff"
+    assert request["year"] == "2020"
+    assert request["area"] == [53.0, -125.0, 24.7, -66.0]
+    assert request["format"] == "netcdf"
+    assert "month" in request and len(request["month"]) == 12
+    assert args[2] == str(out)
+
+
+def test_download_year_skips_existing(tmp_path, monkeypatch):
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    fake_client = MagicMock()
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+    out = tmp_path / "era5_land_ro_2020.nc"
+    out.write_bytes(b"existing")
+    download_year_variable(year=2020, variable="ro", output_path=out)
+    fake_client.retrieve.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -k download_year -v`
+Expected: FAIL (function not defined).
+
+- [ ] **Step 3: Add download wrapper to `fetch/era5_land.py`**
+
+Append:
+
+```python
+# Map short variable name to the CDS request name
+_VARIABLE_REQUEST_NAME = {
+    "ro": "runoff",
+    "sro": "surface_runoff",
+    "ssro": "sub_surface_runoff",
+}
+
+
+def _cds_client():
+    """Construct a cdsapi.Client. Separated for test injection."""
+    import cdsapi
+    return cdsapi.Client()
+
+
+def download_year_variable(
+    year: int,
+    variable: str,
+    output_path: Path,
+) -> Path:
+    """Download one year of one ERA5-Land variable to ``output_path``.
+
+    Idempotent: if ``output_path`` already exists, returns immediately.
+    Submits a single CDS request covering all 12 months × all hours of
+    the given year, clipped to ``BBOX_NWSE``.
+
+    Parameters
+    ----------
+    year : int
+    variable : {"ro", "sro", "ssro"}
+    output_path : Path
+        Target NetCDF file. Parent directory is created if missing.
+
+    Returns
+    -------
+    Path
+        ``output_path`` (for caller convenience).
+    """
+    if variable not in _VARIABLE_REQUEST_NAME:
+        raise ValueError(f"Unknown ERA5-Land variable: {variable!r}")
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        logger.info("Skipping existing ERA5-Land file: %s", output_path)
+        return output_path
+
+    request = {
+        "variable": _VARIABLE_REQUEST_NAME[variable],
+        "year": str(year),
+        "month": [f"{m:02d}" for m in range(1, 13)],
+        "day": [f"{d:02d}" for d in range(1, 32)],
+        "time": [f"{h:02d}:00" for h in range(24)],
+        "area": BBOX_NWSE,
+        "format": "netcdf",
+    }
+    client = _cds_client()
+    logger.info("Submitting CDS request for %s %d → %s", variable, year, output_path)
+    client.retrieve("reanalysis-era5-land", request, str(output_path))
+    return output_path
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/era5_land.py tests/test_era5_land.py
+git commit -m "feat(fetch): add ERA5-Land CDS download wrapper"
+```
+
+---
+
+## Task 8: ERA5-Land orchestrator (`fetch_era5_land`) with consolidation + manifest
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/era5_land.py`
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py` (add ERA5-Land entry to `apply_cf_metadata`)
+- Modify: `tests/test_era5_land.py`
+
+- [ ] **Step 1: Inspect `apply_cf_metadata` to learn the registry pattern**
+
+Run: `grep -n "apply_cf_metadata\|SOURCE_METADATA\|watergap22d" src/nhf_spatial_targets/fetch/consolidate.py | head -40`
+
+- [ ] **Step 2: Add ERA5-Land entry to `consolidate.py`**
+
+Add a registry entry in `consolidate.py` for `era5_land` with both `daily` and `monthly` time steps. Pattern (adapt to the dispatch shape used in the file):
+
+```python
+"era5_land": {
+    "daily": {
+        "title": "ERA5-Land daily runoff (CONUS+ buffered)",
+        "institution": "ECMWF",
+        "source": "reanalysis-era5-land",
+        "references": "doi:10.5194/essd-13-4349-2021",
+        "Conventions": "CF-1.6",
+        "cell_methods": "time: sum",
+        "frequency": "day",
+    },
+    "monthly": {
+        "title": "ERA5-Land monthly runoff (CONUS+ buffered)",
+        "institution": "ECMWF",
+        "source": "reanalysis-era5-land",
+        "references": "doi:10.5194/essd-13-4349-2021",
+        "Conventions": "CF-1.6",
+        "cell_methods": "time: sum",
+        "frequency": "month",
+    },
+},
+```
+
+If `apply_cf_metadata` does not currently support per-time-step variants, extend its signature to take a `time_step` argument and look up the matching sub-entry.
+
+- [ ] **Step 3: Write failing integration-style test (no network) for the orchestrator**
+
+Append to `tests/test_era5_land.py`:
+
+```python
+def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch):
+    """Given pre-existing hourly NCs, consolidation produces daily and monthly NCs."""
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    # Build a synthetic hourly NetCDF for each variable, 2020 full year (sparse)
+    times = pd.date_range("2020-01-01", "2020-01-03 23:00", freq="1h")
+    for var in ("ro", "sro", "ssro"):
+        vals = np.tile(
+            np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
+            (len(times) // 24, 1, 1),
+        )
+        ds = xr.Dataset(
+            {var: (("time", "latitude", "longitude"), vals)},
+            coords={
+                "time": times[: vals.shape[0]],
+                "latitude": [40.0],
+                "longitude": [-100.0],
+            },
+        )
+        ds[var].attrs["units"] = "m"
+        ds.to_netcdf(hourly_dir / f"era5_land_{var}_2020.nc")
+
+    daily_path, monthly_path = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+
+    assert daily_path.exists()
+    daily = xr.open_dataset(daily_path)
+    try:
+        assert set(daily.data_vars) == {"ro", "sro", "ssro"}
+        assert daily.sizes["time"] >= 2
+    finally:
+        daily.close()
+
+    assert monthly_path.exists()
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py::test_consolidate_year_writes_daily_and_updates_monthly -v`
+Expected: FAIL.
+
+- [ ] **Step 5: Implement `consolidate_year` and `fetch_era5_land`**
+
+Append to `fetch/era5_land.py`:
+
+```python
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.workspace import load as _load_project
+
+_SOURCE_KEY = "era5_land"
+
+
+def _atomic_to_netcdf(ds: xr.Dataset, path: Path) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def consolidate_year(
+    year: int,
+    hourly_dir: Path,
+    daily_dir: Path,
+    monthly_dir: Path,
+) -> tuple[Path, Path]:
+    """Build daily and monthly consolidated NCs for one year.
+
+    Reads ``era5_land_{ro,sro,ssro}_{year}.nc`` from ``hourly_dir``,
+    aggregates each variable hourly→daily, merges into a single daily
+    dataset, applies CF metadata, writes atomically. Then aggregates
+    daily→monthly and writes/updates the monthly file.
+
+    Returns (daily_path, monthly_path).
+    """
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    monthly_dir.mkdir(parents=True, exist_ok=True)
+    daily_arrays: dict[str, xr.DataArray] = {}
+    for var in VARIABLES:
+        path = hourly_dir / f"era5_land_{var}_{year}.nc"
+        if not path.exists():
+            raise FileNotFoundError(f"Missing hourly file: {path}")
+        with xr.open_dataset(path) as ds:
+            ds.load()
+        da = ds[var]
+        daily_arrays[var] = hourly_to_daily(da)
+
+    daily_ds = xr.Dataset(daily_arrays)
+    daily_ds = apply_cf_metadata(daily_ds, "era5_land", "daily")
+    daily_path = daily_dir / f"era5_land_daily_{year}.nc"
+    _atomic_to_netcdf(daily_ds, daily_path)
+    logger.info("Wrote %s", daily_path)
+
+    # Monthly: rebuild from the (possibly multi-year) collection of daily files
+    daily_files = sorted(daily_dir.glob("era5_land_daily_*.nc"))
+    with xr.open_mfdataset(daily_files, combine="by_coords") as ds_all:
+        ds_all.load()
+    monthly_ds = xr.Dataset(
+        {v: daily_to_monthly(ds_all[v]) for v in VARIABLES}
+    )
+    monthly_ds = apply_cf_metadata(monthly_ds, "era5_land", "monthly")
+    start_year = pd.Timestamp(monthly_ds.time.min().values).year
+    end_year = pd.Timestamp(monthly_ds.time.max().values).year
+    monthly_path = monthly_dir / f"era5_land_monthly_{start_year}_{end_year}.nc"
+    # Remove any stale monthly file with a different year range
+    for stale in monthly_dir.glob("era5_land_monthly_*.nc"):
+        if stale != monthly_path:
+            stale.unlink()
+    _atomic_to_netcdf(monthly_ds, monthly_path)
+    logger.info("Wrote %s", monthly_path)
+
+    return daily_path, monthly_path
+
+
+def fetch_era5_land(workdir: Path, period: str) -> dict:
+    """Download ERA5-Land hourly runoff and produce daily/monthly NCs.
+
+    Loops over years in ``period``, downloading per-year per-variable
+    hourly NCs from CDS into the project's datastore, then consolidating
+    each year into the daily file and rebuilding the rolling monthly
+    file. Idempotent on already-downloaded years.
+    """
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    start, end = parse_period(period)
+
+    raw_root = ws.raw_dir(_SOURCE_KEY)
+    hourly_dir = raw_root / "hourly"
+    daily_dir = raw_root / "daily"
+    monthly_dir = raw_root / "monthly"
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+    files: list[dict] = []
+
+    for year in range(start.year, end.year + 1):
+        for var in VARIABLES:
+            out = hourly_dir / f"era5_land_{var}_{year}.nc"
+            download_year_variable(year, var, out)
+        daily_path, monthly_path = consolidate_year(
+            year, hourly_dir, daily_dir, monthly_dir
+        )
+        files.append(
+            {
+                "year": year,
+                "daily_path": str(daily_path),
+                "monthly_path": str(monthly_path),
+                "consolidated_utc": now_utc,
+            }
+        )
+
+    bbox = ws.fabric["bbox_buffered"]
+    license_str = meta.get("license", "Copernicus license")
+    _update_manifest(workdir, period, bbox, meta, license_str, files)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": license_str,
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": bbox,
+        "download_timestamp": now_utc,
+        "files": files,
+    }
+
+
+def _update_manifest(workdir, period, bbox, meta, license_str, files):
+    """Merge ERA5-Land provenance into manifest.json (atomic write)."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+    else:
+        manifest = {"sources": {}, "steps": []}
+    manifest.setdefault("sources", {})[_SOURCE_KEY] = {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": license_str,
+        "period": period,
+        "bbox": bbox,
+        "variables": [v["name"] for v in meta["variables"]],
+        "files": files,
+    }
+    fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp).replace(manifest_path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+```
+
+- [ ] **Step 6: Run all ERA5-Land tests**
+
+Run: `pixi run -e dev test -- tests/test_era5_land.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/era5_land.py src/nhf_spatial_targets/fetch/consolidate.py tests/test_era5_land.py
+git commit -m "feat(fetch): ERA5-Land orchestrator with daily/monthly consolidation"
+```
+
+---
+
+## Task 9: GLDAS fetch module
+
+**Files:**
+- Create: `src/nhf_spatial_targets/fetch/gldas.py`
+- Create: `tests/test_gldas.py`
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py` (add `gldas_noah_v21_monthly` registry entry)
+
+- [ ] **Step 1: Read MERRA-2 fetch as the closest pattern**
+
+Run: `cat src/nhf_spatial_targets/fetch/merra2.py | head -120`
+
+- [ ] **Step 2: Write failing tests**
+
+Create `tests/test_gldas.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import pytest
+
+from nhf_spatial_targets.fetch.gldas import (
+    derive_runoff_total,
+    clip_to_bbox,
+    BBOX_NWSE,
+)
+
+
+def _global_grid(value_qs=2.0, value_qsb=3.0):
+    lat = np.arange(-89.875, 90.0, 0.25)
+    lon = np.arange(-179.875, 180.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=2, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    return xr.Dataset(
+        {
+            "Qs_acc": (("time", "lat", "lon"), np.full(shape, value_qs)),
+            "Qsb_acc": (("time", "lat", "lon"), np.full(shape, value_qsb)),
+        },
+        coords={"time": times, "lat": lat, "lon": lon},
+    )
+
+
+def test_derive_runoff_total_sums_qs_and_qsb():
+    ds = _global_grid()
+    out = derive_runoff_total(ds)
+    assert "runoff_total" in out.data_vars
+    np.testing.assert_allclose(out.runoff_total.values, 5.0)
+    assert out.runoff_total.attrs["long_name"] == "total runoff (Qs_acc + Qsb_acc, derived)"
+    assert out.runoff_total.attrs["units"] == "kg m-2"
+
+
+def test_clip_to_bbox_reduces_extent():
+    ds = _global_grid()
+    clipped = clip_to_bbox(ds, BBOX_NWSE)
+    # bbox is N=53.0, W=-125.0, S=24.7, E=-66.0
+    assert clipped.lat.min() >= 24.7 - 0.25
+    assert clipped.lat.max() <= 53.0 + 0.25
+    assert clipped.lon.min() >= -125.0 - 0.25
+    assert clipped.lon.max() <= -66.0 + 0.25
+    assert clipped.lat.size < ds.lat.size
+    assert clipped.lon.size < ds.lon.size
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_gldas.py -v`
+Expected: FAIL (module/functions don't exist).
+
+- [ ] **Step 4: Create `fetch/gldas.py`**
+
+```python
+"""Fetch GLDAS-2.1 NOAH monthly runoff from NASA GES DISC."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import xarray as xr
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "gldas_noah_v21_monthly"
+
+# Lat/lon bbox matches the ERA5-Land bbox: N=53.0, W=-125.0, S=24.7, E=-66.0
+BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
+
+
+def derive_runoff_total(ds: xr.Dataset) -> xr.Dataset:
+    """Add ``runoff_total = Qs_acc + Qsb_acc`` to the dataset.
+
+    Both inputs are kg m-2 (mm equivalent); their sum has the same units.
+    """
+    total = ds["Qs_acc"] + ds["Qsb_acc"]
+    total.attrs = {
+        "long_name": "total runoff (Qs_acc + Qsb_acc, derived)",
+        "units": "kg m-2",
+        "cell_methods": "time: sum",
+    }
+    return ds.assign(runoff_total=total)
+
+
+def clip_to_bbox(ds: xr.Dataset, bbox_nwse: list[float]) -> xr.Dataset:
+    """Clip a global dataset (lat/lon coords) to a [N, W, S, E] bbox."""
+    n, w, s, e = bbox_nwse
+    lat_name = "lat" if "lat" in ds.coords else "latitude"
+    lon_name = "lon" if "lon" in ds.coords else "longitude"
+    lat = ds[lat_name]
+    if float(lat[0]) < float(lat[-1]):
+        lat_slice = slice(s, n)
+    else:
+        lat_slice = slice(n, s)
+    return ds.sel({lat_name: lat_slice, lon_name: slice(w, e)})
+
+
+def fetch_gldas(workdir: Path, period: str) -> dict:
+    """Download GLDAS-2.1 NOAH monthly granules and consolidate.
+
+    Uses earthaccess (NASA EDL) to download monthly granules covering
+    ``period``, then concatenates, derives ``runoff_total``, clips to
+    the project bbox, applies CF metadata, and writes a single
+    consolidated NC to the datastore.
+    """
+    import earthaccess
+
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    start, end = parse_period(period)
+
+    raw_dir = ws.raw_dir(_SOURCE_KEY) / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    cf_path = ws.raw_dir(_SOURCE_KEY) / "gldas_noah_v21_monthly.nc"
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    earthaccess.login(strategy="netrc")
+    results = earthaccess.search_data(
+        short_name=meta["access"]["short_name"],
+        version=meta["access"]["version"],
+        temporal=(start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")),
+    )
+    files = earthaccess.download(results, str(raw_dir))
+    logger.info("Downloaded %d GLDAS granules to %s", len(files), raw_dir)
+
+    with xr.open_mfdataset(sorted(files), combine="by_coords") as ds:
+        ds = ds[["Qs_acc", "Qsb_acc"]].load()
+    ds = derive_runoff_total(ds)
+    ds = clip_to_bbox(ds, BBOX_NWSE)
+    ds = apply_cf_metadata(ds, _SOURCE_KEY, "monthly")
+
+    tmp = cf_path.with_suffix(".nc.tmp")
+    try:
+        ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(cf_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    bbox = ws.fabric["bbox_buffered"]
+    file_info = {
+        "path": str(cf_path),
+        "size_bytes": cf_path.stat().st_size,
+        "downloaded_utc": now_utc,
+        "n_granules": len(files),
+    }
+    _update_manifest(workdir, period, bbox, meta, file_info)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": meta.get("license", "public domain (NASA)"),
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": bbox,
+        "download_timestamp": now_utc,
+        "file": file_info,
+    }
+
+
+def _update_manifest(workdir, period, bbox, meta, file_info):
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    manifest = (
+        json.loads(manifest_path.read_text())
+        if manifest_path.exists()
+        else {"sources": {}, "steps": []}
+    )
+    manifest.setdefault("sources", {})[_SOURCE_KEY] = {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": meta.get("license", "public domain (NASA)"),
+        "period": period,
+        "bbox": bbox,
+        "variables": [v["name"] for v in meta["variables"]],
+        "file": file_info,
+    }
+    fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp).replace(manifest_path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+```
+
+- [ ] **Step 5: Add `gldas_noah_v21_monthly` to `consolidate.py` registry**
+
+Add a registry entry analogous to other monthly sources:
+
+```python
+"gldas_noah_v21_monthly": {
+    "monthly": {
+        "title": "GLDAS-2.1 NOAH monthly runoff (CONUS+ buffered)",
+        "institution": "NASA GES DISC",
+        "source": "GLDAS_NOAH025_M v2.1",
+        "references": "doi:10.1175/BAMS-85-3-381",
+        "Conventions": "CF-1.6",
+        "cell_methods": "time: sum",
+        "frequency": "month",
+    },
+},
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_gldas.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/gldas.py src/nhf_spatial_targets/fetch/consolidate.py tests/test_gldas.py
+git commit -m "feat(fetch): add GLDAS-2.1 NOAH monthly fetch module"
+```
+
+---
+
+## Task 10: Wire ERA5-Land and GLDAS into the CLI
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/cli.py`
+
+- [ ] **Step 1: Read existing CLI command pattern**
+
+Run: `sed -n '300,360p' src/nhf_spatial_targets/cli.py`
+
+- [ ] **Step 2: Add per-source CLI commands**
+
+Following the pattern of `fetch_merra2_cmd`, add two commands:
+
+```python
+@fetch_app.command(name="era5-land")
+def fetch_era5_land_cmd(
+    project_dir: Path,
+    period: str = "1979/2024",
+):
+    """Download ERA5-Land hourly runoff (CDS) and consolidate to daily/monthly."""
+    from nhf_spatial_targets.fetch.era5_land import fetch_era5_land
+    workdir = Path(project_dir).resolve()
+    result = fetch_era5_land(workdir=workdir, period=period)
+    # use the same logging/printing pattern as fetch_merra2_cmd
+
+
+@fetch_app.command(name="gldas")
+def fetch_gldas_cmd(
+    project_dir: Path,
+    period: str = "2000/2023",
+):
+    """Download GLDAS-2.1 NOAH monthly runoff (NASA GES DISC)."""
+    from nhf_spatial_targets.fetch.gldas import fetch_gldas
+    workdir = Path(project_dir).resolve()
+    result = fetch_gldas(workdir=workdir, period=period)
+```
+
+Look at `fetch_merra2_cmd` for the surrounding boilerplate (logging, error handling, return) and replicate it exactly.
+
+- [ ] **Step 3: Add both sources to the `fetch all` registry**
+
+In `fetch_all_cmd`, add to the `sources` list (around line 246-253):
+
+```python
+("era5-land", "era5_land", fetch_era5_land),
+("gldas", "gldas_noah_v21_monthly", fetch_gldas),
+```
+
+And add the matching imports near the existing fetch imports.
+
+- [ ] **Step 4: Add a `pixi run` task entry**
+
+In `pixi.toml`, under `[tasks]` (alongside other `fetch-*` tasks if present), add:
+
+```toml
+fetch-era5-land = "nhf-targets fetch era5-land"
+fetch-gldas = "nhf-targets fetch gldas"
+```
+
+- [ ] **Step 5: Smoke check the CLI registers**
+
+Run: `pixi run -- nhf-targets fetch --help`
+Expected: output lists `era5-land` and `gldas` subcommands.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nhf_spatial_targets/cli.py pixi.toml
+git commit -m "feat(cli): register era5-land and gldas fetch commands"
+```
+
+---
+
+## Task 11: Runoff target builder
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/targets/run.py`
+- Create: `tests/test_run_target.py`
+
+- [ ] **Step 1: Inspect the AET builder for the multi-source minmax pattern**
+
+Run: `cat src/nhf_spatial_targets/targets/aet.py`
+
+- [ ] **Step 2: Write failing tests for unit harmonization and minmax**
+
+Create `tests/test_run_target.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.targets.run import (
+    era5_to_mm_per_month,
+    gldas_to_mm_per_month,
+    mm_per_month_to_cfs,
+    multi_source_runoff_bounds,
+)
+
+HRU_AREA_M2 = 1.0e8  # 100 km²
+
+
+def _series(values, units):
+    times = pd.date_range("2020-01-01", periods=len(values), freq="1MS")
+    da = xr.DataArray(values, dims=("time",), coords={"time": times})
+    da.attrs["units"] = units
+    return da
+
+
+def test_era5_meters_to_mm():
+    da = _series([0.05, 0.10], "m")
+    out = era5_to_mm_per_month(da)
+    np.testing.assert_allclose(out.values, [50.0, 100.0])
+    assert out.attrs["units"] == "mm"
+
+
+def test_gldas_kgm2_passthrough_to_mm():
+    da = _series([20.0, 40.0], "kg m-2")
+    out = gldas_to_mm_per_month(da)
+    np.testing.assert_allclose(out.values, [20.0, 40.0])
+    assert out.attrs["units"] == "mm"
+
+
+def test_mm_to_cfs_uses_days_in_month():
+    # 31 mm in January = 0.001 m/day over 100 km² = 100 m³/day = ~0.0409 cfs
+    da = _series([31.0], "mm")
+    out = mm_per_month_to_cfs(da, hru_area_m2=HRU_AREA_M2)
+    expected_m3_per_day = 0.001 * HRU_AREA_M2  # 100 000 m³/day
+    expected_cfs = expected_m3_per_day / 86400.0 * 35.3147
+    np.testing.assert_allclose(out.values, [expected_cfs], rtol=1e-4)
+    assert out.attrs["units"] == "cfs"
+
+
+def test_multi_source_minmax():
+    a = _series([10.0, 20.0, 30.0], "cfs")
+    b = _series([15.0, 18.0, 32.0], "cfs")
+    lower, upper = multi_source_runoff_bounds([a, b])
+    np.testing.assert_allclose(lower.values, [10.0, 18.0, 30.0])
+    np.testing.assert_allclose(upper.values, [15.0, 20.0, 32.0])
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_run_target.py -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement `targets/run.py`**
+
+Replace the current stub with:
+
+```python
+"""Build runoff calibration targets from ERA5-Land + GLDAS-2.1 NOAH."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+_M3_PER_DAY_TO_CFS = 35.3146667 / 86400.0  # cubic feet per second per m³/day
+
+
+def era5_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
+    """ERA5-Land runoff (m water-eq / month) → mm/month."""
+    out = da * 1000.0
+    out.attrs = dict(da.attrs)
+    out.attrs["units"] = "mm"
+    return out
+
+
+def gldas_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
+    """GLDAS Qs_acc + Qsb_acc (kg m-2) ≡ mm/month directly."""
+    out = da.copy()
+    out.attrs = dict(da.attrs)
+    out.attrs["units"] = "mm"
+    return out
+
+
+def mm_per_month_to_cfs(da: xr.DataArray, hru_area_m2: float | xr.DataArray) -> xr.DataArray:
+    """Convert mm/month → cfs given HRU area and the month length.
+
+    mm/month × 1e-3 m/mm × area_m2 / days_in_month → m³/day → cfs.
+    Days-in-month is read from ``da.time.dt.days_in_month``.
+    """
+    days = da["time"].dt.days_in_month
+    m_per_day = (da * 1e-3) / days
+    m3_per_day = m_per_day * hru_area_m2
+    cfs = m3_per_day * _M3_PER_DAY_TO_CFS
+    cfs.attrs = dict(da.attrs)
+    cfs.attrs["units"] = "cfs"
+    return cfs
+
+
+def multi_source_runoff_bounds(
+    sources: list[xr.DataArray],
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Per-coord minimum and maximum across input sources.
+
+    All inputs must share dimensions and coords. Returns (lower, upper).
+    """
+    stacked = xr.concat(sources, dim="source")
+    return stacked.min("source"), stacked.max("source")
+
+
+def build(config: dict, fabric_path: str, output_path: str) -> None:
+    """Build runoff target dataset.
+
+    Reads HRU-aggregated monthly runoff for ERA5-Land (`ro`) and GLDAS
+    (`runoff_total`), harmonizes units to cfs, computes per-HRU
+    per-month min/max bounds, writes a CF-compliant NetCDF with
+    `lower_bound` and `upper_bound` variables (dims: hru, time).
+    """
+    raise NotImplementedError(
+        "Builder wiring depends on aggregate/ output paths; "
+        "implement once aggregate output schema is finalized."
+    )
+```
+
+The pure functions are exercised by tests; `build()` remains a stub until the aggregation output schema is concretized — see Task 12.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_run_target.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nhf_spatial_targets/targets/run.py tests/test_run_target.py
+git commit -m "feat(targets): runoff unit harmonization + multi-source minmax"
+```
+
+---
+
+## Task 12: Implement runoff `build()` end-to-end
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/targets/run.py`
+- Modify: `tests/test_run_target.py`
+
+- [ ] **Step 1: Read aggregate output conventions**
+
+Run: `cat src/nhf_spatial_targets/aggregate/gdptools_agg.py | head -80`
+Run: `grep -n "agg" src/nhf_spatial_targets/cli.py | head -20`
+
+Identify how aggregated outputs are named/located for each source. The expected pattern (per CLAUDE.md) is `<project>/data/aggregated/<source_key>/<var>.nc`.
+
+- [ ] **Step 2: Write failing test for build() with synthetic aggregated inputs**
+
+Append to `tests/test_run_target.py`:
+
+```python
+def test_build_writes_lower_upper_bounds(tmp_path):
+    from nhf_spatial_targets.targets.run import build
+
+    # Synthetic per-HRU per-month aggregated inputs in mm/month equivalents
+    times = pd.date_range("2020-01-01", periods=3, freq="1MS")
+    hrus = np.arange(3)
+
+    def _save(path: Path, var: str, vals_m_or_kg, units: str):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        da = xr.DataArray(
+            vals_m_or_kg,
+            dims=("time", "hru"),
+            coords={"time": times, "hru": hrus},
+            name=var,
+        )
+        da.attrs["units"] = units
+        ds = da.to_dataset()
+        ds.to_netcdf(path)
+
+    agg = tmp_path / "data" / "aggregated"
+    _save(agg / "era5_land" / "ro.nc", "ro",
+          np.full((3, 3), 0.05), "m")  # 0.05 m = 50 mm
+    _save(agg / "gldas_noah_v21_monthly" / "runoff_total.nc", "runoff_total",
+          np.full((3, 3), 30.0), "kg m-2")  # 30 mm
+
+    out = tmp_path / "targets" / "runoff_target.nc"
+    hru_area = xr.DataArray(np.full(3, 1.0e8), dims=("hru",), coords={"hru": hrus})
+
+    build(
+        config={"aggregated_dir": str(agg), "hru_area_m2": hru_area},
+        fabric_path="unused",
+        output_path=str(out),
+    )
+
+    assert out.exists()
+    ds = xr.open_dataset(out)
+    try:
+        assert "lower_bound" in ds.data_vars
+        assert "upper_bound" in ds.data_vars
+        assert ds["lower_bound"].dims == ("time", "hru")
+        # GLDAS (30 mm) should be the lower bound; ERA5 (50 mm) the upper.
+        # Both convert via mm_per_month_to_cfs with the same area/days, so
+        # ordering is preserved in cfs.
+        assert (ds["lower_bound"].values <= ds["upper_bound"].values).all()
+    finally:
+        ds.close()
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `pixi run -e dev test -- tests/test_run_target.py::test_build_writes_lower_upper_bounds -v`
+Expected: FAIL (NotImplementedError).
+
+- [ ] **Step 4: Implement `build()`**
+
+Replace the `build` function body with:
+
+```python
+def build(config: dict, fabric_path: str, output_path: str) -> None:
+    """Build runoff target dataset.
+
+    config keys:
+      aggregated_dir : str | Path
+          Directory containing per-source per-variable aggregated NCs at
+          ``<aggregated_dir>/<source_key>/<var>.nc``.
+      hru_area_m2 : xr.DataArray
+          Per-HRU area in m², dims=('hru',), coord aligned with the
+          aggregated outputs.
+    """
+    agg_dir = Path(config["aggregated_dir"])
+    hru_area = config["hru_area_m2"]
+
+    with xr.open_dataset(agg_dir / "era5_land" / "ro.nc") as ds:
+        era5 = ds["ro"].load()
+    with xr.open_dataset(
+        agg_dir / "gldas_noah_v21_monthly" / "runoff_total.nc"
+    ) as ds:
+        gldas = ds["runoff_total"].load()
+
+    era5_cfs = mm_per_month_to_cfs(era5_to_mm_per_month(era5), hru_area)
+    gldas_cfs = mm_per_month_to_cfs(gldas_to_mm_per_month(gldas), hru_area)
+
+    lower, upper = multi_source_runoff_bounds([era5_cfs, gldas_cfs])
+    lower.name = "lower_bound"
+    upper.name = "upper_bound"
+    out_ds = xr.Dataset(
+        {"lower_bound": lower, "upper_bound": upper},
+        attrs={
+            "title": "NHM runoff calibration target (ERA5-Land + GLDAS-2.1)",
+            "Conventions": "CF-1.6",
+            "cell_methods": "time: sum",
+            "units": "cfs",
+        },
+    )
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.with_suffix(".nc.tmp")
+    try:
+        out_ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(output_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    logger.info("Wrote runoff target: %s", output_path)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_run_target.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nhf_spatial_targets/targets/run.py tests/test_run_target.py
+git commit -m "feat(targets): runoff target builder writes lower/upper bounds"
+```
+
+---
+
+## Task 13: Drop MWBM from AET target builder
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/targets/aet.py`
+
+- [ ] **Step 1: Inspect current aet.py**
+
+Run: `cat src/nhf_spatial_targets/targets/aet.py`
+
+- [ ] **Step 2: Remove any code path referencing `nhm_mwbm`**
+
+Edit `targets/aet.py` to drop:
+- Imports related to MWBM (none expected, but check)
+- Any source-key reference to `"nhm_mwbm"`
+- Any list element naming MWBM in the sources iteration
+
+If the file is currently a stub (raise NotImplementedError) with no MWBM reference, this task is a verification-only step — note that fact in the commit message and skip the edit.
+
+- [ ] **Step 3: Run all target tests**
+
+Run: `pixi run -e dev test -- tests/ -v`
+Expected: PASS (no regressions).
+
+- [ ] **Step 4: Commit (only if changes made)**
+
+```bash
+git add src/nhf_spatial_targets/targets/aet.py
+git commit -m "refactor(targets/aet): drop nhm_mwbm source"
+```
+
+---
+
+## Task 14: Add ERA5-Land `ssro` to recharge target
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/targets/rch.py`
+- Modify (or create) corresponding test file
+
+- [ ] **Step 1: Inspect current rch.py and any normalization helper**
+
+Run: `cat src/nhf_spatial_targets/targets/rch.py`
+Run: `grep -rn "normalize" src/nhf_spatial_targets/normalize/ src/nhf_spatial_targets/targets/`
+
+- [ ] **Step 2: If `rch.py` is a stub, add a minimum scaffold for the third source**
+
+If the file is `raise NotImplementedError`, leave it as a stub but document the new third source in a module docstring so the upcoming implementation includes it:
+
+```python
+"""Build recharge calibration targets.
+
+Sources (per catalog/variables.yml):
+  - reitz2017: total_recharge (in/yr)
+  - watergap22d: groundwater_recharge (kg m-2 s-1, → mm/yr)
+  - era5_land: ssro summed monthly→annual (m water-eq, → mm/yr)
+
+Method: each source aggregated to HRU, normalized 0-1 per HRU over
+2000-2009, then per-HRU per-year lower/upper = min/max across the three
+normalized sources.
+"""
+```
+
+If the file already has logic, add an `ssro` branch that:
+- Loads aggregated `<aggregated_dir>/era5_land/ssro.nc` (monthly)
+- Sums to annual
+- Converts m → mm (×1000)
+- Normalizes 0-1 over 2000-2009
+- Joins the existing min/max stack
+
+- [ ] **Step 3: Add a test that asserts the recharge sources include era5_land**
+
+Test file `tests/test_rch_target.py` (create if missing):
+
+```python
+from nhf_spatial_targets import catalog
+
+
+def test_recharge_target_lists_three_sources():
+    v = catalog.variable("recharge")
+    assert set(v["sources"]) == {"reitz2017", "watergap22d", "era5_land"}
+```
+
+(Catalog assertion; behavioral test follows when `rch.py` is implemented.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `pixi run -e dev test -- tests/test_rch_target.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/targets/rch.py tests/test_rch_target.py
+git commit -m "feat(targets/rch): document era5_land ssro as third recharge source"
+```
+
+---
+
+## Task 15: Update CLAUDE.md and README
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update CLAUDE.md "Known Gaps" section**
+
+In `CLAUDE.md`, under "Known Gaps":
+- Remove the "MWBM ScienceBase item ID — confirmed: ..." line from "Resolved"
+- Add to "Resolved":
+  - `Runoff source replacement — NHM-MWBM removed; replaced by ERA5-Land (CDS) + GLDAS-2.1 NOAH monthly. ERA5-Land ssro also added as third recharge source. See PR #<N>.`
+
+- [ ] **Step 2: Update README runoff description**
+
+In `README.md`, find the runoff target description (likely a table or paragraph naming MWBM) and replace with:
+
+> Runoff (`basin_cfs`, monthly): multi-source min/max across ERA5-Land
+> total runoff (`ro`) and GLDAS-2.1 NOAH monthly runoff
+> (`Qs_acc + Qsb_acc`). Both aggregated to HRUs via gdptools, harmonized
+> to mm/month, then converted to cfs.
+
+- [ ] **Step 3: Run lint/format/tests once more**
+
+Run: `pixi run -e dev fmt && pixi run -e dev lint && pixi run -e dev test`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: update CLAUDE.md and README for ERA5-Land+GLDAS runoff"
+```
+
+---
+
+## Task 16: Final verification
+
+- [ ] **Step 1: Confirm catalog parses cleanly**
+
+Run: `pixi run catalog-sources`
+Expected: lists `era5_land` and `gldas_noah_v21_monthly`; no `nhm_mwbm`.
+
+Run: `pixi run catalog-variables`
+Expected: runoff sources are `[era5_land, gldas_noah_v21_monthly]`; recharge sources include `era5_land`.
+
+- [ ] **Step 2: CLI smoke test**
+
+Run: `pixi run -- nhf-targets fetch --help`
+Expected: `era5-land` and `gldas` subcommands listed.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pixi run -e dev test`
+Expected: all PASS.
+
+- [ ] **Step 4: Confirm git log shows the expected commit sequence**
+
+Run: `git log --oneline main..HEAD`
+Expected: ~14 commits, one per implementation task.
+
+---
+
+## Notes for the executor
+
+- **CDS account.** The user is provisioning a Copernicus CDS account in parallel. Network-dependent integration tests against the live CDS API are out of scope for this plan; unit tests use mocks (Tasks 5-8).
+- **GLDAS Earthdata.** Earthdata credentials are already configured in this project. `fetch_gldas` uses `earthaccess.login(strategy="netrc")` — make sure `~/.netrc` is set (it is, per existing modules).
+- **Atomic writes.** Every NetCDF write goes through a `.tmp` rename. Don't shortcut this.
+- **No backwards-compat shims.** `nhm_mwbm` is removed cleanly; do not add a deprecation alias.

--- a/docs/superpowers/specs/2026-04-13-era5-land-gldas-runoff-design.md
+++ b/docs/superpowers/specs/2026-04-13-era5-land-gldas-runoff-design.md
@@ -1,0 +1,254 @@
+# ERA5-Land + GLDAS Runoff Replacement Design
+
+**Date:** 2026-04-13
+**Status:** Draft — pending implementation plan
+
+## Summary
+
+Remove the NHM Monthly Water Balance Model (`nhm_mwbm`) as a data source and
+replace it with two reanalysis-based runoff sources:
+
+- **ERA5-Land** (Copernicus, hourly, 0.1°) — primary new source
+- **GLDAS-2.1 NOAH monthly** (NASA GES DISC, 0.25°) — second source
+
+The runoff target switches from a single-source `mwbm_uncertainty` envelope
+to a `multi_source_minmax` range across the two new sources (matching the
+AET pattern). ERA5-Land hourly data is aggregated to daily (and saved) and
+to monthly. ERA5-Land sub-surface runoff (`ssro`) is also added as a third
+source for the recharge calibration target.
+
+## Motivation
+
+`nhm_mwbm` was never implemented as a fetch module. Replacing it with
+modern reanalysis sources gives:
+
+- A reproducible, openly available data path (no dependency on a frozen
+  USGS data release)
+- A `multi_source_minmax` range structure consistent with the AET target
+- Daily ERA5-Land runoff in the datastore for any future daily-resolution
+  work
+
+## Scope of Changes
+
+### Remove
+
+- `nhm_mwbm` entry in `catalog/sources.yml`
+- `nhm_mwbm` from the `aet` source list in `catalog/variables.yml`
+- Stub references to MWBM in `targets/run.py`
+- MWBM-specific notes in `CLAUDE.md` "Resolved" gaps
+
+### Add
+
+- `era5_land` source in `catalog/sources.yml`
+- `gldas_noah_v21_monthly` source in `catalog/sources.yml`
+- `src/nhf_spatial_targets/fetch/era5_land.py` — CDS API client; hourly
+  download; hourly→daily aggregation; daily→monthly aggregation
+- `src/nhf_spatial_targets/fetch/gldas.py` — earthaccess client for
+  `GLDAS_NOAH025_M` v2.1
+- `tests/test_era5_land.py`, `tests/test_gldas.py`, `tests/test_run_target.py`
+- `cdsapi` dependency in `pixi.toml`
+
+### Modify
+
+- `catalog/variables.yml`:
+  - `runoff` block — `range_method: multi_source_minmax`,
+    `sources: [era5_land, gldas_noah_v21_monthly]`,
+    drop `mwbm_uncertainty` notes
+  - `recharge` block — add `era5_land` (using `ssro`) as third source
+  - `aet` block — drop `nhm_mwbm`
+- `src/nhf_spatial_targets/targets/run.py` — implement multi-source minmax
+- `src/nhf_spatial_targets/targets/aet.py` — drop MWBM source
+- `src/nhf_spatial_targets/targets/rch.py` — add ERA5-Land source
+- `src/nhf_spatial_targets/validate.py` — check for CDS credentials and
+  `cdsapi` import
+- `tests/test_catalog.py` — drop MWBM assertions, add new sources
+- `CLAUDE.md` — update Known Gaps section
+- `README.md` — update runoff source description
+
+## Geographic Bounds
+
+A single bbox is used for both new sources, encompassing CONUS plus
+contributing watersheds in Canada and Mexico, with ~10 km buffer
+(snapped to the ERA5-Land 0.1° grid):
+
+- **Lon/Lat (minx, miny, maxx, maxy):** `(-125.0, 24.7, -66.0, 53.0)`
+- **CDS area parameter (N, W, S, E):** `[53.0, -125.0, 24.7, -66.0]`
+
+This constant lives in `fetch/era5_land.py` and is documented in the
+catalog `notes:` field for both sources.
+
+## ERA5-Land Fetch Module
+
+### Access
+
+- Library: `cdsapi`
+- Credentials in project `.credentials.yml`:
+  ```yaml
+  cds:
+    url: https://cds.climate.copernicus.eu/api
+    key: <uid>:<key>
+  ```
+- `validate.py` checks the CDS section is present and that `cdsapi` imports.
+
+### Variables
+
+All three runoff variables are downloaded and stored:
+
+| Short name | Long name              | Units                  | Notes                              |
+|------------|------------------------|------------------------|------------------------------------|
+| `ro`       | total runoff           | m of water equivalent  | Used for runoff target             |
+| `sro`      | surface runoff         | m of water equivalent  | Stored for future use              |
+| `ssro`     | sub-surface runoff     | m of water equivalent  | Used as recharge proxy             |
+
+ERA5-Land accumulated fields reset at 00 UTC each day.
+
+### Period
+
+1979 through "present minus 3 months" (CDS lag for ERA5-Land).
+
+### Hourly → Daily
+
+Implementation: load hourly, compute hourly increments via `.diff('time')`
+to handle the 00 UTC accumulation reset cleanly, then `.resample(time='1D').sum()`.
+The diff-based approach avoids edge cases around the daily reset boundary
+better than a "value at 00 UTC of next day" snapshot.
+
+### Daily → Monthly
+
+`.resample(time='1ME').sum()` on the daily file.
+
+### Datastore Layout
+
+```
+<datastore>/era5_land/
+  hourly/
+    era5_land_<var>_<year>.nc          # raw downloads, kept for reproducibility
+  daily/
+    era5_land_daily_<year>.nc          # all 3 vars in one file per year
+  monthly/
+    era5_land_monthly_<start>_<end>.nc # all 3 vars, full record
+```
+
+### Submission Strategy
+
+CDS jobs are queued and may take minutes to hours. The fetch module
+submits per-year, per-variable requests. Yearly granularity balances job
+runtime vs. resilience to interruption. Successful per-year hourly files
+trigger immediate consolidation into the daily file for that year, so
+partial progress is durable.
+
+### CF Compliance
+
+Daily and monthly NCs follow the same CF-1.6 patterns as `watergap22d`
+and `reitz2017` (per project memory): explicit CRS, `grid_mapping` on
+each variable, time `units`/`calendar` attributes, atomic writes via
+temp-file-and-rename.
+
+### Incremental Behavior
+
+Skip download for any year whose hourly file already exists; skip
+consolidation if the corresponding daily/monthly file is current.
+
+## GLDAS Fetch Module
+
+### Access
+
+- Library: `earthaccess` (NASA EDL credentials already configured)
+- Product: `GLDAS_NOAH025_M` v2.1, monthly, 0.25° global, 2000-present
+
+### Variables
+
+`Qs_acc` (storm surface runoff, kg/m²) and `Qsb_acc`
+(baseflow-groundwater runoff, kg/m²) are downloaded. A derived variable
+`runoff_total = Qs_acc + Qsb_acc` is computed at consolidation time and
+stored alongside the originals.
+
+### Download
+
+Granules are global, ~few MB each. Server-side spatial subsetting via
+earthaccess is not used (matching the existing MERRA-2 pattern). Granules
+are downloaded in full and clipped to the project bbox at consolidation
+time.
+
+### Datastore Layout
+
+```
+<datastore>/gldas_noah_v21/
+  raw/                              # original monthly global granules
+  gldas_noah_v21_monthly.nc         # consolidated, bbox-clipped, CF-compliant
+```
+
+## Aggregation
+
+Existing `aggregate/gdptools_agg.py` patterns are reused. Both new
+monthly NCs are aggregated to HRU polygons via `gdptools` area-weighting,
+producing per-HRU monthly time series. Weight caches land in the standard
+`<project>/weights/` directory.
+
+## Runoff Target Builder
+
+`src/nhf_spatial_targets/targets/run.py` implements the multi-source
+minmax target:
+
+1. Load HRU-aggregated monthly runoff for ERA5-Land (`ro`) and GLDAS
+   (`runoff_total`).
+2. Harmonize units to mm/month, then convert to cfs using HRU area and
+   days-in-month:
+   - ERA5-Land `ro` (m water-eq) × 1000 → mm/month
+   - GLDAS `Qs_acc + Qsb_acc` (kg/m² over month) ≡ mm/month directly
+3. Per HRU, per month: `lower_bound = min(era5, gldas)`,
+   `upper_bound = max(era5, gldas)`.
+4. Write `runoff_target.nc` with `lower_bound` and `upper_bound`
+   variables, dims `(hru, time)`, CF-compliant.
+
+## Recharge Target Update
+
+`targets/rch.py` gains ERA5-Land as a third source. `ssro` (m water-eq)
+is summed monthly→annual, then normalized 0-1 over 2000-2009 alongside
+Reitz2017 and WaterGAP 2.2d, after which `multi_source_minmax` runs over
+the three normalized series. Catalog `recharge` sources list becomes
+`[reitz2017, watergap22d, era5_land]`.
+
+## AET Target Update
+
+`targets/aet.py` source list drops `nhm_mwbm`. Now MOD16A2_v061 + SSEBop
+only. Range method unchanged (`multi_source_minmax`).
+
+## Validation
+
+`validate.py` additions:
+
+- Check `.credentials.yml` has a `cds:` section with non-empty `key`
+- Check `cdsapi` is importable
+- Catalog presence checks for `era5_land` and `gldas_noah_v21_monthly`
+
+## Tests
+
+| File                       | Coverage                                                                  |
+|----------------------------|---------------------------------------------------------------------------|
+| `tests/test_era5_land.py`  | hourly→daily diff/resample logic, daily→monthly, bbox/grid snap, atomic write |
+| `tests/test_gldas.py`      | bbox clip, `runoff_total` derivation, CF metadata                         |
+| `tests/test_run_target.py` | unit harmonization, multi-source minmax over synthetic inputs             |
+| `tests/test_catalog.py`    | drop MWBM assertions, add new-source assertions                           |
+
+Network-dependent tests are marked `@pytest.mark.integration`.
+
+## Build Sequence
+
+1. Catalog edits (`sources.yml`, `variables.yml`) + `CLAUDE.md` update
+2. `cdsapi` dependency in `pixi.toml`; credentials handling in `validate.py`
+3. `fetch/era5_land.py` (download → daily → monthly) + tests
+4. `fetch/gldas.py` (download → consolidation) + tests
+5. Aggregation wiring for both new sources
+6. `targets/run.py` implementation + tests
+7. `targets/aet.py` source-list edit
+8. `targets/rch.py` ERA5-Land integration
+
+## Open Items
+
+- Confirm the exact "present minus N months" lag for ERA5-Land at
+  implementation time (CDS publishes the current lag in their docs;
+  typically 2-3 months).
+- Decide final target period for the runoff target. The recommended
+  default is the intersection of available data: 2000-present (matches
+  GLDAS v2.1 start). Final value set in `variables.yml` `runoff.period`.

--- a/pixi.lock
+++ b/pixi.lock
@@ -47,6 +47,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py313h29aa505_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
@@ -65,6 +66,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
@@ -180,6 +182,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.10-h05a5f5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py313h7037e92_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.18.0-pyhcf101f3_0.conda
@@ -215,6 +218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.0-py313h2005660_0.conda
@@ -331,6 +335,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py313hf5115c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
@@ -349,6 +354,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
@@ -458,6 +464,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.10-hff1a8ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.2-py313ha61f8ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/muparser-2.3.5-h11e0b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.18.0-pyhcf101f3_0.conda
@@ -493,6 +500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h65a2061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.5.0-py313h8ab8132_0.conda
@@ -608,6 +616,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py313h0591002_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
@@ -626,6 +635,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
@@ -725,6 +735,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.2-py313hf069bd2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.7.1-py313hd650c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.18.0-pyhcf101f3_0.conda
@@ -758,6 +769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py313hd650c13_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.5.0-py313h1ced589_0.conda
@@ -889,6 +901,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py313hf46b229_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -914,6 +927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
@@ -1040,6 +1054,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.10-h05a5f5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py313h7037e92_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.19.1-py313h07c4f96_0.conda
@@ -1091,6 +1106,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.8.1-py313h54dd161_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
@@ -1217,6 +1233,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py313h224173a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -1242,6 +1259,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
@@ -1362,6 +1380,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.10-hff1a8ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.2-py313ha61f8ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/muparser-2.3.5-h11e0b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.19.1-py313hd3e6d80_0.conda
@@ -1413,6 +1432,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.8.1-py313h6688731_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h65a2061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
@@ -1537,6 +1557,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py313h5ea7bf4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -1562,6 +1583,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.1.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
@@ -1672,6 +1694,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.2-py313hf069bd2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/multidict-6.7.1-py313hd650c13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.19.1-py313h5ea7bf4_0.conda
@@ -1719,6 +1742,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-librt-0.8.1-py313h5fd188c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py313h40c08fc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py313hd650c13_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.1.0-py312h343a6d4_2.conda
@@ -3212,6 +3236,20 @@ packages:
   - pkg:pypi/cached-property?source=hash-mapping
   size: 11065
   timestamp: 1615209567874
+- conda: https://conda.anaconda.org/conda-forge/noarch/cdsapi-0.7.7-pyhd8ed1ab_0.conda
+  sha256: 1237a587e35fa74b36323084e58620367a3adf7f60f201b7a9c41261958dc5d4
+  md5: 1f878573c1ee2798c052bee1f5a94f50
+  depends:
+  - ecmwf-datastores-client >=0.4.0
+  - python >=3.10
+  - requests >=2.5.0
+  - tqdm
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/cdsapi?source=hash-mapping
+  size: 17643
+  timestamp: 1759286472486
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
   sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
   md5: 765c4d97e877cdbbb88ff33152b86125
@@ -3919,6 +3957,21 @@ packages:
   - xarray ; extra == 'virtualizarr'
   - zarr>=3.1.1 ; extra == 'virtualizarr'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
+  sha256: 65143f563da904873fe3c69cdef3f9fb3b9501fb81d20b4d3ae89eab6ad6b6d3
+  md5: fc8b15af108a2fdb15ef04d12fbfe87d
+  depends:
+  - attrs
+  - multiurl >=0.3.2
+  - python >=3.9
+  - requests
+  - typing_extensions
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/ecmwf-datastores-client?source=hash-mapping
+  size: 26367
+  timestamp: 1774961032884
 - pypi: https://files.pythonhosted.org/packages/47/3e/1b67df0f5412a98eef8e6e442d0ef5c823f863826e3b28d6490fa2fdbb96/exactextract-0.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: exactextract
   version: 0.3.0
@@ -8524,6 +8577,21 @@ packages:
   version: 2.0.2
   sha256: e6e61347765ec0c154aef827bd6952a685a6693eb9d927fb530a6c364c77939e
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/multiurl-0.3.7-pyhd8ed1ab_0.conda
+  sha256: d87816da0e16812f93db1b3b174ef5465047c290457bf72ff750e137f8473a31
+  md5: e585c71c2ed48e4eee1663d627ddcd47
+  depends:
+  - python >=3.9
+  - python-dateutil
+  - pytz
+  - requests
+  - tqdm
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/multiurl?source=hash-mapping
+  size: 22874
+  timestamp: 1753802497931
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -10299,6 +10367,18 @@ packages:
   purls: []
   size: 7002
   timestamp: 1752805902938
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
+  sha256: d35c15c861d5635db1ba847a2e0e7de4c01994999602db1f82e41b5935a9578a
+  md5: f8a489f43a1342219a3a4d69cecc6b25
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytz?source=compressed-mapping
+  size: 201725
+  timestamp: 1773679724369
 - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py313h40c08fc_1.conda
   sha256: 87eaeb79b5961e0f216aa840bc35d5f0b9b123acffaecc4fda4de48891901f20
   md5: 1ce4f826332dca56c76a5b0cc89fb19e

--- a/pixi.toml
+++ b/pixi.toml
@@ -65,6 +65,8 @@ run-som    = { cmd = "nhf-targets run --target soil_moisture" }
 run-sca    = { cmd = "nhf-targets run --target snow_covered_area" }
 
 # Fetch source data
+fetch-era5-land = { cmd = "nhf-targets fetch era5-land", description = "Download ERA5-Land data into a project datastore" }
+fetch-gldas = { cmd = "nhf-targets fetch gldas", description = "Download GLDAS-2 runoff data into a project datastore" }
 fetch-merra2 = { cmd = "nhf-targets fetch merra2", description = "Download MERRA-2 data into a project datastore" }
 fetch-nldas-mosaic = { cmd = "nhf-targets fetch nldas-mosaic", description = "Download NLDAS-2 MOSAIC data into a project datastore" }
 fetch-nldas-noah = { cmd = "nhf-targets fetch nldas-noah", description = "Download NLDAS-2 NOAH data into a project datastore" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,6 +21,7 @@ rich = ">=13.0"
 tqdm = ">=4.60"
 libgdal-hdf4 = ">=3.12.2,<4"
 pangaeapy = ">=1.1.0,<2"
+cdsapi = "*"
 # gdptools: spatial aggregation (install from PyPI if not on conda-forge)
 # sciencebasepy: ScienceBase access
 # earthaccess: NASA EDL access for MODIS, MERRA-2, NLDAS

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -123,7 +123,11 @@ def _dispatch(
     else:
         output_path = pipeline_cfg["output"]["dir"]
 
-    builders[name](target_cfg, fabric_path, output_path)
+    if name == "runoff":
+        # run.build does not use fabric_path (HRU area comes from config)
+        builders[name](target_cfg, output_path)
+    else:
+        builders[name](target_cfg, fabric_path, output_path)
 
 
 @app.command

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -234,6 +234,8 @@ def fetch_all_cmd(
     # Import all fetch functions
     import nhf_spatial_targets.catalog as _catalog
     from nhf_spatial_targets.fetch._period import clamp_period
+    from nhf_spatial_targets.fetch.era5_land import fetch_era5_land
+    from nhf_spatial_targets.fetch.gldas import fetch_gldas
     from nhf_spatial_targets.fetch.merra2 import fetch_merra2
     from nhf_spatial_targets.fetch.modis import fetch_mod10c1, fetch_mod16a2
     from nhf_spatial_targets.fetch.ncep_ncar import fetch_ncep_ncar
@@ -243,6 +245,8 @@ def fetch_all_cmd(
 
     # (display name, catalog source key, fetch function)
     sources = [
+        ("era5-land", "era5_land", fetch_era5_land),
+        ("gldas", "gldas", fetch_gldas),
         ("merra2", "merra2", fetch_merra2),
         ("nldas-mosaic", "nldas_mosaic", fetch_nldas_mosaic),
         ("nldas-noah", "nldas_noah", fetch_nldas_noah),
@@ -613,6 +617,96 @@ def fetch_watergap22d_cmd(
         sys.exit(1)
 
     console.print("[green]WaterGAP 2.2d: downloaded to datastore[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+@fetch_app.command(name="era5-land")
+def fetch_era5_land_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "1979/2024",
+):
+    """Download ERA5-Land monthly soil moisture and runoff data via CDS API."""
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.era5_land import fetch_era5_land
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    console.print(f"[bold]Fetching ERA5-Land for period {period}...[/bold]")
+
+    try:
+        result = fetch_era5_land(workdir=workdir, period=period)
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during ERA5-Land fetch")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]ERA5-Land: downloaded to datastore[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+@fetch_app.command(name="gldas")
+def fetch_gldas_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "2000/2023",
+):
+    """Download GLDAS-2 monthly runoff data via NASA earthaccess."""
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.gldas import fetch_gldas
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    console.print(f"[bold]Fetching GLDAS for period {period}...[/bold]")
+
+    try:
+        result = fetch_gldas(workdir=workdir, period=period)
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during GLDAS fetch")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]GLDAS: downloaded to datastore[/green]")
     console.print(json_mod.dumps(result, indent=2))
 
 

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -634,7 +634,7 @@ def fetch_era5_land_cmd(
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
     ] = "1979/2024",
 ):
-    """Download ERA5-Land monthly soil moisture and runoff data via CDS API."""
+    """Download ERA5-Land hourly runoff (ro, sro, ssro) via CDS API and consolidate to daily/monthly NetCDFs."""
     import json as json_mod
 
     from rich.console import Console

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -246,7 +246,7 @@ def fetch_all_cmd(
     # (display name, catalog source key, fetch function)
     sources = [
         ("era5-land", "era5_land", fetch_era5_land),
-        ("gldas", "gldas", fetch_gldas),
+        ("gldas", "gldas_noah_v21_monthly", fetch_gldas),
         ("merra2", "merra2", fetch_merra2),
         ("nldas-mosaic", "nldas_mosaic", fetch_nldas_mosaic),
         ("nldas-noah", "nldas_noah", fetch_nldas_noah),

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -9,6 +9,7 @@ to the shared datastore.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pandas as pd
 import xarray as xr
@@ -72,3 +73,64 @@ def daily_to_monthly(da: xr.DataArray) -> xr.DataArray:
     monthly = da.resample(time="1ME").sum()
     monthly.attrs = dict(da.attrs)
     return monthly
+
+
+# Map short variable name to the CDS request name
+_VARIABLE_REQUEST_NAME = {
+    "ro": "runoff",
+    "sro": "surface_runoff",
+    "ssro": "sub_surface_runoff",
+}
+
+
+def _cds_client():
+    """Construct a cdsapi.Client. Separated for test injection."""
+    import cdsapi
+
+    return cdsapi.Client()
+
+
+def download_year_variable(
+    year: int,
+    variable: str,
+    output_path: Path,
+) -> Path:
+    """Download one year of one ERA5-Land variable to ``output_path``.
+
+    Idempotent: if ``output_path`` already exists, returns immediately.
+    Submits a single CDS request covering all 12 months × all hours of
+    the given year, clipped to ``BBOX_NWSE``.
+
+    Parameters
+    ----------
+    year : int
+    variable : {"ro", "sro", "ssro"}
+    output_path : Path
+        Target NetCDF file. Parent directory is created if missing.
+
+    Returns
+    -------
+    Path
+        ``output_path`` (for caller convenience).
+    """
+    if variable not in _VARIABLE_REQUEST_NAME:
+        raise ValueError(f"Unknown ERA5-Land variable: {variable!r}")
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        logger.info("Skipping existing ERA5-Land file: %s", output_path)
+        return output_path
+
+    request = {
+        "variable": _VARIABLE_REQUEST_NAME[variable],
+        "year": str(year),
+        "month": [f"{m:02d}" for m in range(1, 13)],
+        "day": [f"{d:02d}" for d in range(1, 32)],
+        "time": [f"{h:02d}:00" for h in range(24)],
+        "area": BBOX_NWSE,
+        "format": "netcdf",
+    }
+    client = _cds_client()
+    logger.info("Submitting CDS request for %s %d → %s", variable, year, output_path)
+    client.retrieve("reanalysis-era5-land", request, str(output_path))
+    return output_path

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -19,6 +19,7 @@ import pandas as pd
 import xarray as xr
 
 import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets import __version__
 from nhf_spatial_targets.fetch._period import years_in_period
 from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
 from nhf_spatial_targets.workspace import load as _load_project
@@ -192,21 +193,36 @@ def consolidate_year(
     daily_dir.mkdir(parents=True, exist_ok=True)
     monthly_dir.mkdir(parents=True, exist_ok=True)
 
-    daily_arrays: dict[str, xr.DataArray] = {}
-    for var in VARIABLES:
-        path = Path(hourly_dir) / f"era5_land_{var}_{year}.nc"
-        if not path.exists():
-            raise FileNotFoundError(f"Missing hourly file: {path}")
-        ds = xr.open_dataset(path)
-        da = ds[var].load()
-        ds.close()
-        daily_arrays[var] = hourly_to_daily(da)
-
-    daily_ds = xr.Dataset(daily_arrays)
-    daily_ds = apply_cf_metadata(daily_ds, _SOURCE_KEY, "daily")
     daily_path = daily_dir / f"era5_land_daily_{year}.nc"
-    _atomic_to_netcdf(daily_ds, daily_path)
-    logger.info("Wrote daily NC: %s", daily_path)
+
+    # Idempotency guard: skip hourly→daily aggregation if the daily NC exists.
+    if daily_path.exists():
+        logger.info("Daily NC already exists, skipping aggregation: %s", daily_path)
+    else:
+        daily_arrays: dict[str, xr.DataArray] = {}
+        for var in VARIABLES:
+            path = Path(hourly_dir) / f"era5_land_{var}_{year}.nc"
+            if not path.exists():
+                raise FileNotFoundError(f"Missing hourly file: {path}")
+            ds = xr.open_dataset(path)
+            da = ds[var].load()
+            ds.close()
+            daily_arrays[var] = hourly_to_daily(da)
+
+        daily_ds = xr.Dataset(daily_arrays)
+        daily_ds = apply_cf_metadata(daily_ds, _SOURCE_KEY, "daily")
+        daily_ds.attrs.update(
+            {
+                "title": f"ERA5-Land daily runoff (CONUS+ buffered) {year}",
+                "institution": "ECMWF",
+                "source": "reanalysis-era5-land",
+                "references": "doi:10.5194/essd-13-4349-2021",
+                "frequency": "day",
+                "history": f"Consolidated by nhf-spatial-targets v{__version__}",
+            }
+        )
+        _atomic_to_netcdf(daily_ds, daily_path)
+        logger.info("Wrote daily NC: %s", daily_path)
 
     # Monthly: rebuild from the (possibly multi-year) collection of daily files
     daily_files = sorted(daily_dir.glob("era5_land_daily_*.nc"))
@@ -218,6 +234,18 @@ def consolidate_year(
     monthly_ds = apply_cf_metadata(monthly_ds, _SOURCE_KEY, "monthly")
     start_year = pd.Timestamp(monthly_ds.time.min().values).year
     end_year = pd.Timestamp(monthly_ds.time.max().values).year
+    monthly_ds.attrs.update(
+        {
+            "title": (
+                f"ERA5-Land monthly runoff (CONUS+ buffered) {start_year}–{end_year}"
+            ),
+            "institution": "ECMWF",
+            "source": "reanalysis-era5-land",
+            "references": "doi:10.5194/essd-13-4349-2021",
+            "frequency": "month",
+            "history": f"Consolidated by nhf-spatial-targets v{__version__}",
+        }
+    )
     monthly_path = monthly_dir / f"era5_land_monthly_{start_year}_{end_year}.nc"
     # Remove any stale monthly file with a different year range
     for stale in monthly_dir.glob("era5_land_monthly_*.nc"):

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -1,0 +1,62 @@
+"""Fetch ERA5-Land hourly runoff from Copernicus CDS.
+
+Downloads hourly accumulated runoff variables (ro, sro, ssro) for the
+CONUS+contributing-watersheds bbox, then aggregates hourly→daily and
+daily→monthly. Both daily and monthly consolidated NetCDFs are written
+to the shared datastore.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+# CDS area parameter [N, W, S, E], snapped to ERA5-Land 0.1° grid.
+# Encompasses CONUS contributing watersheds (Canada/Mexico) + ~10 km buffer.
+BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
+
+VARIABLES = ("ro", "sro", "ssro")
+
+
+def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
+    """Aggregate ERA5-Land hourly accumulated runoff to daily totals.
+
+    ERA5-Land accumulated fields (ro, sro, ssro) reset at 00 UTC each day
+    and represent meters of water equivalent accumulated since 00 UTC.
+    Daily total = sum of hourly increments computed via .diff('time'),
+    then resampled to daily sums. The diff approach is robust to the
+    midnight-reset boundary and to missing hours within a day.
+
+    The first hourly step of each day, after the 00 UTC reset, equals the
+    accumulation over the 23->00 hour of the prior day. We discard the
+    pre-first-midnight increment (which is meaningless without a prior
+    23 UTC value) by requiring the result to come from `.diff` with
+    matching valid timestamps.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Hourly accumulated runoff with a 'time' dimension. Time stamps
+        must be regular hourly.
+
+    Returns
+    -------
+    xr.DataArray
+        Daily-summed runoff. Time coordinate is the date (00:00) of each
+        complete day. Original attrs are preserved.
+    """
+    incr = da.diff("time", label="upper")
+    # Negative jumps occur at the 00 UTC reset; where the diff is negative,
+    # replace it with the raw value at that timestamp (which equals the
+    # accumulation since the midnight reset, i.e. the true hourly increment).
+    incr = xr.where(incr >= 0, incr, da.isel(time=slice(1, None)))
+    # Shift the timestamp back by 1 hour so that the 00 UTC increment
+    # (which is the 23->00 accumulation) lands inside the prior day.
+    incr = incr.assign_coords(time=incr.time - pd.Timedelta(hours=1))
+    daily = incr.resample(time="1D").sum()
+    daily.attrs = dict(da.attrs)
+    return daily

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -212,13 +212,37 @@ def consolidate_year(
 
     daily_path = daily_dir / f"era5_land_daily_{year}.nc"
 
-    # Idempotency guard: skip hourly→daily aggregation if the daily NC exists.
+    # Idempotency guard: skip hourly→daily aggregation if the daily NC is
+    # up-to-date.  "Up-to-date" means the daily NC exists AND either:
+    #   (a) no hourly input files are present (daily NC is authoritative), or
+    #   (b) the daily NC mtime >= the maximum mtime of existing hourly files.
+    # If any hourly file is newer than the daily NC, we re-aggregate so that
+    # upstream changes to the raw downloads are picked up automatically.
+    hourly_paths = [
+        Path(hourly_dir) / f"era5_land_{var}_{year}.nc" for var in VARIABLES
+    ]
+    _skip_aggregation = False
     if daily_path.exists():
-        logger.info("Daily NC already exists, skipping aggregation: %s", daily_path)
+        daily_mtime = daily_path.stat().st_mtime
+        hourly_mtimes = [p.stat().st_mtime for p in hourly_paths if p.exists()]
+        if not hourly_mtimes or max(hourly_mtimes) <= daily_mtime:
+            logger.info(
+                "Daily NC is up-to-date (no newer hourly inputs), "
+                "skipping aggregation: %s",
+                daily_path,
+            )
+            _skip_aggregation = True
+        else:
+            logger.info(
+                "Hourly inputs are newer than daily NC; re-aggregating: %s",
+                daily_path,
+            )
+
+    if _skip_aggregation:
+        pass
     else:
         daily_arrays: dict[str, xr.DataArray] = {}
-        for var in VARIABLES:
-            path = Path(hourly_dir) / f"era5_land_{var}_{year}.nc"
+        for var, path in zip(VARIABLES, hourly_paths):
             if not path.exists():
                 raise FileNotFoundError(f"Missing hourly file: {path}")
             ds = xr.open_dataset(path)

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -8,11 +8,20 @@ to the shared datastore.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
 import xarray as xr
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import years_in_period
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +143,194 @@ def download_year_variable(
     logger.info("Submitting CDS request for %s %d → %s", variable, year, output_path)
     client.retrieve("reanalysis-era5-land", request, str(output_path))
     return output_path
+
+
+_SOURCE_KEY = "era5_land"
+
+
+def _atomic_to_netcdf(ds: xr.Dataset, path: Path) -> None:
+    """Write *ds* to *path* atomically via a temporary file."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def consolidate_year(
+    year: int,
+    hourly_dir: Path,
+    daily_dir: Path,
+    monthly_dir: Path,
+) -> tuple[Path, Path]:
+    """Build daily and monthly consolidated NCs for one year.
+
+    Reads ``era5_land_{ro,sro,ssro}_{year}.nc`` from ``hourly_dir``,
+    aggregates each variable hourly→daily, merges into a single daily
+    dataset, applies CF metadata, and writes atomically. Then aggregates
+    all available daily files into a rolling monthly NC.
+
+    Parameters
+    ----------
+    year : int
+    hourly_dir : Path
+        Directory containing per-variable hourly NCs.
+    daily_dir : Path
+        Directory to write the daily consolidated NC.
+    monthly_dir : Path
+        Directory to write (or overwrite) the monthly consolidated NC.
+
+    Returns
+    -------
+    tuple[Path, Path]
+        ``(daily_path, monthly_path)``
+    """
+    daily_dir = Path(daily_dir)
+    monthly_dir = Path(monthly_dir)
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    monthly_dir.mkdir(parents=True, exist_ok=True)
+
+    daily_arrays: dict[str, xr.DataArray] = {}
+    for var in VARIABLES:
+        path = Path(hourly_dir) / f"era5_land_{var}_{year}.nc"
+        if not path.exists():
+            raise FileNotFoundError(f"Missing hourly file: {path}")
+        ds = xr.open_dataset(path)
+        da = ds[var].load()
+        ds.close()
+        daily_arrays[var] = hourly_to_daily(da)
+
+    daily_ds = xr.Dataset(daily_arrays)
+    daily_ds = apply_cf_metadata(daily_ds, _SOURCE_KEY, "daily")
+    daily_path = daily_dir / f"era5_land_daily_{year}.nc"
+    _atomic_to_netcdf(daily_ds, daily_path)
+    logger.info("Wrote daily NC: %s", daily_path)
+
+    # Monthly: rebuild from the (possibly multi-year) collection of daily files
+    daily_files = sorted(daily_dir.glob("era5_land_daily_*.nc"))
+    with xr.open_mfdataset(daily_files, combine="by_coords") as ds_all:
+        monthly_arrays: dict[str, xr.DataArray] = {}
+        for var in VARIABLES:
+            monthly_arrays[var] = daily_to_monthly(ds_all[var].load())
+    monthly_ds = xr.Dataset(monthly_arrays)
+    monthly_ds = apply_cf_metadata(monthly_ds, _SOURCE_KEY, "monthly")
+    start_year = pd.Timestamp(monthly_ds.time.min().values).year
+    end_year = pd.Timestamp(monthly_ds.time.max().values).year
+    monthly_path = monthly_dir / f"era5_land_monthly_{start_year}_{end_year}.nc"
+    # Remove any stale monthly file with a different year range
+    for stale in monthly_dir.glob("era5_land_monthly_*.nc"):
+        if stale != monthly_path:
+            stale.unlink()
+    _atomic_to_netcdf(monthly_ds, monthly_path)
+    logger.info("Wrote monthly NC: %s", monthly_path)
+
+    return daily_path, monthly_path
+
+
+def fetch_era5_land(workdir: Path, period: str) -> dict:
+    """Download ERA5-Land hourly runoff and produce daily/monthly NCs.
+
+    Loops over years in ``period``, downloading per-year per-variable
+    hourly NCs from CDS into the project's datastore, then consolidating
+    each year into the daily file and rebuilding the rolling monthly
+    file. Idempotent on already-downloaded years.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory containing ``config.yml`` and ``fabric.json``.
+    period : str
+        Temporal range as ``"YYYY/YYYY"``.
+
+    Returns
+    -------
+    dict
+        Provenance record for the caller.
+    """
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+
+    raw_root = ws.raw_dir(_SOURCE_KEY)
+    hourly_dir = raw_root / "hourly"
+    daily_dir = raw_root / "daily"
+    monthly_dir = raw_root / "monthly"
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+    files: list[dict] = []
+
+    for year in years_in_period(period):
+        for var in VARIABLES:
+            out = hourly_dir / f"era5_land_{var}_{year}.nc"
+            download_year_variable(year, var, out)
+        daily_path, monthly_path = consolidate_year(
+            year, hourly_dir, daily_dir, monthly_dir
+        )
+        files.append(
+            {
+                "year": year,
+                "daily_path": str(daily_path),
+                "monthly_path": str(monthly_path),
+                "consolidated_utc": now_utc,
+            }
+        )
+
+    bbox = ws.fabric["bbox_buffered"]
+    license_str = meta.get("license", "Copernicus license")
+    _update_manifest(workdir, period, bbox, meta, license_str, files)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": license_str,
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": bbox,
+        "download_timestamp": now_utc,
+        "files": files,
+    }
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    bbox: dict,
+    meta: dict,
+    license_str: str,
+    files: list[dict],
+) -> None:
+    """Merge ERA5-Land provenance into manifest.json (atomic write)."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"manifest.json in {workdir} is corrupt and cannot be "
+                f"parsed. You may need to delete it and re-run the fetch "
+                f"step. Original error: {exc}"
+            ) from exc
+    else:
+        manifest = {"sources": {}, "steps": []}
+
+    manifest.setdefault("sources", {})[_SOURCE_KEY] = {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": license_str,
+        "period": period,
+        "bbox": bbox,
+        "variables": [v["name"] for v in meta["variables"]],
+        "files": files,
+    }
+
+    fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp).replace(manifest_path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+    logger.info("Updated manifest.json with ERA5-Land provenance")

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -149,7 +149,13 @@ def download_year_variable(
     }
     client = _cds_client()
     logger.info("Submitting CDS request for %s %d → %s", variable, year, output_path)
-    client.retrieve("reanalysis-era5-land", request, str(output_path))
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    try:
+        client.retrieve("reanalysis-era5-land", request, str(tmp_path))
+        tmp_path.rename(output_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
     return output_path
 
 

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -36,17 +36,21 @@ VARIABLES = ("ro", "sro", "ssro")
 def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
     """Aggregate ERA5-Land hourly accumulated runoff to daily totals.
 
-    ERA5-Land accumulated fields (ro, sro, ssro) reset at 00 UTC each day
-    and represent meters of water equivalent accumulated since 00 UTC.
-    Daily total = sum of hourly increments computed via .diff('time'),
-    then resampled to daily sums. The diff approach is robust to the
-    midnight-reset boundary and to missing hours within a day.
+    ERA5-Land accumulated fields (ro, sro, ssro) represent meters of water
+    equivalent accumulated since 00 UTC of the current day, and reset to 0
+    at the start of each new day. The conversion proceeds in four steps:
 
-    The first hourly step of each day, after the 00 UTC reset, equals the
-    accumulation over the 23->00 hour of the prior day. We discard the
-    pre-first-midnight increment (which is meaningless without a prior
-    23 UTC value) by requiring the result to come from `.diff` with
-    matching valid timestamps.
+    1. Compute hourly increments via ``.diff(time, label="upper")``.
+       Each diff value is the accumulation during the preceding hour.
+    2. At the 00 UTC reset, the diff is negative (the accumulation jumps from
+       the previous day's total back toward 0). Where the diff is negative,
+       substitute the raw accumulated value at that timestamp — which equals
+       the 23→00 UTC increment because accumulation restarted at 0 at 00 UTC.
+    3. Shift all timestamps back 1 hour so that the 00 UTC increment
+       (representing the 23→00 accumulation) is credited to the prior day
+       rather than the new day.
+    4. Resample to daily sums, which correctly accumulates all hourly
+       increments within each calendar day.
 
     Parameters
     ----------
@@ -79,6 +83,9 @@ def daily_to_monthly(da: xr.DataArray) -> xr.DataArray:
     Uses month-end frequency ('1ME') so the time coordinate marks the
     last day of each month — consistent with other monthly products in
     this codebase. Original attrs are preserved.
+
+    Note: called by ``consolidate_year``, which also deletes any stale
+    monthly NCs whose filenames fall outside the updated year range.
     """
     monthly = da.resample(time="1ME").sum()
     monthly.attrs = dict(da.attrs)
@@ -172,6 +179,10 @@ def consolidate_year(
     aggregates each variable hourly→daily, merges into a single daily
     dataset, applies CF metadata, and writes atomically. Then aggregates
     all available daily files into a rolling monthly NC.
+
+    **Destructive side effect:** any existing monthly NC in ``monthly_dir``
+    whose filename year range differs from the updated range is deleted
+    before the new monthly NC is written.
 
     Parameters
     ----------

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -60,3 +60,15 @@ def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
     daily = incr.resample(time="1D").sum()
     daily.attrs = dict(da.attrs)
     return daily
+
+
+def daily_to_monthly(da: xr.DataArray) -> xr.DataArray:
+    """Sum daily totals to monthly totals.
+
+    Uses month-end frequency ('1ME') so the time coordinate marks the
+    last day of each month — consistent with other monthly products in
+    this codebase. Original attrs are preserved.
+    """
+    monthly = da.resample(time="1ME").sum()
+    monthly.attrs = dict(da.attrs)
+    return monthly

--- a/src/nhf_spatial_targets/fetch/gldas.py
+++ b/src/nhf_spatial_targets/fetch/gldas.py
@@ -1,0 +1,231 @@
+"""Fetch GLDAS-2.1 NOAH monthly runoff from NASA GES DISC via earthaccess."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import xarray as xr
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "gldas_noah_v21_monthly"
+
+# Lat/lon bbox matches the ERA5-Land bbox: N=53.0, W=-125.0, S=24.7, E=-66.0
+BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
+
+
+def derive_runoff_total(ds: xr.Dataset) -> xr.Dataset:
+    """Add ``runoff_total = Qs_acc + Qsb_acc`` to the dataset.
+
+    Both inputs are kg m-2 (mm equivalent); their sum has the same units.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset containing ``Qs_acc`` and ``Qsb_acc`` variables.
+
+    Returns
+    -------
+    xr.Dataset
+        Input dataset with ``runoff_total`` added.
+    """
+    total = ds["Qs_acc"] + ds["Qsb_acc"]
+    total.attrs = {
+        "long_name": "total runoff (Qs_acc + Qsb_acc, derived)",
+        "units": "kg m-2",
+        "cell_methods": "time: sum",
+    }
+    return ds.assign(runoff_total=total)
+
+
+def clip_to_bbox(ds: xr.Dataset, bbox_nwse: list[float]) -> xr.Dataset:
+    """Clip a global lat/lon dataset to a [N, W, S, E] bounding box.
+
+    Supports both ``lat``/``lon`` and ``latitude``/``longitude`` coordinate
+    names, and handles both ascending and descending latitude ordering.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset with geographic coordinates.
+    bbox_nwse : list[float]
+        Bounding box as ``[north, west, south, east]`` in decimal degrees.
+
+    Returns
+    -------
+    xr.Dataset
+        Subset of *ds* clipped to the bounding box.
+    """
+    n, w, s, e = bbox_nwse
+    lat_name = "lat" if "lat" in ds.coords else "latitude"
+    lon_name = "lon" if "lon" in ds.coords else "longitude"
+    lat = ds[lat_name]
+    # sel with slice requires the slice direction to match the coord order
+    if float(lat[0]) < float(lat[-1]):
+        lat_slice = slice(s, n)
+    else:
+        lat_slice = slice(n, s)
+    return ds.sel({lat_name: lat_slice, lon_name: slice(w, e)})
+
+
+def fetch_gldas(workdir: Path, period: str) -> dict:
+    """Download GLDAS-2.1 NOAH monthly granules and consolidate.
+
+    Uses earthaccess (NASA EDL) to download monthly granules covering
+    ``period``, then concatenates, derives ``runoff_total``, clips to the
+    project bbox, applies CF metadata, and writes a single consolidated NC
+    to the datastore.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory. Reads ``fabric.json`` for the project bbox;
+        writes consolidated output to the shared datastore.
+    period : str
+        Temporal range as ``"YYYY/YYYY"`` (start/end years inclusive).
+
+    Returns
+    -------
+    dict
+        Provenance record for ``manifest.json``.
+    """
+    import earthaccess
+
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    start_str, end_str = parse_period(period)
+
+    raw_dir = ws.raw_dir(_SOURCE_KEY) / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    cf_path = ws.raw_dir(_SOURCE_KEY) / "gldas_noah_v21_monthly.nc"
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    earthaccess.login(strategy="netrc")
+    results = earthaccess.search_data(
+        short_name=meta["access"]["short_name"],
+        version=meta["access"]["version"],
+        temporal=(start_str, end_str),
+    )
+    logger.info("Found %d GLDAS granules for period %s", len(results), period)
+
+    if not results:
+        raise ValueError(
+            f"No GLDAS granules found for short_name="
+            f"{meta['access']['short_name']!r}, period={period!r}. "
+            "Check network connectivity and Earthdata credentials."
+        )
+
+    downloaded = earthaccess.download(results, str(raw_dir))
+    logger.info("Downloaded %d GLDAS granules to %s", len(downloaded), raw_dir)
+
+    if not downloaded:
+        raise RuntimeError(
+            "earthaccess.download() returned no files. "
+            "Check network connectivity and Earthdata credentials."
+        )
+
+    with xr.open_mfdataset(sorted(downloaded), combine="by_coords") as raw_ds:
+        ds = raw_ds[["Qs_acc", "Qsb_acc"]].load()
+
+    ds = derive_runoff_total(ds)
+    ds = clip_to_bbox(ds, BBOX_NWSE)
+    ds = apply_cf_metadata(ds, _SOURCE_KEY, "monthly")
+
+    # Add source-level global attributes
+    ds.attrs.update(
+        {
+            "title": "GLDAS-2.1 NOAH monthly runoff (CONUS+ buffered)",
+            "institution": "NASA GES DISC",
+            "source": "GLDAS_NOAH025_M v2.1",
+            "references": "doi:10.1175/BAMS-85-3-381",
+            "frequency": "month",
+        }
+    )
+
+    tmp = cf_path.with_suffix(".nc.tmp")
+    try:
+        ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(cf_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    bbox = ws.fabric["bbox_buffered"]
+    file_info = {
+        "path": str(cf_path),
+        "size_bytes": cf_path.stat().st_size,
+        "downloaded_utc": now_utc,
+        "n_granules": len(downloaded),
+    }
+    _update_manifest(workdir, period, bbox, meta, file_info)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "license": meta.get("license", "public domain (NASA)"),
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": bbox,
+        "download_timestamp": now_utc,
+        "file": file_info,
+    }
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    bbox: dict,
+    meta: dict,
+    file_info: dict,
+) -> None:
+    """Merge GLDAS-2.1 provenance into manifest.json."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"manifest.json in {workdir} is corrupted and cannot be "
+                f"parsed. Inspect the file manually or restore from backup. "
+                f"Detail: {exc}"
+            ) from exc
+    else:
+        manifest = {"sources": {}, "steps": []}
+
+    if "sources" not in manifest:
+        manifest["sources"] = {}
+
+    entry = manifest["sources"].get(_SOURCE_KEY, {})
+    entry.update(
+        {
+            "source_key": _SOURCE_KEY,
+            "access_url": meta["access"]["url"],
+            "license": meta.get("license", "public domain (NASA)"),
+            "period": period,
+            "bbox": bbox,
+            "variables": [v["name"] for v in meta["variables"]],
+            "file": file_info,
+        }
+    )
+    manifest["sources"][_SOURCE_KEY] = entry
+
+    fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp).replace(manifest_path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+    logger.info("Updated manifest.json with GLDAS-2.1 provenance")

--- a/src/nhf_spatial_targets/fetch/gldas.py
+++ b/src/nhf_spatial_targets/fetch/gldas.py
@@ -133,6 +133,11 @@ def fetch_gldas(workdir: Path, period: str) -> dict:
             "earthaccess.download() returned no files. "
             "Check network connectivity and Earthdata credentials."
         )
+    if len(downloaded) < len(results):
+        raise RuntimeError(
+            f"Partial GLDAS download: got {len(downloaded)}/{len(results)} granules. "
+            f"Re-run to retry, or inspect earthaccess logs."
+        )
 
     with xr.open_mfdataset(sorted(downloaded), combine="by_coords") as raw_ds:
         ds = raw_ds[["Qs_acc", "Qsb_acc"]].load()

--- a/src/nhf_spatial_targets/fetch/gldas.py
+++ b/src/nhf_spatial_targets/fetch/gldas.py
@@ -53,6 +53,8 @@ def clip_to_bbox(ds: xr.Dataset, bbox_nwse: list[float]) -> xr.Dataset:
 
     Supports both ``lat``/``lon`` and ``latitude``/``longitude`` coordinate
     names, and handles both ascending and descending latitude ordering.
+    If the longitude coordinate is 0–360 (detected by max > 180), it is
+    converted to -180–180 before slicing.
 
     Parameters
     ----------
@@ -65,17 +67,52 @@ def clip_to_bbox(ds: xr.Dataset, bbox_nwse: list[float]) -> xr.Dataset:
     -------
     xr.Dataset
         Subset of *ds* clipped to the bounding box.
+
+    Raises
+    ------
+    ValueError
+        If the dataset has neither ``lat``/``lon`` nor
+        ``latitude``/``longitude`` coordinate names, or if the clipped
+        result is empty (e.g. due to a longitude-convention mismatch).
     """
     n, w, s, e = bbox_nwse
-    lat_name = "lat" if "lat" in ds.coords else "latitude"
-    lon_name = "lon" if "lon" in ds.coords else "longitude"
+
+    if "lat" in ds.coords and "lon" in ds.coords:
+        lat_name, lon_name = "lat", "lon"
+    elif "latitude" in ds.coords and "longitude" in ds.coords:
+        lat_name, lon_name = "latitude", "longitude"
+    else:
+        raise ValueError(
+            f"Dataset must have lat/lon or latitude/longitude coordinates; "
+            f"got {list(ds.coords)}"
+        )
+
+    # Convert 0-360 longitude to -180-180 if necessary
+    if float(ds[lon_name].max()) > 180:
+        lon_vals = ds[lon_name].values.copy()
+        lon_vals = (lon_vals + 180) % 360 - 180
+        ds = ds.assign_coords({lon_name: lon_vals}).sortby(lon_name)
+
     lat = ds[lat_name]
     # sel with slice requires the slice direction to match the coord order
     if float(lat[0]) < float(lat[-1]):
         lat_slice = slice(s, n)
     else:
         lat_slice = slice(n, s)
-    return ds.sel({lat_name: lat_slice, lon_name: slice(w, e)})
+    clipped = ds.sel({lat_name: lat_slice, lon_name: slice(w, e)})
+
+    if clipped.sizes[lat_name] == 0 or clipped.sizes[lon_name] == 0:
+        lat_range = (float(ds[lat_name].min()), float(ds[lat_name].max()))
+        lon_range = (float(ds[lon_name].min()), float(ds[lon_name].max()))
+        raise ValueError(
+            f"Clipping produced an empty dataset. "
+            f"Input {lat_name} range: {lat_range}, {lon_name} range: {lon_range}. "
+            f"Requested bbox: N={n}, W={w}, S={s}, E={e}. "
+            f"Check that the dataset and bbox use the same longitude convention "
+            f"(-180/180 vs 0/360)."
+        )
+
+    return clipped
 
 
 def fetch_gldas(workdir: Path, period: str) -> dict:

--- a/src/nhf_spatial_targets/init_run.py
+++ b/src/nhf_spatial_targets/init_run.py
@@ -51,17 +51,17 @@ targets:
   runoff:
     enabled: true
     sources:
-      - nhm_mwbm
+      - era5_land
+      - gldas_noah_v21_monthly
     time_step: monthly
-    period: "1982-01-01/2010-12-31"
+    period: "2000-01-01/2010-12-31"
     prms_variable: basin_cfs
-    range_method: mwbm_uncertainty
+    range_method: multi_source_minmax
     output_file: runoff_targets.nc
 
   aet:
     enabled: true
     sources:
-      - nhm_mwbm
       - mod16a2_v061
       - ssebop
     time_step: monthly

--- a/src/nhf_spatial_targets/init_run.py
+++ b/src/nhf_spatial_targets/init_run.py
@@ -75,6 +75,7 @@ targets:
     sources:
       - reitz2017
       - watergap22d
+      - era5_land
     time_step: annual
     period: "2000-01-01/2009-12-31"
     prms_variable: recharge
@@ -117,6 +118,11 @@ _CREDENTIALS_TEMPLATE = {
         "_comment": "NASA Earthdata login — https://urs.earthdata.nasa.gov",
         "username": "",
         "password": "",
+    },
+    "cds": {
+        "_comment": "Copernicus CDS API — https://cds.climate.copernicus.eu",
+        "url": "https://cds.climate.copernicus.eu/api",
+        "key": "<uid>:<key>",
     },
 }
 

--- a/src/nhf_spatial_targets/targets/aet.py
+++ b/src/nhf_spatial_targets/targets/aet.py
@@ -1,6 +1,6 @@
-"""Build AET calibration targets from MWBM, MOD16A2, and SSEBop."""
+"""Build AET calibration targets from MOD16A2 and SSEBop."""
 
-# Sources:  nhm_mwbm, mod16a2 (or v061), ssebop
+# Sources:  mod16a2_v061, ssebop
 # Method:   multi_source_minmax
 # Variable: hru_actet
 # Timestep: monthly

--- a/src/nhf_spatial_targets/targets/rch.py
+++ b/src/nhf_spatial_targets/targets/rch.py
@@ -1,9 +1,16 @@
-"""Build recharge calibration targets from Reitz 2017 and WaterGAP 2.2a."""
+"""Build recharge calibration targets.
 
-# Sources:  reitz2017, watergap22a
-# Method:   normalized_minmax
-# Variable: recharge
-# Timestep: annual
+Sources (per catalog/variables.yml):
+  - reitz2017: total_recharge (in/yr)
+  - watergap22d: groundwater_recharge (kg m-2 s-1, → mm/yr)
+  - era5_land: ssro summed monthly→annual (m water-eq, → mm/yr)
+
+Method: each source aggregated to HRU, normalized 0-1 per HRU over
+2000-2009, then per-HRU per-year lower/upper = min/max across the three
+normalized sources.
+"""
+
+from __future__ import annotations
 
 
 def build(config: dict, fabric_path: str, output_path: str) -> None:

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import xarray as xr
 
@@ -58,12 +59,52 @@ def multi_source_runoff_bounds(
 def build(config: dict, fabric_path: str, output_path: str) -> None:
     """Build runoff target dataset.
 
-    Reads HRU-aggregated monthly runoff for ERA5-Land (`ro`) and GLDAS
-    (`runoff_total`), harmonizes units to cfs, computes per-HRU
-    per-month min/max bounds, writes a CF-compliant NetCDF with
-    `lower_bound` and `upper_bound` variables (dims: hru, time).
+    Reads HRU-aggregated monthly runoff for ERA5-Land (``ro``) and GLDAS
+    (``runoff_total``), harmonizes units to cfs, computes per-HRU per-month
+    min/max bounds, and writes a CF-compliant NetCDF atomically (via ``.tmp``
+    rename) with ``lower_bound`` and ``upper_bound`` variables, dims
+    ``(time, hru)``.
+
+    Aggregated input convention: ``<aggregated_dir>/<source_key>/<var>.nc``
+
+    config keys:
+      aggregated_dir : str | Path
+          Directory containing per-source per-variable aggregated NCs at
+          ``<aggregated_dir>/<source_key>/<var>.nc``.
+      hru_area_m2 : xr.DataArray
+          Per-HRU area in m², dims=('hru',), coord aligned with the
+          aggregated outputs.
     """
-    raise NotImplementedError(
-        "Builder wiring depends on aggregate/ output paths; "
-        "implement once aggregate output schema is finalized."
+    agg_dir = Path(config["aggregated_dir"])
+    hru_area = config["hru_area_m2"]
+
+    with xr.open_dataset(agg_dir / "era5_land" / "ro.nc") as ds:
+        era5 = ds["ro"].load()
+    with xr.open_dataset(agg_dir / "gldas_noah_v21_monthly" / "runoff_total.nc") as ds:
+        gldas = ds["runoff_total"].load()
+
+    era5_cfs = mm_per_month_to_cfs(era5_to_mm_per_month(era5), hru_area)
+    gldas_cfs = mm_per_month_to_cfs(gldas_to_mm_per_month(gldas), hru_area)
+
+    lower, upper = multi_source_runoff_bounds([era5_cfs, gldas_cfs])
+    lower.name = "lower_bound"
+    upper.name = "upper_bound"
+    out_ds = xr.Dataset(
+        {"lower_bound": lower, "upper_bound": upper},
+        attrs={
+            "title": "NHM runoff calibration target (ERA5-Land + GLDAS-2.1)",
+            "Conventions": "CF-1.6",
+            "cell_methods": "time: sum",
+            "units": "cfs",
+        },
     )
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.with_suffix(".nc.tmp")
+    try:
+        out_ds.to_netcdf(tmp, format="NETCDF4")
+        tmp.rename(output_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    logger.info("Wrote runoff target: %s", output_path)

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -1,11 +1,69 @@
-"""Build runoff calibration targets from NHM-MWBM output."""
+"""Build runoff calibration targets from ERA5-Land + GLDAS-2.1 NOAH."""
 
-# Sources:  nhm_mwbm
-# Method:   mwbm_uncertainty (pre-computed bounds from Bock et al. 2018)
-# Variable: basin_cfs
-# Timestep: monthly
+from __future__ import annotations
+
+import logging
+
+import xarray as xr
+
+logger = logging.getLogger(__name__)
+
+_M3_PER_DAY_TO_CFS = 35.3146667 / 86400.0  # cubic feet per second per m³/day
+
+
+def era5_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
+    """ERA5-Land runoff (m water-eq / month) → mm/month."""
+    out = da * 1000.0
+    out.attrs = dict(da.attrs)
+    out.attrs["units"] = "mm"
+    return out
+
+
+def gldas_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
+    """GLDAS Qs_acc + Qsb_acc (kg m-2) ≡ mm/month directly."""
+    out = da.copy()
+    out.attrs = dict(da.attrs)
+    out.attrs["units"] = "mm"
+    return out
+
+
+def mm_per_month_to_cfs(
+    da: xr.DataArray, hru_area_m2: float | xr.DataArray
+) -> xr.DataArray:
+    """Convert mm/month → cfs given HRU area and the month length.
+
+    mm/month × 1e-3 m/mm × area_m2 / days_in_month → m³/day → cfs.
+    Days-in-month is read from ``da.time.dt.days_in_month``.
+    """
+    days = da["time"].dt.days_in_month
+    m_per_day = (da * 1e-3) / days
+    m3_per_day = m_per_day * hru_area_m2
+    cfs = m3_per_day * _M3_PER_DAY_TO_CFS
+    cfs.attrs = dict(da.attrs)
+    cfs.attrs["units"] = "cfs"
+    return cfs
+
+
+def multi_source_runoff_bounds(
+    sources: list[xr.DataArray],
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Per-coord minimum and maximum across input sources.
+
+    All inputs must share dimensions and coords. Returns (lower, upper).
+    """
+    stacked = xr.concat(sources, dim="source")
+    return stacked.min("source"), stacked.max("source")
 
 
 def build(config: dict, fabric_path: str, output_path: str) -> None:
-    """Build runoff target dataset."""
-    raise NotImplementedError
+    """Build runoff target dataset.
+
+    Reads HRU-aggregated monthly runoff for ERA5-Land (`ro`) and GLDAS
+    (`runoff_total`), harmonizes units to cfs, computes per-HRU
+    per-month min/max bounds, writes a CF-compliant NetCDF with
+    `lower_bound` and `upper_bound` variables (dims: hru, time).
+    """
+    raise NotImplementedError(
+        "Builder wiring depends on aggregate/ output paths; "
+        "implement once aggregate output schema is finalized."
+    )

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -1,15 +1,28 @@
-"""Build runoff calibration targets from ERA5-Land + GLDAS-2.1 NOAH."""
+"""Build runoff calibration targets from ERA5-Land + GLDAS-2.1 NOAH.
+
+Two reanalysis sources are used to produce per-HRU per-month bounds:
+  - ERA5-Land 'ro' (m water equivalent / month, ECMWF)
+  - GLDAS-2.1 NOAH 'runoff_total' = Qs_acc + Qsb_acc (kg m-2 / month, NASA)
+
+Unit chain: source native units → mm/month → m³/day → cfs, using HRU area
+and days-in-month.  Per-HRU per-month:
+  lower_bound = min(era5_cfs, gldas_cfs)
+  upper_bound = max(era5_cfs, gldas_cfs)
+"""
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
 
+import pandas as pd
 import xarray as xr
 
 logger = logging.getLogger(__name__)
 
-_M3_PER_DAY_TO_CFS = 35.3146667 / 86400.0  # cubic feet per second per m³/day
+# 1 m³/day = (1/86400) m³/s = (35.3147/86400) ft³/s
+# i.e. multiply m³/day by (35.3147 / 86400) to get cfs
+_M3_PER_DAY_TO_CFS = 35.3146667 / 86400.0
 
 
 def era5_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
@@ -21,7 +34,10 @@ def era5_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
 
 
 def gldas_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
-    """GLDAS Qs_acc + Qsb_acc (kg m-2) ≡ mm/month directly."""
+    """GLDAS Qs_acc + Qsb_acc (kg m-2) ≡ mm/month directly.
+
+    Equivalence holds because 1 kg m-2 = 1 mm depth (assuming ρ_water = 1000 kg/m³).
+    """
     out = da.copy()
     out.attrs = dict(da.attrs)
     out.attrs["units"] = "mm"
@@ -56,11 +72,60 @@ def multi_source_runoff_bounds(
     return stacked.min("source"), stacked.max("source")
 
 
-def build(config: dict, fabric_path: str, output_path: str) -> None:
+def _validate_alignment(
+    era5: xr.DataArray, gldas: xr.DataArray
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Validate that two DataArrays are compatible and return overlap-sliced copies.
+
+    Checks:
+    - Both have the same dimension names.
+    - HRU coordinates are identical.
+    - Time ranges overlap; raises ValueError if disjoint.
+
+    Returns the two arrays sliced to the overlapping time range.
+    """
+    if set(era5.dims) != set(gldas.dims):
+        raise ValueError(
+            f"ERA5-Land and GLDAS have different dimension names: "
+            f"{list(era5.dims)} vs {list(gldas.dims)}"
+        )
+
+    era5_hrus = era5.coords.get("hru")
+    gldas_hrus = gldas.coords.get("hru")
+    if era5_hrus is not None and gldas_hrus is not None:
+        if not era5_hrus.equals(gldas_hrus):
+            raise ValueError(
+                "ERA5-Land and GLDAS HRU coordinates differ. "
+                "Ensure both were aggregated to the same fabric."
+            )
+
+    era5_start = pd.Timestamp(era5.time.min().values)
+    era5_end = pd.Timestamp(era5.time.max().values)
+    gldas_start = pd.Timestamp(gldas.time.min().values)
+    gldas_end = pd.Timestamp(gldas.time.max().values)
+
+    overlap_start = max(era5_start, gldas_start)
+    overlap_end = min(era5_end, gldas_end)
+
+    if overlap_start > overlap_end:
+        raise ValueError(
+            f"ERA5-Land and GLDAS time ranges do not overlap. "
+            f"ERA5-Land: {era5_start} – {era5_end}. "
+            f"GLDAS: {gldas_start} – {gldas_end}."
+        )
+
+    logger.info("Runoff target overlap window: %s – %s", overlap_start, overlap_end)
+    era5 = era5.sel(time=slice(overlap_start, overlap_end))
+    gldas = gldas.sel(time=slice(overlap_start, overlap_end))
+    return era5, gldas
+
+
+def build(config: dict, output_path: str) -> None:
     """Build runoff target dataset.
 
     Reads HRU-aggregated monthly runoff for ERA5-Land (``ro``) and GLDAS
-    (``runoff_total``), harmonizes units to cfs, computes per-HRU per-month
+    (``runoff_total``), validates alignment (same dims, HRU coords, overlapping
+    time ranges), harmonizes units to cfs, computes per-HRU per-month
     min/max bounds, and writes a CF-compliant NetCDF atomically (via ``.tmp``
     rename) with ``lower_bound`` and ``upper_bound`` variables, dims
     ``(time, hru)``.
@@ -83,19 +148,23 @@ def build(config: dict, fabric_path: str, output_path: str) -> None:
     with xr.open_dataset(agg_dir / "gldas_noah_v21_monthly" / "runoff_total.nc") as ds:
         gldas = ds["runoff_total"].load()
 
+    era5, gldas = _validate_alignment(era5, gldas)
+
     era5_cfs = mm_per_month_to_cfs(era5_to_mm_per_month(era5), hru_area)
     gldas_cfs = mm_per_month_to_cfs(gldas_to_mm_per_month(gldas), hru_area)
 
     lower, upper = multi_source_runoff_bounds([era5_cfs, gldas_cfs])
     lower.name = "lower_bound"
     upper.name = "upper_bound"
+    lower.attrs["units"] = "cfs"
+    lower.attrs["cell_methods"] = "time: sum"
+    upper.attrs["units"] = "cfs"
+    upper.attrs["cell_methods"] = "time: sum"
     out_ds = xr.Dataset(
         {"lower_bound": lower, "upper_bound": upper},
         attrs={
             "title": "NHM runoff calibration target (ERA5-Land + GLDAS-2.1)",
             "Conventions": "CF-1.6",
-            "cell_methods": "time: sum",
-            "units": "cfs",
         },
     )
     output_path = Path(output_path)

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -35,7 +35,7 @@ def validate_credentials(path: Path, required: list[str]) -> None:
 
     Supported section names:
 
-    - ``"earthdata"`` — requires non-empty ``username`` and ``password``
+    - ``"nasa_earthdata"`` — requires non-empty ``username`` and ``password``
     - ``"cds"`` — requires non-empty ``url`` and ``key``
 
     Raises ``ValueError`` naming the missing or incomplete section.
@@ -53,11 +53,11 @@ def validate_credentials(path: Path, required: list[str]) -> None:
 
     for name in required:
         section = creds.get(name, {}) or {}
-        if name == "earthdata":
+        if name == "nasa_earthdata":
             if not section.get("username") or not section.get("password"):
                 raise ValueError(
-                    f"earthdata credentials incomplete — "
-                    f"earthdata.username and earthdata.password "
+                    f"Earthdata credentials incomplete — "
+                    f"nasa_earthdata.username and nasa_earthdata.password "
                     f"must be non-empty in {path.name}"
                 )
         elif name == "cds":
@@ -156,41 +156,19 @@ def _check_id_column(gdf: object, id_col: str) -> None:
 
 def _check_credentials(workdir: Path) -> None:
     cred_path = workdir / ".credentials.yml"
-    if not cred_path.exists():
-        raise FileNotFoundError(
-            f".credentials.yml not found in {workdir}. "
-            "Create it with NASA Earthdata credentials before validating."
-        )
-    try:
-        creds = yaml.safe_load(cred_path.read_text()) or {}
-    except yaml.YAMLError as exc:
-        raise ValueError(
-            f"Cannot parse {cred_path}: {exc}. "
-            f"Fix the YAML syntax in your credentials file."
-        ) from exc
-    earthdata = creds.get("nasa_earthdata", {}) or {}
-    if not earthdata.get("username") or not earthdata.get("password"):
-        raise ValueError(
-            "Earthdata credentials incomplete — "
-            "nasa_earthdata.username and nasa_earthdata.password "
-            "must be non-empty in .credentials.yml"
-        )
 
-    # Check CDS credentials if any catalog source requires Copernicus CDS access
+    # Build the required list: always need nasa_earthdata; add cds if catalog requires it
     from nhf_spatial_targets.catalog import sources as catalog_sources
 
+    required: list[str] = ["nasa_earthdata"]
     needs_cds = any(
         (src.get("access") or {}).get("type") == "copernicus_cds"
         for src in catalog_sources().values()
     )
     if needs_cds:
-        cds = creds.get("cds", {}) or {}
-        if not cds.get("url") or not cds.get("key"):
-            raise ValueError(
-                "cds credentials incomplete — "
-                "cds.url and cds.key must be non-empty in .credentials.yml "
-                "(required because catalog sources use Copernicus CDS access)"
-            )
+        required.append("cds")
+
+    validate_credentials(cred_path, required=required)
 
 
 def _ensure_datastore(datastore: Path, dir_mode: int | None) -> None:

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -26,8 +26,48 @@ _SOURCE_KEYS: list[str] = [
 
 
 # ---------------------------------------------------------------------------
-# Public entry point
+# Public entry points
 # ---------------------------------------------------------------------------
+
+
+def validate_credentials(path: Path, required: list[str]) -> None:
+    """Validate that *path* contains all *required* credential sections.
+
+    Supported section names:
+
+    - ``"earthdata"`` — requires non-empty ``username`` and ``password``
+    - ``"cds"`` — requires non-empty ``url`` and ``key``
+
+    Raises ``ValueError`` naming the missing or incomplete section.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f".credentials.yml not found: {path}. "
+            "Create it with the required credentials before validating."
+        )
+    try:
+        creds = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Cannot parse {path}: {exc}") from exc
+
+    for name in required:
+        section = creds.get(name, {}) or {}
+        if name == "earthdata":
+            if not section.get("username") or not section.get("password"):
+                raise ValueError(
+                    f"earthdata credentials incomplete — "
+                    f"earthdata.username and earthdata.password "
+                    f"must be non-empty in {path.name}"
+                )
+        elif name == "cds":
+            if not section.get("url") or not section.get("key"):
+                raise ValueError(
+                    f"cds credentials incomplete — "
+                    f"cds.url and cds.key must be non-empty in {path.name}"
+                )
+        else:
+            raise ValueError(f"Unknown credential section: '{name}'")
 
 
 def validate_workspace(workdir: Path) -> None:
@@ -135,6 +175,22 @@ def _check_credentials(workdir: Path) -> None:
             "nasa_earthdata.username and nasa_earthdata.password "
             "must be non-empty in .credentials.yml"
         )
+
+    # Check CDS credentials if any catalog source requires Copernicus CDS access
+    from nhf_spatial_targets.catalog import sources as catalog_sources
+
+    needs_cds = any(
+        (src.get("access") or {}).get("type") == "copernicus_cds"
+        for src in catalog_sources().values()
+    )
+    if needs_cds:
+        cds = creds.get("cds", {}) or {}
+        if not cds.get("url") or not cds.get("key"):
+            raise ValueError(
+                "cds credentials incomplete — "
+                "cds.url and cds.key must be non-empty in .credentials.yml "
+                "(required because catalog sources use Copernicus CDS access)"
+            )
 
 
 def _ensure_datastore(datastore: Path, dir_mode: int | None) -> None:

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -167,22 +167,95 @@ def _import_cdsapi() -> None:
         ) from exc
 
 
+def _check_cdsapirc(_home: Path | None = None) -> None:
+    """Check that ~/.cdsapirc exists so cdsapi can authenticate.
+
+    Raises ``ValueError`` with a clear remediation message if the file is
+    missing.  Does not validate the content — cdsapi itself will error at
+    request time with a more specific message if the key is wrong.
+
+    Parameters
+    ----------
+    _home : Path | None
+        Override the home directory (used in tests). Defaults to
+        ``Path.home()``.
+    """
+    home = _home if _home is not None else Path.home()
+    cdsapirc = home / ".cdsapirc"
+    if not cdsapirc.exists():
+        raise ValueError(
+            "CDS credentials are required but ~/.cdsapirc was not found. "
+            "Create ~/.cdsapirc with your Copernicus CDS URL and API key:\n\n"
+            "  url: https://cds.climate.copernicus.eu/api\n"
+            "  key: <your-api-key>\n\n"
+            "You can obtain an API key from https://cds.climate.copernicus.eu "
+            "after registering and accepting the Terms of Use."
+        )
+
+
+def _check_netrc_earthdata(_home: Path | None = None) -> None:
+    """Check that ~/.netrc has an entry for urs.earthdata.nasa.gov.
+
+    Raises ``ValueError`` with a clear remediation message if the entry is
+    absent.  Does not validate the credentials — earthaccess will produce its
+    own error at download time if they are incorrect.
+
+    Parameters
+    ----------
+    _home : Path | None
+        Override the home directory (used in tests). Defaults to
+        ``Path.home()``.
+    """
+    home = _home if _home is not None else Path.home()
+    netrc_path = home / ".netrc"
+    if not netrc_path.exists():
+        raise ValueError(
+            "NASA Earthdata credentials are required but ~/.netrc was not found. "
+            "Create ~/.netrc with:\n\n"
+            "  machine urs.earthdata.nasa.gov\n"
+            "  login <your-username>\n"
+            "  password <your-password>\n\n"
+            "Register at https://urs.earthdata.nasa.gov to obtain credentials."
+        )
+    content = netrc_path.read_text()
+    if "urs.earthdata.nasa.gov" not in content:
+        raise ValueError(
+            "~/.netrc exists but does not contain an entry for "
+            "urs.earthdata.nasa.gov. Add:\n\n"
+            "  machine urs.earthdata.nasa.gov\n"
+            "  login <your-username>\n"
+            "  password <your-password>\n\n"
+            "See https://urs.earthdata.nasa.gov for registration."
+        )
+
+
 def _check_credentials(workdir: Path) -> None:
     cred_path = workdir / ".credentials.yml"
 
     # Build the required list: always need nasa_earthdata; add cds if catalog requires it
     from nhf_spatial_targets.catalog import sources as catalog_sources
 
+    srcs = catalog_sources()
     required: list[str] = ["nasa_earthdata"]
     needs_cds = any(
         (src.get("access") or {}).get("type") == "copernicus_cds"
-        for src in catalog_sources().values()
+        for src in srcs.values()
+    )
+    needs_earthdata = any(
+        (src.get("access") or {}).get("type") in ("nasa_gesdisc", "nasa_earthdata")
+        for src in srcs.values()
     )
     if needs_cds:
         required.append("cds")
         _import_cdsapi()
 
     validate_credentials(cred_path, required=required)
+
+    # Preflight: check that system credential files exist so tools can authenticate.
+    if needs_cds:
+        _check_cdsapirc()
+    if needs_earthdata or "nasa_earthdata" in required:
+        _check_netrc_earthdata()
 
 
 def _ensure_datastore(datastore: Path, dir_mode: int | None) -> None:

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -12,8 +12,10 @@ import yaml
 from nhf_spatial_targets import __version__
 from nhf_spatial_targets.workspace import make_dir
 
-# The eight source keys whose raw-data subdirectories are created.
+# The source keys whose raw-data subdirectories are created.
 _SOURCE_KEYS: list[str] = [
+    "era5_land",
+    "gldas_noah_v21_monthly",
     "merra2",
     "nldas_mosaic",
     "nldas_noah",
@@ -154,6 +156,17 @@ def _check_id_column(gdf: object, id_col: str) -> None:
         )
 
 
+def _import_cdsapi() -> None:
+    """Attempt to import cdsapi; raise ValueError if not installed."""
+    try:
+        import cdsapi  # noqa: F401
+    except ImportError as exc:
+        raise ValueError(
+            "cdsapi is required for Copernicus CDS sources but is not installed. "
+            "Install it with: pip install cdsapi"
+        ) from exc
+
+
 def _check_credentials(workdir: Path) -> None:
     cred_path = workdir / ".credentials.yml"
 
@@ -167,6 +180,7 @@ def _check_credentials(workdir: Path) -> None:
     )
     if needs_cds:
         required.append("cds")
+        _import_cdsapi()
 
     validate_credentials(cred_path, required=required)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared pytest fixtures for unit tests.
+
+The preflight system-file checks (_check_cdsapirc, _check_netrc_earthdata)
+require ~/.cdsapirc and ~/.netrc to exist on the developer's machine.  Unit
+tests that call validate_workspace() use the ``no_system_cred_checks`` fixture
+to suppress these checks so that CI and dev machines without those files can
+still run the full unit suite.
+
+Tests that exercise the check functions themselves call the functions directly
+with the ``_home`` parameter rather than relying on module-level patching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def no_system_cred_checks():
+    """Suppress ~/.cdsapirc and ~/.netrc existence checks (for validate_workspace tests)."""
+    with (
+        patch(
+            "nhf_spatial_targets.validate._check_cdsapirc",
+            return_value=None,
+        ),
+        patch(
+            "nhf_spatial_targets.validate._check_netrc_earthdata",
+            return_value=None,
+        ),
+    ):
+        yield

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -48,3 +48,28 @@ def test_nhm_mwbm_removed():
     )
     aet = catalog.variable("aet")
     assert "nhm_mwbm" not in aet["sources"]
+
+
+def test_era5_land_source_present():
+    from nhf_spatial_targets import catalog
+
+    s = catalog.source("era5_land")
+    assert s["access"]["type"] == "copernicus_cds"
+    assert s["access"]["dataset"] == "reanalysis-era5-land"
+    var_names = [v["name"] for v in s["variables"]]
+    assert var_names == ["ro", "sro", "ssro"]
+    assert s["time_step"] == "hourly (aggregated to daily and monthly)"
+    assert s["status"] == "current"
+
+
+def test_gldas_source_present():
+    from nhf_spatial_targets import catalog
+
+    s = catalog.source("gldas_noah_v21_monthly")
+    assert s["access"]["short_name"] == "GLDAS_NOAH025_M"
+    assert s["access"]["version"] == "2.1"
+    var_names = [v["name"] for v in s["variables"]]
+    assert "Qs_acc" in var_names
+    assert "Qsb_acc" in var_names
+    assert "runoff_total" in var_names  # derived
+    assert s["status"] == "current"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -7,7 +7,7 @@ from nhf_spatial_targets.catalog import sources, variables, source, variable
 def test_sources_loads():
     s = sources()
     assert isinstance(s, dict)
-    assert "nhm_mwbm" in s
+    assert "ssebop" in s
 
 
 def test_variables_loads():
@@ -17,8 +17,8 @@ def test_variables_loads():
 
 
 def test_source_lookup():
-    s = source("nhm_mwbm")
-    assert s["time_step"] == "monthly"
+    s = source("ssebop")
+    assert s["status"] == "current"
 
 
 def test_variable_lookup():
@@ -36,3 +36,15 @@ def test_ssebop_source_is_usgs_gdp_stac():
 def test_source_missing():
     with pytest.raises(KeyError):
         source("not_a_real_source")
+
+
+def test_nhm_mwbm_removed():
+    """nhm_mwbm has been replaced by ERA5-Land + GLDAS."""
+    from nhf_spatial_targets import catalog
+
+    sources = catalog.sources()
+    assert "nhm_mwbm" not in sources, (
+        "nhm_mwbm should be removed; replaced by era5_land + gldas_noah_v21_monthly"
+    )
+    aet = catalog.variable("aet")
+    assert "nhm_mwbm" not in aet["sources"]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -73,3 +73,19 @@ def test_gldas_source_present():
     assert "Qsb_acc" in var_names
     assert "runoff_total" in var_names  # derived
     assert s["status"] == "current"
+
+
+def test_runoff_uses_era5_and_gldas():
+    from nhf_spatial_targets import catalog
+
+    v = catalog.variable("runoff")
+    assert v["sources"] == ["era5_land", "gldas_noah_v21_monthly"]
+    assert v["range_method"] == "multi_source_minmax"
+
+
+def test_recharge_includes_era5_land():
+    from nhf_spatial_targets import catalog
+
+    v = catalog.variable("recharge")
+    assert "era5_land" in v["sources"]
+    assert v["range_method"] == "normalized_minmax"

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -145,3 +146,124 @@ def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch
         daily.close()
 
     assert monthly_path.exists()
+
+
+def _write_hourly_ncs(hourly_dir: Path, year: int) -> None:
+    """Write synthetic hourly NCs for all three ERA5-Land runoff variables."""
+
+    times = pd.date_range(f"{year}-01-01", f"{year}-01-03 23:00", freq="1h")
+    for var in ("ro", "sro", "ssro"):
+        vals = np.tile(
+            np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
+            (len(times) // 24, 1, 1),
+        )
+        ds = xr.Dataset(
+            {var: (("time", "latitude", "longitude"), vals)},
+            coords={
+                "time": times[: vals.shape[0]],
+                "latitude": [40.0],
+                "longitude": [-100.0],
+            },
+        )
+        ds[var].attrs["units"] = "m"
+        ds.to_netcdf(hourly_dir / f"era5_land_{var}_{year}.nc")
+
+
+def test_consolidate_year_writes_global_attrs(tmp_path):
+    """Daily and monthly NCs include source-level global attrs."""
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    _write_hourly_ncs(hourly_dir, 2020)
+
+    daily_path, monthly_path = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+
+    daily = xr.open_dataset(daily_path)
+    try:
+        assert "title" in daily.attrs, "daily NC missing 'title' global attr"
+        assert "institution" in daily.attrs, (
+            "daily NC missing 'institution' global attr"
+        )
+        assert "references" in daily.attrs, "daily NC missing 'references' global attr"
+        assert "frequency" in daily.attrs, "daily NC missing 'frequency' global attr"
+        assert daily.attrs["institution"] == "ECMWF"
+        assert "doi:10.5194/essd-13-4349-2021" in daily.attrs["references"]
+        assert daily.attrs["frequency"] == "day"
+        assert "source" in daily.attrs
+        assert daily.attrs["source"] == "reanalysis-era5-land"
+    finally:
+        daily.close()
+
+    monthly = xr.open_dataset(monthly_path)
+    try:
+        assert "title" in monthly.attrs, "monthly NC missing 'title' global attr"
+        assert "institution" in monthly.attrs, (
+            "monthly NC missing 'institution' global attr"
+        )
+        assert "references" in monthly.attrs, (
+            "monthly NC missing 'references' global attr"
+        )
+        assert "frequency" in monthly.attrs, (
+            "monthly NC missing 'frequency' global attr"
+        )
+        assert monthly.attrs["institution"] == "ECMWF"
+        assert "doi:10.5194/essd-13-4349-2021" in monthly.attrs["references"]
+        assert monthly.attrs["frequency"] == "month"
+        assert "source" in monthly.attrs
+        assert monthly.attrs["source"] == "reanalysis-era5-land"
+    finally:
+        monthly.close()
+
+
+def test_consolidate_year_is_idempotent(tmp_path, monkeypatch):
+    """Re-running consolidate_year on a year whose daily NC already exists is a no-op."""
+    from unittest.mock import patch
+
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    _write_hourly_ncs(hourly_dir, 2020)
+
+    # First call: produces the daily NC
+    daily_path, monthly_path = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+    assert daily_path.exists()
+
+    # Record the mtime of the daily file so we can confirm it wasn't rewritten
+    mtime_before = daily_path.stat().st_mtime
+
+    # Empty the hourly dir to simulate post-cleanup state
+    for f in hourly_dir.iterdir():
+        f.unlink()
+
+    # Spy on hourly_to_daily to confirm it is NOT called on the second run
+    with patch("nhf_spatial_targets.fetch.era5_land.hourly_to_daily") as mock_h2d:
+        daily_path2, monthly_path2 = consolidate_year(
+            year=2020,
+            hourly_dir=hourly_dir,
+            daily_dir=daily_dir,
+            monthly_dir=monthly_dir,
+        )
+
+    mock_h2d.assert_not_called()
+    assert daily_path2 == daily_path
+    assert daily_path2.exists()
+    # Daily file was NOT rewritten (mtime unchanged)
+    assert daily_path2.stat().st_mtime == mtime_before

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -32,6 +32,82 @@ def _make_hourly(start: str, hours: int, value_per_hour: float = 1.0) -> xr.Data
     return da
 
 
+def _make_era5_midnight_reset(
+    n_days: int = 2, value_per_hour: float = 1.0
+) -> xr.DataArray:
+    """Synthetic ERA5-Land accumulation with true midnight resets.
+
+    ERA5-Land convention:
+    - At 01:00 through 23:00 of day D: value = hours_since_midnight * per_hour
+    - At 00:00 of day D+1: value = 24 * per_hour  (full-day-D accumulation;
+      reset happens AFTER this timestamp)
+    - At 01:00 of day D+1: value = 1 * per_hour   (new day, accumulation restarts)
+
+    This means the raw .diff() at the 00->01 UTC boundary is negative, which
+    is the sign that triggers the xr.where rescue branch in hourly_to_daily().
+    """
+    # Build timestamps from day 1 00:00 through day n_days 00:00 (inclusive of
+    # the last "full-day" accumulation value)
+    start = pd.Timestamp("2020-01-01 00:00")
+    # We need n_days * 24 + 1 timestamps: hours 0..24 for day1, then 1..24 for day2, etc.
+    # Simplest: build 25*n_days steps and let the accumulation logic fill them
+    hours = n_days * 24 + 1
+    times = pd.date_range(start, periods=hours, freq="1h")
+    vals = np.zeros(hours)
+    for i, t in enumerate(times):
+        h = t.hour
+        # At 00:00: value = 24 (full-day accumulation from prior day, not yet reset)
+        # But only for timestamps after the very first 00:00
+        if h == 0 and i > 0:
+            vals[i] = 24.0 * value_per_hour
+        else:
+            vals[i] = h * value_per_hour
+    da = xr.DataArray(
+        vals.reshape(-1, 1, 1),
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+        attrs={"units": "m"},
+    )
+    return da
+
+
+def test_midnight_reset_branch_is_exercised():
+    """Verify xr.where substitution is triggered at midnight resets.
+
+    Build a 2-day synthetic array where the 00 UTC value is the full prior-day
+    accumulation (not yet reset). Confirm:
+    1. The raw diff IS negative at the 00 UTC reset (the rescue branch fires).
+    2. Each complete day sums to 24 * per_hour.
+    """
+    per_hour = 0.001  # 1 mm per step
+    da = _make_era5_midnight_reset(n_days=2, value_per_hour=per_hour)
+
+    # Confirm the raw diff is negative at the 00 UTC reset boundary (day2 00:00).
+    # That is the hour where val goes from 23*per_hour (day1 23:00) up to
+    # 24*per_hour (day2 00:00) — wait, that's positive. But from 24*per_hour
+    # (day2 00:00) to 1*per_hour (day2 01:00), the diff IS negative.
+    raw_diff = da.diff("time", label="upper")
+    # Find the step where we go from 24 to 1 (day2 01:00)
+    negative_mask = (raw_diff < 0).values.squeeze()
+    assert negative_mask.any(), (
+        "Expected at least one negative diff (midnight reset) but found none. "
+        "The xr.where rescue branch would never be triggered."
+    )
+
+    daily = hourly_to_daily(da)
+
+    # Each complete day should equal 24 * per_hour
+    expected = 24.0 * per_hour
+    for i in range(min(daily.sizes["time"], 2)):
+        np.testing.assert_allclose(
+            daily.isel(time=i).values,
+            expected,
+            rtol=1e-6,
+            err_msg=f"Day {i} daily sum incorrect; midnight-reset logic may be broken",
+        )
+
+
 def test_hourly_to_daily_full_24h():
     # 48 hours starting 2020-01-01 00:00 → two full days of accumulation
     da = _make_hourly("2020-01-01 00:00", hours=49, value_per_hour=0.001)

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -101,3 +101,47 @@ def test_download_year_skips_existing(tmp_path, monkeypatch):
     out.write_bytes(b"existing")
     download_year_variable(year=2020, variable="ro", output_path=out)
     fake_client.retrieve.assert_not_called()
+
+
+def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch):
+    """Given pre-existing hourly NCs, consolidation produces daily and monthly NCs."""
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    times = pd.date_range("2020-01-01", "2020-01-03 23:00", freq="1h")
+    for var in ("ro", "sro", "ssro"):
+        vals = np.tile(
+            np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
+            (len(times) // 24, 1, 1),
+        )
+        ds = xr.Dataset(
+            {var: (("time", "latitude", "longitude"), vals)},
+            coords={
+                "time": times[: vals.shape[0]],
+                "latitude": [40.0],
+                "longitude": [-100.0],
+            },
+        )
+        ds[var].attrs["units"] = "m"
+        ds.to_netcdf(hourly_dir / f"era5_land_{var}_2020.nc")
+
+    daily_path, monthly_path = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+
+    assert daily_path.exists()
+    daily = xr.open_dataset(daily_path)
+    try:
+        assert {"ro", "sro", "ssro"}.issubset(set(daily.data_vars))
+        assert daily.sizes["time"] >= 2
+    finally:
+        daily.close()
+
+    assert monthly_path.exists()

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from nhf_spatial_targets.fetch.era5_land import hourly_to_daily
+from nhf_spatial_targets.fetch.era5_land import daily_to_monthly, hourly_to_daily
 
 
 def _make_hourly(start: str, hours: int, value_per_hour: float = 1.0) -> xr.DataArray:
@@ -44,3 +44,21 @@ def test_hourly_to_daily_preserves_units_attr():
     da.attrs["units"] = "m"
     daily = hourly_to_daily(da)
     assert daily.attrs["units"] == "m"
+
+
+def test_daily_to_monthly_sum():
+    times = pd.date_range("2020-01-01", periods=60, freq="1D")
+    vals = np.full((60, 1, 1), 0.001)
+    da = xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+        attrs={"units": "m"},
+    )
+    monthly = daily_to_monthly(da)
+    # January (31 days) and February 2020 (29 days, leap year)
+    assert monthly.sizes["time"] == 2
+    np.testing.assert_allclose(monthly.isel(time=0).values, 0.031, rtol=1e-6)
+    np.testing.assert_allclose(monthly.isel(time=1).values, 0.029, rtol=1e-6)
+    assert monthly.attrs["units"] == "m"

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -62,3 +64,40 @@ def test_daily_to_monthly_sum():
     np.testing.assert_allclose(monthly.isel(time=0).values, 0.031, rtol=1e-6)
     np.testing.assert_allclose(monthly.isel(time=1).values, 0.029, rtol=1e-6)
     assert monthly.attrs["units"] == "m"
+
+
+def test_download_year_calls_cds_client(tmp_path, monkeypatch):
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock()
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    out = tmp_path / "era5_land_ro_2020.nc"
+    download_year_variable(year=2020, variable="ro", output_path=out)
+
+    fake_client.retrieve.assert_called_once()
+    args, kwargs = fake_client.retrieve.call_args
+    assert args[0] == "reanalysis-era5-land"
+    request = args[1]
+    assert request["variable"] == "runoff"
+    assert request["year"] == "2020"
+    assert request["area"] == [53.0, -125.0, 24.7, -66.0]
+    assert request["format"] == "netcdf"
+    assert "month" in request and len(request["month"]) == 12
+    assert args[2] == str(out)
+
+
+def test_download_year_skips_existing(tmp_path, monkeypatch):
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    fake_client = MagicMock()
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+    out = tmp_path / "era5_land_ro_2020.nc"
+    out.write_bytes(b"existing")
+    download_year_variable(year=2020, variable="ro", output_path=out)
+    fake_client.retrieve.assert_not_called()

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -382,3 +382,56 @@ def test_consolidate_year_is_idempotent(tmp_path, monkeypatch):
     assert daily_path2.exists()
     # Daily file was NOT rewritten (mtime unchanged)
     assert daily_path2.stat().st_mtime == mtime_before
+
+
+def test_consolidate_year_reaggregates_when_hourly_is_newer(tmp_path):
+    """If a hourly NC is touched after the daily NC, re-aggregation happens."""
+    import time
+    from unittest.mock import patch
+
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    _write_hourly_ncs(hourly_dir, 2020)
+
+    # First pass: produce the daily NC
+    daily_path, _ = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+    assert daily_path.exists()
+
+    # Force the daily NC to appear older by back-dating it 2 seconds
+    old_mtime = daily_path.stat().st_mtime - 2.0
+    import os
+
+    os.utime(daily_path, (old_mtime, old_mtime))
+
+    # Now touch one of the hourly files so it is newer than the daily NC
+    hourly_ro = hourly_dir / "era5_land_ro_2020.nc"
+    current = time.time()
+    os.utime(hourly_ro, (current, current))
+
+    # Second pass: should re-aggregate because the hourly file is newer
+    with patch(
+        "nhf_spatial_targets.fetch.era5_land.hourly_to_daily",
+        wraps=__import__(
+            "nhf_spatial_targets.fetch.era5_land", fromlist=["hourly_to_daily"]
+        ).hourly_to_daily,
+    ) as mock_h2d:
+        consolidate_year(
+            year=2020,
+            hourly_dir=hourly_dir,
+            daily_dir=daily_dir,
+            monthly_dir=monthly_dir,
+        )
+
+    assert mock_h2d.called, (
+        "hourly_to_daily should be called when a hourly NC is newer than the daily NC"
+    )

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -146,14 +146,23 @@ def test_daily_to_monthly_sum():
 def test_download_year_calls_cds_client(tmp_path, monkeypatch):
     from nhf_spatial_targets.fetch.era5_land import download_year_variable
 
+    out = tmp_path / "era5_land_ro_2020.nc"
+    expected_tmp = str(out) + ".tmp"
+
+    def fake_retrieve(dataset, request, path):
+        # Simulate CDS writing to the tmp path (not the final path)
+        assert path == expected_tmp, (
+            f"CDS retrieve should write to tmp path {expected_tmp!r}, got {path!r}"
+        )
+        Path(path).write_bytes(b"fake_nc_data")
+
     fake_client = MagicMock()
-    fake_client.retrieve = MagicMock()
+    fake_client.retrieve = MagicMock(side_effect=fake_retrieve)
     monkeypatch.setattr(
         "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
     )
 
-    out = tmp_path / "era5_land_ro_2020.nc"
-    download_year_variable(year=2020, variable="ro", output_path=out)
+    result = download_year_variable(year=2020, variable="ro", output_path=out)
 
     fake_client.retrieve.assert_called_once()
     args, kwargs = fake_client.retrieve.call_args
@@ -164,7 +173,37 @@ def test_download_year_calls_cds_client(tmp_path, monkeypatch):
     assert request["area"] == [53.0, -125.0, 24.7, -66.0]
     assert request["format"] == "netcdf"
     assert "month" in request and len(request["month"]) == 12
-    assert args[2] == str(out)
+    # The retrieve is passed the .tmp path; final output_path exists after rename
+    assert out.exists(), "Final output file should exist after atomic rename"
+    assert not Path(expected_tmp).exists(), "Tmp file should be gone after rename"
+    assert result == out
+
+
+def test_download_year_atomic_cleanup_on_failure(tmp_path, monkeypatch):
+    """If CDS retrieve raises, the .tmp file is cleaned up and output_path is absent."""
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    out = tmp_path / "era5_land_ro_2020.nc"
+    tmp_path_expected = Path(str(out) + ".tmp")
+
+    def fake_retrieve_fail(dataset, request, path):
+        # Write partial data to tmp, then raise
+        Path(path).write_bytes(b"partial")
+        raise RuntimeError("CDS server error")
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock(side_effect=fake_retrieve_fail)
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="CDS server error"):
+        download_year_variable(year=2020, variable="ro", output_path=out)
+
+    assert not out.exists(), "output_path must not exist after a failed download"
+    assert not tmp_path_expected.exists(), ".tmp file must be cleaned up on failure"
 
 
 def test_download_year_skips_existing(tmp_path, monkeypatch):

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.fetch.era5_land import hourly_to_daily
+
+
+def _make_hourly(start: str, hours: int, value_per_hour: float = 1.0) -> xr.DataArray:
+    """Synthetic ERA5-Land accumulated field.
+
+    ERA5-Land accumulates from 00 UTC: at hour H, value = H * per_hour
+    (resetting to 0 at the next 00 UTC, where it then represents the
+    accumulation step from 23->00 of the prior day).
+    """
+    times = pd.date_range(start, periods=hours, freq="1h")
+    vals = np.zeros(hours)
+    for i, t in enumerate(times):
+        # value at time t = accumulation since 00 UTC of t's date
+        hours_since_midnight = t.hour if t.hour != 0 else (24 if i > 0 else 0)
+        vals[i] = hours_since_midnight * value_per_hour
+    da = xr.DataArray(
+        vals.reshape(-1, 1, 1),
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+    )
+    return da
+
+
+def test_hourly_to_daily_full_24h():
+    # 48 hours starting 2020-01-01 00:00 → two full days of accumulation
+    da = _make_hourly("2020-01-01 00:00", hours=49, value_per_hour=0.001)
+    daily = hourly_to_daily(da)
+    # Two complete days should each show 24 * 0.001 = 0.024 m
+    assert daily.sizes["time"] == 2
+    np.testing.assert_allclose(daily.isel(time=0).values, 0.024, rtol=1e-6)
+    np.testing.assert_allclose(daily.isel(time=1).values, 0.024, rtol=1e-6)
+
+
+def test_hourly_to_daily_preserves_units_attr():
+    da = _make_hourly("2020-01-01 00:00", hours=49, value_per_hour=0.001)
+    da.attrs["units"] = "m"
+    daily = hourly_to_daily(da)
+    assert daily.attrs["units"] == "m"

--- a/tests/test_gldas.py
+++ b/tests/test_gldas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from nhf_spatial_targets.fetch.gldas import (
@@ -47,3 +48,42 @@ def test_clip_to_bbox_reduces_extent():
     assert clipped.lon.max() <= -66.0 + 0.25
     assert clipped.lat.size < ds.lat.size
     assert clipped.lon.size < ds.lon.size
+
+
+def test_partial_download_raises(tmp_path, monkeypatch):
+    """fetch_gldas must raise if earthaccess returns fewer files than granules found."""
+    import earthaccess
+
+    from nhf_spatial_targets.fetch.gldas import fetch_gldas
+
+    # Build a minimal workspace so _load_project and fabric.json work
+    config_yml = tmp_path / "config.yml"
+    config_yml.write_text(
+        "fabric:\n  path: /nonexistent/fabric.gpkg\n  id_col: hru_id\n"
+        f"datastore: {tmp_path / 'ds'}\n"
+    )
+    fabric_json = tmp_path / "fabric.json"
+    fabric_json.write_text(
+        '{"path": "/nonexistent/fabric.gpkg", "sha256": "abc", "crs": "EPSG:4326",'
+        '"id_col": "hru_id", "hru_count": 1,'
+        '"bbox": {"minx": -125.0, "miny": 24.7, "maxx": -66.0, "maxy": 53.0},'
+        '"bbox_buffered": {"minx": -125.1, "miny": 24.6, "maxx": -65.9, "maxy": 53.1},'
+        '"buffer_deg": 0.1}'
+    )
+
+    # Monkeypatch earthaccess: search returns 3 granules, download returns only 2
+    fake_granule = object()
+    monkeypatch.setattr(earthaccess, "login", lambda strategy=None: None)
+    monkeypatch.setattr(
+        earthaccess,
+        "search_data",
+        lambda **kwargs: [fake_granule, fake_granule, fake_granule],
+    )
+    monkeypatch.setattr(
+        earthaccess,
+        "download",
+        lambda results, dest: ["file1.nc", "file2.nc"],  # only 2 of 3
+    )
+
+    with pytest.raises(RuntimeError, match="Partial GLDAS download"):
+        fetch_gldas(tmp_path, "2020/2020")

--- a/tests/test_gldas.py
+++ b/tests/test_gldas.py
@@ -50,6 +50,94 @@ def test_clip_to_bbox_reduces_extent():
     assert clipped.lon.size < ds.lon.size
 
 
+def _global_grid_descending(value_qs=2.0, value_qsb=3.0):
+    """Grid with latitude in descending order (89.875 down to -89.875)."""
+    lat = np.arange(89.875, -90.0, -0.25)
+    lon = np.arange(-179.875, 180.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=2, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    return xr.Dataset(
+        {
+            "Qs_acc": (("time", "lat", "lon"), np.full(shape, value_qs)),
+            "Qsb_acc": (("time", "lat", "lon"), np.full(shape, value_qsb)),
+        },
+        coords={"time": times, "lat": lat, "lon": lon},
+    )
+
+
+def _global_grid_latlon_names(value_qs=2.0, value_qsb=3.0):
+    """Grid using 'latitude'/'longitude' coord names."""
+    lat = np.arange(-89.875, 90.0, 0.25)
+    lon = np.arange(-179.875, 180.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=2, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    return xr.Dataset(
+        {
+            "Qs_acc": (("time", "latitude", "longitude"), np.full(shape, value_qs)),
+            "Qsb_acc": (("time", "latitude", "longitude"), np.full(shape, value_qsb)),
+        },
+        coords={"time": times, "latitude": lat, "longitude": lon},
+    )
+
+
+def _global_grid_360(value_qs=2.0, value_qsb=3.0):
+    """Grid with 0-360 longitude convention."""
+    lat = np.arange(-89.875, 90.0, 0.25)
+    lon = np.arange(0.125, 360.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=2, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    return xr.Dataset(
+        {
+            "Qs_acc": (("time", "lat", "lon"), np.full(shape, value_qs)),
+            "Qsb_acc": (("time", "lat", "lon"), np.full(shape, value_qsb)),
+        },
+        coords={"time": times, "lat": lat, "lon": lon},
+    )
+
+
+def test_clip_to_bbox_descending_lat():
+    """clip_to_bbox handles descending latitude ordering."""
+    ds = _global_grid_descending()
+    clipped = clip_to_bbox(ds, BBOX_NWSE)
+    assert clipped.lat.min() >= 24.7 - 0.25
+    assert clipped.lat.max() <= 53.0 + 0.25
+    assert clipped.lat.size < ds.lat.size
+
+
+def test_clip_to_bbox_latitude_longitude_names():
+    """clip_to_bbox handles 'latitude'/'longitude' coordinate names."""
+    ds = _global_grid_latlon_names()
+    clipped = clip_to_bbox(ds, BBOX_NWSE)
+    assert clipped.latitude.min() >= 24.7 - 0.25
+    assert clipped.latitude.max() <= 53.0 + 0.25
+    assert clipped.longitude.min() >= -125.0 - 0.25
+    assert clipped.longitude.max() <= -66.0 + 0.25
+
+
+def test_clip_to_bbox_unknown_coord_names_raises():
+    """clip_to_bbox raises ValueError when neither lat/lon naming found."""
+    lat = np.arange(-89.875, 90.0, 0.25)
+    lon = np.arange(-179.875, 180.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=1, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    ds = xr.Dataset(
+        {"Qs_acc": (("time", "y", "x"), np.zeros(shape))},
+        coords={"time": times, "y": lat, "x": lon},
+    )
+    with pytest.raises(ValueError, match="lat/lon or latitude/longitude"):
+        clip_to_bbox(ds, BBOX_NWSE)
+
+
+def test_clip_to_bbox_360_lon_converted():
+    """clip_to_bbox converts 0-360 longitude to -180-180 before slicing."""
+    ds = _global_grid_360()
+    # Without conversion this would produce an empty result or raise
+    clipped = clip_to_bbox(ds, BBOX_NWSE)
+    assert clipped.lon.min() >= -125.0 - 0.25
+    assert clipped.lon.max() <= -66.0 + 0.25
+    assert clipped.lon.size > 0
+
+
 def test_partial_download_raises(tmp_path, monkeypatch):
     """fetch_gldas must raise if earthaccess returns fewer files than granules found."""
     import earthaccess

--- a/tests/test_gldas.py
+++ b/tests/test_gldas.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.fetch.gldas import (
+    BBOX_NWSE,
+    clip_to_bbox,
+    derive_runoff_total,
+)
+
+
+def _global_grid(value_qs=2.0, value_qsb=3.0):
+    lat = np.arange(-89.875, 90.0, 0.25)
+    lon = np.arange(-179.875, 180.0, 0.25)
+    times = pd.date_range("2020-01-01", periods=2, freq="1MS")
+    shape = (len(times), len(lat), len(lon))
+    return xr.Dataset(
+        {
+            "Qs_acc": (("time", "lat", "lon"), np.full(shape, value_qs)),
+            "Qsb_acc": (("time", "lat", "lon"), np.full(shape, value_qsb)),
+        },
+        coords={"time": times, "lat": lat, "lon": lon},
+    )
+
+
+def test_derive_runoff_total_sums_qs_and_qsb():
+    ds = _global_grid()
+    out = derive_runoff_total(ds)
+    assert "runoff_total" in out.data_vars
+    np.testing.assert_allclose(out.runoff_total.values, 5.0)
+    assert (
+        out.runoff_total.attrs["long_name"]
+        == "total runoff (Qs_acc + Qsb_acc, derived)"
+    )
+    assert out.runoff_total.attrs["units"] == "kg m-2"
+
+
+def test_clip_to_bbox_reduces_extent():
+    ds = _global_grid()
+    clipped = clip_to_bbox(ds, BBOX_NWSE)
+    # bbox is N=53.0, W=-125.0, S=24.7, E=-66.0
+    assert clipped.lat.min() >= 24.7 - 0.25
+    assert clipped.lat.max() <= 53.0 + 0.25
+    assert clipped.lon.min() >= -125.0 - 0.25
+    assert clipped.lon.max() <= -66.0 + 0.25
+    assert clipped.lat.size < ds.lat.size
+    assert clipped.lon.size < ds.lon.size

--- a/tests/test_rch_target.py
+++ b/tests/test_rch_target.py
@@ -1,0 +1,10 @@
+"""Tests for the recharge calibration target configuration."""
+
+from __future__ import annotations
+
+
+def test_recharge_target_lists_three_sources():
+    from nhf_spatial_targets import catalog
+
+    v = catalog.variable("recharge")
+    assert set(v["sources"]) == {"reitz2017", "watergap22d", "era5_land"}

--- a/tests/test_run_target.py
+++ b/tests/test_run_target.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -51,3 +53,50 @@ def test_multi_source_minmax():
     lower, upper = multi_source_runoff_bounds([a, b])
     np.testing.assert_allclose(lower.values, [10.0, 18.0, 30.0])
     np.testing.assert_allclose(upper.values, [15.0, 20.0, 32.0])
+
+
+def test_build_writes_lower_upper_bounds(tmp_path):
+    from nhf_spatial_targets.targets.run import build
+
+    times = pd.date_range("2020-01-01", periods=3, freq="1MS")
+    hrus = np.arange(3)
+
+    def _save(path: Path, var: str, vals_m_or_kg, units: str):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        da = xr.DataArray(
+            vals_m_or_kg,
+            dims=("time", "hru"),
+            coords={"time": times, "hru": hrus},
+            name=var,
+        )
+        da.attrs["units"] = units
+        ds = da.to_dataset()
+        ds.to_netcdf(path)
+
+    agg = tmp_path / "data" / "aggregated"
+    _save(agg / "era5_land" / "ro.nc", "ro", np.full((3, 3), 0.05), "m")
+    _save(
+        agg / "gldas_noah_v21_monthly" / "runoff_total.nc",
+        "runoff_total",
+        np.full((3, 3), 30.0),
+        "kg m-2",
+    )
+
+    out = tmp_path / "targets" / "runoff_target.nc"
+    hru_area = xr.DataArray(np.full(3, 1.0e8), dims=("hru",), coords={"hru": hrus})
+
+    build(
+        config={"aggregated_dir": str(agg), "hru_area_m2": hru_area},
+        fabric_path="unused",
+        output_path=str(out),
+    )
+
+    assert out.exists()
+    ds = xr.open_dataset(out)
+    try:
+        assert "lower_bound" in ds.data_vars
+        assert "upper_bound" in ds.data_vars
+        assert ds["lower_bound"].dims == ("time", "hru")
+        assert (ds["lower_bound"].values <= ds["upper_bound"].values).all()
+    finally:
+        ds.close()

--- a/tests/test_run_target.py
+++ b/tests/test_run_target.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.targets.run import (
+    era5_to_mm_per_month,
+    gldas_to_mm_per_month,
+    mm_per_month_to_cfs,
+    multi_source_runoff_bounds,
+)
+
+HRU_AREA_M2 = 1.0e8  # 100 km²
+
+
+def _series(values, units):
+    times = pd.date_range("2020-01-01", periods=len(values), freq="1MS")
+    da = xr.DataArray(values, dims=("time",), coords={"time": times})
+    da.attrs["units"] = units
+    return da
+
+
+def test_era5_meters_to_mm():
+    da = _series([0.05, 0.10], "m")
+    out = era5_to_mm_per_month(da)
+    np.testing.assert_allclose(out.values, [50.0, 100.0])
+    assert out.attrs["units"] == "mm"
+
+
+def test_gldas_kgm2_passthrough_to_mm():
+    da = _series([20.0, 40.0], "kg m-2")
+    out = gldas_to_mm_per_month(da)
+    np.testing.assert_allclose(out.values, [20.0, 40.0])
+    assert out.attrs["units"] == "mm"
+
+
+def test_mm_to_cfs_uses_days_in_month():
+    # 31 mm in January = 0.001 m/day over 100 km² = 100 m³/day = ~0.0409 cfs
+    da = _series([31.0], "mm")
+    out = mm_per_month_to_cfs(da, hru_area_m2=HRU_AREA_M2)
+    expected_m3_per_day = 0.001 * HRU_AREA_M2  # 100 000 m³/day
+    expected_cfs = expected_m3_per_day / 86400.0 * 35.3147
+    np.testing.assert_allclose(out.values, [expected_cfs], rtol=1e-4)
+    assert out.attrs["units"] == "cfs"
+
+
+def test_multi_source_minmax():
+    a = _series([10.0, 20.0, 30.0], "cfs")
+    b = _series([15.0, 18.0, 32.0], "cfs")
+    lower, upper = multi_source_runoff_bounds([a, b])
+    np.testing.assert_allclose(lower.values, [10.0, 18.0, 30.0])
+    np.testing.assert_allclose(upper.values, [15.0, 20.0, 32.0])

--- a/tests/test_run_target.py
+++ b/tests/test_run_target.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from nhf_spatial_targets.targets.run import (
+    _M3_PER_DAY_TO_CFS,
+    _validate_alignment,
     era5_to_mm_per_month,
     gldas_to_mm_per_month,
     mm_per_month_to_cfs,
@@ -87,7 +90,6 @@ def test_build_writes_lower_upper_bounds(tmp_path):
 
     build(
         config={"aggregated_dir": str(agg), "hru_area_m2": hru_area},
-        fabric_path="unused",
         output_path=str(out),
     )
 
@@ -98,5 +100,115 @@ def test_build_writes_lower_upper_bounds(tmp_path):
         assert "upper_bound" in ds.data_vars
         assert ds["lower_bound"].dims == ("time", "hru")
         assert (ds["lower_bound"].values <= ds["upper_bound"].values).all()
+        # CF attrs on variables, not dataset
+        assert ds["lower_bound"].attrs.get("units") == "cfs"
+        assert ds["upper_bound"].attrs.get("units") == "cfs"
+        assert "units" not in ds.attrs, "Dataset-level 'units' should not exist"
+        assert "cell_methods" not in ds.attrs, (
+            "Dataset-level 'cell_methods' should not exist"
+        )
+        assert ds.attrs.get("Conventions") == "CF-1.6"
     finally:
         ds.close()
+
+
+def test_build_numeric_correctness(tmp_path):
+    """Verify exact cfs values for ERA5=0.05 m and GLDAS=30 kg/m² in January."""
+    from nhf_spatial_targets.targets.run import build
+
+    HRU_AREA = 1.0e8  # m²
+    ERA5_M = 0.05  # m/month
+    GLDAS_KGM2 = 30.0  # kg m-2 = mm
+
+    times = pd.date_range("2020-01-01", periods=1, freq="1MS")
+    hrus = np.arange(1)
+
+    def _save(path: Path, var: str, val, units: str):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        da = xr.DataArray(
+            np.full((1, 1), val),
+            dims=("time", "hru"),
+            coords={"time": times, "hru": hrus},
+            name=var,
+            attrs={"units": units},
+        )
+        da.to_dataset().to_netcdf(path)
+
+    agg = tmp_path / "data" / "aggregated"
+    _save(agg / "era5_land" / "ro.nc", "ro", ERA5_M, "m")
+    _save(
+        agg / "gldas_noah_v21_monthly" / "runoff_total.nc",
+        "runoff_total",
+        GLDAS_KGM2,
+        "kg m-2",
+    )
+
+    out = tmp_path / "targets" / "runoff_target.nc"
+    hru_area = xr.DataArray(np.full(1, HRU_AREA), dims=("hru",), coords={"hru": hrus})
+    build(
+        config={"aggregated_dir": str(agg), "hru_area_m2": hru_area},
+        output_path=str(out),
+    )
+
+    ds = xr.open_dataset(out)
+    try:
+        # January 2020 has 31 days
+        days_jan = 31
+        # ERA5: 0.05 m → 50 mm; GLDAS: 30 mm → lower=30, upper=50
+        for mm_val, bound_name in [(30.0, "lower_bound"), (50.0, "upper_bound")]:
+            expected_m3_per_day = (mm_val * 1e-3 / days_jan) * HRU_AREA
+            expected_cfs = expected_m3_per_day * _M3_PER_DAY_TO_CFS
+            np.testing.assert_allclose(
+                ds[bound_name].values.squeeze(),
+                expected_cfs,
+                rtol=1e-4,
+                err_msg=f"{bound_name}: expected {expected_cfs:.6f} cfs",
+            )
+    finally:
+        ds.close()
+
+
+def test_build_disjoint_time_ranges_raises(tmp_path):
+    """build() raises ValueError when ERA5 and GLDAS have no time overlap."""
+    from nhf_spatial_targets.targets.run import build
+
+    hrus = np.arange(2)
+    hru_area = xr.DataArray(np.full(2, 1.0e8), dims=("hru",), coords={"hru": hrus})
+
+    def _save(path: Path, var: str, times):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        da = xr.DataArray(
+            np.ones((len(times), 2)),
+            dims=("time", "hru"),
+            coords={"time": times, "hru": hrus},
+            name=var,
+            attrs={"units": "m"},
+        )
+        da.to_dataset().to_netcdf(path)
+
+    agg = tmp_path / "data" / "aggregated"
+    era5_times = pd.date_range("2000-01-01", periods=3, freq="1MS")
+    gldas_times = pd.date_range("2010-01-01", periods=3, freq="1MS")
+    _save(agg / "era5_land" / "ro.nc", "ro", era5_times)
+    _save(
+        agg / "gldas_noah_v21_monthly" / "runoff_total.nc",
+        "runoff_total",
+        gldas_times,
+    )
+
+    out = tmp_path / "targets" / "runoff_target.nc"
+    with pytest.raises(ValueError, match="do not overlap"):
+        build(
+            config={"aggregated_dir": str(agg), "hru_area_m2": hru_area},
+            output_path=str(out),
+        )
+
+
+def test_validate_alignment_disjoint_raises():
+    """_validate_alignment raises ValueError for disjoint time ranges."""
+    times_a = pd.date_range("2000-01-01", periods=3, freq="1MS")
+    times_b = pd.date_range("2010-01-01", periods=3, freq="1MS")
+    da_a = xr.DataArray(np.ones((3,)), dims=("time",), coords={"time": times_a})
+    da_b = xr.DataArray(np.ones((3,)), dims=("time",), coords={"time": times_b})
+    with pytest.raises(ValueError, match="do not overlap"):
+        _validate_alignment(da_a, da_b)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -10,7 +10,11 @@ import pytest
 import yaml
 from shapely.geometry import box
 
-from nhf_spatial_targets.validate import _SOURCE_KEYS, validate_workspace
+from nhf_spatial_targets.validate import (
+    _SOURCE_KEYS,
+    validate_credentials,
+    validate_workspace,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -57,11 +61,17 @@ def _write_credentials(
     workdir: Path,
     earthdata_user: str = "user",
     earthdata_pass: str = "pass",
+    cds_url: str = "https://cds.climate.copernicus.eu/api",
+    cds_key: str = "uid:testkey",
 ) -> Path:
-    creds = {
+    creds: dict = {
         "nasa_earthdata": {
             "username": earthdata_user,
             "password": earthdata_pass,
+        },
+        "cds": {
+            "url": cds_url,
+            "key": cds_key,
         },
     }
     path = workdir / ".credentials.yml"
@@ -158,6 +168,29 @@ def test_validate_empty_earthdata_creds(tmp_path, minimal_fabric):
     _write_credentials(tmp_path, earthdata_user="", earthdata_pass="")
     with pytest.raises(ValueError, match="Earthdata"):
         validate_workspace(tmp_path)
+
+
+def test_validate_credentials_missing_cds(tmp_path: Path) -> None:
+    creds = tmp_path / ".credentials.yml"
+    creds.write_text(yaml.safe_dump({"earthdata": {"username": "u", "password": "p"}}))
+    with pytest.raises(ValueError, match="cds"):
+        validate_credentials(creds, required=["earthdata", "cds"])
+
+
+def test_validate_credentials_with_cds(tmp_path: Path) -> None:
+    creds = tmp_path / ".credentials.yml"
+    creds.write_text(
+        yaml.safe_dump(
+            {
+                "earthdata": {"username": "u", "password": "p"},
+                "cds": {
+                    "url": "https://cds.climate.copernicus.eu/api",
+                    "key": "uid:abc",
+                },
+            }
+        )
+    )
+    validate_credentials(creds, required=["earthdata", "cds"])  # no raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -172,9 +172,11 @@ def test_validate_empty_earthdata_creds(tmp_path, minimal_fabric):
 
 def test_validate_credentials_missing_cds(tmp_path: Path) -> None:
     creds = tmp_path / ".credentials.yml"
-    creds.write_text(yaml.safe_dump({"earthdata": {"username": "u", "password": "p"}}))
+    creds.write_text(
+        yaml.safe_dump({"nasa_earthdata": {"username": "u", "password": "p"}})
+    )
     with pytest.raises(ValueError, match="cds"):
-        validate_credentials(creds, required=["earthdata", "cds"])
+        validate_credentials(creds, required=["nasa_earthdata", "cds"])
 
 
 def test_validate_credentials_with_cds(tmp_path: Path) -> None:
@@ -182,7 +184,7 @@ def test_validate_credentials_with_cds(tmp_path: Path) -> None:
     creds.write_text(
         yaml.safe_dump(
             {
-                "earthdata": {"username": "u", "password": "p"},
+                "nasa_earthdata": {"username": "u", "password": "p"},
                 "cds": {
                     "url": "https://cds.climate.copernicus.eu/api",
                     "key": "uid:abc",
@@ -190,7 +192,7 @@ def test_validate_credentials_with_cds(tmp_path: Path) -> None:
             }
         )
     )
-    validate_credentials(creds, required=["earthdata", "cds"])  # no raise
+    validate_credentials(creds, required=["nasa_earthdata", "cds"])  # no raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import geopandas as gpd
@@ -12,6 +13,7 @@ from shapely.geometry import box
 
 from nhf_spatial_targets.validate import (
     _SOURCE_KEYS,
+    _import_cdsapi,
     validate_credentials,
     validate_workspace,
 )
@@ -193,6 +195,13 @@ def test_validate_credentials_with_cds(tmp_path: Path) -> None:
         )
     )
     validate_credentials(creds, required=["nasa_earthdata", "cds"])  # no raise
+
+
+def test_validate_credentials_with_cds_requires_cdsapi(monkeypatch) -> None:
+    """If cds creds are required but cdsapi is not installed, _import_cdsapi raises."""
+    monkeypatch.setitem(sys.modules, "cdsapi", None)
+    with pytest.raises(ValueError, match="cdsapi"):
+        _import_cdsapi()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -205,11 +205,65 @@ def test_validate_credentials_with_cds_requires_cdsapi(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Preflight system-credential file checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_cdsapirc_missing_raises(tmp_path):
+    """_check_cdsapirc raises ValueError when ~/.cdsapirc does not exist."""
+    from nhf_spatial_targets.validate import _check_cdsapirc
+
+    assert not (tmp_path / ".cdsapirc").exists()
+    with pytest.raises(ValueError, match="cdsapirc"):
+        _check_cdsapirc(_home=tmp_path)
+
+
+def test_check_cdsapirc_present_no_raise(tmp_path):
+    """_check_cdsapirc does not raise when ~/.cdsapirc exists."""
+    from nhf_spatial_targets.validate import _check_cdsapirc
+
+    (tmp_path / ".cdsapirc").write_text(
+        "url: https://cds.climate.copernicus.eu/api\nkey: abc\n"
+    )
+    _check_cdsapirc(_home=tmp_path)  # must not raise
+
+
+def test_check_netrc_missing_raises(tmp_path):
+    """_check_netrc_earthdata raises ValueError when ~/.netrc is absent."""
+    from nhf_spatial_targets.validate import _check_netrc_earthdata
+
+    assert not (tmp_path / ".netrc").exists()
+    with pytest.raises(ValueError, match="netrc"):
+        _check_netrc_earthdata(_home=tmp_path)
+
+
+def test_check_netrc_no_earthdata_entry_raises(tmp_path):
+    """_check_netrc_earthdata raises ValueError when the earthdata host is absent."""
+    from nhf_spatial_targets.validate import _check_netrc_earthdata
+
+    (tmp_path / ".netrc").write_text(
+        "machine other.example.com\nlogin user\npassword pass\n"
+    )
+    with pytest.raises(ValueError, match="urs.earthdata.nasa.gov"):
+        _check_netrc_earthdata(_home=tmp_path)
+
+
+def test_check_netrc_present_with_earthdata_no_raise(tmp_path):
+    """_check_netrc_earthdata does not raise when the earthdata entry exists."""
+    from nhf_spatial_targets.validate import _check_netrc_earthdata
+
+    (tmp_path / ".netrc").write_text(
+        "machine urs.earthdata.nasa.gov\nlogin user\npassword pass\n"
+    )
+    _check_netrc_earthdata(_home=tmp_path)  # must not raise
+
+
+# ---------------------------------------------------------------------------
 # Output files: fabric.json, manifest.json
 # ---------------------------------------------------------------------------
 
 
-def test_validate_writes_fabric_json(tmp_path, minimal_fabric):
+def test_validate_writes_fabric_json(tmp_path, minimal_fabric, no_system_cred_checks):
     _full_setup(tmp_path, minimal_fabric)
     validate_workspace(tmp_path)
 
@@ -225,7 +279,7 @@ def test_validate_writes_fabric_json(tmp_path, minimal_fabric):
     assert fabric["bbox_buffered"]["maxy"] > fabric["bbox"]["maxy"]
 
 
-def test_validate_writes_manifest_json(tmp_path, minimal_fabric):
+def test_validate_writes_manifest_json(tmp_path, minimal_fabric, no_system_cred_checks):
     _full_setup(tmp_path, minimal_fabric)
     validate_workspace(tmp_path)
 
@@ -244,7 +298,7 @@ def test_validate_writes_manifest_json(tmp_path, minimal_fabric):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_creates_datastore(tmp_path, minimal_fabric):
+def test_validate_creates_datastore(tmp_path, minimal_fabric, no_system_cred_checks):
     ds = tmp_path / "new_datastore"
     _write_config(
         tmp_path,
@@ -259,7 +313,9 @@ def test_validate_creates_datastore(tmp_path, minimal_fabric):
     assert ds.is_dir()
 
 
-def test_validate_creates_source_subdirs(tmp_path, minimal_fabric):
+def test_validate_creates_source_subdirs(
+    tmp_path, minimal_fabric, no_system_cred_checks
+):
     ds = tmp_path / "datastore"
     _write_config(
         tmp_path,


### PR DESCRIPTION
Closes #41.

## Summary
- Removes unimplemented `nhm_mwbm` source and replaces the runoff calibration target with a `multi_source_minmax` over **ERA5-Land** (Copernicus CDS, hourly → daily → monthly, 0.1°) and **GLDAS-2.1 NOAH monthly** (NASA GES DISC, 0.25°).
- Adds ERA5-Land `ssro` (sub-surface runoff) as a third recharge source alongside Reitz2017 and WaterGAP 2.2d.
- Drops MWBM from the AET source list (now MOD16A2_v061 + SSEBop only).
- ERA5-Land hourly data is aggregated to daily (saved) and monthly. Both sources cover the CONUS+contributing-watersheds bbox `[-125.0, 24.7, -66.0, 53.0]` (lon/lat), snapped to the ERA5-Land 0.1° grid.

## Key changes
- `catalog/sources.yml` — drop `nhm_mwbm`; add `era5_land`, `gldas_noah_v21_monthly`.
- `catalog/variables.yml` — runoff → `multi_source_minmax` with new sources; recharge gains `era5_land`; AET drops `nhm_mwbm`.
- `src/nhf_spatial_targets/fetch/era5_land.py` — CDS download + hourly→daily→monthly aggregation + atomic CF-compliant consolidation.
- `src/nhf_spatial_targets/fetch/gldas.py` — earthaccess download + bbox clip + `runoff_total = Qs_acc + Qsb_acc`.
- `src/nhf_spatial_targets/targets/run.py` — unit harmonization (m, kg/m² → mm → cfs) and multi-source bounds.
- `src/nhf_spatial_targets/validate.py` — `cdsapi` importability check and `cds:` credential validation (catalog-driven).
- `src/nhf_spatial_targets/cli.py` — `fetch era5-land` and `fetch gldas` subcommands, plus `fetch all` wiring.
- `init_run.py` / `config/pipeline.yml` templates updated to reference new sources and include `cds:` credential stub.
- `pixi.toml` — `cdsapi` dependency; `fetch-era5-land` / `fetch-gldas` tasks.

**Spec:** `docs/superpowers/specs/2026-04-13-era5-land-gldas-runoff-design.md`
**Plan:** `docs/superpowers/plans/2026-04-13-era5-land-gldas-runoff.md`

## Test Plan
- [x] `pixi run -e dev test` — 281 passed, 0 failed
- [x] `pixi run -e dev fmt && pixi run -e dev lint` — clean
- [x] `pixi run catalog-sources` / `catalog-variables` — new sources present, no `nhm_mwbm` references
- [x] `pixi run -- nhf-targets fetch --help` — `era5-land` and `gldas` subcommands registered
- [ ] Live CDS fetch (requires Copernicus account — user provisioning in parallel)
- [ ] Live GLDAS fetch via existing Earthdata credentials
- [ ] End-to-end runoff target build against an HRU fabric (requires aggregation wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)