### PR TITLE
Fix/era5 consolidate manifest cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 runs/
 data/
 outputs/
+logs/
 
 # credentials (never commit)
 .credentials.yml

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Array index → source mapping:
 | 8 | MOD16A2 v061 | 2000/2025 | LP DAAC via earthaccess; ~10–20 GB |
 | 9 | MOD10C1 v061 | 2000/2025 | NSIDC via earthaccess |
 
-All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 16 GB RAM per task with a 24-hour wall-clock limit. SLURM directives (`--account`, `--partition`, `--chdir`) at the top of `fetch_all.slurm` may need to be adjusted for your cluster.
+All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. The 128 GB figure is driven by ERA5-Land hourly CONUS concatenation (`xr.open_mfdataset` over 12 monthly chunks × 3 variables); other tasks use far less. Override `PROJECT_DIR` via environment before submission (e.g. `export PROJECT_DIR=/path/to/project; sbatch fetch_all.slurm`). SLURM directives (`--account`, `--partition`, `--chdir`) at the top of `fetch_all.slurm` may need to be adjusted for your cluster.
 
 ## Aggregation
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Array index → source mapping:
 | 8 | MOD16A2 v061 | 2000/2025 | LP DAAC via earthaccess; ~10–20 GB |
 | 9 | MOD10C1 v061 | 2000/2025 | NSIDC via earthaccess |
 
-All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. The 128 GB figure is driven by ERA5-Land hourly CONUS concatenation (`xr.open_mfdataset` over 12 monthly chunks × 3 variables); other tasks use far less. Override `PROJECT_DIR` via environment before submission (e.g. `export PROJECT_DIR=/path/to/project; sbatch fetch_all.slurm`). SLURM directives (`--account`, `--partition`, `--chdir`) at the top of `fetch_all.slurm` may need to be adjusted for your cluster.
+All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. The 128 GB figure is driven by ERA5-Land hourly CONUS concatenation (each year's 12 monthly chunks are combined into a per-year NC via `xr.open_mfdataset`); other tasks use far less. Override `PROJECT_DIR` and `REPO_DIR` via environment before submission (e.g. `export PROJECT_DIR=/path/to/project; sbatch fetch_all.slurm`). SLURM directives (`--account`, `--partition`, `--chdir`) at the top of `fetch_all.slurm` may need to be adjusted for your cluster.
 
 ## Aggregation
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,57 @@ Each `fetch` command downloads source granules and consolidates them into a sing
 
 All fetch commands support **incremental download** — periods already recorded in `manifest.json` are skipped.
 
+### Datastore Storage Estimates
+
+Rough per-source estimates for the reference pipeline period (2000–2010 for most sources; see `config/pipeline.yml`). ERA5-Land dominates because raw per-year hourly files are retained for idempotent re-runs.
+
+| Source | Period fetched | Files kept on disk | Estimated size |
+|---|---|---|---|
+| ERA5-Land | 2000–2010 (11 yr) | 3 vars × 11 yr hourly CONUS NCs + consolidated daily + monthly | **30–60 GB** |
+| MERRA-2 | 1982–2010 (29 yr) | 348 monthly global `.nc4` files + consolidated | **3–5 GB** |
+| NLDAS-2 MOSAIC | 1982–2010 (29 yr) | 348 monthly CONUS `.nc4` files + consolidated | **1–3 GB** |
+| NLDAS-2 NOAH | 1982–2010 (29 yr) | 348 monthly CONUS `.nc4` files + consolidated | **1–3 GB** |
+| NCEP/NCAR | 1982–2010 (29 yr) | Daily annual files deleted after monthly aggregation | **< 1 GB** |
+| MOD16A2 v061 | 2000–2010 (11 yr) | HDF tiles deleted; 11 yearly consolidated NCs at 500m CONUS | **10–20 GB** |
+| MOD10C1 v061 | 2000–2010 (11 yr) | Daily files deleted; 11 yearly consolidated NCs at 0.05° | **2–5 GB** |
+| GLDAS-2.1 NOAH | 2000–2010 (11 yr) | ~132 monthly global granules + consolidated | **1–2 GB** |
+| Reitz 2017 | 2000–2013 (14 yr) | 28 zip files + consolidated NC | **2–4 GB** |
+| WaterGAP 2.2d | 1901–2016 (full) | Single global NC4 | **< 1 GB** |
+| **Total** | | | **~50–100 GB** |
+
+These are order-of-magnitude estimates. Actual sizes depend on CDS compression, exact MODIS tile counts for the CONUS bbox, and how far back the pipeline period extends. Sizes scale roughly linearly with the number of years fetched.
+
+### Running Fetches on SLURM
+
+A SLURM array job script [`fetch_all.slurm`](fetch_all.slurm) is provided to run all 10 fetch tasks as independent jobs (one per array index), allowing them to run concurrently on a cluster:
+
+```bash
+# From the repo root
+mkdir -p logs
+# Edit PROJECT_DIR inside fetch_all.slurm, then:
+sbatch fetch_all.slurm
+
+# Rerun a single source (e.g. index 2 = MERRA-2):
+sbatch --array=2 fetch_all.slurm
+```
+
+Array index → source mapping:
+
+| Index | Source |
+|---|---|
+| 0 | ERA5-Land |
+| 1 | GLDAS-2.1 NOAH |
+| 2 | MERRA-2 |
+| 3 | NLDAS-2 MOSAIC |
+| 4 | NLDAS-2 NOAH |
+| 5 | NCEP/NCAR |
+| 6 | WaterGAP 2.2d |
+| 7 | Reitz 2017 |
+| 8 | MOD16A2 v061 |
+| 9 | MOD10C1 v061 |
+
+All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 16 GB RAM per task.
+
 ## Aggregation
 
 Sources that are accessed remotely (e.g. via STAC) are aggregated directly to the HRU fabric without local download:

--- a/README.md
+++ b/README.md
@@ -9,46 +9,65 @@ Builds the five baseline calibration targets documented in [Hay and others (2022
 | Target | PRMS Variable | Sources | Method | Time Step |
 |---|---|---|---|---|
 | Runoff | `basin_cfs` | ERA5-Land (`ro`) + GLDAS-2.1 NOAH (`Qs_acc + Qsb_acc`) | Multi-source min/max | Monthly |
-| AET | `hru_actet` | MWBM + MOD16A2 v061 + SSEBop | Multi-source min/max | Monthly |
+| AET | `hru_actet` | MOD16A2 v061 + SSEBop | Multi-source min/max | Monthly |
 | Recharge | `recharge` | Reitz 2017 + WaterGAP 2.2d | Normalized min/max | Annual |
 | Soil Moisture | `soil_rechr` | MERRA-2 + NCEP/NCAR + NLDAS-MOSAIC + NLDAS-NOAH | Normalized min/max | Monthly + Annual |
 | Snow Cover | `snowcov_area` | MOD10C1 v061 | MODIS CI bounds | Daily |
 
 ## Quick Start
 
+**Install pixi first** (the only system prerequisite — manages Python and all dependencies):
+
 ```bash
-# Install with pixi
+# Linux / macOS
+curl -fsSL https://pixi.sh/install.sh | sh
+
+# Windows (PowerShell)
+irm https://pixi.sh/install.ps1 | iex
+```
+
+Then restart your shell (or `source ~/.bashrc`) so `pixi` is on your PATH.
+
+```bash
+# Install the project environment
 pixi install
 
-# 1. Create a project
+# 1. Create a project directory skeleton
 pixi run init -- --project-dir /data/gfv11-targets
 
-# 2. Edit the generated config.yml to set:
-#    - fabric.path     (path to HRU GeoPackage)
-#    - fabric.id_col   (HRU identifier column)
-#    - datastore        (shared raw-data directory, e.g. /data/nhf-datastore)
-#    Then fill in .credentials.yml with NASA Earthdata credentials.
+# 2. Edit the generated files:
+#    config.yml  — set:
+#      fabric.path     (path to HRU GeoPackage or Parquet)
+#      fabric.id_col   (HRU identifier column name)
+#      datastore       (shared raw-data directory, SEPARATE from project,
+#                       e.g. /data/nhf-datastore — see "Projects & Datastore" below)
+#    .credentials.yml  — fill in NASA Earthdata and Copernicus CDS credentials
+#
+# 3. Accept the ERA5-Land CDS licence (one-time, per CDS account):
+#    https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=download#manage-licences
 
-# 3. Validate the project (writes fabric.json and manifest.json)
+# 4. Materialize credentials into ~/.cdsapirc and ~/.netrc
+pixi run materialize-credentials -- --project-dir /data/gfv11-targets
+
+# 5. Validate the project (checks fabric, credentials, datastore; writes fabric.json)
 pixi run validate -- --project-dir /data/gfv11-targets
 
-# 4. Fetch source datasets into the shared datastore
-pixi run fetch-all -- --project-dir /data/gfv11-targets --period 2000/2020
-
-# Or fetch individual sources:
-pixi run fetch-merra2       -- --project-dir /data/gfv11-targets --period 1980/2020
-pixi run fetch-nldas-mosaic -- --project-dir /data/gfv11-targets --period 1980/2020
-pixi run fetch-nldas-noah   -- --project-dir /data/gfv11-targets --period 1980/2020
-pixi run fetch-ncep-ncar    -- --project-dir /data/gfv11-targets --period 1980/2020
-pixi run fetch-mod16a2      -- --project-dir /data/gfv11-targets --period 2000/2020
-pixi run fetch-mod10c1      -- --project-dir /data/gfv11-targets --period 2000/2020
-pixi run fetch-watergap22d  -- --project-dir /data/gfv11-targets --period 1901/2016
+# 6. Fetch source datasets into the shared datastore (run individually or via SLURM)
+pixi run fetch-era5-land    -- --project-dir /data/gfv11-targets --period 1979/2025
+pixi run fetch-gldas        -- --project-dir /data/gfv11-targets --period 2000/2025
+pixi run fetch-merra2       -- --project-dir /data/gfv11-targets --period 1980/2025
+pixi run fetch-nldas-mosaic -- --project-dir /data/gfv11-targets --period 1979/2025
+pixi run fetch-nldas-noah   -- --project-dir /data/gfv11-targets --period 1979/2025
+pixi run fetch-ncep-ncar    -- --project-dir /data/gfv11-targets --period 1979/2025
+pixi run fetch-mod16a2      -- --project-dir /data/gfv11-targets --period 2000/2025
+pixi run fetch-mod10c1      -- --project-dir /data/gfv11-targets --period 2000/2025
+pixi run fetch-watergap22d  -- --project-dir /data/gfv11-targets --period 1979/2016
 pixi run fetch-reitz2017    -- --project-dir /data/gfv11-targets --period 2000/2013
 
-# 5. Aggregate (sources that use remote/STAC data)
+# 7. Aggregate (sources served remotely via STAC — no local download)
 pixi run agg-ssebop -- --project-dir /data/gfv11-targets --period 2000/2020  # --batch-size N (default 500)
 
-# 6. Run all targets
+# 8. Build calibration targets
 pixi run run -- --project-dir /data/gfv11-targets
 
 # Inspect the catalog
@@ -58,35 +77,73 @@ pixi run catalog-variables
 
 ## Projects & Datastore
 
-The pipeline separates **projects** (fabric-specific) from the **datastore** (shared raw data, fabric-independent). Multiple projects can share one datastore — if data has already been fetched, another project pointing to the same datastore will reuse it.
+The pipeline has two independent concepts:
+
+| Concept | What it holds | Tied to fabric? |
+|---|---|---|
+| **Datastore** | Raw downloaded source files (ERA5-Land hourly NCs, MERRA-2 granules, MODIS HDF, …) | **No** — one datastore can serve many fabrics |
+| **Project** | Everything fabric-specific: config, credentials, aggregated outputs, targets, weight caches | **Yes** — one project = one HRU fabric |
+
+This separation means expensive downloads only happen once. If you switch fabrics (e.g. GFv1.1 → GFv2.0), create a new project directory pointing at the **same datastore** — all raw data is reused.
 
 ```
-/data/nhf-datastore/               # DATASTORE (shared, fabric-independent)
-  ├── merra2/                      #   consolidated NCs from fetch
-  ├── nldas_mosaic/
-  ├── reitz2017/
-  └── ...
+/data/nhf-datastore/               # DATASTORE — shared, fabric-independent
+  ├── era5_land/                   #   hourly monthly chunks + per-year NCs
+  ├── gldas/                       #   monthly global granules
+  ├── merra2/                      #   monthly .nc4 files + consolidated NC
+  ├── nldas_mosaic/                #   monthly CONUS files + consolidated NC
+  ├── nldas_noah/                  #   monthly CONUS files + consolidated NC
+  ├── ncep_ncar/                   #   annual daily files + consolidated NC
+  ├── mod16a2/                     #   yearly consolidated NCs (HDF tiles deleted)
+  ├── mod10c1/                     #   yearly consolidated NCs (daily files deleted)
+  ├── watergap22d/                 #   single global NC4
+  └── reitz2017/                   #   annual GeoTIFFs + consolidated NC
 
-/data/gfv11-targets/               # PROJECT (fabric-specific)
-  ├── config.yml                   #   points to datastore + fabric
-  ├── .credentials.yml
-  ├── fabric.json
-  ├── manifest.json
-  ├── data/aggregated/             #   aggregated outputs
-  ├── targets/                     #   final calibration targets
-  └── weights/                     #   weight caches (fabric × source grid)
+/data/gfv11-targets/               # PROJECT — fabric-specific (GFv1.1)
+  ├── config.yml                   #   fabric path + datastore path + settings
+  ├── .credentials.yml             #   NASA Earthdata + CDS credentials (gitignored)
+  ├── fabric.json                  #   computed fabric metadata (written by validate)
+  ├── manifest.json                #   provenance: download timestamps, checksums
+  ├── data/aggregated/             #   source data aggregated to this fabric's HRUs
+  ├── targets/                     #   final calibration target NetCDF files
+  └── weights/                     #   gdptools weight caches (fabric × source grid)
+
+/data/gfv20-targets/               # PROJECT — same datastore, different fabric (GFv2.0)
+  ├── config.yml                   #   points to same /data/nhf-datastore
+  └── ...                          #   all fetch data reused; only agg/targets differ
 ```
 
-**Workflow:** `init` &rarr; edit config &rarr; `materialize-credentials` &rarr; `validate` &rarr; `fetch` &rarr; `run`
+### Using a different fabric
+
+To build targets for a new fabric (e.g. upgrading from GFv1.1 to GFv2.0, or a custom HRU delineation):
+
+1. Create a new project directory — **do not reuse an existing one**:
+   ```bash
+   pixi run init -- --project-dir /data/gfv20-targets
+   ```
+2. Edit `/data/gfv20-targets/config.yml`:
+   - Set `fabric.path` to the new fabric file (GeoPackage, GeoParquet, or Shapefile)
+   - Set `fabric.id_col` to the HRU identifier column in that file
+   - Set `datastore` to the **same** datastore path used by other projects (so fetched data is reused)
+3. Copy or symlink `.credentials.yml` from an existing project, or fill it in fresh
+4. Run `materialize-credentials` and `validate` for the new project
+5. Skip `fetch` steps — the datastore already has the raw data
+6. Run `agg` and `run` — weight caches are recomputed for the new fabric geometry
+
+The fabric file must contain a polygon geometry column and a unique integer HRU ID column. Supported formats: GeoPackage (`.gpkg`), GeoParquet (`.parquet`), Shapefile (`.shp`).
+
+### Workflow
+
+`init` &rarr; edit config &rarr; `materialize-credentials` &rarr; `validate` &rarr; `fetch` &rarr; `run`
 
 | Step | Command | What it does |
 |---|---|---|
 | 1 | `nhf-targets init --project-dir <dir>` | Creates project skeleton with `config.yml` and `.credentials.yml` templates |
-| 2 | *(manual)* | Edit `config.yml` to set fabric path, datastore, and target settings; fill in `.credentials.yml` with NASA Earthdata and CDS credentials |
-| 3 | `nhf-targets materialize-credentials --project-dir <dir>` | Copies credentials from `.credentials.yml` into `~/.cdsapirc` and `~/.netrc` (run after editing or rotating `.credentials.yml`) |
-| 4 | `nhf-targets validate --project-dir <dir>` | Verifies config, fabric, credentials; writes `fabric.json` and `manifest.json` |
-| 5 | `nhf-targets fetch <source> --project-dir <dir> --period YYYY/YYYY` | Downloads source granules into `<datastore>/<source_key>/` |
-| 6 | `nhf-targets agg <source> --project-dir <dir> --period YYYY/YYYY` | Aggregates remote data to HRU fabric |
+| 2 | *(manual)* | Edit `config.yml`: set `fabric.path`, `fabric.id_col`, `datastore` path, and target settings. Fill in `.credentials.yml` with NASA Earthdata **and** Copernicus CDS credentials. **Accept the ERA5-Land CDS licence** (one-time) at <https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=download#manage-licences> |
+| 3 | `nhf-targets materialize-credentials --project-dir <dir>` | Writes `~/.cdsapirc` (CDS) and `~/.netrc` (NASA Earthdata) from `.credentials.yml`. Re-run whenever credentials change. |
+| 4 | `nhf-targets validate --project-dir <dir>` | Verifies config, fabric, datastore, credentials; writes `fabric.json` and `manifest.json` |
+| 5 | `nhf-targets fetch <source> --project-dir <dir> --period YYYY/YYYY` | Downloads source granules into `<datastore>/<source_key>/` (skipped if already fetched) |
+| 6 | `nhf-targets agg <source> --project-dir <dir> --period YYYY/YYYY` | Aggregates remote/STAC data to HRU fabric |
 | 7 | `nhf-targets run --project-dir <dir>` | Builds calibration targets from fetched/aggregated data |
 
 **Key paths:**
@@ -94,11 +151,11 @@ The pipeline separates **projects** (fabric-specific) from the **datastore** (sh
 - `<project>/config.yml` — project configuration (fabric, datastore, targets, dir_mode)
 - `<project>/fabric.json` — computed fabric metadata (bbox, HRU count, CRS, sha256)
 - `<project>/manifest.json` — provenance record (download timestamps, checksums, periods)
-- `<project>/.credentials.yml` — NASA Earthdata credentials (gitignored)
-- `<datastore>/<source_key>/` — shared raw downloads (can be on a separate drive)
-- `<project>/data/aggregated/` — spatially aggregated outputs
+- `<project>/.credentials.yml` — NASA Earthdata + CDS credentials (gitignored, never commit)
+- `<datastore>/<source_key>/` — shared raw downloads (fabric-independent, can be on a separate drive)
+- `<project>/data/aggregated/` — spatially aggregated outputs (fabric-specific)
 - `<project>/targets/` — final calibration target datasets
-- `<project>/weights/` — gdptools weight caches (reusable across runs)
+- `<project>/weights/` — gdptools weight caches (fabric × source grid, reusable across runs)
 
 ## Fetch & Consolidation Pipeline
 
@@ -106,6 +163,8 @@ Each `fetch` command downloads source granules and consolidates them into a sing
 
 | Source | Command | Access Method | Consolidated Output |
 |---|---|---|---|
+| ERA5-Land | `fetch era5-land` | CDS API (monthly CONUS NetCDF, 0.1°) — **requires CDS licence; see note below** | `era5_land_{var}_{year}.nc` per variable/year |
+| GLDAS-2.1 NOAH | `fetch gldas` | earthaccess (monthly global NetCDF) | `gldas_consolidated.nc` |
 | MERRA-2 | `fetch merra2` | earthaccess (monthly `.nc4`) | `merra2_consolidated.nc` |
 | NLDAS-2 MOSAIC | `fetch nldas-mosaic` | earthaccess (monthly NetCDF) | `nldas_mosaic_consolidated.nc` |
 | NLDAS-2 NOAH | `fetch nldas-noah` | earthaccess (monthly NetCDF) | `nldas_noah_consolidated.nc` |
@@ -116,6 +175,8 @@ Each `fetch` command downloads source granules and consolidates them into a sing
 | Reitz 2017 | `fetch reitz2017` | sciencebasepy (annual GeoTIFF) | `reitz2017_consolidated.nc` |
 
 All fetch commands support **incremental download** — periods already recorded in `manifest.json` are skipped.
+
+> **ERA5-Land CDS licence** — Before running `fetch era5-land` for the first time, you must accept the dataset licence in your Copernicus CDS account. Log in at <https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=download#manage-licences> and accept any pending licences. Without this step the fetch will fail with `403 Forbidden: required licences not accepted`.
 
 ### Datastore Storage Estimates
 
@@ -137,36 +198,72 @@ Rough per-source estimates for the reference pipeline period (2000–2010 for mo
 
 These are order-of-magnitude estimates. Actual sizes depend on CDS compression, exact MODIS tile counts for the CONUS bbox, and how far back the pipeline period extends. Sizes scale roughly linearly with the number of years fetched.
 
-### Running Fetches on SLURM
+### Running Fetches: PC vs HPC
 
-A SLURM array job script [`fetch_all.slurm`](fetch_all.slurm) is provided to run all 10 fetch tasks as independent jobs (one per array index), allowing them to run concurrently on a cluster:
+#### On a PC / workstation
+
+Run each fetch sequentially in a terminal. Each command is independently resumable — partial runs are safe:
 
 ```bash
-# From the repo root
+# Once per project setup:
+pixi run materialize-credentials -- --project-dir /data/gfv11-targets
+pixi run validate               -- --project-dir /data/gfv11-targets
+
+# Then run fetches one at a time (or in separate terminal windows):
+pixi run fetch-era5-land    -- --project-dir /data/gfv11-targets --period 1979/2025
+pixi run fetch-gldas        -- --project-dir /data/gfv11-targets --period 2000/2025
+pixi run fetch-merra2       -- --project-dir /data/gfv11-targets --period 1980/2025
+# ... etc.
+```
+
+Expect ERA5-Land and MODIS fetches to take many hours for a full 1979–2025 period. All fetches are incremental — interrupting and restarting picks up where it left off.
+
+#### On HPC (SLURM)
+
+The [`fetch_all.slurm`](fetch_all.slurm) script submits all 10 sources as a SLURM array job (one job per array index), so they run concurrently on separate compute nodes.
+
+**Prerequisites — complete these before submitting:**
+
+1. Project is initialised and `config.yml` is filled in
+2. Credentials materialised: `pixi run materialize-credentials -- --project-dir <dir>`
+3. Project validated: `pixi run validate -- --project-dir <dir>` (writes `fabric.json`)
+4. ERA5-Land CDS licence accepted at <https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=download#manage-licences>
+5. `PROJECT_DIR` updated inside `fetch_all.slurm` to your actual project path
+
+```bash
+# From the repo root:
 mkdir -p logs
-# Edit PROJECT_DIR inside fetch_all.slurm, then:
+
+# Edit PROJECT_DIR at the top of fetch_all.slurm, then submit all 10 sources:
 sbatch fetch_all.slurm
 
-# Rerun a single source (e.g. index 2 = MERRA-2):
-sbatch --array=2 fetch_all.slurm
+# Or submit a single source by index (e.g. rerun ERA5-Land only):
+sbatch --array=0 fetch_all.slurm
+
+# Monitor jobs:
+squeue -u $USER
+
+# Check output / errors (format: logs/fetch_<arrayindex>_<jobid>.out/err):
+tail -f logs/fetch_0_*.out   # ERA5-Land live log
+cat  logs/fetch_2_*.err      # MERRA-2 error output
 ```
 
 Array index → source mapping:
 
-| Index | Source |
-|---|---|
-| 0 | ERA5-Land |
-| 1 | GLDAS-2.1 NOAH |
-| 2 | MERRA-2 |
-| 3 | NLDAS-2 MOSAIC |
-| 4 | NLDAS-2 NOAH |
-| 5 | NCEP/NCAR |
-| 6 | WaterGAP 2.2d |
-| 7 | Reitz 2017 |
-| 8 | MOD16A2 v061 |
-| 9 | MOD10C1 v061 |
+| Index | Source | Period in script | Notes |
+|---|---|---|---|
+| 0 | ERA5-Land | 1979/2025 | CDS API; licence required; ~30–60 GB |
+| 1 | GLDAS-2.1 NOAH | 2000/2025 | NASA GES DISC via earthaccess |
+| 2 | MERRA-2 | 1980/2025 | NASA GES DISC via earthaccess |
+| 3 | NLDAS-2 MOSAIC | 1979/2025 | NASA GES DISC via earthaccess |
+| 4 | NLDAS-2 NOAH | 1979/2025 | NASA GES DISC via earthaccess |
+| 5 | NCEP/NCAR | 1979/2025 | NOAA PSL via HTTP |
+| 6 | WaterGAP 2.2d | 1979/2016 | PANGAEA; dataset ends 2016 |
+| 7 | Reitz 2017 | 2000/2013 | USGS ScienceBase; dataset ends 2013 |
+| 8 | MOD16A2 v061 | 2000/2025 | LP DAAC via earthaccess; ~10–20 GB |
+| 9 | MOD10C1 v061 | 2000/2025 | NSIDC via earthaccess |
 
-All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 16 GB RAM per task.
+All fetch routines are network I/O-bound (sequential downloads); the script allocates 1 CPU and 16 GB RAM per task with a 24-hour wall-clock limit. SLURM directives (`--account`, `--partition`, `--chdir`) at the top of `fetch_all.slurm` may need to be adjusted for your cluster.
 
 ## Aggregation
 
@@ -303,8 +400,9 @@ Pixi supports **linux-64**, **osx-arm64**, and **win-64** (see `pixi.toml`).
 | SSEBop AET aggregation (STAC + gdptools) | Done |
 | Spatial batching for large fabrics | Done |
 | Visualization notebooks (all sources + SSEBop agg) | Done |
-| `fetch all` command (sequential, all 8 sources) | Done |
-| ERA5-Land + GLDAS-2.1 NOAH runoff fetch | Not started |
+| `fetch all` command (sequential, all 10 sources) | Done |
+| ERA5-Land fetch + monthly CDS splitting (closes #41 follow-up) | Done |
+| GLDAS-2.1 NOAH fetch | Done |
 | Generic gdptools aggregation module | Not started |
 | Normalization and range-bound methods | Not started |
 | Target builders (runoff, AET, recharge, soil moisture, SCA) | Not started |

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -34,7 +34,9 @@ sources:
         shifting timestamps back 1 h before resampling. Pipeline aggregates
         hourly→daily and daily→monthly. Both consolidated NCs are stored in
         the datastore; the daily NC is re-aggregated if any hourly input is
-        newer (mtime comparison).
+        newer (mtime comparison). Annual downloads are split into 12 monthly
+        CDS requests to stay under the CDS per-request cost limit; monthly
+        chunk files are retained on disk for idempotent re-runs.
     variables:
       - name: ro
         long_name: total runoff

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -517,3 +517,4 @@ sources:
     units: percent (convert to fraction 0-1)
     ci_threshold: 70
     license: public domain (NASA)
+    status: current

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -147,6 +147,7 @@ sources:
     spatial_extent: CONUS
     spatial_resolution: 500m
     units: kg/m2/8day
+    license: public domain (NASA)
     status: current
 
   ssebop:
@@ -354,6 +355,8 @@ sources:
     period: "1980/present"
     spatial_extent: global
     spatial_resolution: 0.5 x 0.625 degree
+    units: dimensionless (fraction of saturation, 0-1)
+    license: public domain (NASA)
     status: current
 
   ncep_ncar:
@@ -387,6 +390,7 @@ sources:
     spatial_extent: global
     spatial_resolution: T62 Gaussian grid (~1.875 degree)
     units: kg/m2 (normalized to dimensionless for calibration)
+    license: public domain (NOAA)
     status: current
 
   nldas_mosaic:
@@ -421,6 +425,7 @@ sources:
     spatial_extent: CONUS
     spatial_resolution: 0.125 degree
     units: kg/m2 (normalized to dimensionless for calibration)
+    license: public domain (NASA)
     status: current
 
   nldas_noah:
@@ -460,6 +465,7 @@ sources:
     spatial_extent: CONUS
     spatial_resolution: 0.125 degree
     units: kg/m2 (normalized to dimensionless for calibration)
+    license: public domain (NASA)
     status: current
 
   # ---------------------------------------------------------------------------
@@ -510,4 +516,4 @@ sources:
     spatial_resolution: 0.05 degree CMG
     units: percent (convert to fraction 0-1)
     ci_threshold: 70
-    status: current
+    license: public domain (NASA)

--- a/fetch_all.slurm
+++ b/fetch_all.slurm
@@ -14,7 +14,7 @@
 # Submits one SLURM job per source dataset (10 total).
 # Each job downloads independently; they can run concurrently.
 #
-# Usage (the repo dir and project dir are required overrides):
+# Usage (REPO_DIR and PROJECT_DIR are overridable via environment):
 #   mkdir -p logs
 #   export REPO_DIR=/path/to/nhf-spatial-targets
 #   export PROJECT_DIR=/path/to/your/project

--- a/fetch_all.slurm
+++ b/fetch_all.slurm
@@ -7,7 +7,6 @@
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
 #SBATCH --time=24:00:00
-#SBATCH --chdir=/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets
 #SBATCH --output=logs/fetch_%a_%A.out
 #SBATCH --error=logs/fetch_%a_%A.err
 
@@ -15,8 +14,10 @@
 # Submits one SLURM job per source dataset (10 total).
 # Each job downloads independently; they can run concurrently.
 #
-# Usage:
+# Usage (the repo dir and project dir are required overrides):
 #   mkdir -p logs
+#   export REPO_DIR=/path/to/nhf-spatial-targets
+#   export PROJECT_DIR=/path/to/your/project
 #   sbatch fetch_all.slurm
 #
 # To run a single source only (e.g. index 2 = merra2):
@@ -24,7 +25,13 @@
 
 set -euo pipefail
 
-PROJECT_DIR="/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets"
+# Repo and project directories — override via environment, or edit these
+# defaults for your site. The repo default mirrors the USGS Hovenweep path;
+# $PROJECT_DIR must be a project directory created by `nhf-targets init`.
+REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets}"
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
+
+cd "$REPO_DIR"
 
 # Map array index → pixi task name
 FETCH_TASKS=(
@@ -62,9 +69,6 @@ PERIOD="${FETCH_PERIODS[$SLURM_ARRAY_TASK_ID]}"
 echo "=== Array task $SLURM_ARRAY_TASK_ID: $TASK  period=$PERIOD ==="
 echo "=== Start: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 echo "=== Host:  $(hostname) ==="
-
-# Activate pixi environment (--chdir in SBATCH header sets cwd to repo root)
-eval "$(pixi shell-hook)"
 
 pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --period "$PERIOD"
 

--- a/fetch_all.slurm
+++ b/fetch_all.slurm
@@ -5,7 +5,7 @@
 #SBATCH --array=0-9
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=16G
+#SBATCH --mem=128G
 #SBATCH --time=24:00:00
 #SBATCH --chdir=/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets
 #SBATCH --output=logs/fetch_%a_%A.out

--- a/fetch_all.slurm
+++ b/fetch_all.slurm
@@ -1,0 +1,71 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-fetch
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --array=0-9
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH --time=24:00:00
+#SBATCH --chdir=/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets
+#SBATCH --output=logs/fetch_%a_%A.out
+#SBATCH --error=logs/fetch_%a_%A.err
+
+# NHF Spatial Targets — parallel fetch array
+# Submits one SLURM job per source dataset (10 total).
+# Each job downloads independently; they can run concurrently.
+#
+# Usage:
+#   mkdir -p logs
+#   sbatch fetch_all.slurm
+#
+# To run a single source only (e.g. index 2 = merra2):
+#   sbatch --array=2 fetch_all.slurm
+
+set -euo pipefail
+
+PROJECT_DIR="/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets"
+
+# Map array index → pixi task name
+FETCH_TASKS=(
+    "fetch-era5-land"      # 0  — 1979–present at 0.1°, hourly (CDS)
+    "fetch-gldas"          # 1  — 2000–present at 0.25°, monthly (NASA GES DISC)
+    "fetch-merra2"         # 2  — 1980–present at 0.5×0.625°, monthly (NASA GES DISC)
+    "fetch-nldas-mosaic"   # 3  — 1979–present at 0.125°, monthly (NASA GES DISC)
+    "fetch-nldas-noah"     # 4  — 1979–present at 0.125°, monthly (NASA GES DISC)
+    "fetch-ncep-ncar"      # 5  — 1948–present at ~1.875°, daily→monthly (NOAA PSL)
+    "fetch-watergap22d"    # 6  — 1901–2016 at 0.5°, monthly (PANGAEA) — ends 2016
+    "fetch-reitz2017"      # 7  — 2000–2013 at 800m, annual (ScienceBase) — ends 2013
+    "fetch-mod16a2"        # 8  — 2000–present at 500m, 8-day (LP DAAC/earthaccess)
+    "fetch-mod10c1"        # 9  — 2000–present at 0.05°, daily (NSIDC/earthaccess)
+)
+
+# Map array index → fetch period (YYYY/YYYY)
+# Periods chosen to cover the NHM model run (1979–2025) as fully as each
+# source allows.  Sources with fixed ends (WaterGAP 2.2d: 2016,
+# Reitz 2017: 2013, MODIS: 2000) are clamped to their available range.
+FETCH_PERIODS=(
+    "1979/2025"   # 0  era5-land
+    "2000/2025"   # 1  gldas       (v2.1 starts 2000)
+    "1980/2025"   # 2  merra2      (starts 1980)
+    "1979/2025"   # 3  nldas-mosaic
+    "1979/2025"   # 4  nldas-noah
+    "1979/2025"   # 5  ncep-ncar   (product starts 1948; clamp to model start)
+    "1979/2016"   # 6  watergap22d (dataset ends 2016)
+    "2000/2013"   # 7  reitz2017   (dataset ends 2013)
+    "2000/2025"   # 8  mod16a2     (MODIS starts 2000)
+    "2000/2025"   # 9  mod10c1     (MODIS starts 2000)
+)
+
+TASK="${FETCH_TASKS[$SLURM_ARRAY_TASK_ID]}"
+PERIOD="${FETCH_PERIODS[$SLURM_ARRAY_TASK_ID]}"
+echo "=== Array task $SLURM_ARRAY_TASK_ID: $TASK  period=$PERIOD ==="
+echo "=== Start: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:  $(hostname) ==="
+
+# Activate pixi environment (--chdir in SBATCH header sets cwd to repo root)
+eval "$(pixi shell-hook)"
+
+pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --period "$PERIOD"
+
+echo "=== Done:  $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/notebooks/inspect_consolidated.ipynb
+++ b/notebooks/inspect_consolidated.ipynb
@@ -16,7 +16,15 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": "from pathlib import Path\n\nimport matplotlib.pyplot as plt\nimport xarray as xr\n\nRUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\""
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import xarray as xr\n",
+    "\n",
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -35,22 +43,22 @@
    "source": [
     "datasets = {\n",
     "    \"MERRA-2 (GWETTOP)\": {\n",
-    "        \"path\": RUN_DIR / \"data\" / \"raw\" / \"merra2\" / \"merra2_consolidated.nc\",\n",
+    "        \"path\": DATASTORE / \"merra2\" / \"merra2_consolidated.nc\",\n",
     "        \"var\": \"GWETTOP\",\n",
     "        \"units\": \"fraction (0-1)\",\n",
     "    },\n",
     "    \"NLDAS-2 MOSAIC (SoilM 0-10cm)\": {\n",
-    "        \"path\": RUN_DIR / \"data\" / \"raw\" / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\",\n",
+    "        \"path\": DATASTORE / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\",\n",
     "        \"var\": \"SoilM_0_10cm\",\n",
     "        \"units\": \"kg/m²\",\n",
     "    },\n",
     "    \"NLDAS-2 NOAH (SoilM 0-10cm)\": {\n",
-    "        \"path\": RUN_DIR / \"data\" / \"raw\" / \"nldas_noah\" / \"nldas_noah_consolidated.nc\",\n",
+    "        \"path\": DATASTORE / \"nldas_noah\" / \"nldas_noah_consolidated.nc\",\n",
     "        \"var\": \"SoilM_0_10cm\",\n",
     "        \"units\": \"kg/m²\",\n",
     "    },\n",
     "    \"NCEP/NCAR (soilw 0-10cm)\": {\n",
-    "        \"path\": RUN_DIR / \"data\" / \"raw\" / \"ncep_ncar\" / \"ncep_ncar_consolidated.nc\",\n",
+    "        \"path\": DATASTORE / \"ncep_ncar\" / \"ncep_ncar_consolidated.nc\",\n",
     "        \"var\": \"soilw_0_10cm\",\n",
     "        \"units\": \"kg/m²\",\n",
     "    },\n",
@@ -154,9 +162,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nhf-spatial-targets\n  (dev)",
+   "display_name": "geoenv",
    "language": "python",
-   "name": "nhf-spatial-targets"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -168,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualize_era5_land.ipynb
+++ b/notebooks/visualize_era5_land.ipynb
@@ -5,15 +5,20 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# NCEP/NCAR Reanalysis — Soil Moisture\n",
+    "# ERA5-Land — Runoff (ro, sro, ssro)\n",
     "\n",
-    "Visualize the consolidated NCEP/NCAR Reanalysis 1 soil moisture\n",
-    "from NOAA PSL (daily files resampled to monthly means).\n",
+    "Visualize the consolidated ERA5-Land monthly runoff dataset from ECMWF\n",
+    "(Copernicus CDS, `reanalysis-era5-land`).\n",
     "\n",
-    "- **Variables:** `soilw_0_10cm` (0–10 cm), `soilw_10_200cm` (10–200 cm) — kg/m²\n",
-    "- **Resolution:** T62 Gaussian grid (~1.875°) global\n",
-    "- **Period:** 1948–present (monthly, derived from daily)\n",
-    "- **Note:** Coarsest resolution among the four soil moisture sources"
+    "> **Note:** The fetch is still running; the monthly file currently accessible\n",
+    "> covers only the years completed so far.  The notebook adapts to whatever\n",
+    "> data are present.\n",
+    "\n",
+    "- **Variable:** `ro` — total runoff (m per month)\n",
+    "- **Also stored:** `sro` (surface runoff), `ssro` (sub-surface runoff / recharge proxy)\n",
+    "- **Resolution:** 0.1° × 0.1° CONUS + contributing watersheds\n",
+    "- **Period:** 1979–present (monthly, fetch in progress)\n",
+    "- **Reference:** Muñoz-Sabater et al., 2021, doi:10.5194/essd-13-4349-2021"
    ]
   },
   {
@@ -24,6 +29,7 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
+    "from glob import glob\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -31,9 +37,16 @@
     "\n",
     "# --- Configuration ---\n",
     "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
-    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
-    "NC_PATH = DATASTORE / \"ncep_ncar\" / \"ncep_ncar_consolidated.nc\"\n",
-    "PRIMARY_VAR = \"soilw_0_10cm\"\n"
+    "PROJECT   = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "\n",
+    "# Pick the latest completed monthly file (rolling filename)\n",
+    "monthly_files = sorted(glob(str(DATASTORE / \"era5_land\" / \"monthly\" / \"era5_land_monthly_*.nc\")))\n",
+    "if not monthly_files:\n",
+    "    raise FileNotFoundError(\"No era5_land monthly files found — is the fetch still in progress?\")\n",
+    "NC_PATH = Path(monthly_files[-1])\n",
+    "print(f\"Using: {NC_PATH.name}\")\n",
+    "\n",
+    "PRIMARY_VAR = \"ro\"   # total runoff (m)\n"
    ]
   },
   {
@@ -47,10 +60,9 @@
     "print(ds)\n",
     "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
     "print(f\"Time steps: {ds.time.size}\")\n",
-    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
-    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
-    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
-    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+    "print(f\"Grid:       {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Variables:  {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n"
    ]
   },
   {
@@ -58,7 +70,7 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "## Single-month soil moisture map (global)"
+    "## Single-month total runoff map"
    ]
   },
   {
@@ -68,14 +80,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TARGET_TIME = \"2000-01-15\"\n",
-    "\n",
-    "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
+    "# Use the most recent available timestep\n",
+    "target_time = ds.time.values[-1]\n",
+    "da = ds[PRIMARY_VAR].sel(time=target_time)\n",
     "actual_time = str(da.time.values)[:10]\n",
     "\n",
-    "fig, ax = plt.subplots(figsize=(16, 6))\n",
-    "da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
-    "ax.set_title(f\"NCEP/NCAR Soil Moisture (0–10 cm) — {actual_time}\")\n",
+    "fig, ax = plt.subplots(figsize=(14, 6))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"m\"})\n",
+    "ax.set_title(f\"ERA5-Land Total Runoff (ro) — {actual_time}\")\n",
     "ax.set_xlabel(\"Longitude\")\n",
     "ax.set_ylabel(\"Latitude\")\n",
     "ax.set_aspect(\"equal\")\n",
@@ -83,9 +95,9 @@
     "plt.show()\n",
     "\n",
     "print(f\"Stats for {actual_time}:\")\n",
-    "print(f\"  min:  {float(da.min()):.2f}\")\n",
-    "print(f\"  max:  {float(da.max()):.2f}\")\n",
-    "print(f\"  mean: {float(da.mean()):.2f}\")\n",
+    "print(f\"  min:  {float(da.min(skipna=True)):.5f} m\")\n",
+    "print(f\"  max:  {float(da.max(skipna=True)):.5f} m\")\n",
+    "print(f\"  mean: {float(da.mean(skipna=True)):.5f} m\")\n",
     "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
    ]
   },
@@ -94,7 +106,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Both soil layers — single timestep comparison"
+    "## All three runoff variables — single timestep"
    ]
   },
   {
@@ -104,23 +116,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "layer_vars = {\n",
-    "    \"soilw_0_10cm\": \"0–10 cm\",\n",
-    "    \"soilw_10_200cm\": \"10–200 cm\",\n",
+    "run_vars = {\n",
+    "    \"ro\":   \"Total runoff (m)\",\n",
+    "    \"sro\":  \"Surface runoff (m)\",\n",
+    "    \"ssro\": \"Sub-surface runoff / recharge proxy (m)\",\n",
     "}\n",
     "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(18, 6))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(20, 5))\n",
     "\n",
-    "for ax, (var, label) in zip(axes, layer_vars.items()):\n",
+    "for ax, (var, label) in zip(axes, run_vars.items()):\n",
     "    if var not in ds.data_vars:\n",
+    "        ax.set_title(f\"{label}\\n(not in dataset)\")\n",
     "        ax.set_visible(False)\n",
     "        continue\n",
-    "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
-    "    da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    da = ds[var].sel(time=target_time)\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"m\"})\n",
     "    ax.set_title(f\"{var}\\n{label}\")\n",
     "    ax.set_aspect(\"equal\")\n",
     "\n",
-    "fig.suptitle(f\"NCEP/NCAR Soil Moisture Layers — {actual_time}\", fontsize=14, y=1.02)\n",
+    "fig.suptitle(f\"ERA5-Land Runoff Variables — {actual_time}\", fontsize=14, y=1.02)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -130,7 +144,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "## CONUS subset — calibration period mean (2000–2009)"
+    "## CONUS subset — mean over available data"
    ]
   },
   {
@@ -140,28 +154,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NCEP/NCAR uses 0–360 longitudes; convert CONUS bounds accordingly\n",
+    "# ERA5-Land lat is descending (53→24.7); slice(upper, lower) selects CONUS\n",
     "conus = ds[PRIMARY_VAR].sel(\n",
     "    lat=slice(50.1, 23.9),\n",
-    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
-    "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
+    "    lon=slice(-125.1, -65.9),\n",
     ")\n",
     "\n",
-    "mean_sm = conus.mean(dim=\"time\")\n",
+    "mean_runoff = conus.mean(dim=\"time\")\n",
+    "start_yr = str(ds.time.values[0])[:4]\n",
+    "end_yr   = str(ds.time.values[-1])[:4]\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(14, 8))\n",
-    "mean_sm.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
-    "ax.set_title(\"Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\")\n",
+    "mean_runoff.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"m\"})\n",
+    "ax.set_title(f\"Mean Total Runoff (ro) — CONUS {start_yr}–{end_yr}\")\n",
     "ax.set_xlabel(\"Longitude\")\n",
     "ax.set_ylabel(\"Latitude\")\n",
     "ax.set_aspect(\"equal\")\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "print(f\"CONUS 2000-2009 mean stats:\")\n",
-    "print(f\"  min:  {float(mean_sm.min()):.2f}\")\n",
-    "print(f\"  max:  {float(mean_sm.max()):.2f}\")\n",
-    "print(f\"  mean: {float(mean_sm.mean()):.2f}\")\n"
+    "print(f\"CONUS {start_yr}–{end_yr} mean stats:\")\n",
+    "print(f\"  min:  {float(mean_runoff.min(skipna=True)):.5f} m\")\n",
+    "print(f\"  max:  {float(mean_runoff.max(skipna=True)):.5f} m\")\n",
+    "print(f\"  mean: {float(mean_runoff.mean(skipna=True)):.5f} m\")\n"
    ]
   },
   {
@@ -169,7 +184,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "## Seasonal comparison (CONUS, 2000–2009)"
+    "## Seasonal comparison (CONUS, available data)"
    ]
   },
   {
@@ -183,18 +198,21 @@
     "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
     "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
     "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
-    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "    \"SON (Fall)\":   conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
     "}\n",
     "\n",
     "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
     "\n",
     "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
+    "    if seasonal_data.time.size == 0:\n",
+    "        ax.set_title(f\"{label}\\n(no data available)\")\n",
+    "        continue\n",
     "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
-    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"m\"})\n",
     "    ax.set_title(f\"{label} mean\")\n",
     "    ax.set_aspect(\"equal\")\n",
     "\n",
-    "fig.suptitle(\"Seasonal Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\", fontsize=14, y=1.01)\n",
+    "fig.suptitle(f\"Seasonal Mean Total Runoff (ro) — CONUS {start_yr}–{end_yr}\", fontsize=14, y=1.01)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -216,16 +234,15 @@
    "source": [
     "conus_full = ds[PRIMARY_VAR].sel(\n",
     "    lat=slice(50.1, 23.9),\n",
-    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
+    "    lon=slice(-125.1, -65.9),\n",
     ")\n",
     "monthly_mean = conus_full.mean(dim=[\"lat\", \"lon\"])\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(16, 4))\n",
-    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
-    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
-    "ax.set_title(\"CONUS-mean monthly soil moisture (NCEP/NCAR, 0–10 cm)\")\n",
-    "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
-    "ax.legend()\n",
+    "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.8)\n",
+    "ax.set_ylabel(\"Mean Total Runoff (m)\")\n",
+    "ax.set_title(\"CONUS-mean monthly total runoff (ro) — ERA5-Land\")\n",
+    "ax.set_ylim(bottom=0)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -235,7 +252,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "## Monthly climatology (CONUS, 2000–2009)"
+    "## Monthly climatology (CONUS, available data)"
    ]
   },
   {
@@ -250,10 +267,11 @@
     "fig, ax = plt.subplots(figsize=(10, 5))\n",
     "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
     "ax.set_xlabel(\"Month\")\n",
-    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
-    "ax.set_title(\"Monthly Climatology — NCEP/NCAR CONUS 2000–2009 (0–10 cm)\")\n",
+    "ax.set_ylabel(\"Mean Total Runoff (m)\")\n",
+    "ax.set_title(f\"Monthly Climatology — CONUS {start_yr}–{end_yr} (ro)\")\n",
     "ax.set_xticks(range(1, 13))\n",
     "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "ax.set_ylim(bottom=0)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -281,14 +299,16 @@
     "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
     "if \"crs\" in ds.data_vars:\n",
     "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
-    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "    crs_wkt = ds['crs'].attrs.get('crs_wkt', 'MISSING')\n",
+    "    print(f\"  CRS WKT:           {str(crs_wkt)[:60]}...\")\n",
     "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
-    "for var in [\"soilw_0_10cm\", \"soilw_10_200cm\"]:\n",
+    "for var in [\"ro\", \"sro\", \"ssro\"]:\n",
     "    if var in ds.data_vars:\n",
     "        print(f\"  {var}:\")\n",
     "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
     "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
-    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n",
+    "        print(f\"    cell_methods: {ds[var].attrs.get('cell_methods', 'MISSING')}\")\n"
    ]
   },
   {
@@ -306,19 +326,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
+    "import json as _json\n",
     "\n",
     "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
-    "    manifest = json.loads(manifest_path.read_text())\n",
-    "    entry = manifest[\"sources\"].get(\"ncep_ncar\", {})\n",
-    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
-    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
-    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
-    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
-    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
-    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
-    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "    manifest = _json.loads(manifest_path.read_text())\n",
+    "    entry = manifest.get(\"sources\", {}).get(\"era5_land\", {})\n",
+    "    print(f\"Source key:     {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Period:         {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:      {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Monthly NC:     {entry.get('monthly_nc', 'N/A')}\")\n",
+    "    print(f\"Years fetched:  {entry.get('years_fetched', 'N/A')}\")\n",
+    "    print(f\"Timestamp:      {entry.get('download_timestamp', 'N/A')}\")\n",
     "else:\n",
     "    print(f\"manifest.json not found at {manifest_path}\")\n"
    ]
@@ -336,9 +355,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nhf-spatial-targets\n  (dev)",
+   "display_name": "geoenv",
    "language": "python",
-   "name": "nhf-spatial-targets"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -350,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualize_gldas.ipynb
+++ b/notebooks/visualize_gldas.ipynb
@@ -5,15 +5,16 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# NCEP/NCAR Reanalysis — Soil Moisture\n",
+    "# GLDAS-2.1 NOAH — Monthly Runoff (Qs_acc, Qsb_acc, runoff_total)\n",
     "\n",
-    "Visualize the consolidated NCEP/NCAR Reanalysis 1 soil moisture\n",
-    "from NOAA PSL (daily files resampled to monthly means).\n",
+    "Visualize the consolidated GLDAS-2.1 NOAH 0.25° monthly runoff dataset\n",
+    "(NASA GES DISC, `GLDAS_NOAH025_M v2.1`).\n",
     "\n",
-    "- **Variables:** `soilw_0_10cm` (0–10 cm), `soilw_10_200cm` (10–200 cm) — kg/m²\n",
-    "- **Resolution:** T62 Gaussian grid (~1.875°) global\n",
-    "- **Period:** 1948–present (monthly, derived from daily)\n",
-    "- **Note:** Coarsest resolution among the four soil moisture sources"
+    "- **Primary variable:** `runoff_total` — total runoff (Qs_acc + Qsb_acc, kg m⁻² ≡ mm)\n",
+    "- **Also stored:** `Qs_acc` (storm surface runoff), `Qsb_acc` (baseflow–groundwater runoff)\n",
+    "- **Resolution:** 0.25° × 0.25° CONUS + contributing watersheds\n",
+    "- **Period:** 2000-01 to 2025-12 (312 months)\n",
+    "- **Reference:** Rodell et al., 2004, doi:10.1175/BAMS-85-3-381"
    ]
   },
   {
@@ -31,9 +32,9 @@
     "\n",
     "# --- Configuration ---\n",
     "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
-    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
-    "NC_PATH = DATASTORE / \"ncep_ncar\" / \"ncep_ncar_consolidated.nc\"\n",
-    "PRIMARY_VAR = \"soilw_0_10cm\"\n"
+    "PROJECT   = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH   = DATASTORE / \"gldas_noah_v21_monthly\" / \"gldas_noah_v21_monthly.nc\"\n",
+    "PRIMARY_VAR = \"runoff_total\"   # kg m-2 (≡ mm per month)\n"
    ]
   },
   {
@@ -47,10 +48,9 @@
     "print(ds)\n",
     "print(f\"\\nTime range: {ds.time.values[0]} to {ds.time.values[-1]}\")\n",
     "print(f\"Time steps: {ds.time.size}\")\n",
-    "print(f\"Grid: {ds.lat.size} lat x {ds.lon.size} lon\")\n",
-    "print(f\"Data variables: {list(ds.data_vars)}\")\n",
-    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n",
-    "print(f\"Grid mapping: {ds[PRIMARY_VAR].attrs.get('grid_mapping', 'N/A')}\")\n"
+    "print(f\"Grid:       {ds.lat.size} lat x {ds.lon.size} lon\")\n",
+    "print(f\"Variables:  {list(ds.data_vars)}\")\n",
+    "print(f\"Conventions: {ds.attrs.get('Conventions', 'N/A')}\")\n"
    ]
   },
   {
@@ -58,7 +58,7 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "## Single-month soil moisture map (global)"
+    "## Single-month total runoff map"
    ]
   },
   {
@@ -68,14 +68,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TARGET_TIME = \"2000-01-15\"\n",
+    "TARGET_TIME = \"2000-07-01\"\n",
     "\n",
     "da = ds[PRIMARY_VAR].sel(time=TARGET_TIME, method=\"nearest\")\n",
     "actual_time = str(da.time.values)[:10]\n",
     "\n",
-    "fig, ax = plt.subplots(figsize=(16, 6))\n",
-    "da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
-    "ax.set_title(f\"NCEP/NCAR Soil Moisture (0–10 cm) — {actual_time}\")\n",
+    "fig, ax = plt.subplots(figsize=(14, 6))\n",
+    "da.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"kg m⁻² (mm)\"})\n",
+    "ax.set_title(f\"GLDAS-2.1 NOAH Total Runoff (runoff_total) — {actual_time}\")\n",
     "ax.set_xlabel(\"Longitude\")\n",
     "ax.set_ylabel(\"Latitude\")\n",
     "ax.set_aspect(\"equal\")\n",
@@ -83,9 +83,9 @@
     "plt.show()\n",
     "\n",
     "print(f\"Stats for {actual_time}:\")\n",
-    "print(f\"  min:  {float(da.min()):.2f}\")\n",
-    "print(f\"  max:  {float(da.max()):.2f}\")\n",
-    "print(f\"  mean: {float(da.mean()):.2f}\")\n",
+    "print(f\"  min:  {float(da.min(skipna=True)):.2f} mm\")\n",
+    "print(f\"  max:  {float(da.max(skipna=True)):.2f} mm\")\n",
+    "print(f\"  mean: {float(da.mean(skipna=True)):.2f} mm\")\n",
     "print(f\"  NaN%: {float(da.isnull().mean()) * 100:.1f}%\")\n"
    ]
   },
@@ -94,7 +94,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Both soil layers — single timestep comparison"
+    "## All three runoff variables — single timestep"
    ]
   },
   {
@@ -104,23 +104,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "layer_vars = {\n",
-    "    \"soilw_0_10cm\": \"0–10 cm\",\n",
-    "    \"soilw_10_200cm\": \"10–200 cm\",\n",
+    "run_vars = {\n",
+    "    \"runoff_total\": \"Total runoff (kg m⁻²)\",\n",
+    "    \"Qs_acc\":       \"Storm surface runoff (kg m⁻²)\",\n",
+    "    \"Qsb_acc\":      \"Baseflow–groundwater runoff (kg m⁻²)\",\n",
     "}\n",
     "\n",
-    "fig, axes = plt.subplots(1, 2, figsize=(18, 6))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(20, 5))\n",
     "\n",
-    "for ax, (var, label) in zip(axes, layer_vars.items()):\n",
+    "for ax, (var, label) in zip(axes, run_vars.items()):\n",
     "    if var not in ds.data_vars:\n",
+    "        ax.set_title(f\"{label}\\n(not in dataset)\")\n",
     "        ax.set_visible(False)\n",
     "        continue\n",
     "    da = ds[var].sel(time=TARGET_TIME, method=\"nearest\")\n",
-    "    da.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    da.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"kg m⁻²\"})\n",
     "    ax.set_title(f\"{var}\\n{label}\")\n",
     "    ax.set_aspect(\"equal\")\n",
     "\n",
-    "fig.suptitle(f\"NCEP/NCAR Soil Moisture Layers — {actual_time}\", fontsize=14, y=1.02)\n",
+    "fig.suptitle(f\"GLDAS-2.1 NOAH Runoff Variables — {actual_time}\", fontsize=14, y=1.02)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -140,28 +142,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NCEP/NCAR uses 0–360 longitudes; convert CONUS bounds accordingly\n",
+    "# GLDAS lat is ascending (24.88→52.88); slice(lower, upper)\n",
     "conus = ds[PRIMARY_VAR].sel(\n",
-    "    lat=slice(50.1, 23.9),\n",
-    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
+    "    lat=slice(23.9, 50.1),\n",
+    "    lon=slice(-125.1, -65.9),\n",
     "    time=slice(\"2000-01-01\", \"2009-12-31\"),\n",
     ")\n",
     "\n",
-    "mean_sm = conus.mean(dim=\"time\")\n",
+    "mean_runoff = conus.mean(dim=\"time\")\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(14, 8))\n",
-    "mean_sm.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
-    "ax.set_title(\"Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\")\n",
+    "mean_runoff.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"kg m⁻² (mm)\"})\n",
+    "ax.set_title(\"Mean Total Runoff (runoff_total) — CONUS 2000–2009\")\n",
     "ax.set_xlabel(\"Longitude\")\n",
     "ax.set_ylabel(\"Latitude\")\n",
     "ax.set_aspect(\"equal\")\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "print(f\"CONUS 2000-2009 mean stats:\")\n",
-    "print(f\"  min:  {float(mean_sm.min()):.2f}\")\n",
-    "print(f\"  max:  {float(mean_sm.max()):.2f}\")\n",
-    "print(f\"  mean: {float(mean_sm.mean()):.2f}\")\n"
+    "print(\"CONUS 2000-2009 mean stats:\")\n",
+    "print(f\"  min:  {float(mean_runoff.min(skipna=True)):.2f} mm\")\n",
+    "print(f\"  max:  {float(mean_runoff.max(skipna=True)):.2f} mm\")\n",
+    "print(f\"  mean: {float(mean_runoff.mean(skipna=True)):.2f} mm\")\n"
    ]
   },
   {
@@ -183,18 +185,18 @@
     "    \"DJF (Winter)\": conus.sel(time=conus.time.dt.month.isin([12, 1, 2])),\n",
     "    \"MAM (Spring)\": conus.sel(time=conus.time.dt.month.isin([3, 4, 5])),\n",
     "    \"JJA (Summer)\": conus.sel(time=conus.time.dt.month.isin([6, 7, 8])),\n",
-    "    \"SON (Fall)\": conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
+    "    \"SON (Fall)\":   conus.sel(time=conus.time.dt.month.isin([9, 10, 11])),\n",
     "}\n",
     "\n",
     "fig, axes = plt.subplots(2, 2, figsize=(16, 12))\n",
     "\n",
     "for ax, (label, seasonal_data) in zip(axes.flatten(), seasons.items()):\n",
     "    seasonal_mean = seasonal_data.mean(dim=\"time\")\n",
-    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", robust=True, cbar_kwargs={\"label\": \"kg/m²\"})\n",
+    "    seasonal_mean.plot(ax=ax, cmap=\"YlGnBu\", cbar_kwargs={\"label\": \"kg m⁻²\"})\n",
     "    ax.set_title(f\"{label} mean\")\n",
     "    ax.set_aspect(\"equal\")\n",
     "\n",
-    "fig.suptitle(\"Seasonal Mean Soil Moisture (0–10 cm) — NCEP/NCAR CONUS 2000–2009\", fontsize=14, y=1.01)\n",
+    "fig.suptitle(\"Seasonal Mean Total Runoff — CONUS 2000–2009\", fontsize=14, y=1.01)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -215,16 +217,17 @@
    "outputs": [],
    "source": [
     "conus_full = ds[PRIMARY_VAR].sel(\n",
-    "    lat=slice(50.1, 23.9),\n",
-    "    lon=slice(360 - 125.1, 360 - 65.9),\n",
+    "    lat=slice(23.9, 50.1),\n",
+    "    lon=slice(-125.1, -65.9),\n",
     ")\n",
     "monthly_mean = conus_full.mean(dim=[\"lat\", \"lon\"])\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(16, 4))\n",
     "monthly_mean.plot(ax=ax, color=\"#2980b9\", linewidth=0.5)\n",
-    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
-    "ax.set_title(\"CONUS-mean monthly soil moisture (NCEP/NCAR, 0–10 cm)\")\n",
+    "ax.set_ylabel(\"Mean Total Runoff (kg m⁻²)\")\n",
+    "ax.set_title(\"CONUS-mean monthly total runoff (runoff_total) — GLDAS-2.1 NOAH\")\n",
     "ax.axvspan(\"2000-01-01\", \"2009-12-31\", alpha=0.15, color=\"orange\", label=\"Calibration period\")\n",
+    "ax.set_ylim(bottom=0)\n",
     "ax.legend()\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
@@ -250,10 +253,11 @@
     "fig, ax = plt.subplots(figsize=(10, 5))\n",
     "ax.bar(monthly_clim.month, monthly_clim.values, color=\"#2980b9\", edgecolor=\"white\")\n",
     "ax.set_xlabel(\"Month\")\n",
-    "ax.set_ylabel(\"Mean Soil Moisture (kg/m²)\")\n",
-    "ax.set_title(\"Monthly Climatology — NCEP/NCAR CONUS 2000–2009 (0–10 cm)\")\n",
+    "ax.set_ylabel(\"Mean Total Runoff (kg m⁻²)\")\n",
+    "ax.set_title(\"Monthly Climatology — CONUS 2000–2009 (runoff_total)\")\n",
     "ax.set_xticks(range(1, 13))\n",
     "ax.set_xticklabels([\"J\", \"F\", \"M\", \"A\", \"M\", \"J\", \"J\", \"A\", \"S\", \"O\", \"N\", \"D\"])\n",
+    "ax.set_ylim(bottom=0)\n",
     "plt.tight_layout()\n",
     "plt.show()\n"
    ]
@@ -281,14 +285,16 @@
     "print(f\"  CRS variable:      {'crs' in ds.data_vars}\")\n",
     "if \"crs\" in ds.data_vars:\n",
     "    print(f\"  Grid mapping name: {ds['crs'].attrs.get('grid_mapping_name', 'MISSING')}\")\n",
-    "    print(f\"  CRS WKT:           {ds['crs'].attrs.get('crs_wkt', 'MISSING')[:60]}...\")\n",
+    "    crs_wkt = ds['crs'].attrs.get('crs_wkt', 'MISSING')\n",
+    "    print(f\"  CRS WKT:           {str(crs_wkt)[:60]}...\")\n",
     "print(f\"  time_bnds:         {'time_bnds' in ds.data_vars}\")\n",
-    "for var in [\"soilw_0_10cm\", \"soilw_10_200cm\"]:\n",
+    "for var in [\"runoff_total\", \"Qs_acc\", \"Qsb_acc\"]:\n",
     "    if var in ds.data_vars:\n",
     "        print(f\"  {var}:\")\n",
     "        print(f\"    grid_mapping: {ds[var].attrs.get('grid_mapping', 'MISSING')}\")\n",
     "        print(f\"    units:        {ds[var].attrs.get('units', 'MISSING')}\")\n",
-    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n"
+    "        print(f\"    long_name:    {ds[var].attrs.get('long_name', 'MISSING')}\")\n",
+    "        print(f\"    cell_methods: {ds[var].attrs.get('cell_methods', 'MISSING')}\")\n"
    ]
   },
   {
@@ -306,19 +312,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
+    "import json as _json\n",
     "\n",
     "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
-    "    manifest = json.loads(manifest_path.read_text())\n",
-    "    entry = manifest[\"sources\"].get(\"ncep_ncar\", {})\n",
-    "    print(f\"Source key:       {entry.get('source_key', 'N/A')}\")\n",
-    "    print(f\"Access URL:       {entry.get('access_url', 'N/A')}\")\n",
-    "    print(f\"Period:           {entry.get('period', 'N/A')}\")\n",
-    "    print(f\"Variables:        {entry.get('variables', 'N/A')}\")\n",
-    "    print(f\"Consolidated NC:  {entry.get('consolidated_nc', 'N/A')}\")\n",
-    "    print(f\"Files downloaded: {len(entry.get('files', []))}\")\n",
-    "    print(f\"Downloaded UTC:   {entry.get('download_timestamp', 'N/A')}\")\n",
+    "    manifest = _json.loads(manifest_path.read_text())\n",
+    "    entry = manifest.get(\"sources\", {}).get(\"gldas_noah_v21_monthly\", {})\n",
+    "    print(f\"Source key:     {entry.get('source_key', 'N/A')}\")\n",
+    "    print(f\"Period:         {entry.get('period', 'N/A')}\")\n",
+    "    print(f\"Variables:      {entry.get('variables', 'N/A')}\")\n",
+    "    print(f\"Consolidated:   {entry.get('consolidated_nc', 'N/A')}\")\n",
+    "    print(f\"Files:          {len(entry.get('files', []))}\")\n",
+    "    print(f\"Timestamp:      {entry.get('download_timestamp', 'N/A')}\")\n",
     "else:\n",
     "    print(f\"manifest.json not found at {manifest_path}\")\n"
    ]
@@ -336,9 +341,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nhf-spatial-targets\n  (dev)",
+   "display_name": "geoenv",
    "language": "python",
-   "name": "nhf-spatial-targets"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -350,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualize_merra2.ipynb
+++ b/notebooks/visualize_merra2.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "z0dpo4fe9c",
+   "id": "0",
    "metadata": {},
    "source": [
     "# MERRA-2 — Surface Soil Wetness (GWETTOP)\n",
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "393byp2vi9g",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,15 +30,16 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
-    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"merra2\" / \"merra2_consolidated.nc\"\n",
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"merra2\" / \"merra2_consolidated.nc\"\n",
     "PRIMARY_VAR = \"GWETTOP\"\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2gwat8zxrt",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nx3ccxyaqjr",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Single-month soil wetness map (global)"
@@ -63,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caj62zpw0vh",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126sc9voz8v",
+   "id": "5",
    "metadata": {},
    "source": [
     "## All three soil wetness variables — single timestep comparison"
@@ -99,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1w7l0h77zg2",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7djqn4isryo",
+   "id": "7",
    "metadata": {},
    "source": [
     "## CONUS subset — calibration period mean (2000–2009)"
@@ -137,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "xv3ybl14dhs",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2707j5v7kx3",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Seasonal comparison (CONUS, 2000–2009)"
@@ -175,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hy926e1m0q",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "z51hnu5o57h",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Monthly time series (CONUS spatial mean)"
@@ -210,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hu366nfkn6",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dwl79qy1jhb",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Monthly climatology (CONUS, 2000–2009)"
@@ -242,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aazzhre030m",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cu4438gg8gf",
+   "id": "15",
    "metadata": {},
    "source": [
     "## CF compliance verification"
@@ -271,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9gksc7t2py9",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35xmixfmz6l",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Manifest provenance check"
@@ -304,13 +305,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "jd8b4t1zomr",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest[\"sources\"].get(\"merra2\", {})\n",
@@ -328,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1s12bq2n18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,9 +339,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nhf-spatial-targets\n  (dev)",
+   "display_name": "geoenv",
    "language": "python",
-   "name": "nhf-spatial-targets"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -352,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/visualize_mod10c1.ipynb
+++ b/notebooks/visualize_mod10c1.ipynb
@@ -30,10 +30,9 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "NC_PATH = (\n",
-    "    Path.home()\n",
-    "    / \"data/nhf-runs/2026-03-16_gfv11_v0.1.0/data/raw/mod10c1_v061/mod10c1_v061_2005_consolidated.nc\"\n",
-    ")\n",
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"mod10c1_v061\" / \"mod10c1_v061_2005_consolidated.nc\"\n",
     "TIMESTEP = 0  # 0-364 for daily 2005\n"
    ]
   },
@@ -266,7 +265,7 @@
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = NC_PATH.parent.parent.parent.parent / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "manifest = json.loads(manifest_path.read_text())\n",
     "entry = manifest[\"sources\"][\"mod10c1_v061\"]\n",
     "\n",

--- a/notebooks/visualize_mod16a2.ipynb
+++ b/notebooks/visualize_mod16a2.ipynb
@@ -21,9 +21,10 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "# NC_PATH = Path.home() / \"data/nhf_runs/2026-03-14_gfv11_v0.1.0/data/raw/mod16a2_v061/mod16a2_v061_2005_consolidated.nc\"\n",
-    "NC_PATH = \"/mnt/d/nhf-conus-targets/mod16a2_v061/mod16a2_v061_2005_consolidated.nc\"\n",
-    "TIMESTEP = 0  # Change this to view different 8-day composites (0-45 for 2001)\n"
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"mod16a2_v061\" / \"mod16a2_v061_2005_consolidated.nc\"\n",
+    "TIMESTEP = 0  # Change this to view different 8-day composites\n"
    ]
   },
   {

--- a/notebooks/visualize_nldas_mosaic.ipynb
+++ b/notebooks/visualize_nldas_mosaic.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# NLDAS-2 MOSAIC — Soil Moisture\n",
@@ -18,6 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,14 +30,16 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
-    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
     "PRIMARY_VAR = \"SoilM_0_10cm\"\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Single-month soil moisture map"
@@ -59,6 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "## All soil layers — single timestep comparison"
@@ -93,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +128,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Calibration period mean (2000–2009)"
@@ -128,6 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,6 +164,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Seasonal comparison (2000–2009)"
@@ -162,6 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,6 +199,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Monthly time series (spatial mean)"
@@ -195,6 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,6 +226,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Monthly climatology (2000–2009)"
@@ -220,6 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,6 +254,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "15",
    "metadata": {},
    "source": [
     "## CF compliance verification"
@@ -246,6 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,6 +287,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Manifest provenance check"
@@ -277,12 +296,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest[\"sources\"].get(\"nldas_mosaic\", {})\n",
@@ -300,6 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/visualize_nldas_noah.ipynb
+++ b/notebooks/visualize_nldas_noah.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# NLDAS-2 NOAH — Soil Moisture\n",
@@ -18,6 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,14 +30,16 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-17_gfv11_v0.1.0\"\n",
-    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"nldas_noah\" / \"nldas_noah_consolidated.nc\"\n",
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"nldas_noah\" / \"nldas_noah_consolidated.nc\"\n",
     "PRIMARY_VAR = \"SoilM_0_10cm\"\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Single-month soil moisture map"
@@ -59,6 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "## All soil layers — single timestep comparison"
@@ -93,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,6 +129,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Calibration period mean (2000–2009)"
@@ -129,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,6 +165,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Seasonal comparison (2000–2009)"
@@ -163,6 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,6 +200,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Monthly time series (spatial mean)"
@@ -196,6 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,6 +227,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Monthly climatology (2000–2009)"
@@ -221,6 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,6 +255,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "15",
    "metadata": {},
    "source": [
     "## NOAH vs MOSAIC comparison (0–10 cm)"
@@ -247,10 +264,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic_path = RUN_DIR / \"data\" / \"raw\" / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
+    "mosaic_path = DATASTORE / \"nldas_mosaic\" / \"nldas_mosaic_consolidated.nc\"\n",
     "\n",
     "if mosaic_path.exists():\n",
     "    ds_mosaic = xr.open_dataset(mosaic_path)\n",
@@ -272,6 +290,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17",
    "metadata": {},
    "source": [
     "## CF compliance verification"
@@ -280,6 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,6 +323,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Manifest provenance check"
@@ -311,12 +332,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest[\"sources\"].get(\"nldas_noah\", {})\n",
@@ -334,6 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/visualize_reitz2017.ipynb
+++ b/notebooks/visualize_reitz2017.ipynb
@@ -30,8 +30,9 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-16_gfv11_v0.1.0\"\n",
-    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"reitz2017\" / \"reitz2017_consolidated.nc\"\n"
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"reitz2017\" / \"reitz2017_consolidated.nc\"\n"
    ]
   },
   {
@@ -303,7 +304,7 @@
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest[\"sources\"].get(\"reitz2017\", {})\n",

--- a/notebooks/visualize_ssebop_aet.ipynb
+++ b/notebooks/visualize_ssebop_aet.ipynb
@@ -31,10 +31,10 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "WORKDIR = Path(\"/mnt/d/nhf-spatial-data\")\n",
-    "NC_PATH = WORKDIR / \"data\" / \"aggregated\" / \"ssebop_agg_aet.nc\"\n",
-    "FABRIC_PATH = Path(\"/home/rmcd/data/geofabric/GFv1.1_nhru_v1_1.geoparquet\")\n",
-    "ID_COL = \"nhru_v1_1\""
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = PROJECT / \"data\" / \"aggregated\" / \"ssebop_agg_aet.nc\"\n",
+    "FABRIC_PATH = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/gfv2/fabric/gfv2_nhru_merged.gpkg\")\n",
+    "ID_COL = \"nat_hru_id\"\n"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = WORKDIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest.get(\"sources\", {}).get(\"ssebop\", {})\n",

--- a/notebooks/visualize_watergap22d.ipynb
+++ b/notebooks/visualize_watergap22d.ipynb
@@ -30,8 +30,9 @@
     "import xarray as xr\n",
     "\n",
     "# --- Configuration ---\n",
-    "RUN_DIR = Path.home() / \"data\" / \"nhf-runs\" / \"2026-03-16_gfv11_v0.1.0\"\n",
-    "NC_PATH = RUN_DIR / \"data\" / \"raw\" / \"watergap22d\" / \"watergap22d_qrdif_cf.nc\"\n"
+    "DATASTORE = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "PROJECT = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "NC_PATH = DATASTORE / \"watergap22d\" / \"watergap22d_qrdif_cf.nc\"\n"
    ]
   },
   {
@@ -267,7 +268,7 @@
    "source": [
     "import json\n",
     "\n",
-    "manifest_path = RUN_DIR / \"manifest.json\"\n",
+    "manifest_path = PROJECT / \"manifest.json\"\n",
     "if manifest_path.exists():\n",
     "    manifest = json.loads(manifest_path.read_text())\n",
     "    entry = manifest[\"sources\"].get(\"watergap22d\", {})\n",

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -19,6 +19,28 @@ from nhf_spatial_targets import __version__
 
 logger = logging.getLogger(__name__)
 
+_LICENSE_UNKNOWN = "UNKNOWN — see catalog/sources.yml"
+
+
+def resolve_license(meta: dict, source_key: str) -> str:
+    """Return the license string for a manifest entry.
+
+    If the catalog ``license`` field is missing or empty, log a WARNING
+    and return ``_LICENSE_UNKNOWN``. The fallback is explicit in the
+    manifest so operators auditing provenance can distinguish "no
+    license info captured" from "no license applies".
+    """
+    lic = meta.get("license")
+    if not lic:
+        logger.warning(
+            "Catalog source %r has missing/empty 'license' field; "
+            "writing %r into manifest. Please fix catalog/sources.yml.",
+            source_key,
+            _LICENSE_UNKNOWN,
+        )
+        return _LICENSE_UNKNOWN
+    return lic
+
 
 def log_memory(label: str) -> None:
     """Log current RSS (Linux /proc) or peak RSS (resource module fallback).

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -190,6 +190,16 @@ def apply_cf_metadata(
     if rename_map:
         ds = ds.rename(rename_map)
 
+    # After the rename, a time-stepped dataset must have a 'time' dim.
+    # Raise clearly if neither 'time' nor 'valid_time' was present —
+    # otherwise downstream steps produce time-less output silently.
+    if "time" not in ds.dims:
+        raise ValueError(
+            f"apply_cf_metadata: source {source_key!r} with "
+            f"time_step={time_step!r} has no 'time' or 'valid_time' dim; "
+            f"got dims {list(ds.dims)}."
+        )
+
     # Ensure (time, lat, lon) dimension order; use ellipsis to pass through any
     # extra dims (e.g. "nv" from time_bnds).
     dim_order = [d for d in ("time", "lat", "lon") if d in ds.dims]

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -319,13 +319,15 @@ def apply_cf_metadata(
         )
         # Pin the time encoding so that the time coordinate and any
         # associated time_bnds variable are serialized with the same units
-        # reference. Per CF-1.6 §7.1, bounds variables inherit units and
-        # calendar from the parent coordinate — xarray writes the bounds
-        # as raw integers and does NOT duplicate units/calendar attrs on
-        # disk. Pinning time.encoding is therefore sufficient (and
-        # necessary — without it, xarray emits a SerializationWarning that
-        # the two may not match). Use setdefault so source-specific
-        # encoding is preserved when present.
+        # reference. CF-1.6 §7.1 recommends that bounds variables inherit
+        # units/calendar from the parent coordinate rather than carry
+        # their own; xarray implements this by stripping duplicate
+        # units/calendar attrs from bounds variables on write. Pinning
+        # time.encoding is therefore sufficient to establish the shared
+        # reference (and also silences a SerializationWarning emitted
+        # when the parent has no units encoding but a bounds variable
+        # is present). Use setdefault so source-specific encoding is
+        # preserved when present.
         ds["time"].encoding.setdefault("units", "days since 1970-01-01")
         ds["time"].encoding.setdefault("calendar", "standard")
 

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -174,9 +174,12 @@ def apply_cf_metadata(
             f"Invalid time_step {time_step!r}; expected one of {sorted(_VALID_TIME_STEPS)}"
         )
 
-    # 1. Normalize coordinates to lat/lon
+    # 1. Normalize coordinates to lat/lon and time dimension name.
+    # CDS API ≥0.7 renames the time dimension from "time" to "valid_time";
+    # normalise here so all downstream code sees a consistent "time" dim.
     rename_map: dict[str, str] = {}
     for old, new in [
+        ("valid_time", "time"),
         ("y", "lat"),
         ("x", "lon"),
         ("latitude", "lat"),
@@ -282,6 +285,12 @@ def apply_cf_metadata(
         ds.time.attrs.update(
             {"standard_name": "time", "long_name": "time", "axis": "T"}
         )
+        # Pin the time encoding so that the time coordinate and any
+        # time_bnds variable are written with the same units reference
+        # (CF-1.6 §7.1 requires them to match).  Use setdefault so that
+        # any source-specific encoding already present is not overwritten.
+        ds["time"].encoding.setdefault("units", "days since 1970-01-01")
+        ds["time"].encoding.setdefault("calendar", "standard")
 
     # 7. Add time_bnds for monthly data
     if time_step == "monthly" and "time_bnds" not in ds:

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -296,9 +296,14 @@ def apply_cf_metadata(
             {"standard_name": "time", "long_name": "time", "axis": "T"}
         )
         # Pin the time encoding so that the time coordinate and any
-        # time_bnds variable are written with the same units reference
-        # (CF-1.6 §7.1 requires them to match).  Use setdefault so that
-        # any source-specific encoding already present is not overwritten.
+        # associated time_bnds variable are serialized with the same units
+        # reference. Per CF-1.6 §7.1, bounds variables inherit units and
+        # calendar from the parent coordinate — xarray writes the bounds
+        # as raw integers and does NOT duplicate units/calendar attrs on
+        # disk. Pinning time.encoding is therefore sufficient (and
+        # necessary — without it, xarray emits a SerializationWarning that
+        # the two may not match). Use setdefault so source-specific
+        # encoding is preserved when present.
         ds["time"].encoding.setdefault("units", "days since 1970-01-01")
         ds["time"].encoding.setdefault("calendar", "standard")
 
@@ -330,11 +335,14 @@ def apply_cf_metadata(
                 )
             bounds_list.append([(m_start - epoch).days, (m_end - epoch).days])
 
+        # time_bnds stores raw days-since-epoch integers; no units/calendar
+        # attrs are set because xarray strips them on write (CF-1.6 §7.1
+        # inheritance from the parent time coordinate). time.encoding above
+        # pins the reference for both variables.
         nv = np.array([0, 1])
         ds["time_bnds"] = xr.DataArray(
             np.array(bounds_list, dtype="<i8"),
             dims=["time", "nv"],
-            attrs={"units": "days since 1970-01-01", "calendar": "standard"},
         )
         if "nv" not in ds.coords:
             ds = ds.assign_coords(nv=nv)
@@ -399,12 +407,14 @@ def _fix_time_merra2(ds: xr.Dataset) -> xr.Dataset:
         }
     )
 
+    # time_bnds stores raw days-since-epoch integers; no units/calendar
+    # attrs are set because xarray strips them on write (CF-1.6 §7.1
+    # inheritance from the parent time coordinate).
     bnds_arr = np.array(bounds_list, dtype="<i8")
     nv = np.array([0, 1])
     ds["time_bnds"] = xr.DataArray(
         bnds_arr,
         dims=["time", "nv"],
-        attrs={"units": "days since 1970-01-01", "calendar": "standard"},
     )
     ds = ds.assign_coords(nv=nv)
 

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -406,6 +406,7 @@ def consolidate_year(
     # Remove any stale monthly file with a different year range
     for stale in monthly_dir.glob("era5_land_monthly_*.nc"):
         if stale != monthly_path:
+            logger.info("Removing stale monthly NC: %s", stale)
             stale.unlink()
     _atomic_to_netcdf(monthly_ds, monthly_path)
     logger.info("Wrote monthly NC: %s", monthly_path)

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -120,8 +120,10 @@ def download_month_variable(
     Submits a single CDS request covering all days × all hours of the
     given year-month, clipped to ``BBOX_NWSE``.
 
-    Monthly requests (~480 MB for the CONUS bbox) stay comfortably within
-    the CDS per-request cost limit. Called by ``download_year_variable``.
+    Monthly requests (~100 MB per variable-month for the CONUS+buffered
+    bbox) stay comfortably within the CDS per-request cost limit. Called
+    by ``download_year_variable``. See README "Datastore Storage
+    Estimates" for the authoritative per-period totals.
 
     Parameters
     ----------
@@ -193,9 +195,10 @@ def download_year_variable(
     """Download one year of one ERA5-Land variable to ``output_path``.
 
     Splits the annual download into 12 monthly CDS requests to stay within
-    the CDS per-request cost/size limit (~480 MB/month vs ~5.8 GB/year for
-    the CONUS bbox at hourly resolution). Monthly chunk files are written
-    alongside ``output_path`` as::
+    the CDS per-request cost/size limit (~100 MB per variable-month, i.e.
+    ~1.2 GB per variable-year, for the CONUS+buffered bbox at hourly
+    resolution). Monthly chunk files are written alongside ``output_path``
+    as::
 
         era5_land_{variable}_{year}_{month:02d}.nc
 

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -350,9 +350,17 @@ def consolidate_year(
             ds = xr.open_dataset(path)
             # CDS API ≥0.7 changed the time dimension from "time" to
             # "valid_time"; normalize here so downstream code always sees
-            # a "time" dimension.
+            # a "time" dimension. apply_cf_metadata also renames
+            # valid_time→time, but hourly_to_daily (below) indexes the
+            # "time" dim directly, so we must rename before it runs.
             if "valid_time" in ds.dims:
                 ds = ds.rename({"valid_time": "time"})
+            if "time" not in ds.dims:
+                raise ValueError(
+                    f"ERA5-Land hourly file {path} has no 'time' or "
+                    f"'valid_time' dim; got dims {list(ds.dims)}. "
+                    f"CDS schema may have changed."
+                )
             da = ds[var].load()
             ds.close()
             daily_arrays[var] = hourly_to_daily(da)

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import tempfile
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -164,6 +165,19 @@ def download_month_variable(
     tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
     try:
         client.retrieve("reanalysis-era5-land", request, str(tmp_path))
+        # CDS API (cdsapi ≥0.7.7) wraps the NetCDF in a zip archive.
+        # Detect and extract the .nc member before renaming to output_path.
+        if zipfile.is_zipfile(tmp_path):
+            with zipfile.ZipFile(tmp_path) as zf:
+                nc_names = [n for n in zf.namelist() if n.endswith(".nc")]
+                if not nc_names:
+                    raise ValueError(
+                        f"No .nc file found in CDS zip: {list(zf.namelist())}"
+                    )
+                zf.extract(nc_names[0], path=tmp_path.parent)
+                extracted = tmp_path.parent / nc_names[0]
+                tmp_path.unlink()
+                extracted.rename(tmp_path)
         tmp_path.rename(output_path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)
@@ -331,6 +345,11 @@ def consolidate_year(
             if not path.exists():
                 raise FileNotFoundError(f"Missing hourly file: {path}")
             ds = xr.open_dataset(path)
+            # CDS API ≥0.7 changed the time dimension from "time" to
+            # "valid_time"; normalize here so downstream code always sees
+            # a "time" dimension.
+            if "valid_time" in ds.dims:
+                ds = ds.rename({"valid_time": "time"})
             da = ds[var].load()
             ds.close()
             daily_arrays[var] = hourly_to_daily(da)
@@ -469,15 +488,30 @@ def _update_manifest(
     else:
         manifest = {"sources": {}, "steps": []}
 
-    manifest.setdefault("sources", {})[_SOURCE_KEY] = {
-        "source_key": _SOURCE_KEY,
-        "access_url": meta["access"]["url"],
-        "license": license_str,
-        "period": period,
-        "bbox": bbox,
-        "variables": [v["name"] for v in meta["variables"]],
-        "files": files,
-    }
+    manifest.setdefault("sources", {})
+    entry = manifest["sources"].get(_SOURCE_KEY, {})
+
+    # Merge files by year so incremental runs accumulate records
+    existing_by_year: dict[int, dict] = {f["year"]: f for f in entry.get("files", [])}
+    for f in files:
+        existing_by_year[f["year"]] = f
+    merged_files = [existing_by_year[y] for y in sorted(existing_by_year)]
+
+    all_years = sorted(f["year"] for f in merged_files)
+    effective_period = f"{all_years[0]}/{all_years[-1]}" if all_years else period
+
+    entry.update(
+        {
+            "source_key": _SOURCE_KEY,
+            "access_url": meta["access"]["url"],
+            "license": license_str,
+            "period": effective_period,
+            "bbox": bbox,
+            "variables": [v["name"] for v in meta["variables"]],
+            "files": merged_files,
+        }
+    )
+    manifest["sources"][_SOURCE_KEY] = entry
 
     fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
     try:

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -444,25 +444,35 @@ def fetch_era5_land(workdir: Path, period: str) -> dict:
     now_utc = datetime.now(timezone.utc).isoformat()
     files: list[dict] = []
 
-    for year in years_in_period(period):
-        for var in VARIABLES:
-            out = hourly_dir / f"era5_land_{var}_{year}.nc"
-            download_year_variable(year, var, out)
-        daily_path, monthly_path = consolidate_year(
-            year, hourly_dir, daily_dir, monthly_dir
-        )
-        files.append(
-            {
-                "year": year,
-                "daily_path": str(daily_path),
-                "monthly_path": str(monthly_path),
-                "consolidated_utc": now_utc,
-            }
-        )
-
     bbox = ws.fabric["bbox_buffered"]
     license_str = meta.get("license", "Copernicus license")
-    _update_manifest(workdir, period, bbox, meta, license_str, files)
+
+    try:
+        for year in years_in_period(period):
+            for var in VARIABLES:
+                out = hourly_dir / f"era5_land_{var}_{year}.nc"
+                download_year_variable(year, var, out)
+            daily_path, monthly_path = consolidate_year(
+                year, hourly_dir, daily_dir, monthly_dir
+            )
+            files.append(
+                {
+                    "year": year,
+                    "daily_path": str(daily_path),
+                    "monthly_path": str(monthly_path),
+                    "consolidated_utc": now_utc,
+                }
+            )
+    except Exception:
+        logger.error(
+            "ERA5-Land fetch failed after completing %d year(s); "
+            "completed chunks preserved on disk, re-run to resume.",
+            len(files),
+        )
+        raise
+    finally:
+        if files:
+            _update_manifest(workdir, period, bbox, meta, license_str, files)
 
     return {
         "source_key": _SOURCE_KEY,
@@ -502,13 +512,39 @@ def _update_manifest(
     manifest.setdefault("sources", {})
     entry = manifest["sources"].get(_SOURCE_KEY, {})
 
-    # Merge files by year so incremental runs accumulate records
-    existing_by_year: dict[int, dict] = {f["year"]: f for f in entry.get("files", [])}
+    # Merge files by year so incremental runs accumulate records.
+    # Parse defensively: prior manifests may have been hand-edited or
+    # written by an older version with a different schema.
+    existing_by_year: dict[int, dict] = {}
+    for f in entry.get("files", []):
+        if "year" not in f:
+            logger.warning(
+                "Skipping malformed manifest entry in %s (missing 'year' key): %s",
+                manifest_path,
+                f,
+            )
+            continue
+        try:
+            existing_by_year[int(f["year"])] = f
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"manifest.json entry for {_SOURCE_KEY} has invalid year "
+                f"{f['year']!r}: {exc}"
+            ) from exc
     for f in files:
-        existing_by_year[f["year"]] = f
+        existing_by_year[int(f["year"])] = f
+
+    # Refresh monthly_path on every merged entry — consolidate_year writes
+    # a single rolling monthly NC, so all year entries should point to the
+    # current filename (prior entries pointed at the now-deleted old name).
+    latest_monthly_path = files[-1]["monthly_path"] if files else None
+    if latest_monthly_path is not None:
+        for entry_file in existing_by_year.values():
+            entry_file["monthly_path"] = latest_monthly_path
+
     merged_files = [existing_by_year[y] for y in sorted(existing_by_year)]
 
-    all_years = sorted(f["year"] for f in merged_files)
+    all_years = sorted(existing_by_year)
     effective_period = f"{all_years[0]}/{all_years[-1]}" if all_years else period
 
     entry.update(

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -481,11 +481,22 @@ def fetch_era5_land(workdir: Path, period: str) -> dict:
             "ERA5-Land fetch failed after completing %d year(s); "
             "completed chunks preserved on disk, re-run to resume.",
             len(files),
+            exc_info=True,
         )
         raise
     finally:
+        # Persist partial-run provenance even if the loop raised above.
+        # Swallow any manifest-write exception so it does not mask the
+        # original fetch failure (which is the important signal).
         if files:
-            _update_manifest(workdir, period, bbox, meta, license_str, files)
+            try:
+                _update_manifest(workdir, period, bbox, meta, license_str, files)
+            except Exception:
+                logger.exception(
+                    "Failed to persist partial ERA5-Land manifest for "
+                    "%d year(s); manifest.json may be stale.",
+                    len(files),
+                )
 
     return {
         "source_key": _SOURCE_KEY,
@@ -540,10 +551,17 @@ def _update_manifest(
         try:
             existing_by_year[int(f["year"])] = f
         except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"manifest.json entry for {_SOURCE_KEY} has invalid year "
-                f"{f['year']!r}: {exc}"
-            ) from exc
+            # Match the sibling "missing year" handler above: skip-and-warn
+            # rather than raise. A corrupt prior entry shouldn't block
+            # recording of newly fetched years (which is arguably more
+            # valuable than failing hard on old cruft).
+            logger.warning(
+                "Skipping manifest entry with invalid year %r in %s: %s",
+                f.get("year"),
+                manifest_path,
+                exc,
+            )
+            continue
     for f in files:
         existing_by_year[int(f["year"])] = f
 
@@ -552,8 +570,17 @@ def _update_manifest(
     # current filename (prior entries pointed at the now-deleted old name).
     latest_monthly_path = files[-1]["monthly_path"] if files else None
     if latest_monthly_path is not None:
+        refreshed = 0
         for entry_file in existing_by_year.values():
-            entry_file["monthly_path"] = latest_monthly_path
+            if entry_file.get("monthly_path") != latest_monthly_path:
+                entry_file["monthly_path"] = latest_monthly_path
+                refreshed += 1
+        if refreshed > len(files):
+            logger.info(
+                "Refreshed monthly_path on %d prior manifest entries to %s",
+                refreshed - len(files),
+                latest_monthly_path,
+            )
 
     merged_files = [existing_by_year[y] for y in sorted(existing_by_year)]
 

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -22,7 +22,7 @@ import xarray as xr
 import nhf_spatial_targets.catalog as _catalog
 from nhf_spatial_targets import __version__
 from nhf_spatial_targets.fetch._period import years_in_period
-from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata, resolve_license
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
@@ -458,7 +458,7 @@ def fetch_era5_land(workdir: Path, period: str) -> dict:
     files: list[dict] = []
 
     bbox = ws.fabric["bbox_buffered"]
-    license_str = meta.get("license", "Copernicus license")
+    license_str = resolve_license(meta, _SOURCE_KEY)
 
     try:
         for year in years_in_period(period):

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -234,13 +234,25 @@ def download_year_variable(
         output_path.parent / f"{stem}_{month:02d}.nc" for month in range(1, 13)
     ]
 
-    # Fast path: year file exists and is not older than any present chunk.
+    # Fast path: year file exists, all 12 chunks present, and no chunk newer.
+    # Requiring all 12 chunks on disk guards against the case where the year
+    # file was written from a partial set (e.g. 6/12) and later chunks arrive
+    # with an older mtime (rsync -a, restore-from-backup) that would otherwise
+    # bypass the mtime check.
     if output_path.exists():
-        year_mtime = output_path.stat().st_mtime
-        chunk_mtimes = [p.stat().st_mtime for p in chunk_paths if p.exists()]
-        if not chunk_mtimes or max(chunk_mtimes) <= year_mtime:
-            logger.info("Skipping up-to-date ERA5-Land year file: %s", output_path)
-            return output_path
+        existing_chunks = [p for p in chunk_paths if p.exists()]
+        if len(existing_chunks) == 12:
+            year_mtime = output_path.stat().st_mtime
+            chunk_mtimes = [p.stat().st_mtime for p in existing_chunks]
+            if max(chunk_mtimes) <= year_mtime:
+                logger.info("Skipping up-to-date ERA5-Land year file: %s", output_path)
+                return output_path
+        else:
+            logger.info(
+                "Rebuilding %s: year file exists but only %d/12 chunks on disk",
+                output_path,
+                len(existing_chunks),
+            )
 
     # Download any missing monthly chunks.
     for month, chunk_path in enumerate(chunk_paths, start=1):

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -107,20 +107,26 @@ def _cds_client():
     return cdsapi.Client()
 
 
-def download_year_variable(
+def download_month_variable(
     year: int,
+    month: int,
     variable: str,
     output_path: Path,
 ) -> Path:
-    """Download one year of one ERA5-Land variable to ``output_path``.
+    """Download one month of one ERA5-Land variable to ``output_path``.
 
     Idempotent: if ``output_path`` already exists, returns immediately.
-    Submits a single CDS request covering all 12 months × all hours of
-    the given year, clipped to ``BBOX_NWSE``.
+    Submits a single CDS request covering all days × all hours of the
+    given year-month, clipped to ``BBOX_NWSE``.
+
+    Monthly requests (~480 MB for the CONUS bbox) stay comfortably within
+    the CDS per-request cost limit. Called by ``download_year_variable``.
 
     Parameters
     ----------
     year : int
+    month : int
+        Calendar month (1–12).
     variable : {"ro", "sro", "ssro"}
     output_path : Path
         Target NetCDF file. Parent directory is created if missing.
@@ -141,14 +147,20 @@ def download_year_variable(
     request = {
         "variable": _VARIABLE_REQUEST_NAME[variable],
         "year": str(year),
-        "month": [f"{m:02d}" for m in range(1, 13)],
+        "month": f"{month:02d}",
         "day": [f"{d:02d}" for d in range(1, 32)],
         "time": [f"{h:02d}:00" for h in range(24)],
         "area": BBOX_NWSE,
         "format": "netcdf",
     }
     client = _cds_client()
-    logger.info("Submitting CDS request for %s %d → %s", variable, year, output_path)
+    logger.info(
+        "Submitting CDS request for %s %d-%02d → %s",
+        variable,
+        year,
+        month,
+        output_path,
+    )
     tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
     try:
         client.retrieve("reanalysis-era5-land", request, str(tmp_path))
@@ -156,6 +168,79 @@ def download_year_variable(
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
+    return output_path
+
+
+def download_year_variable(
+    year: int,
+    variable: str,
+    output_path: Path,
+) -> Path:
+    """Download one year of one ERA5-Land variable to ``output_path``.
+
+    Splits the annual download into 12 monthly CDS requests to stay within
+    the CDS per-request cost/size limit (~480 MB/month vs ~5.8 GB/year for
+    the CONUS bbox at hourly resolution). Monthly chunk files are written
+    alongside ``output_path`` as::
+
+        era5_land_{variable}_{year}_{month:02d}.nc
+
+    and kept on disk for re-run idempotency. Once all 12 chunks are present
+    they are concatenated along the time axis into ``output_path``.
+
+    Idempotent at two levels:
+    - If ``output_path`` (year file) exists and is not older than any monthly
+      chunk, the function returns immediately without any CDS calls.
+    - If an individual monthly chunk already exists, that month's CDS request
+      is skipped.
+
+    Parameters
+    ----------
+    year : int
+    variable : {"ro", "sro", "ssro"}
+    output_path : Path
+        Target per-year NetCDF file. Parent directory is created if missing.
+
+    Returns
+    -------
+    Path
+        ``output_path`` (for caller convenience).
+    """
+    if variable not in _VARIABLE_REQUEST_NAME:
+        raise ValueError(f"Unknown ERA5-Land variable: {variable!r}")
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Monthly chunk paths live in the same directory as the year file.
+    stem = output_path.stem  # e.g. "era5_land_ro_2020"
+    chunk_paths = [
+        output_path.parent / f"{stem}_{month:02d}.nc" for month in range(1, 13)
+    ]
+
+    # Fast path: year file exists and is not older than any present chunk.
+    if output_path.exists():
+        year_mtime = output_path.stat().st_mtime
+        chunk_mtimes = [p.stat().st_mtime for p in chunk_paths if p.exists()]
+        if not chunk_mtimes or max(chunk_mtimes) <= year_mtime:
+            logger.info("Skipping up-to-date ERA5-Land year file: %s", output_path)
+            return output_path
+
+    # Download any missing monthly chunks.
+    for month, chunk_path in enumerate(chunk_paths, start=1):
+        download_month_variable(year, month, variable, chunk_path)
+
+    # Concatenate all 12 monthly chunks into the year file.
+    logger.info("Concatenating monthly chunks into year file: %s", output_path)
+    with xr.open_mfdataset(chunk_paths, combine="by_coords") as ds:
+        year_ds = ds.load()
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    try:
+        year_ds.to_netcdf(tmp_path, format="NETCDF4")
+        tmp_path.rename(output_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    logger.info("Wrote year file: %s", output_path)
     return output_path
 
 

--- a/src/nhf_spatial_targets/fetch/merra2.py
+++ b/src/nhf_spatial_targets/fetch/merra2.py
@@ -254,7 +254,7 @@ def _update_manifest(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license", ""),
+            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/merra2.py
+++ b/src/nhf_spatial_targets/fetch/merra2.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import tempfile
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -247,11 +249,12 @@ def _update_manifest(
     if "sources" not in manifest:
         manifest["sources"] = {}
 
-    merra2 = manifest["sources"].get("merra2", {})
+    merra2 = manifest["sources"].get(_SOURCE_KEY, {})
     merra2.update(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
+            "license": meta.get("license", ""),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],
@@ -260,14 +263,10 @@ def _update_manifest(
             "last_consolidated_utc": consolidation["last_consolidated_utc"],
         }
     )
-    manifest["sources"]["merra2"] = merra2
-
-    import tempfile
+    manifest["sources"][_SOURCE_KEY] = merra2
 
     tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
     try:
-        import os
-
         with os.fdopen(tmp_fd, "w") as f:
             json.dump(manifest, f, indent=2)
         Path(tmp_path).replace(manifest_path)

--- a/src/nhf_spatial_targets/fetch/merra2.py
+++ b/src/nhf_spatial_targets/fetch/merra2.py
@@ -16,7 +16,7 @@ import earthaccess
 import nhf_spatial_targets.catalog as _catalog
 from nhf_spatial_targets.fetch._auth import earthdata_login
 from nhf_spatial_targets.fetch._period import months_in_period, parse_period
-from nhf_spatial_targets.fetch.consolidate import consolidate_merra2
+from nhf_spatial_targets.fetch.consolidate import resolve_license, consolidate_merra2
 from nhf_spatial_targets.workspace import load as _load_project
 
 _SOURCE_KEY = "merra2"
@@ -254,7 +254,7 @@ def _update_manifest(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
+            "license": resolve_license(meta, _SOURCE_KEY),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -283,9 +283,12 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
+            "license": meta.get("license", ""),
             "period": period,
             "bbox": bbox,
-            "variables": meta["variables"],
+            "variables": [
+                v["name"] if isinstance(v, dict) else v for v in meta["variables"]
+            ],
             "files": files,
             "consolidated_ncs": consolidated_ncs,
             "last_consolidated_utc": now_utc if consolidated_ncs else None,

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -24,6 +24,7 @@ from nhf_spatial_targets.fetch.consolidate import (
     consolidate_mod16a2_finalize,
     consolidate_mod16a2_timestep,
     log_memory,
+    resolve_license,
 )
 from nhf_spatial_targets.workspace import load as _load_project
 
@@ -300,7 +301,7 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
+            "license": resolve_license(meta, source_key),
             "period": period,
             "bbox": bbox,
             "variables": [_variable_name(v) for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -283,7 +283,7 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license", ""),
+            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
             "period": period,
             "bbox": bbox,
             "variables": [

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -38,6 +38,23 @@ _MODIS_YEAR_RE = re.compile(r"\.A(\d{4})\d{3}\.")
 _MODIS_YDOY_RE = re.compile(r"\.A(\d{7})\.")
 
 
+def _variable_name(v: dict | str) -> str:
+    """Extract a variable name from a catalog entry.
+
+    Catalog entries may be either a dict with a ``name`` key (canonical
+    form) or a bare string (legacy form). Raise on anything else so a
+    malformed catalog surfaces a clear error instead of writing the
+    raw object into the manifest.
+    """
+    if isinstance(v, dict):
+        return v["name"]
+    if isinstance(v, str):
+        return v
+    raise TypeError(
+        f"Unexpected variable entry type in MODIS catalog: {type(v).__name__} ({v!r})"
+    )
+
+
 def _granule_overlaps_bbox(
     granule: object,
     bbox: tuple[float, float, float, float],
@@ -286,9 +303,7 @@ def _update_manifest(
             "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
             "period": period,
             "bbox": bbox,
-            "variables": [
-                v["name"] if isinstance(v, dict) else v for v in meta["variables"]
-            ],
+            "variables": [_variable_name(v) for v in meta["variables"]],
             "files": files,
             "consolidated_ncs": consolidated_ncs,
             "last_consolidated_utc": now_utc if consolidated_ncs else None,
@@ -338,7 +353,7 @@ def fetch_mod16a2(workdir: Path, period: str) -> dict:
     source_key = _MOD16A2_SOURCE_KEY
     meta = _catalog.source(source_key)
     short_name = meta["access"]["short_name"]
-    variables = [v["name"] if isinstance(v, dict) else v for v in meta["variables"]]
+    variables = [_variable_name(v) for v in meta["variables"]]
 
     _check_superseded(meta, source_key)
     earthdata_login(workdir)
@@ -821,7 +836,7 @@ def fetch_mod10c1(workdir: Path, period: str) -> dict:
         )
 
     # Per-year consolidation
-    variables = [v["name"] if isinstance(v, dict) else v for v in meta["variables"]]
+    variables = [_variable_name(v) for v in meta["variables"]]
     consolidated_ncs: dict[str, str] = {}
     years_on_disk = sorted({f["year"] for f in files})
     for year in years_on_disk:

--- a/src/nhf_spatial_targets/fetch/ncep_ncar.py
+++ b/src/nhf_spatial_targets/fetch/ncep_ncar.py
@@ -253,7 +253,7 @@ def _update_manifest(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license", ""),
+            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/ncep_ncar.py
+++ b/src/nhf_spatial_targets/fetch/ncep_ncar.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 import urllib.error
 import urllib.request
 import warnings
@@ -251,6 +253,7 @@ def _update_manifest(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
+            "license": meta.get("license", ""),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],
@@ -261,12 +264,8 @@ def _update_manifest(
     )
     manifest["sources"][_SOURCE_KEY] = entry
 
-    import tempfile
-
     tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
     try:
-        import os
-
         with os.fdopen(tmp_fd, "w") as f:
             json.dump(manifest, f, indent=2)
         Path(tmp_path).replace(manifest_path)

--- a/src/nhf_spatial_targets/fetch/ncep_ncar.py
+++ b/src/nhf_spatial_targets/fetch/ncep_ncar.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 
 import nhf_spatial_targets.catalog as _catalog
 from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.fetch.consolidate import resolve_license
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
@@ -253,7 +254,7 @@ def _update_manifest(
         {
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
+            "license": resolve_license(meta, _SOURCE_KEY),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/nldas.py
+++ b/src/nhf_spatial_targets/fetch/nldas.py
@@ -14,6 +14,7 @@ import earthaccess
 import nhf_spatial_targets.catalog as _catalog
 from nhf_spatial_targets.fetch._auth import earthdata_login
 from nhf_spatial_targets.fetch._period import months_in_period, parse_period
+from nhf_spatial_targets.fetch.consolidate import resolve_license
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
@@ -302,7 +303,7 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
+            "license": resolve_license(meta, source_key),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/nldas.py
+++ b/src/nhf_spatial_targets/fetch/nldas.py
@@ -302,6 +302,7 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
+            "license": meta.get("license", ""),
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/src/nhf_spatial_targets/fetch/nldas.py
+++ b/src/nhf_spatial_targets/fetch/nldas.py
@@ -302,7 +302,7 @@ def _update_manifest(
         {
             "source_key": source_key,
             "access_url": meta["access"]["url"],
-            "license": meta.get("license", ""),
+            "license": meta.get("license") or "UNKNOWN — see catalog/sources.yml",
             "period": period,
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -89,3 +89,17 @@ def test_recharge_includes_era5_land():
     v = catalog.variable("recharge")
     assert "era5_land" in v["sources"]
     assert v["range_method"] == "normalized_minmax"
+
+
+def test_every_current_source_has_status_field():
+    """Every non-superseded source must declare ``status: current``.
+
+    Guards against accidents where status is dropped (e.g., the
+    mod10c1_v061 regression where a trailing key got overwritten).
+    """
+    for key, src in sources().items():
+        if src.get("superseded_by") is not None:
+            continue
+        assert src.get("status") == "current", (
+            f"Source {key!r} is missing 'status: current'"
+        )

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -830,3 +830,67 @@ def test_apply_cf_metadata_raises_when_time_missing():
     )
     with pytest.raises(ValueError, match="no 'time' or 'valid_time' dim"):
         apply_cf_metadata(ds, "era5_land", "daily")
+
+
+def test_time_bnds_roundtrip_no_warning(tmp_path):
+    """Monthly datasets written by apply_cf_metadata decode time_bnds correctly.
+
+    Guards the CF-1.6 §7.1 inheritance contract:
+    - time.encoding carries the units/calendar reference
+    - time_bnds is written as raw int64 days-since-epoch (no duplicate attrs)
+    - on read-back, xarray correctly decodes time_bnds to datetime64 via
+      the parent time coord
+    - no SerializationWarning is emitted during write
+    """
+    import warnings
+
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+
+    times = pd.date_range("2020-01-01", periods=3, freq="1MS")
+    ds = xr.Dataset(
+        {"foo": (("time", "lat", "lon"), np.zeros((3, 2, 2)))},
+        coords={"time": times, "lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    ds = apply_cf_metadata(ds, "era5_land", "monthly")
+
+    out = tmp_path / "roundtrip.nc"
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ds.to_netcdf(out)
+
+    # No time-related SerializationWarning — any such warning indicates the
+    # units pinning has regressed.
+    time_warnings = [
+        w
+        for w in caught
+        if "time" in str(w.message).lower() and "bounds" in str(w.message).lower()
+    ]
+    assert not time_warnings, f"Unexpected time/bounds warnings: {time_warnings}"
+
+    # Read back with full CF decoding; time_bnds should be datetime64.
+    decoded = xr.open_dataset(out)
+    try:
+        assert decoded.time_bnds.dtype == np.dtype("datetime64[ns]")
+        assert decoded.time.attrs["bounds"] == "time_bnds"
+        # Bounds must bracket their time value.
+        t0 = decoded.time.values[0]
+        lo, hi = decoded.time_bnds.values[0]
+        assert lo <= t0 < hi
+    finally:
+        decoded.close()
+
+    # Raw on-disk: time has explicit units; time_bnds has raw ints with no
+    # units attr (xarray strips it per CF inheritance). Pin this behavior.
+    raw = xr.open_dataset(out, decode_times=False)
+    try:
+        assert raw.time.attrs.get("units") == "days since 1970-01-01"
+        assert raw.time.attrs.get("calendar") == "standard"
+        assert raw.time_bnds.dtype.kind == "i"
+        # Bounds variable itself has no units attr per CF-1.6 §7.1 inheritance.
+        assert "units" not in raw.time_bnds.attrs
+    finally:
+        raw.close()

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -894,3 +894,38 @@ def test_time_bnds_roundtrip_no_warning(tmp_path):
         assert "units" not in raw.time_bnds.attrs
     finally:
         raw.close()
+
+
+def test_resolve_license_returns_catalog_value_when_present():
+    """When the catalog provides a license, it's returned verbatim."""
+    from nhf_spatial_targets.fetch.consolidate import resolve_license
+
+    meta = {"license": "public domain (NASA)"}
+    assert resolve_license(meta, "some_source") == "public domain (NASA)"
+
+
+def test_resolve_license_falls_back_with_warning_when_missing(caplog):
+    """Missing license → UNKNOWN sentinel + WARNING log mentioning the source."""
+    import logging
+
+    from nhf_spatial_targets.fetch.consolidate import resolve_license
+
+    with caplog.at_level(logging.WARNING):
+        result = resolve_license({}, "test_source")
+    assert result == "UNKNOWN — see catalog/sources.yml"
+    assert any(
+        "test_source" in rec.message and "license" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_resolve_license_falls_back_when_empty_string(caplog):
+    """An explicit empty string triggers the fallback too."""
+    import logging
+
+    from nhf_spatial_targets.fetch.consolidate import resolve_license
+
+    with caplog.at_level(logging.WARNING):
+        result = resolve_license({"license": ""}, "test_source")
+    assert result == "UNKNOWN — see catalog/sources.yml"
+    assert len(caplog.records) >= 1

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -815,3 +815,18 @@ def test_write_netcdf_atomic_failure_no_partial(tmp_path):
 
     assert not out.exists()
     assert not list(tmp_path.glob("*.nc.tmp"))
+
+
+def test_apply_cf_metadata_raises_when_time_missing():
+    """apply_cf_metadata for a time-stepped product must have a time dim."""
+    import numpy as np
+    import xarray as xr
+    from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+
+    # Dataset with lat/lon but no time (or valid_time) dim.
+    ds = xr.Dataset(
+        {"foo": (("lat", "lon"), np.zeros((2, 2)))},
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    with pytest.raises(ValueError, match="no 'time' or 'valid_time' dim"):
+        apply_cf_metadata(ds, "era5_land", "daily")

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -908,3 +908,80 @@ def test_update_manifest_refreshes_monthly_path_on_prior_entries(tmp_path):
     entry = json.loads((wd / "manifest.json").read_text())["sources"]["era5_land"]
     # Both the prior 1979 entry AND the new 1980 entry point to the new path.
     assert all(f["monthly_path"] == new_monthly for f in entry["files"])
+
+
+def test_fetch_era5_land_writes_partial_manifest_on_failure(tmp_path, monkeypatch):
+    """If a later year raises, the manifest records only the completed years.
+
+    Guards the try/finally pattern in fetch_era5_land that persists
+    partial-run state so operators can distinguish "completed" from
+    "needs re-run" years after a SLURM crash.
+    """
+    import json
+
+    import yaml
+
+    from nhf_spatial_targets.fetch import era5_land
+    from nhf_spatial_targets.fetch.era5_land import fetch_era5_land
+
+    wd = tmp_path / "run"
+    wd.mkdir()
+    (wd / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": "", "id_col": "nhm_id"},
+                "datastore": str(wd / "datastore"),
+                "dir_mode": "2775",
+            }
+        )
+    )
+    (wd / "fabric.json").write_text(
+        json.dumps(
+            {
+                "hru_count": 3,
+                "id_col": "nhm_id",
+                "bbox_buffered": {
+                    "minx": -125.0,
+                    "miny": 24.7,
+                    "maxx": -66.0,
+                    "maxy": 53.0,
+                },
+            }
+        )
+    )
+    (wd / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+
+    def fake_download(year, variable, output_path):
+        pass
+
+    def fake_consolidate(year, hourly_dir, daily_dir, monthly_dir):
+        if year == 1981:
+            raise RuntimeError("simulated failure at year 1981")
+        daily_dir.mkdir(parents=True, exist_ok=True)
+        monthly_dir.mkdir(parents=True, exist_ok=True)
+        daily = daily_dir / f"era5_land_daily_{year}.nc"
+        monthly = monthly_dir / f"era5_land_monthly_{year}_{year}.nc"
+        daily.write_bytes(b"fake")
+        monthly.write_bytes(b"fake")
+        return daily, monthly
+
+    monkeypatch.setattr(era5_land, "download_year_variable", fake_download)
+    monkeypatch.setattr(era5_land, "consolidate_year", fake_consolidate)
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        fetch_era5_land(workdir=wd, period="1979/1982")
+
+    # Manifest should contain 1979 and 1980 (completed); not 1981 or 1982.
+    manifest = json.loads((wd / "manifest.json").read_text())
+    years = sorted(f["year"] for f in manifest["sources"]["era5_land"]["files"])
+    assert years == [1979, 1980]
+
+
+def test_variable_name_raises_on_unexpected_type():
+    """_variable_name raises TypeError naming the bad entry."""
+    from nhf_spatial_targets.fetch.modis import _variable_name
+
+    with pytest.raises(TypeError, match="Unexpected variable entry type"):
+        _variable_name(42)
+    with pytest.raises(TypeError, match="Unexpected variable entry type"):
+        _variable_name(["list_not_allowed"])

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -316,6 +316,7 @@ def test_download_year_atomic_cleanup_on_failure(tmp_path, monkeypatch):
 
 
 def test_download_year_skips_existing(tmp_path, monkeypatch):
+    """Fast path: year file + all 12 chunks present, no newer chunks → skip."""
     from nhf_spatial_targets.fetch.era5_land import download_year_variable
 
     fake_client = MagicMock()
@@ -323,9 +324,58 @@ def test_download_year_skips_existing(tmp_path, monkeypatch):
         "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
     )
     out = tmp_path / "era5_land_ro_2020.nc"
+    # Pre-stage all 12 monthly chunks older than the year file.
+    for month in range(1, 13):
+        chunk = tmp_path / f"era5_land_ro_2020_{month:02d}.nc"
+        chunk.write_bytes(b"chunk")
     out.write_bytes(b"existing")
     download_year_variable(year=2020, variable="ro", output_path=out)
     fake_client.retrieve.assert_not_called()
+
+
+def test_download_year_rebuilds_when_chunks_incomplete(tmp_path, monkeypatch):
+    """If year file exists but fewer than 12 chunks on disk, rebuild.
+
+    Guards against the case where the year file was written from a
+    partial set of chunks and later chunks arrive with an older mtime
+    (e.g. rsync -a, restore-from-backup) that would otherwise bypass
+    the mtime check.
+    """
+    from nhf_spatial_targets.fetch.era5_land import download_year_variable
+
+    fake_client = MagicMock()
+
+    def fake_retrieve(dataset, request, target_path):
+        # Minimal valid NC so open_mfdataset can read back during concat.
+        import numpy as np
+        import pandas as pd
+        import xarray as xr
+
+        month = int(request["month"])
+        times = pd.date_range(f"2020-{month:02d}-01", periods=1, freq="h")
+        da = xr.DataArray(
+            np.zeros((1, 1, 1)),
+            dims=("time", "latitude", "longitude"),
+            coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+            name="ro",
+        )
+        da.to_dataset().to_netcdf(target_path)
+
+    fake_client.retrieve.side_effect = fake_retrieve
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+    out = tmp_path / "era5_land_ro_2020.nc"
+    # Pre-stage only 6 chunks; year file pretends to be up to date but isn't.
+    for month in range(1, 7):
+        chunk = tmp_path / f"era5_land_ro_2020_{month:02d}.nc"
+        fake_retrieve(None, {"month": f"{month:02d}"}, chunk)
+    out.write_bytes(b"partial")
+    download_year_variable(year=2020, variable="ro", output_path=out)
+    # Exactly the 6 missing months should have been fetched from CDS.
+    assert fake_client.retrieve.call_count == 6
+    # Final year file exists.
+    assert out.exists()
 
 
 def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch):

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -242,8 +242,6 @@ def test_download_month_variable_atomic_cleanup_on_failure(tmp_path, monkeypatch
         "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
     )
 
-    import pytest
-
     with pytest.raises(RuntimeError, match="CDS server error"):
         download_month_variable(year=2020, month=3, variable="ro", output_path=out)
 
@@ -305,8 +303,6 @@ def test_download_year_atomic_cleanup_on_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
     )
-
-    import pytest
 
     with pytest.raises(RuntimeError, match="CDS server error"):
         download_year_variable(year=2020, variable="ro", output_path=out)
@@ -800,9 +796,14 @@ def test_update_manifest_handles_missing_year_key(tmp_path, caplog):
     assert years == [1979, 1980]
 
 
-def test_update_manifest_raises_on_bad_year_type(tmp_path):
-    """Prior manifest entry with a non-numeric 'year' raises a clear error."""
+def test_update_manifest_skips_bad_year_with_warning(tmp_path, caplog):
+    """Prior manifest entry with a non-numeric 'year' is skipped + warned.
+
+    Consistency with the sibling missing-'year' handler: corrupt prior
+    entries should not block recording of newly fetched years.
+    """
     import json
+    import logging
 
     from nhf_spatial_targets.fetch.era5_land import _update_manifest
 
@@ -814,11 +815,22 @@ def test_update_manifest_raises_on_bad_year_type(tmp_path):
     bbox = {"minx": -125.0, "miny": 24.7, "maxx": -66.0, "maxy": 53.0}
 
     manifest = {
-        "sources": {"era5_land": {"files": [{"year": "twenty", "daily_path": "/x.nc"}]}}
+        "sources": {
+            "era5_land": {
+                "files": [
+                    {"year": "twenty", "daily_path": "/bad.nc"},
+                    {
+                        "year": 1979,
+                        "daily_path": "/good.nc",
+                        "monthly_path": "/m.nc",
+                    },
+                ]
+            }
+        }
     }
     (wd / "manifest.json").write_text(json.dumps(manifest))
 
-    with pytest.raises(ValueError, match="invalid year"):
+    with caplog.at_level(logging.WARNING):
         _update_manifest(
             wd,
             "1980/1980",
@@ -834,6 +846,15 @@ def test_update_manifest_raises_on_bad_year_type(tmp_path):
                 }
             ],
         )
+
+    assert any(
+        "invalid year" in rec.message and "twenty" in rec.message
+        for rec in caplog.records
+    )
+    result = json.loads((wd / "manifest.json").read_text())
+    years = sorted(f["year"] for f in result["sources"]["era5_land"]["files"])
+    # Bad entry skipped; the good 1979 entry and new 1980 entry both kept.
+    assert years == [1979, 1980]
 
 
 def test_update_manifest_refreshes_monthly_path_on_prior_entries(tmp_path):

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -143,18 +143,92 @@ def test_daily_to_monthly_sum():
     assert monthly.attrs["units"] == "m"
 
 
+def test_download_month_variable_calls_cds_client(tmp_path, monkeypatch):
+    """download_month_variable submits a single-month CDS request."""
+    from nhf_spatial_targets.fetch.era5_land import download_month_variable
+
+    out = tmp_path / "era5_land_ro_2020_03.nc"
+
+    def fake_retrieve(dataset, request, path):
+        Path(path).write_bytes(b"fake_nc_data")
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock(side_effect=fake_retrieve)
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    result = download_month_variable(year=2020, month=3, variable="ro", output_path=out)
+
+    fake_client.retrieve.assert_called_once()
+    args, _ = fake_client.retrieve.call_args
+    assert args[0] == "reanalysis-era5-land"
+    request = args[1]
+    assert request["variable"] == "runoff"
+    assert request["year"] == "2020"
+    assert request["month"] == "03"
+    assert request["area"] == [53.0, -125.0, 24.7, -66.0]
+    assert request["format"] == "netcdf"
+    assert len(request["day"]) == 31
+    assert len(request["time"]) == 24
+    assert out.exists()
+    assert not Path(str(out) + ".tmp").exists()
+    assert result == out
+
+
+def test_download_month_variable_skips_existing(tmp_path, monkeypatch):
+    from nhf_spatial_targets.fetch.era5_land import download_month_variable
+
+    fake_client = MagicMock()
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+    out = tmp_path / "era5_land_ro_2020_03.nc"
+    out.write_bytes(b"existing")
+    download_month_variable(year=2020, month=3, variable="ro", output_path=out)
+    fake_client.retrieve.assert_not_called()
+
+
+def test_download_month_variable_atomic_cleanup_on_failure(tmp_path, monkeypatch):
+    """If CDS retrieve raises, the .tmp file is cleaned up."""
+    from nhf_spatial_targets.fetch.era5_land import download_month_variable
+
+    out = tmp_path / "era5_land_ro_2020_03.nc"
+
+    def fake_retrieve_fail(dataset, request, path):
+        Path(path).write_bytes(b"partial")
+        raise RuntimeError("CDS server error")
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock(side_effect=fake_retrieve_fail)
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="CDS server error"):
+        download_month_variable(year=2020, month=3, variable="ro", output_path=out)
+
+    assert not out.exists()
+    assert not Path(str(out) + ".tmp").exists()
+
+
 def test_download_year_calls_cds_client(tmp_path, monkeypatch):
+    """download_year_variable submits 12 single-month CDS requests."""
     from nhf_spatial_targets.fetch.era5_land import download_year_variable
 
     out = tmp_path / "era5_land_ro_2020.nc"
-    expected_tmp = str(out) + ".tmp"
 
     def fake_retrieve(dataset, request, path):
-        # Simulate CDS writing to the tmp path (not the final path)
-        assert path == expected_tmp, (
-            f"CDS retrieve should write to tmp path {expected_tmp!r}, got {path!r}"
+        # Write a minimal valid NetCDF so the concatenation step succeeds.
+        month = int(request["month"])
+        times = pd.date_range(f"2020-{month:02d}-01", periods=1, freq="1h")
+        ds = xr.Dataset(
+            {"ro": (("time", "latitude", "longitude"), np.zeros((1, 1, 1)))},
+            coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
         )
-        Path(path).write_bytes(b"fake_nc_data")
+        ds.to_netcdf(path)
 
     fake_client = MagicMock()
     fake_client.retrieve = MagicMock(side_effect=fake_retrieve)
@@ -164,30 +238,28 @@ def test_download_year_calls_cds_client(tmp_path, monkeypatch):
 
     result = download_year_variable(year=2020, variable="ro", output_path=out)
 
-    fake_client.retrieve.assert_called_once()
-    args, kwargs = fake_client.retrieve.call_args
-    assert args[0] == "reanalysis-era5-land"
-    request = args[1]
-    assert request["variable"] == "runoff"
-    assert request["year"] == "2020"
-    assert request["area"] == [53.0, -125.0, 24.7, -66.0]
-    assert request["format"] == "netcdf"
-    assert "month" in request and len(request["month"]) == 12
-    # The retrieve is passed the .tmp path; final output_path exists after rename
-    assert out.exists(), "Final output file should exist after atomic rename"
-    assert not Path(expected_tmp).exists(), "Tmp file should be gone after rename"
+    assert fake_client.retrieve.call_count == 12
+    for i, (args, _) in enumerate(fake_client.retrieve.call_args_list, start=1):
+        assert args[0] == "reanalysis-era5-land"
+        request = args[1]
+        assert request["variable"] == "runoff"
+        assert request["year"] == "2020"
+        assert request["month"] == f"{i:02d}"
+        assert request["area"] == [53.0, -125.0, 24.7, -66.0]
+        assert request["format"] == "netcdf"
+    assert out.exists(), "Year file should exist after all monthly chunks are assembled"
+    assert not Path(str(out) + ".tmp").exists()
     assert result == out
 
 
 def test_download_year_atomic_cleanup_on_failure(tmp_path, monkeypatch):
-    """If CDS retrieve raises, the .tmp file is cleaned up and output_path is absent."""
+    """If a monthly CDS download fails, the .tmp is cleaned up and year file absent."""
     from nhf_spatial_targets.fetch.era5_land import download_year_variable
 
     out = tmp_path / "era5_land_ro_2020.nc"
-    tmp_path_expected = Path(str(out) + ".tmp")
+    chunk_01_tmp = tmp_path / "era5_land_ro_2020_01.nc.tmp"
 
     def fake_retrieve_fail(dataset, request, path):
-        # Write partial data to tmp, then raise
         Path(path).write_bytes(b"partial")
         raise RuntimeError("CDS server error")
 
@@ -202,8 +274,8 @@ def test_download_year_atomic_cleanup_on_failure(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError, match="CDS server error"):
         download_year_variable(year=2020, variable="ro", output_path=out)
 
-    assert not out.exists(), "output_path must not exist after a failed download"
-    assert not tmp_path_expected.exists(), ".tmp file must be cleaned up on failure"
+    assert not out.exists(), "Year file must not exist after a failed monthly download"
+    assert not chunk_01_tmp.exists(), ".tmp for the failed month must be cleaned up"
 
 
 def test_download_year_skips_existing(tmp_path, monkeypatch):

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from nhf_spatial_targets.fetch.era5_land import daily_to_monthly, hourly_to_daily
@@ -699,3 +700,140 @@ def test_update_manifest_updates_existing_year(tmp_path):
     entry = m["sources"]["era5_land"]
     assert len(entry["files"]) == 1
     assert entry["files"][0]["consolidated_utc"] == "2024-06-01T00:00:00+00:00"
+
+
+def test_update_manifest_handles_missing_year_key(tmp_path, caplog):
+    """Prior manifest entries missing 'year' are skipped with a warning."""
+    import json
+    import logging
+
+    from nhf_spatial_targets.fetch.era5_land import _update_manifest
+
+    wd = _minimal_workdir(tmp_path)
+    meta = {
+        "access": {"url": "https://cds.climate.copernicus.eu"},
+        "variables": [{"name": "ro"}],
+    }
+    bbox = {"minx": -125.0, "miny": 24.7, "maxx": -66.0, "maxy": 53.0}
+
+    # Seed a manifest with a malformed file entry (no "year" key)
+    manifest = {
+        "sources": {
+            "era5_land": {
+                "files": [
+                    {"daily_path": "/orphan.nc"},  # missing year
+                    {
+                        "year": 1979,
+                        "daily_path": "/ds/daily_1979.nc",
+                        "monthly_path": "/ds/monthly_1979_1979.nc",
+                    },
+                ]
+            }
+        }
+    }
+    (wd / "manifest.json").write_text(json.dumps(manifest))
+
+    files_new = [
+        {
+            "year": 1980,
+            "daily_path": "/ds/daily_1980.nc",
+            "monthly_path": "/ds/monthly_1979_1980.nc",
+            "consolidated_utc": "2024-01-01T00:00:00+00:00",
+        }
+    ]
+    with caplog.at_level(logging.WARNING):
+        _update_manifest(wd, "1980/1980", bbox, meta, "L", files_new)
+
+    assert any("missing 'year' key" in rec.message for rec in caplog.records)
+    result = json.loads((wd / "manifest.json").read_text())
+    years = sorted(f["year"] for f in result["sources"]["era5_land"]["files"])
+    assert years == [1979, 1980]
+
+
+def test_update_manifest_raises_on_bad_year_type(tmp_path):
+    """Prior manifest entry with a non-numeric 'year' raises a clear error."""
+    import json
+
+    from nhf_spatial_targets.fetch.era5_land import _update_manifest
+
+    wd = _minimal_workdir(tmp_path)
+    meta = {
+        "access": {"url": "https://cds.climate.copernicus.eu"},
+        "variables": [{"name": "ro"}],
+    }
+    bbox = {"minx": -125.0, "miny": 24.7, "maxx": -66.0, "maxy": 53.0}
+
+    manifest = {
+        "sources": {"era5_land": {"files": [{"year": "twenty", "daily_path": "/x.nc"}]}}
+    }
+    (wd / "manifest.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="invalid year"):
+        _update_manifest(
+            wd,
+            "1980/1980",
+            bbox,
+            meta,
+            "L",
+            [
+                {
+                    "year": 1980,
+                    "daily_path": "/d.nc",
+                    "monthly_path": "/m.nc",
+                    "consolidated_utc": "2024-01-01",
+                }
+            ],
+        )
+
+
+def test_update_manifest_refreshes_monthly_path_on_prior_entries(tmp_path):
+    """After rolling rebuild, every merged entry points to the current monthly file."""
+    import json
+
+    from nhf_spatial_targets.fetch.era5_land import _update_manifest
+
+    wd = _minimal_workdir(tmp_path)
+    meta = {
+        "access": {"url": "https://cds.climate.copernicus.eu"},
+        "variables": [{"name": "ro"}],
+    }
+    bbox = {"minx": -125.0, "miny": 24.7, "maxx": -66.0, "maxy": 53.0}
+
+    # First run: year 1979, monthly path reflects 1979-only range.
+    _update_manifest(
+        wd,
+        "1979/1979",
+        bbox,
+        meta,
+        "L",
+        [
+            {
+                "year": 1979,
+                "daily_path": "/ds/daily_1979.nc",
+                "monthly_path": "/ds/monthly_1979_1979.nc",
+                "consolidated_utc": "2024-01-01T00:00:00+00:00",
+            }
+        ],
+    )
+
+    # Second run: year 1980, rolling rebuild produces a new monthly path.
+    new_monthly = "/ds/monthly_1979_1980.nc"
+    _update_manifest(
+        wd,
+        "1980/1980",
+        bbox,
+        meta,
+        "L",
+        [
+            {
+                "year": 1980,
+                "daily_path": "/ds/daily_1980.nc",
+                "monthly_path": new_monthly,
+                "consolidated_utc": "2024-01-02T00:00:00+00:00",
+            }
+        ],
+    )
+
+    entry = json.loads((wd / "manifest.json").read_text())["sources"]["era5_land"]
+    # Both the prior 1979 entry AND the new 1980 entry point to the new path.
+    assert all(f["monthly_path"] == new_monthly for f in entry["files"])

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -176,6 +176,42 @@ def test_download_month_variable_calls_cds_client(tmp_path, monkeypatch):
     assert result == out
 
 
+def test_download_month_variable_extracts_zip(tmp_path, monkeypatch):
+    """download_month_variable extracts the .nc from a CDS zip response."""
+    import io
+    import zipfile
+
+    from nhf_spatial_targets.fetch.era5_land import download_month_variable
+
+    out = tmp_path / "era5_land_ro_2020_03.nc"
+    nc_content = b"fake_nc_data_inside_zip"
+
+    def fake_retrieve(dataset, request, path):
+        # Simulate CDS API returning a zip-wrapped NetCDF.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("data.nc", nc_content)
+        Path(path).write_bytes(buf.getvalue())
+
+    fake_client = MagicMock()
+    fake_client.retrieve = MagicMock(side_effect=fake_retrieve)
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.era5_land._cds_client", lambda: fake_client
+    )
+
+    result = download_month_variable(year=2020, month=3, variable="ro", output_path=out)
+
+    assert result == out
+    assert out.exists()
+    assert out.read_bytes() == nc_content
+    # Confirm the output file is not a zip.
+    assert not zipfile.is_zipfile(out)
+    # No .tmp file should remain.
+    assert not Path(str(out) + ".tmp").exists()
+    # Extracted intermediate file should not remain.
+    assert not (tmp_path / "data.nc").exists()
+
+
 def test_download_month_variable_skips_existing(tmp_path, monkeypatch):
     from nhf_spatial_targets.fetch.era5_land import download_month_variable
 
@@ -333,6 +369,51 @@ def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch
         daily.close()
 
     assert monthly_path.exists()
+
+
+def test_consolidate_year_valid_time_dim(tmp_path):
+    """consolidate_year normalises CDS API v2 'valid_time' → 'time' dimension."""
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly_dir = tmp_path / "hourly"
+    daily_dir = tmp_path / "daily"
+    monthly_dir = tmp_path / "monthly"
+    hourly_dir.mkdir()
+
+    # Write hourly NCs using 'valid_time' (CDS API ≥0.7 output convention)
+    times = pd.date_range("2020-01-01", "2020-01-03 23:00", freq="1h")
+    for var in ("ro", "sro", "ssro"):
+        vals = np.tile(
+            np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
+            (len(times) // 24, 1, 1),
+        )
+        ds = xr.Dataset(
+            {var: (("valid_time", "latitude", "longitude"), vals)},
+            coords={
+                "valid_time": times[: vals.shape[0]],
+                "latitude": [40.0],
+                "longitude": [-100.0],
+            },
+        )
+        ds[var].attrs["units"] = "m"
+        ds.to_netcdf(hourly_dir / f"era5_land_{var}_2020.nc")
+
+    # Should not raise "Dimensions {'time'} do not exist"
+    daily_path, monthly_path = consolidate_year(
+        year=2020,
+        hourly_dir=hourly_dir,
+        daily_dir=daily_dir,
+        monthly_dir=monthly_dir,
+    )
+
+    assert daily_path.exists()
+    with xr.open_dataset(daily_path) as ds:
+        assert "time" in ds.dims, "daily NC must have 'time' dimension"
+        assert {"ro", "sro", "ssro"}.issubset(set(ds.data_vars))
+
+    assert monthly_path.exists()
+    with xr.open_dataset(monthly_path) as ds:
+        assert "time" in ds.dims, "monthly NC must have 'time' dimension"
 
 
 def _write_hourly_ncs(hourly_dir: Path, year: int) -> None:
@@ -507,3 +588,114 @@ def test_consolidate_year_reaggregates_when_hourly_is_newer(tmp_path):
     assert mock_h2d.called, (
         "hourly_to_daily should be called when a hourly NC is newer than the daily NC"
     )
+
+
+# ---- Manifest merge --------------------------------------------------------
+
+
+def _minimal_workdir(tmp_path: Path) -> Path:
+    """Create a minimal project workdir for _update_manifest tests."""
+    import json
+
+    import yaml
+
+    wd = tmp_path / "run"
+    wd.mkdir()
+    config = {
+        "fabric": {"path": "", "id_col": "nhm_id"},
+        "datastore": str(wd / "datastore"),
+        "dir_mode": "2775",
+    }
+    (wd / "config.yml").write_text(yaml.dump(config))
+    (wd / "fabric.json").write_text(json.dumps({"hru_count": 3, "id_col": "nhm_id"}))
+    (wd / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    return wd
+
+
+def test_update_manifest_accumulates_years(tmp_path):
+    """Successive _update_manifest calls merge files rather than overwriting."""
+    import json
+
+    from nhf_spatial_targets.fetch.era5_land import _update_manifest
+
+    wd = _minimal_workdir(tmp_path)
+    meta = {
+        "access": {"url": "https://cds.climate.copernicus.eu"},
+        "variables": [{"name": "ro"}],
+    }
+    bbox = {"minx": -125.1, "miny": 23.9, "maxx": -65.9, "maxy": 50.1}
+    license_str = "Copernicus license"
+
+    files_1979 = [
+        {
+            "year": 1979,
+            "daily_path": "/ds/era5_land/daily/era5_land_daily_1979.nc",
+            "monthly_path": "/ds/era5_land/monthly/era5_land_monthly_1979_1979.nc",
+            "consolidated_utc": "2024-01-01T00:00:00+00:00",
+        }
+    ]
+    files_1980 = [
+        {
+            "year": 1980,
+            "daily_path": "/ds/era5_land/daily/era5_land_daily_1980.nc",
+            "monthly_path": "/ds/era5_land/monthly/era5_land_monthly_1979_1980.nc",
+            "consolidated_utc": "2024-01-02T00:00:00+00:00",
+        }
+    ]
+
+    # First run: fetch 1979
+    _update_manifest(wd, "1979/1979", bbox, meta, license_str, files_1979)
+    m1 = json.loads((wd / "manifest.json").read_text())
+    entry1 = m1["sources"]["era5_land"]
+    assert entry1["period"] == "1979/1979"
+    assert len(entry1["files"]) == 1
+    assert entry1["files"][0]["year"] == 1979
+
+    # Second run: fetch 1980 — should not overwrite 1979
+    _update_manifest(wd, "1980/1980", bbox, meta, license_str, files_1980)
+    m2 = json.loads((wd / "manifest.json").read_text())
+    entry2 = m2["sources"]["era5_land"]
+    assert entry2["period"] == "1979/1980"
+    assert len(entry2["files"]) == 2
+    years = [f["year"] for f in entry2["files"]]
+    assert years == [1979, 1980]
+
+
+def test_update_manifest_updates_existing_year(tmp_path):
+    """Re-running for the same year replaces that year's file record."""
+    import json
+
+    from nhf_spatial_targets.fetch.era5_land import _update_manifest
+
+    wd = _minimal_workdir(tmp_path)
+    meta = {
+        "access": {"url": "https://cds.climate.copernicus.eu"},
+        "variables": [{"name": "ro"}],
+    }
+    bbox = {"minx": -125.1, "miny": 23.9, "maxx": -65.9, "maxy": 50.1}
+    license_str = "Copernicus license"
+
+    files_v1 = [
+        {
+            "year": 1979,
+            "daily_path": "/ds/era5_land/daily/era5_land_daily_1979.nc",
+            "monthly_path": "/ds/era5_land/monthly/era5_land_monthly_1979_1979.nc",
+            "consolidated_utc": "2024-01-01T00:00:00+00:00",
+        }
+    ]
+    files_v2 = [
+        {
+            "year": 1979,
+            "daily_path": "/ds/era5_land/daily/era5_land_daily_1979.nc",
+            "monthly_path": "/ds/era5_land/monthly/era5_land_monthly_1979_1979.nc",
+            "consolidated_utc": "2024-06-01T00:00:00+00:00",  # updated timestamp
+        }
+    ]
+
+    _update_manifest(wd, "1979/1979", bbox, meta, license_str, files_v1)
+    _update_manifest(wd, "1979/1979", bbox, meta, license_str, files_v2)
+
+    m = json.loads((wd / "manifest.json").read_text())
+    entry = m["sources"]["era5_land"]
+    assert len(entry["files"]) == 1
+    assert entry["files"][0]["consolidated_utc"] == "2024-06-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary

Retroactive PR capturing post-#42 fixes and housekeeping across fetch, consolidation, manifest, and notebooks.

## Changes

### Fetch
- **ERA5-Land** (`98c614f`): Split CDS requests by month to stay within the per-request cost limit; previously the annual request was rejected
- **SLURM script** (`b00ec26`): Add `fetch_all.slurm` array job and datastore storage estimates

### Consolidation
- **`fix(consolidate)`** (`a811409`): Normalize `valid_time` dim to `time` and pin CF-compliant time encoding for consolidated MERRA-2/NLDAS NetCDFs

### Manifest consistency (`62dfc38`)
- Add `license` field to manifest entries for: `merra2`, `ncep_ncar`, `nldas_mosaic`, `nldas_noah`, `mod10c1_v061`, `mod16a2_v061`
- Fix MODIS `variables` format (full dicts → string names)
- Fix MERRA-2 hardcoded source key (`"merra2"` → `_SOURCE_KEY`)
- Move inline imports to module top in `merra2.py` and `ncep_ncar.py`
- Fix ERA5-Land manifest overwrite → merge pattern (accumulates years, derives `effective_period` from all fetched years)
- Add tests for the `_update_manifest` merge behavior in `test_era5_land.py`

### Housekeeping (`53acac8`)
- Bump SLURM memory allocation to 128 GB (required for ERA5-Land hourly CONUS downloads)
- Add `logs/` to `.gitignore`

### Docs (`b2205f5`)
- README: add pixi install instructions, CDS licence acceptance step, `materialize-credentials` step, ERA5-Land and GLDAS fetch commands, updated AET source table

### Notebooks (`f4a4698`)
- Update all existing notebooks to use separate `DATASTORE` / `PROJECT` path layout
- Update ERA5-Land notebook for `valid_time` rename and CF time encoding
- Add `visualize_era5_land.ipynb` and `visualize_gldas.ipynb`

## Tests

All 339 unit tests pass. New merge-behavior tests added for `era5_land._update_manifest`.