### PR TITLE
refactor: per-year streaming aggregation with CF coord detection

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,8 @@
       "Bash(/home/rmcd/projects/usgs/nhf-spatial-targets/.pixi/envs/dev/bin/ruff format:*)",
       "Bash(/home/rmcd/projects/usgs/nhf-spatial-targets/.pixi/envs/dev/bin/ruff check:*)",
       "Bash(PYTHONPATH=/tmp/nhf-project-rename/src /home/rmcd/projects/usgs/nhf-spatial-targets/.pixi/envs/dev/bin/python -m pytest /tmp/nhf-project-rename/tests/ -m 'not integration' -q 2>&1)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "Bash(grep *)"
     ]
   }
 }

--- a/docs/strategy-deck.html
+++ b/docs/strategy-deck.html
@@ -1,0 +1,1195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>nhf-spatial-targets — Strategy</title>
+
+<!-- Fonts: Cormorant Garamond (display serif) + Source Serif 4 + IBM Plex Mono for code -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Source+Serif+4:ital,wght@0,300;0,400;0,600;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap"
+  rel="stylesheet"
+/>
+
+<style>
+/* ===========================================
+   THEME — PAPER & INK (editorial, literary)
+   =========================================== */
+:root {
+    --bg-paper:       #faf7f1;   /* warm cream */
+    --bg-paper-deep:  #f3ede1;   /* slightly deeper cream for gradient */
+    --ink:            #1a1a1a;   /* near-black */
+    --ink-soft:       #3d3a36;
+    --ink-muted:      #6b665e;
+    --rule:           #cfc7b8;   /* hairline rules */
+    --accent:         #a62a2a;   /* deep crimson */
+    --accent-soft:    #c4504b;
+    --gold:           #b38b3f;   /* secondary accent */
+
+    --font-display:   "Cormorant Garamond", "Times New Roman", serif;
+    --font-body:      "Source Serif 4", Georgia, serif;
+    --font-mono:      "IBM Plex Mono", ui-monospace, monospace;
+
+    --title-size:     clamp(2.2rem, 6vw, 5.2rem);
+    --h2-size:        clamp(1.5rem, 3.6vw, 2.8rem);
+    --h3-size:        clamp(1rem, 2.1vw, 1.5rem);
+    --body-size:      clamp(0.85rem, 1.25vw, 1.1rem);
+    --small-size:     clamp(0.7rem, 1vw, 0.9rem);
+
+    --slide-padding:  clamp(1.5rem, 5vw, 5rem);
+    --content-gap:    clamp(0.75rem, 2vw, 1.75rem);
+    --element-gap:    clamp(0.4rem, 1vw, 1rem);
+
+    --ease:           cubic-bezier(0.16, 1, 0.3, 1);
+    --dur:            0.7s;
+}
+
+/* =========================================
+   RESET
+   ========================================= */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* =========================================
+   VIEWPORT BASE (mandatory viewport fitting)
+   ========================================= */
+html, body { height: 100%; overflow-x: hidden; }
+html {
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: var(--font-body);
+    font-size: var(--body-size);
+    color: var(--ink);
+    background: var(--bg-paper);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+}
+
+.slide {
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: var(--slide-padding);
+    background:
+        radial-gradient(ellipse at 18% 12%, rgba(255,255,255,0.45) 0%, transparent 55%),
+        radial-gradient(ellipse at 85% 90%, rgba(179,139,63,0.08) 0%, transparent 60%),
+        linear-gradient(180deg, var(--bg-paper) 0%, var(--bg-paper-deep) 100%);
+}
+
+/* Subtle paper texture via SVG noise */
+.slide::before {
+    content: "";
+    position: absolute; inset: 0;
+    pointer-events: none;
+    opacity: 0.35;
+    mix-blend-mode: multiply;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.1 0 0 0 0 0.09 0 0 0 0 0.08 0 0 0 0.08 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+}
+
+.slide-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-height: 100%;
+    overflow: hidden;
+    position: relative;
+    z-index: 1;
+}
+
+/* Typography */
+h1, h2, h3 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    line-height: 1.05;
+}
+h1 { font-size: var(--title-size); font-weight: 700; }
+h2 { font-size: var(--h2-size); }
+h3 { font-size: var(--h3-size); font-weight: 600; }
+
+p { color: var(--ink-soft); }
+
+.eyebrow {
+    font-family: var(--font-body);
+    font-size: var(--small-size);
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.lede {
+    font-family: var(--font-display);
+    font-size: clamp(1.1rem, 2vw, 1.5rem);
+    font-style: italic;
+    color: var(--ink-muted);
+    font-weight: 400;
+    max-width: 60ch;
+}
+
+/* Hairline rule with ornamental dot */
+.rule {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: var(--rule);
+}
+.rule::before, .rule::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--rule);
+}
+.rule-dot {
+    width: 6px; height: 6px;
+    background: var(--accent);
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+/* Drop cap */
+.dropcap::first-letter {
+    font-family: var(--font-display);
+    float: left;
+    font-size: clamp(3.5rem, 8vw, 6rem);
+    line-height: 0.85;
+    padding: 0.25rem 0.6rem 0 0;
+    color: var(--accent);
+    font-weight: 700;
+}
+
+/* Slide number, top-left corner */
+.slide-num {
+    position: absolute;
+    top: clamp(1rem, 2.5vw, 2rem);
+    left: clamp(1.5rem, 5vw, 5rem);
+    font-family: var(--font-mono);
+    font-size: var(--small-size);
+    color: var(--ink-muted);
+    letter-spacing: 0.15em;
+    z-index: 2;
+}
+.slide-footer {
+    position: absolute;
+    bottom: clamp(1rem, 2.5vw, 2rem);
+    left: clamp(1.5rem, 5vw, 5rem);
+    right: clamp(1.5rem, 5vw, 5rem);
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: var(--small-size);
+    color: var(--ink-muted);
+    letter-spacing: 0.1em;
+    z-index: 2;
+}
+
+/* Two-column editorial layout */
+.two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: clamp(1.25rem, 3vw, 3rem);
+    align-items: start;
+    height: 100%;
+}
+@media (max-width: 780px) { .two-col { grid-template-columns: 1fr; } }
+
+/* Pull quote */
+.pullquote {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(1.3rem, 2.8vw, 2.2rem);
+    line-height: 1.25;
+    color: var(--ink);
+    border-left: 3px solid var(--accent);
+    padding-left: clamp(0.8rem, 2vw, 1.5rem);
+    max-width: 24ch;
+}
+
+/* Feature list (bulleted) */
+.feature-list { list-style: none; display: flex; flex-direction: column; gap: clamp(0.5rem, 1.2vw, 1rem); }
+.feature-list li {
+    position: relative;
+    padding-left: 1.6rem;
+    font-size: var(--body-size);
+    color: var(--ink-soft);
+}
+.feature-list li::before {
+    content: "§";
+    position: absolute;
+    left: 0;
+    top: 0;
+    font-family: var(--font-display);
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 1.15em;
+    line-height: 1.4;
+}
+
+/* Simple grid of cards */
+.grid-3 {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: clamp(0.8rem, 2vw, 1.4rem);
+}
+.grid-2 {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: clamp(0.8rem, 2vw, 1.4rem);
+}
+@media (max-width: 780px) { .grid-3, .grid-2 { grid-template-columns: 1fr; } }
+
+.card {
+    border: 1px solid var(--rule);
+    background: rgba(255, 253, 248, 0.5);
+    padding: clamp(0.75rem, 1.6vw, 1.25rem);
+    position: relative;
+}
+.card .marker {
+    font-family: var(--font-mono);
+    font-size: var(--small-size);
+    color: var(--accent);
+    letter-spacing: 0.15em;
+    display: block;
+    margin-bottom: 0.4rem;
+}
+.card h3 { margin-bottom: 0.35rem; font-size: clamp(0.95rem, 1.6vw, 1.25rem); }
+.card p { font-size: var(--small-size); color: var(--ink-muted); line-height: 1.45; }
+
+/* Pipeline stages — horizontal timeline */
+.pipeline {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: clamp(0.5rem, 1.2vw, 1rem);
+    position: relative;
+    margin-top: clamp(1rem, 2vw, 2rem);
+}
+.pipeline::before {
+    content: "";
+    position: absolute;
+    top: clamp(1.2rem, 2vw, 1.8rem);
+    left: 5%; right: 5%;
+    height: 1px;
+    background: var(--rule);
+    z-index: 0;
+}
+.stage {
+    position: relative;
+    text-align: center;
+    z-index: 1;
+}
+.stage .dot {
+    width: clamp(1.8rem, 3vw, 2.4rem);
+    height: clamp(1.8rem, 3vw, 2.4rem);
+    border-radius: 50%;
+    background: var(--bg-paper);
+    border: 1.5px solid var(--accent);
+    color: var(--accent);
+    display: grid;
+    place-items: center;
+    margin: 0 auto clamp(0.4rem, 1vw, 0.7rem);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    font-size: var(--small-size);
+}
+.stage.future .dot {
+    border-color: var(--rule);
+    color: var(--ink-muted);
+    background: var(--bg-paper-deep);
+}
+.stage.future .label, .stage.future .sub { color: var(--ink-muted); opacity: 0.75; }
+.stage .label {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: clamp(0.85rem, 1.4vw, 1.1rem);
+    color: var(--ink);
+}
+.stage .sub {
+    font-family: var(--font-mono);
+    font-size: clamp(0.6rem, 0.9vw, 0.75rem);
+    color: var(--ink-muted);
+    letter-spacing: 0.08em;
+    margin-top: 0.15rem;
+}
+
+/* Code block */
+.code {
+    font-family: var(--font-mono);
+    font-size: clamp(0.7rem, 1.05vw, 0.88rem);
+    background: #1a1a1a;
+    color: #e8e2d5;
+    padding: clamp(0.8rem, 1.6vw, 1.2rem) clamp(1rem, 2vw, 1.5rem);
+    border-radius: 2px;
+    line-height: 1.6;
+    white-space: pre;
+    overflow: hidden;
+    border-left: 3px solid var(--accent);
+}
+.code .k  { color: #c9b896; }   /* keyword */
+.code .c  { color: #7a7468; font-style: italic; } /* comment */
+.code .s  { color: #c4504b; }   /* string */
+.code .n  { color: #b38b3f; }   /* number */
+
+/* Source list (for fetch slide) */
+.source-table {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    column-gap: clamp(0.8rem, 2vw, 1.8rem);
+    row-gap: clamp(0.3rem, 0.8vw, 0.6rem);
+    font-size: var(--small-size);
+    align-items: baseline;
+}
+.source-table .s-name {
+    font-family: var(--font-mono);
+    color: var(--ink);
+    font-weight: 500;
+}
+.source-table .s-desc { color: var(--ink-muted); }
+.source-table .s-api {
+    font-family: var(--font-mono);
+    font-size: clamp(0.6rem, 0.85vw, 0.72rem);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 0.12rem 0.45rem;
+    border-radius: 2px;
+    white-space: nowrap;
+}
+
+/* =========================================
+   TITLE SLIDE
+   ========================================= */
+.title-slide { justify-content: center; }
+.title-slide .title-wrap {
+    max-width: 20ch;
+    margin: 0 auto;
+    text-align: center;
+}
+.title-slide h1 {
+    font-size: clamp(2.5rem, 9vw, 7rem);
+    line-height: 0.95;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+.title-slide h1 em {
+    font-family: var(--font-display);
+    font-style: italic;
+    color: var(--accent);
+    font-weight: 600;
+}
+.title-slide .subtitle {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(1rem, 2.2vw, 1.5rem);
+    color: var(--ink-muted);
+    margin-top: clamp(1rem, 2vw, 1.5rem);
+}
+.title-ornament {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin: clamp(1rem, 2.5vw, 2rem) 0;
+    color: var(--accent);
+    font-size: 1.2rem;
+    letter-spacing: 0.6em;
+}
+
+/* Abstract ornament: single crimson rule + circle */
+.cornermark {
+    position: absolute;
+    top: clamp(1rem, 2.5vw, 2rem);
+    right: clamp(1.5rem, 5vw, 5rem);
+    font-family: var(--font-mono);
+    font-size: var(--small-size);
+    color: var(--ink-muted);
+    letter-spacing: 0.2em;
+    z-index: 2;
+    text-align: right;
+}
+.cornermark strong { color: var(--accent); font-weight: 500; }
+
+/* =========================================
+   ANIMATIONS — reveal on .visible
+   ========================================= */
+.reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity var(--dur) var(--ease),
+                transform var(--dur) var(--ease),
+                filter var(--dur) var(--ease);
+    filter: blur(4px);
+}
+.slide.visible .reveal {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+}
+.slide.visible .reveal.delay-1 { transition-delay: 0.08s; }
+.slide.visible .reveal.delay-2 { transition-delay: 0.18s; }
+.slide.visible .reveal.delay-3 { transition-delay: 0.30s; }
+.slide.visible .reveal.delay-4 { transition-delay: 0.42s; }
+.slide.visible .reveal.delay-5 { transition-delay: 0.54s; }
+.slide.visible .reveal.delay-6 { transition-delay: 0.66s; }
+.slide.visible .reveal.delay-7 { transition-delay: 0.78s; }
+.slide.visible .reveal.delay-8 { transition-delay: 0.90s; }
+
+/* Slow wash on title */
+@keyframes gentleDrift {
+    0%, 100% { transform: translateX(0) translateY(0); }
+    50%      { transform: translateX(-3px) translateY(-5px); }
+}
+.title-slide h1 em { display: inline-block; animation: gentleDrift 9s ease-in-out infinite; }
+
+/* =========================================
+   PROGRESS BAR & NAV DOTS
+   ========================================= */
+.progress-bar {
+    position: fixed;
+    top: 0; left: 0;
+    height: 2px;
+    width: 0%;
+    background: var(--accent);
+    z-index: 1000;
+    transition: width 0.2s linear;
+}
+
+.nav-dots {
+    position: fixed;
+    right: clamp(0.75rem, 1.5vw, 1.2rem);
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    z-index: 1000;
+}
+.nav-dots button {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    border: 1px solid var(--ink-muted);
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+    transition: all 0.25s ease;
+}
+.nav-dots button.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    transform: scale(1.35);
+}
+
+/* =========================================
+   INLINE EDITING (opt-in)
+   ========================================= */
+.edit-hotzone {
+    position: fixed;
+    top: 0; left: 0;
+    width: 80px; height: 80px;
+    z-index: 10000;
+    cursor: pointer;
+}
+.edit-toggle {
+    position: fixed;
+    top: clamp(0.75rem, 1.5vw, 1rem);
+    left: clamp(0.75rem, 1.5vw, 1rem);
+    width: clamp(2rem, 3vw, 2.5rem);
+    height: clamp(2rem, 3vw, 2.5rem);
+    border-radius: 50%;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.2s ease;
+    z-index: 10001;
+    box-shadow: 0 3px 12px rgba(0,0,0,0.25);
+}
+.edit-toggle.show, .edit-toggle.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+.edit-toggle:hover { transform: scale(1.1); }
+.edit-banner {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--ink);
+    color: var(--bg-paper);
+    font-family: var(--font-mono);
+    font-size: var(--small-size);
+    padding: 0.5rem 1rem;
+    border-radius: 2px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 10001;
+    letter-spacing: 0.1em;
+}
+.edit-banner.active { opacity: 1; }
+body.edit-active [contenteditable="true"] {
+    outline: 1px dashed var(--accent-soft);
+    outline-offset: 4px;
+    cursor: text;
+}
+body.edit-active [contenteditable="true"]:focus {
+    outline: 2px solid var(--accent);
+    background: rgba(198, 100, 95, 0.06);
+}
+
+/* =========================================
+   RESPONSIVE SCALING
+   ========================================= */
+@media (max-height: 700px) {
+    :root {
+        --slide-padding: clamp(1rem, 3.5vw, 2.5rem);
+        --content-gap:   clamp(0.5rem, 1.5vw, 1rem);
+        --title-size:    clamp(1.8rem, 5vw, 3.5rem);
+        --h2-size:       clamp(1.25rem, 3vw, 2rem);
+    }
+    .pipeline::before { top: 1rem; }
+}
+@media (max-height: 600px) {
+    :root {
+        --slide-padding: clamp(0.75rem, 2.5vw, 1.5rem);
+        --body-size:     clamp(0.75rem, 1.1vw, 0.95rem);
+    }
+    .nav-dots, .slide-footer { display: none; }
+}
+@media (max-height: 500px) {
+    :root {
+        --title-size: clamp(1.4rem, 4vw, 2rem);
+        --h2-size:    clamp(1rem, 2.5vw, 1.4rem);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.2s !important;
+    }
+    html { scroll-behavior: auto; }
+    .reveal { filter: none; transform: none; opacity: 1; }
+}
+</style>
+</head>
+<body>
+
+<!-- Progress bar — updates as user scrolls -->
+<div class="progress-bar" id="progressBar"></div>
+
+<!-- Navigation dots — generated by JS -->
+<nav class="nav-dots" id="navDots" aria-label="Slide navigation"></nav>
+
+<!-- Inline edit affordances (opt-in) -->
+<div class="edit-hotzone" aria-hidden="true"></div>
+<button class="edit-toggle" id="editToggle" title="Edit mode (E)" aria-label="Toggle edit mode">✎</button>
+<div class="edit-banner" id="editBanner">EDIT MODE — Ctrl+S to save</div>
+
+
+<!-- =========================================
+     SLIDE 1 — TITLE
+     ========================================= -->
+<section class="slide title-slide">
+    <div class="cornermark reveal delay-1">
+        USGS · NATIONAL HYDROLOGIC MODEL<br/>
+        <strong>TM 6-B10 CALIBRATION TARGETS</strong>
+    </div>
+
+    <div class="title-wrap">
+        <div class="eyebrow reveal">An internal walkthrough</div>
+        <div class="title-ornament reveal delay-1">· · ·</div>
+        <h1 class="reveal delay-2">
+            nhf-<em>spatial</em>-<br/>targets
+        </h1>
+        <div class="title-ornament reveal delay-3">· · ·</div>
+        <p class="subtitle reveal delay-4">
+            Curating calibration targets from heterogeneous earth-system data
+        </p>
+    </div>
+
+    <div class="slide-footer reveal delay-5">
+        <span>R. MCDONALD</span>
+        <span>2026 · VOL. I</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 2 — THE MISSION
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">I / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">The Mission</div>
+        <h2 class="reveal delay-1" style="max-width: 20ch; margin-top: 0.5rem;">
+            Turn gridded earth-system data into <em style="color:var(--accent);font-style:italic;">calibration targets</em> for the National Hydrologic Model.
+        </h2>
+
+        <div class="rule reveal delay-2" style="margin: clamp(1rem,2.5vw,2rem) 0;">
+            <span class="rule-dot"></span>
+        </div>
+
+        <div class="two-col">
+            <p class="reveal delay-3 dropcap" style="font-size: var(--body-size); max-width: 42ch;">
+                Five targets defined in USGS TM&nbsp;6-B10 — runoff, actual ET, recharge, soil moisture, and snow-covered area — are built by spatially aggregating public gridded datasets onto an HRU fabric with <span style="font-family:var(--font-mono);color:var(--accent);">gdptools</span>. Each target is a normalized range of plausible values, not a single estimate.
+            </p>
+            <div class="reveal delay-4">
+                <p class="pullquote">
+                    Many sources, one fabric, one reproducible answer.
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="slide-footer reveal delay-5">
+        <span>THE MISSION</span>
+        <span>HAY ET AL. 2022</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 3 — ARCHITECTURE: PROJECT vs DATASTORE
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">II / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">Architecture</div>
+        <h2 class="reveal delay-1" style="margin-bottom: clamp(0.5rem, 1.5vw, 1rem);">
+            Projects are fabric-specific.<br/>
+            <em style="font-style: italic; color: var(--ink-muted);">The datastore is shared.</em>
+        </h2>
+
+        <div class="two-col" style="margin-top: clamp(0.75rem, 2vw, 1.5rem);">
+            <!-- Datastore side -->
+            <div class="card reveal delay-2">
+                <span class="marker">◆ DATASTORE — shared</span>
+                <h3>Raw consolidated data, fabric-agnostic</h3>
+                <p>One directory per source: <span style="font-family:var(--font-mono);">merra2/</span>, <span style="font-family:var(--font-mono);">era5_land/</span>, <span style="font-family:var(--font-mono);">reitz2017/</span>… Fetch writes here once; every project that points at the same datastore reuses the data.</p>
+            </div>
+
+            <!-- Project side -->
+            <div class="card reveal delay-3" style="border-color: var(--accent);">
+                <span class="marker">◇ PROJECT — per fabric</span>
+                <h3>config · manifest · weights · targets</h3>
+                <p>Holds <span style="font-family:var(--font-mono);">config.yml</span>, <span style="font-family:var(--font-mono);">fabric.json</span>, credentials, the run manifest, aggregated outputs, weight caches, and final calibration targets — never deleted; it <em>is</em> the audit trail.</p>
+            </div>
+        </div>
+
+        <p class="reveal delay-4" style="margin-top: clamp(0.75rem, 2vw, 1.5rem); font-style: italic; color: var(--ink-muted); max-width: 70ch;">
+            Two projects (GFv1.1 and GFv2.0, say) can share a single datastore on a large drive while their project directories live wherever the modeler wants them.
+        </p>
+    </div>
+    <div class="slide-footer reveal delay-5">
+        <span>ARCHITECTURE</span>
+        <span>SEPARATION OF CONCERNS</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 4 — PIPELINE STAGES
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">III / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">The Pipeline</div>
+        <h2 class="reveal delay-1" style="margin-bottom: clamp(0.25rem, 1vw, 0.5rem);">
+            Five stages, <em style="font-style:italic;color:var(--accent);">catalog-driven</em> end to end.
+        </h2>
+        <p class="reveal delay-2 lede" style="margin-bottom: clamp(1rem, 2vw, 1.5rem);">
+            Today’s focus — the first three. The last two are deliberately left for later.
+        </p>
+
+        <div class="pipeline">
+            <div class="stage reveal delay-3">
+                <div class="dot">01</div>
+                <div class="label">Catalog</div>
+                <div class="sub">SOURCES · VARIABLES</div>
+            </div>
+            <div class="stage reveal delay-4">
+                <div class="dot">02</div>
+                <div class="label">Fetch</div>
+                <div class="sub">DOWNLOAD</div>
+            </div>
+            <div class="stage reveal delay-5">
+                <div class="dot">03</div>
+                <div class="label">Consolidate</div>
+                <div class="sub">CF-1.6 NETCDF</div>
+            </div>
+            <div class="stage future reveal delay-6">
+                <div class="dot">04</div>
+                <div class="label">Aggregate</div>
+                <div class="sub">LATER</div>
+            </div>
+            <div class="stage future reveal delay-7">
+                <div class="dot">05</div>
+                <div class="label">Targets</div>
+                <div class="sub">LATER</div>
+            </div>
+        </div>
+
+        <div class="rule reveal delay-7" style="margin-top: clamp(1.5rem, 3vw, 2.5rem);">
+            <span class="rule-dot"></span>
+        </div>
+        <p class="reveal delay-8" style="text-align:center; font-style: italic; color: var(--ink-muted); margin-top: clamp(0.5rem, 1.2vw, 0.8rem);">
+            catalog/ YAML is the only source of truth — no URLs, no product IDs, no magic strings in Python.
+        </p>
+    </div>
+    <div class="slide-footer reveal delay-8">
+        <span>PIPELINE</span>
+        <span>SCOPE · TODAY</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 5 — SOURCE LANDSCAPE
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">IV / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">The Source Landscape</div>
+        <h2 class="reveal delay-1" style="max-width: 22ch;">
+            Nine active sources across <em style="color:var(--accent);font-style:italic;">six different APIs</em>.
+        </h2>
+
+        <div class="source-table reveal delay-2" style="margin-top: clamp(1rem, 2.5vw, 1.8rem);">
+            <span class="s-name">era5_land</span>
+            <span class="s-desc">ECMWF reanalysis · runoff (ro, sro, ssro)</span>
+            <span class="s-api">CDS</span>
+
+            <span class="s-name">gldas_noah_v21</span>
+            <span class="s-desc">Monthly land-surface runoff</span>
+            <span class="s-api">Earthdata</span>
+
+            <span class="s-name">mod16a2_v061</span>
+            <span class="s-desc">MODIS 8-day actual ET</span>
+            <span class="s-api">Earthdata</span>
+
+            <span class="s-name">ssebop</span>
+            <span class="s-desc">Monthly AET — remote Zarr, no download</span>
+            <span class="s-api">STAC</span>
+
+            <span class="s-name">reitz2017</span>
+            <span class="s-desc">Empirical recharge rasters</span>
+            <span class="s-api">ScienceBase</span>
+
+            <span class="s-name">watergap22d</span>
+            <span class="s-desc">Global diffuse recharge (qrdif)</span>
+            <span class="s-api">PANGAEA</span>
+
+            <span class="s-name">merra2</span>
+            <span class="s-desc">Surface soil wetness (GWETTOP)</span>
+            <span class="s-api">Earthdata</span>
+
+            <span class="s-name">nldas_mosaic / noah</span>
+            <span class="s-desc">Multi-layer soil moisture</span>
+            <span class="s-api">Earthdata</span>
+
+            <span class="s-name">ncep_ncar</span>
+            <span class="s-desc">Reanalysis-1 soil moisture (daily→monthly)</span>
+            <span class="s-api">NOAA&nbsp;PSL</span>
+
+            <span class="s-name">mod10c1_v061</span>
+            <span class="s-desc">Daily snow-covered area</span>
+            <span class="s-api">NSIDC</span>
+        </div>
+    </div>
+    <div class="slide-footer reveal delay-3">
+        <span>CATALOG / SOURCES.YML</span>
+        <span>N = 9 CURRENT</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 6 — FETCH: COMMON SHAPE
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">V / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">Fetch Routines</div>
+        <h2 class="reveal delay-1" style="max-width: 24ch;">
+            One module per source.<br/>
+            <em style="font-style:italic;color:var(--ink-muted);">One shape.</em>
+        </h2>
+
+        <div class="two-col" style="margin-top: clamp(1rem, 2vw, 1.5rem);">
+            <ul class="feature-list reveal delay-2">
+                <li>Metadata (URL, product ID, bbox, variables) comes <em>only</em> from <span style="font-family:var(--font-mono);">catalog.py</span>.</li>
+                <li>Downloads land in <span style="font-family:var(--font-mono);color:var(--accent);">&lt;datastore&gt;/&lt;source_key&gt;/</span> — never inside a project.</li>
+                <li>Credentials resolved from <span style="font-family:var(--font-mono);">.credentials.yml</span> → <span style="font-family:var(--font-mono);">~/.netrc</span>, <span style="font-family:var(--font-mono);">~/.cdsapirc</span>.</li>
+                <li>Idempotent: mtime checks + atomic rename — never re-download what’s already current.</li>
+                <li>Annual splits where APIs demand it (ERA5-Land: 12 monthly CDS requests per year).</li>
+                <li>Every module has a matching <span style="font-family:var(--font-mono);">tests/test_&lt;module&gt;.py</span>.</li>
+            </ul>
+
+            <div class="reveal delay-3">
+                <div class="code"><span class="c"># fetch/era5_land.py — abridged</span>
+<span class="k">def</span> fetch(project, year):
+    src = catalog.<span class="k">get_source</span>(<span class="s">"era5_land"</span>)
+    dest = project.datastore / src.key
+    <span class="k">for</span> month <span class="k">in</span> <span class="n">range</span>(<span class="n">1</span>, <span class="n">13</span>):
+        chunk = _download_chunk(src, year, month)
+        _atomic_write(dest / chunk.name, chunk)
+    project.manifest.<span class="k">record</span>(src, year)</div>
+            </div>
+        </div>
+    </div>
+    <div class="slide-footer reveal delay-4">
+        <span>FETCH / PATTERNS</span>
+        <span>src/…/fetch/*.py</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 7 — CONSOLIDATION
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">VI / VIII</div>
+    <div class="slide-content">
+        <div class="eyebrow reveal">Consolidation</div>
+        <h2 class="reveal delay-1" style="max-width: 24ch;">
+            From raw chunks to one <em style="color:var(--accent);font-style:italic;">CF-1.6 NetCDF</em> per source.
+        </h2>
+
+        <div class="grid-3 reveal delay-2" style="margin-top: clamp(1rem, 2.5vw, 1.8rem);">
+            <div class="card">
+                <span class="marker">◆ CF-COMPLIANT</span>
+                <h3>Standards in, standards out</h3>
+                <p>Explicit CRS, <span style="font-family:var(--font-mono);">grid_mapping</span>, units, coordinates, cell methods — so downstream tools (gdptools, xarray) never guess.</p>
+            </div>
+            <div class="card">
+                <span class="marker">◆ ATOMIC</span>
+                <h3>Write-then-rename</h3>
+                <p>Consolidated NCs are written to a temp path and renamed on success. A killed run never leaves a half-valid file behind.</p>
+            </div>
+            <div class="card">
+                <span class="marker">◆ INCREMENTAL</span>
+                <h3>mtime-aware re-aggregation</h3>
+                <p>Daily NCs rebuild only when any hourly input is newer; the monthly roll-up follows. Re-runs are near-free when nothing has changed.</p>
+            </div>
+        </div>
+
+        <div class="rule reveal delay-3" style="margin-top: clamp(1.25rem, 2.5vw, 1.8rem);">
+            <span class="rule-dot"></span>
+        </div>
+        <p class="reveal delay-4" style="margin-top: clamp(0.5rem, 1.2vw, 0.8rem); font-style: italic; color: var(--ink-muted); max-width: 70ch;">
+            The consolidated NC is the hand-off point — aggregation (later) reads it and nothing else.
+        </p>
+    </div>
+    <div class="slide-footer reveal delay-4">
+        <span>CONSOLIDATION</span>
+        <span>fetch/consolidate.py</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 8 — WHAT'S NEXT
+     ========================================= -->
+<section class="slide">
+    <div class="slide-num reveal">VII / VIII</div>
+    <div class="slide-content" style="justify-content: center; text-align: center;">
+        <div class="eyebrow reveal">Still Ahead</div>
+        <h2 class="reveal delay-1" style="max-width: 22ch; margin: 0.5rem auto 0;">
+            Aggregation &amp; target generation<br/>
+            <em style="font-style:italic; color:var(--ink-muted);">— intentionally deferred.</em>
+        </h2>
+
+        <div class="title-ornament reveal delay-2" style="margin: clamp(1.5rem, 3vw, 2.5rem) 0;">· · ·</div>
+
+        <div class="grid-2 reveal delay-3" style="max-width: min(900px, 90vw); margin: 0 auto; text-align: left;">
+            <div class="card">
+                <span class="marker">◇ AGGREGATE</span>
+                <h3>HRU area-weighted means</h3>
+                <p>gdptools weight caches (fabric × source grid), reused across every run against the same fabric.</p>
+            </div>
+            <div class="card">
+                <span class="marker">◇ TARGETS</span>
+                <h3>Normalized ranges per variable</h3>
+                <p>Min–max bands across sources, per TM 6-B10. Output: one calibration target dataset per HRU.</p>
+            </div>
+        </div>
+
+        <p class="reveal delay-4" style="margin-top: clamp(1.5rem, 3vw, 2.5rem); font-style: italic; color: var(--ink-muted);">
+            The foundation is stable. We build upward from here.
+        </p>
+    </div>
+    <div class="slide-footer reveal delay-5">
+        <span>ROADMAP</span>
+        <span>POST-FOUNDATION</span>
+    </div>
+</section>
+
+
+<!-- =========================================
+     SLIDE 9 — COLOPHON / CLOSE
+     ========================================= -->
+<section class="slide title-slide">
+    <div class="slide-num reveal">VIII / VIII</div>
+    <div class="title-wrap">
+        <div class="eyebrow reveal">fin.</div>
+        <div class="title-ornament reveal delay-1">· · ·</div>
+        <h1 class="reveal delay-2" style="font-size: clamp(2rem, 6vw, 4.5rem);">
+            Thank you.
+        </h1>
+        <div class="title-ornament reveal delay-3">· · ·</div>
+        <p class="subtitle reveal delay-4" style="max-width: 40ch; margin-left:auto; margin-right:auto;">
+            Questions, corrections, or ideas — welcome on the repo.
+        </p>
+        <p class="reveal delay-5" style="font-family: var(--font-mono); font-size: var(--small-size); color: var(--ink-muted); margin-top: clamp(1.5rem, 3vw, 2.5rem); letter-spacing: 0.15em;">
+            github.com · usgs · nhf-spatial-targets
+        </p>
+    </div>
+</section>
+
+
+<script>
+/* ===========================================
+   PRESENTATION CONTROLLER
+   =========================================== */
+class SlidePresentation {
+    constructor() {
+        this.slides = Array.from(document.querySelectorAll('.slide'));
+        this.currentSlide = 0;
+        this.progressBar = document.getElementById('progressBar');
+        this.navDotsContainer = document.getElementById('navDots');
+
+        this.setupIntersectionObserver();
+        this.setupKeyboardNav();
+        this.setupTouchNav();
+        this.setupProgressBar();
+        this.setupNavDots();
+    }
+
+    /* Add .visible class when a slide scrolls into view */
+    setupIntersectionObserver() {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (entry.intersectionRatio >= 0.55) {
+                    entry.target.classList.add('visible');
+                    this.currentSlide = this.slides.indexOf(entry.target);
+                    this.updateNavDots();
+                }
+            });
+        }, { threshold: [0, 0.55, 1] });
+        this.slides.forEach((s) => observer.observe(s));
+    }
+
+    /* Arrow keys, Space, Home/End */
+    setupKeyboardNav() {
+        document.addEventListener('keydown', (e) => {
+            // Skip nav when editing a contenteditable element
+            if (e.target.getAttribute && e.target.getAttribute('contenteditable') === 'true') return;
+
+            if (e.key === 'ArrowDown' || e.key === 'PageDown' || e.key === ' ') {
+                e.preventDefault();
+                this.goTo(this.currentSlide + 1);
+            } else if (e.key === 'ArrowUp' || e.key === 'PageUp') {
+                e.preventDefault();
+                this.goTo(this.currentSlide - 1);
+            } else if (e.key === 'Home') { e.preventDefault(); this.goTo(0); }
+            else if (e.key === 'End')    { e.preventDefault(); this.goTo(this.slides.length - 1); }
+        });
+    }
+
+    /* Touch swipe for mobile */
+    setupTouchNav() {
+        let startY = null;
+        document.addEventListener('touchstart', (e) => { startY = e.touches[0].clientY; }, { passive: true });
+        document.addEventListener('touchend', (e) => {
+            if (startY === null) return;
+            const dy = e.changedTouches[0].clientY - startY;
+            if (Math.abs(dy) > 60) {
+                this.goTo(this.currentSlide + (dy < 0 ? 1 : -1));
+            }
+            startY = null;
+        }, { passive: true });
+    }
+
+    /* Progress bar follows scroll */
+    setupProgressBar() {
+        const update = () => {
+            const total = document.documentElement.scrollHeight - window.innerHeight;
+            const pct = total > 0 ? (window.scrollY / total) * 100 : 0;
+            this.progressBar.style.width = pct + '%';
+        };
+        window.addEventListener('scroll', update, { passive: true });
+        update();
+    }
+
+    /* Navigation dots — always clear before rebuilding (prevents
+       duplicate dots if an exported file captured existing ones) */
+    setupNavDots() {
+        this.navDotsContainer.innerHTML = '';
+        this.slides.forEach((_, i) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.setAttribute('aria-label', 'Go to slide ' + (i + 1));
+            btn.addEventListener('click', () => this.goTo(i));
+            this.navDotsContainer.appendChild(btn);
+        });
+        this.updateNavDots();
+    }
+
+    updateNavDots() {
+        const buttons = this.navDotsContainer.querySelectorAll('button');
+        buttons.forEach((b, i) => b.classList.toggle('active', i === this.currentSlide));
+    }
+
+    goTo(idx) {
+        idx = Math.max(0, Math.min(this.slides.length - 1, idx));
+        this.slides[idx].scrollIntoView({ behavior: 'smooth' });
+    }
+}
+
+
+/* ===========================================
+   INLINE EDITOR (opt-in)
+   Hotzone hover + E key + click-to-edit.
+   =========================================== */
+class InlineEditor {
+    constructor() {
+        this.isActive = false;
+        this.toggleBtn = document.getElementById('editToggle');
+        this.banner = document.getElementById('editBanner');
+        this.editableSelector = 'h1, h2, h3, p, li, .eyebrow, .marker, .subtitle, .lede, .pullquote, .label, .s-name, .s-desc';
+
+        this.setupHotzone();
+        this.setupToggleButton();
+        this.setupKeyboard();
+        this.setupSaveShortcut();
+        this.restoreFromStorage();
+    }
+
+    setupHotzone() {
+        const hotzone = document.querySelector('.edit-hotzone');
+        let hideTimeout = null;
+
+        hotzone.addEventListener('mouseenter', () => {
+            clearTimeout(hideTimeout);
+            this.toggleBtn.classList.add('show');
+        });
+        hotzone.addEventListener('mouseleave', () => {
+            hideTimeout = setTimeout(() => {
+                if (!this.isActive) this.toggleBtn.classList.remove('show');
+            }, 400);
+        });
+        this.toggleBtn.addEventListener('mouseenter', () => clearTimeout(hideTimeout));
+        this.toggleBtn.addEventListener('mouseleave', () => {
+            hideTimeout = setTimeout(() => {
+                if (!this.isActive) this.toggleBtn.classList.remove('show');
+            }, 400);
+        });
+        hotzone.addEventListener('click', () => this.toggleEditMode());
+    }
+
+    setupToggleButton() {
+        this.toggleBtn.addEventListener('click', () => this.toggleEditMode());
+    }
+
+    setupKeyboard() {
+        document.addEventListener('keydown', (e) => {
+            if ((e.key === 'e' || e.key === 'E') &&
+                !e.target.getAttribute('contenteditable') &&
+                !e.ctrlKey && !e.metaKey) {
+                this.toggleEditMode();
+            }
+        });
+    }
+
+    setupSaveShortcut() {
+        document.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+                e.preventDefault();
+                this.persistToStorage();
+                this.exportFile();
+            }
+        });
+    }
+
+    toggleEditMode() {
+        this.isActive = !this.isActive;
+        document.body.classList.toggle('edit-active', this.isActive);
+        this.toggleBtn.classList.toggle('active', this.isActive);
+        this.banner.classList.toggle('active', this.isActive);
+        this.toggleBtn.textContent = this.isActive ? '✓' : '✎';
+
+        const els = document.querySelectorAll(this.editableSelector);
+        els.forEach((el) => {
+            if (this.isActive) el.setAttribute('contenteditable', 'true');
+            else el.removeAttribute('contenteditable');
+        });
+
+        if (!this.isActive) this.persistToStorage();
+    }
+
+    persistToStorage() {
+        const snapshot = {};
+        document.querySelectorAll(this.editableSelector).forEach((el, i) => {
+            snapshot[i] = el.innerHTML;
+        });
+        try { localStorage.setItem('nhf-deck-edits', JSON.stringify(snapshot)); } catch (e) {}
+    }
+
+    restoreFromStorage() {
+        try {
+            const raw = localStorage.getItem('nhf-deck-edits');
+            if (!raw) return;
+            const snapshot = JSON.parse(raw);
+            document.querySelectorAll(this.editableSelector).forEach((el, i) => {
+                if (snapshot[i] !== undefined) el.innerHTML = snapshot[i];
+            });
+        } catch (e) {}
+    }
+
+    /* Strip edit state from DOM before capturing outerHTML so the
+       saved file opens cleanly — then restore so editing continues. */
+    exportFile() {
+        const editableEls = Array.from(document.querySelectorAll('[contenteditable]'));
+        editableEls.forEach((el) => el.removeAttribute('contenteditable'));
+        document.body.classList.remove('edit-active');
+        this.toggleBtn.classList.remove('active', 'show');
+        this.banner.classList.remove('active', 'show');
+
+        const html = '<!DOCTYPE html>\n' + document.documentElement.outerHTML;
+
+        // Restore so user can keep editing
+        if (this.isActive) {
+            document.body.classList.add('edit-active');
+            editableEls.forEach((el) => el.setAttribute('contenteditable', 'true'));
+            this.toggleBtn.classList.add('active');
+            this.banner.classList.add('active');
+        }
+
+        const blob = new Blob([html], { type: 'text/html' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'nhf-strategy-deck.html';
+        a.click();
+        URL.revokeObjectURL(a.href);
+    }
+}
+
+/* Boot */
+const deck = new SlidePresentation();
+const editor = new InlineEditor();
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-04-15-per-year-streaming-aggregation.md
+++ b/docs/superpowers/plans/2026-04-15-per-year-streaming-aggregation.md
@@ -1,0 +1,1521 @@
+# Per-Year Streaming Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `aggregate/_driver.py` so every adapter streams aggregation year-by-year with CF-based coord detection and restartable per-year intermediates, fixing MOD16A2/MOD10C1 OOM and the `['time','lat','lon']`-vs-`time,y,x` coord mismatch.
+
+**Architecture:** One uniform pipeline — enumerate years from `*_consolidated.nc` time coords → aggregate each year via gdptools with explicit `period=(YYYY-01-01, YYYY-12-31)` → write per-year NC atomically to `data/aggregated/_by_year/` (idempotent; skip if exists) → final concat on time → atomic write to `data/aggregated/<src>_agg.nc`. MOD10C1 becomes an adapter with `pre_aggregate_hook` (CI mask) and `post_aggregate_hook` (rename + warn). Coord names come from CF attrs (`axis`, `standard_name`) with adapter fields as optional overrides.
+
+**Tech Stack:** Python 3.11+, xarray, gdptools (`UserCatData`, `WeightGen`, `AggGen`), geopandas, pandas, pytest. All commands go through `pixi run -e dev …`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-15-per-year-streaming-aggregation-design.md`](../specs/2026-04-15-per-year-streaming-aggregation-design.md)
+
+---
+
+## File structure
+
+Files created / modified across tasks:
+
+| Path | Action | Purpose |
+|---|---|---|
+| `src/nhf_spatial_targets/aggregate/_coords.py` | **Create** | CF coord detection. |
+| `src/nhf_spatial_targets/aggregate/_adapter.py` | **Modify** | Optional coord overrides; `pre/post_aggregate_hook` fields. |
+| `src/nhf_spatial_targets/aggregate/_driver.py` | **Modify** | Per-year enumeration, `aggregate_year`, `concat_years`, new orchestration in `aggregate_source`; delete `_default_open_hook` concat branch. |
+| `src/nhf_spatial_targets/aggregate/mod10c1.py` | **Modify** | Collapse to adapter + hooks. |
+| `src/nhf_spatial_targets/aggregate/mod16a2.py` | **Modify** | Drop hard-coded `x_coord`/`y_coord` (fall through to CF detection). |
+| `tests/test_aggregate_coords.py` | **Create** | Unit tests for `detect_coords`. |
+| `tests/test_aggregate_driver_per_year.py` | **Create** | Unit tests for `enumerate_years`, `aggregate_year` (idempotency), `concat_years`. |
+| `tests/test_aggregate_driver.py` | **Modify** | Delete tests for the removed concat-in-`_default_open_hook` path; update `test_aggregate_source_writes_multi_var_nc_and_manifest` to the new pipeline. |
+| `tests/test_aggregate_mod10c1.py` | **Modify** | Delete `_open` tests; add adapter-wiring test. |
+
+---
+
+## Task 1: Coordinate detection module
+
+**Files:**
+- Create: `src/nhf_spatial_targets/aggregate/_coords.py`
+- Test: `tests/test_aggregate_coords.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_aggregate_coords.py`:
+
+```python
+"""Tests for CF-based coordinate detection."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from nhf_spatial_targets.aggregate._coords import detect_coords
+
+
+def _ds_with_axis_attrs() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["t", "y", "x"], np.zeros((1, 2, 2)))},
+        coords={
+            "t": ("t", [0], {"axis": "T", "standard_name": "time"}),
+            "y": ("y", [0.0, 1.0], {"axis": "Y", "standard_name": "latitude"}),
+            "x": ("x", [0.0, 1.0], {"axis": "X", "standard_name": "longitude"}),
+        },
+    )
+    return ds
+
+
+def _ds_with_standard_names_only() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.0, 1.0], {"standard_name": "longitude"}),
+        },
+    )
+    return ds
+
+
+def _ds_projected() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["time", "y", "x"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "y": ("y", [0.0, 1.0], {"standard_name": "projection_y_coordinate"}),
+            "x": ("x", [0.0, 1.0], {"standard_name": "projection_x_coordinate"}),
+        },
+    )
+    return ds
+
+
+def test_detects_via_axis_attrs():
+    x, y, t = detect_coords(_ds_with_axis_attrs(), "v")
+    assert (x, y, t) == ("x", "y", "t")
+
+
+def test_detects_via_standard_name_when_axis_missing():
+    x, y, t = detect_coords(_ds_with_standard_names_only(), "v")
+    assert (x, y, t) == ("lon", "lat", "time")
+
+
+def test_detects_projected_xy():
+    x, y, t = detect_coords(_ds_projected(), "v")
+    assert (x, y, t) == ("x", "y", "time")
+
+
+def test_override_takes_precedence():
+    ds = _ds_with_axis_attrs()
+    x, y, t = detect_coords(ds, "v", x_override="x", y_override="y", time_override="t")
+    assert (x, y, t) == ("x", "y", "t")
+
+
+def test_override_must_be_in_var_dims():
+    ds = _ds_with_axis_attrs()
+    with pytest.raises(ValueError, match="override"):
+        detect_coords(ds, "v", x_override="bogus")
+
+
+def test_raises_when_axis_unresolvable():
+    ds = xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0]),  # no attrs
+            "lon": ("lon", [0.0, 1.0]),  # no attrs
+        },
+    )
+    with pytest.raises(ValueError, match=r"(x|X)"):
+        detect_coords(ds, "v")
+
+
+def test_raises_when_var_missing():
+    ds = _ds_with_axis_attrs()
+    with pytest.raises(KeyError):
+        detect_coords(ds, "not_a_var")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pixi run -e dev test -- tests/test_aggregate_coords.py
+```
+
+Expected: ImportError / ModuleNotFoundError on `nhf_spatial_targets.aggregate._coords`.
+
+- [ ] **Step 3: Implement `_coords.py`**
+
+Create `src/nhf_spatial_targets/aggregate/_coords.py`:
+
+```python
+"""CF-based coordinate detection for source datasets."""
+
+from __future__ import annotations
+
+import xarray as xr
+
+_X_STANDARD_NAMES = frozenset({"longitude", "projection_x_coordinate"})
+_Y_STANDARD_NAMES = frozenset({"latitude", "projection_y_coordinate"})
+_T_STANDARD_NAMES = frozenset({"time"})
+
+
+def _find_axis(
+    ds: xr.Dataset,
+    dims: tuple[str, ...],
+    axis_letter: str,
+    standard_names: frozenset[str],
+) -> str | None:
+    # First pass: CF axis attribute.
+    for name in dims:
+        if name in ds.coords and ds.coords[name].attrs.get("axis") == axis_letter:
+            return name
+    # Second pass: CF standard_name.
+    for name in dims:
+        if name in ds.coords and ds.coords[name].attrs.get("standard_name") in standard_names:
+            return name
+    return None
+
+
+def detect_coords(
+    ds: xr.Dataset,
+    var: str,
+    x_override: str | None = None,
+    y_override: str | None = None,
+    time_override: str | None = None,
+) -> tuple[str, str, str]:
+    """Return (x_coord, y_coord, time_coord) for ``ds[var]``.
+
+    Resolution order per axis:
+      1. Explicit override (must be one of ``ds[var].dims``).
+      2. Coordinate whose ``axis`` attr is 'X' / 'Y' / 'T'.
+      3. Coordinate whose ``standard_name`` attr matches a CF name for that axis.
+
+    Raises KeyError if ``var`` is not in ``ds``.
+    Raises ValueError if an override is not in ``ds[var].dims`` or if any axis
+    cannot be resolved after overrides + CF passes.
+    """
+    if var not in ds.data_vars:
+        raise KeyError(f"Variable {var!r} not in dataset (have {list(ds.data_vars)})")
+    dims = tuple(ds[var].dims)
+
+    def _resolve(
+        override: str | None,
+        axis_letter: str,
+        standard_names: frozenset[str],
+        label: str,
+    ) -> str:
+        if override is not None:
+            if override not in dims:
+                raise ValueError(
+                    f"{label} override {override!r} is not a dim of {var!r} "
+                    f"(dims={dims})"
+                )
+            return override
+        found = _find_axis(ds, dims, axis_letter, standard_names)
+        if found is None:
+            attrs_by_dim = {d: dict(ds.coords[d].attrs) for d in dims if d in ds.coords}
+            raise ValueError(
+                f"Could not detect {label} coord for {var!r}. "
+                f"No dim has axis={axis_letter!r} or standard_name in "
+                f"{sorted(standard_names)}. "
+                f"dims={dims}, coord attrs={attrs_by_dim}"
+            )
+        return found
+
+    x = _resolve(x_override, "X", _X_STANDARD_NAMES, "x")
+    y = _resolve(y_override, "Y", _Y_STANDARD_NAMES, "y")
+    t = _resolve(time_override, "T", _T_STANDARD_NAMES, "time")
+    return x, y, t
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+pixi run -e dev test -- tests/test_aggregate_coords.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Lint, format, and commit**
+
+```
+pixi run -e dev fmt && pixi run -e dev lint
+git add src/nhf_spatial_targets/aggregate/_coords.py tests/test_aggregate_coords.py
+git commit -m "feat: CF-based coord detection for aggregate driver"
+```
+
+---
+
+## Task 2: Extend `SourceAdapter` with optional coord overrides and hooks
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_adapter.py`
+- Modify: `tests/test_aggregate_driver.py` (adapter default assertions)
+
+- [ ] **Step 1: Update adapter default-field tests**
+
+In `tests/test_aggregate_driver.py`, replace `test_source_adapter_defaults`:
+
+```python
+def test_source_adapter_defaults():
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP", "GWETROOT"],
+    )
+    assert adapter.source_crs == "EPSG:4326"
+    assert adapter.x_coord is None
+    assert adapter.y_coord is None
+    assert adapter.time_coord is None
+    assert adapter.open_hook is None
+    assert adapter.pre_aggregate_hook is None
+    assert adapter.post_aggregate_hook is None
+```
+
+Add a new test:
+
+```python
+def test_source_adapter_accepts_hooks():
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+
+    def _pre(ds):
+        return ds
+
+    def _post(ds):
+        return ds
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+        pre_aggregate_hook=_pre,
+        post_aggregate_hook=_post,
+    )
+    assert adapter.pre_aggregate_hook is _pre
+    assert adapter.post_aggregate_hook is _post
+```
+
+- [ ] **Step 2: Run tests to verify failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py::test_source_adapter_defaults tests/test_aggregate_driver.py::test_source_adapter_accepts_hooks
+```
+
+Expected: FAIL (fields don't yet exist / have wrong defaults).
+
+- [ ] **Step 3: Implement adapter changes**
+
+Edit `src/nhf_spatial_targets/aggregate/_adapter.py` — change the three coord fields to optional and add the two hook fields. Replace the dataclass body with:
+
+```python
+@dataclass(frozen=True)
+class SourceAdapter:
+    """..."""
+
+    source_key: str
+    output_name: str
+    variables: tuple[str, ...]
+    x_coord: str | None = None
+    y_coord: str | None = None
+    time_coord: str | None = None
+    source_crs: str = "EPSG:4326"
+    grid_variable: str | None = None
+    open_hook: Callable[[Project], xr.Dataset] | None = field(default=None)
+    pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
+    post_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
+```
+
+Leave `__post_init__` unchanged; coord validation is now deferred to `detect_coords` at run time.
+
+- [ ] **Step 4: Verify tests pass**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py
+```
+
+Expected: all pass (note `test_aggregate_variables_for_batch_merges_variables` still passes because it bypasses the adapter).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_adapter.py tests/test_aggregate_driver.py
+git commit -m "refactor: make SourceAdapter coord fields optional and add pre/post aggregate hooks"
+```
+
+---
+
+## Task 3: Add explicit `period` parameter to batch helpers
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_driver.py` (`compute_or_load_weights`, `aggregate_variables_for_batch`)
+- Modify: `tests/test_aggregate_driver.py`
+
+The per-year pipeline needs each batch call to target a specific year's period. Today both helpers derive `period` from `source_ds[time_coord].values[0]` / `[-1]`. Take `period: tuple[str, str]` as a required parameter instead.
+
+- [ ] **Step 1: Update existing tests to pass `period`**
+
+In `tests/test_aggregate_driver.py`, add `period=("2000-01-01", "2000-02-01")` to the `compute_or_load_weights` and `aggregate_variables_for_batch` calls in:
+
+- `test_aggregate_variables_for_batch_merges_variables`
+- `test_compute_or_load_weights_writes_cache_on_miss`
+- `test_compute_or_load_weights_uses_cache_on_hit`
+- `test_compute_or_load_weights_ignores_stray_tmp_from_crashed_run`
+
+- [ ] **Step 2: Add a test that verifies `period` is passed through to `UserCatData`**
+
+Append to `tests/test_aggregate_driver.py`:
+
+```python
+def test_aggregate_variables_for_batch_passes_period_through(tiny_fabric):
+    from nhf_spatial_targets.aggregate._driver import aggregate_variables_for_batch
+
+    batch_gdf = gpd.read_file(tiny_fabric)
+    batch_gdf["batch_id"] = 0
+    times = pd.date_range("2005-01-01", periods=12, freq="MS")
+    source_ds = xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+    )
+
+    with (
+        patch("nhf_spatial_targets.aggregate._driver.AggGen") as mock_agg,
+        patch("nhf_spatial_targets.aggregate._driver.UserCatData") as mock_ucd,
+    ):
+        mock_ucd.return_value = _fake_user_data()
+        inst = MagicMock()
+        mock_agg.return_value = inst
+        inst.calculate_agg.side_effect = [_fake_agg_result("a", [0, 1, 2, 3])]
+
+        aggregate_variables_for_batch(
+            batch_gdf=batch_gdf,
+            source_ds=source_ds,
+            variables=["a"],
+            source_crs="EPSG:4326",
+            x_coord="lon",
+            y_coord="lat",
+            time_coord="time",
+            id_col="hru_id",
+            weights=_fake_weights(),
+            period=("2005-01-01", "2005-12-01"),
+        )
+
+    call_kwargs = mock_ucd.call_args.kwargs
+    assert call_kwargs["period"] == ["2005-01-01", "2005-12-01"]
+```
+
+- [ ] **Step 3: Run tests to verify failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py
+```
+
+Expected: the updated tests fail with TypeError ("unexpected keyword argument 'period'").
+
+- [ ] **Step 4: Modify the helpers**
+
+Edit `src/nhf_spatial_targets/aggregate/_driver.py`. Change the signatures and the body of both helpers to use an explicit period.
+
+`compute_or_load_weights` — add `period: tuple[str, str]` as a keyword-only argument before `source_key`:
+
+```python
+def compute_or_load_weights(
+    batch_gdf: gpd.GeoDataFrame,
+    source_ds: xr.Dataset,
+    source_var: str,
+    source_crs: str,
+    x_coord: str,
+    y_coord: str,
+    time_coord: str,
+    id_col: str,
+    source_key: str,
+    batch_id: int,
+    workdir: Path,
+    period: tuple[str, str],
+) -> pd.DataFrame:
+    ...
+    user_data = UserCatData(
+        ds=source_ds,
+        proj_ds=source_crs,
+        x_coord=x_coord,
+        y_coord=y_coord,
+        t_coord=time_coord,
+        var=[source_var],
+        f_feature=batch_gdf,
+        proj_feature=batch_gdf.crs.to_string(),
+        id_feature=id_col,
+        period=[period[0], period[1]],
+    )
+    ...
+```
+
+`aggregate_variables_for_batch` — same treatment; accept `period` and pass it through:
+
+```python
+def aggregate_variables_for_batch(
+    batch_gdf: gpd.GeoDataFrame,
+    source_ds: xr.Dataset,
+    variables: list[str],
+    source_crs: str,
+    x_coord: str,
+    y_coord: str,
+    time_coord: str,
+    id_col: str,
+    weights: pd.DataFrame,
+    period: tuple[str, str],
+) -> xr.Dataset:
+    per_var: list[xr.Dataset] = []
+    for var in variables:
+        user_data = UserCatData(
+            ds=source_ds,
+            proj_ds=source_crs,
+            x_coord=x_coord,
+            y_coord=y_coord,
+            t_coord=time_coord,
+            var=[var],
+            f_feature=batch_gdf,
+            proj_feature=batch_gdf.crs.to_string(),
+            id_feature=id_col,
+            period=[period[0], period[1]],
+        )
+        agg = AggGen(
+            user_data=user_data,
+            stat_method="masked_mean",
+            agg_engine="serial",
+            agg_writer="none",
+            weights=weights,
+        )
+        _gdf, ds = agg.calculate_agg()
+        per_var.append(ds)
+    return xr.merge(per_var)
+```
+
+No other callers exist today (they're inside `aggregate_source` which we rewrite in Task 7).
+
+- [ ] **Step 5: Run tests**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_driver.py tests/test_aggregate_driver.py
+git commit -m "refactor: require explicit period in compute_or_load_weights / aggregate_variables_for_batch"
+```
+
+---
+
+## Task 4: `enumerate_years` — map consolidated NCs to years
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_driver.py`
+- Create: `tests/test_aggregate_driver_per_year.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_aggregate_driver_per_year.py`:
+
+```python
+"""Unit tests for per-year streaming aggregation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+
+def _write_nc(path: Path, times: pd.DatetimeIndex) -> None:
+    xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.ones((len(times), 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.0, 1.0], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(path)
+
+
+def test_enumerate_years_per_year_files(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f2000 = tmp_path / "src_2000_consolidated.nc"
+    f2001 = tmp_path / "src_2001_consolidated.nc"
+    _write_nc(f2000, pd.date_range("2000-01-01", periods=12, freq="MS"))
+    _write_nc(f2001, pd.date_range("2001-01-01", periods=12, freq="MS"))
+
+    year_files = enumerate_years([f2000, f2001])
+    assert year_files == [(2000, f2000), (2001, f2001)]
+
+
+def test_enumerate_years_single_multi_year_file(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f = tmp_path / "src_consolidated.nc"
+    _write_nc(f, pd.date_range("2000-01-01", periods=36, freq="MS"))
+
+    year_files = enumerate_years([f])
+    assert year_files == [(2000, f), (2001, f), (2002, f)]
+
+
+def test_enumerate_years_raises_on_year_overlap(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    fa = tmp_path / "src_a_consolidated.nc"
+    fb = tmp_path / "src_b_consolidated.nc"
+    _write_nc(fa, pd.date_range("2001-01-01", periods=12, freq="MS"))
+    _write_nc(fb, pd.date_range("2001-06-01", periods=12, freq="MS"))
+
+    with pytest.raises(ValueError, match="overlap"):
+        enumerate_years([fa, fb])
+
+
+def test_enumerate_years_raises_when_no_time_coord(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f = tmp_path / "no_time_consolidated.nc"
+    xr.Dataset({"v": (["y", "x"], np.zeros((2, 2)))}).to_netcdf(f)
+    with pytest.raises(ValueError, match="time"):
+        enumerate_years([f])
+```
+
+- [ ] **Step 2: Run tests — expect ImportError**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 3: Implement `enumerate_years`**
+
+Add to `src/nhf_spatial_targets/aggregate/_driver.py` (alongside the existing helpers). Include the `detect_coords` import at the top of the module.
+
+```python
+from nhf_spatial_targets.aggregate._coords import detect_coords
+
+
+def enumerate_years(files: list[Path]) -> list[tuple[int, Path]]:
+    """Map each year covered by the files to its source file.
+
+    Opens each NC lazily, reads its time coord, and expands to one
+    ``(year, file)`` tuple per distinct year. Returns results sorted by year.
+
+    Raises:
+        ValueError: two files cover the same year (stale fetch), or a file has
+            no resolvable time coord.
+    """
+    year_to_file: dict[int, Path] = {}
+    for path in files:
+        with xr.open_dataset(path) as ds:
+            time_name = _find_time_coord_name(ds)
+            if time_name is None:
+                raise ValueError(
+                    f"No time coord found in {path.name}. "
+                    f"dims={list(ds.dims)}, coord attrs="
+                    f"{ {n: dict(ds.coords[n].attrs) for n in ds.coords} }"
+                )
+            years = pd.DatetimeIndex(ds[time_name].values).year.unique().tolist()
+        for y in years:
+            if y in year_to_file:
+                raise ValueError(
+                    f"Year {y} overlaps between {year_to_file[y].name} "
+                    f"and {path.name}. Check the datastore for a stale "
+                    f"fetch artifact."
+                )
+            year_to_file[y] = path
+    return sorted(year_to_file.items())
+
+
+def _find_time_coord_name(ds: xr.Dataset) -> str | None:
+    """Return the name of the time coord via CF attrs, or None."""
+    for name in ds.coords:
+        attrs = ds.coords[name].attrs
+        if attrs.get("axis") == "T" or attrs.get("standard_name") == "time":
+            return name
+    # Fall back: any coord literally named 'time' (non-CF legacy NCs).
+    return "time" if "time" in ds.coords else None
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_driver.py tests/test_aggregate_driver_per_year.py
+git commit -m "feat: enumerate_years helper for per-year streaming aggregation"
+```
+
+---
+
+## Task 5: `per_year_output_path` + idempotent `aggregate_year`
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_driver.py`
+- Modify: `tests/test_aggregate_driver_per_year.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/test_aggregate_driver_per_year.py`:
+
+```python
+import json
+import yaml
+import geopandas as gpd
+from unittest.mock import MagicMock, patch
+from shapely.geometry import box
+
+from nhf_spatial_targets.workspace import load as load_project
+
+
+@pytest.fixture()
+def project(tmp_path):
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    (tmp_path / "config.yml").write_text(
+        yaml.dump({"fabric": {"path": "", "id_col": "hru_id"}, "datastore": str(datastore)})
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "abc"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+    return load_project(tmp_path)
+
+
+@pytest.fixture()
+def tiny_batched_fabric():
+    polys = [box(i, 0, i + 1, 1) for i in range(2)]
+    gdf = gpd.GeoDataFrame(
+        {"hru_id": range(2), "batch_id": [0, 0]}, geometry=polys, crs="EPSG:4326"
+    )
+    return gdf
+
+
+def test_per_year_output_path(project):
+    from nhf_spatial_targets.aggregate._driver import per_year_output_path
+
+    p = per_year_output_path(project, "foo", 2005)
+    assert p == project.workdir / "data" / "aggregated" / "_by_year" / "foo_2005_agg.nc"
+
+
+def test_aggregate_year_skips_when_intermediate_exists(project, tiny_batched_fabric):
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_year, per_year_output_path
+
+    out_path = per_year_output_path(project, "merra2", 2005)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Write a stub intermediate so aggregate_year short-circuits.
+    times = pd.date_range("2005-01-01", periods=1, freq="MS")
+    xr.Dataset(
+        {"GWETTOP": (["time", "hru_id"], np.ones((1, 2)))},
+        coords={"time": times, "hru_id": [0, 1]},
+    ).to_netcdf(out_path)
+
+    src_file = project.raw_dir("merra2")
+    src_file.mkdir(parents=True, exist_ok=True)
+    src_file = src_file / "src_2005_consolidated.nc"
+    _write_nc(src_file, pd.date_range("2005-01-01", periods=12, freq="MS"))
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["v"]
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch"
+    ) as mock_batch:
+        path = aggregate_year(adapter, project, 2005, src_file, tiny_batched_fabric, "hru_id")
+    assert path == out_path
+    assert not mock_batch.called, "existing intermediate must skip aggregation"
+
+
+def test_aggregate_year_writes_intermediate_when_missing(project, tiny_batched_fabric):
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_year, per_year_output_path
+
+    src_dir = project.raw_dir("merra2")
+    src_dir.mkdir(parents=True, exist_ok=True)
+    src_file = src_dir / "src_2005_consolidated.nc"
+    _write_nc(src_file, pd.date_range("2005-01-01", periods=12, freq="MS"))
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["v"]
+    )
+
+    fake_weights = pd.DataFrame({"i": [0], "j": [0], "wght": [1.0], "hru_id": [0]})
+    fake_year_ds = xr.Dataset(
+        {"v": (["time", "hru_id"], np.ones((1, 2)))},
+        coords={
+            "time": ("time", pd.date_range("2005-01-01", periods=1, freq="MS"),
+                     {"standard_name": "time"}),
+            "hru_id": [0, 1],
+        },
+    )
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=fake_weights,
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ) as mock_batch,
+    ):
+        path = aggregate_year(
+            adapter, project, 2005, src_file, tiny_batched_fabric, "hru_id"
+        )
+
+    assert path == per_year_output_path(project, "merra2", 2005)
+    assert path.exists()
+    # Period was passed through with the year bounds.
+    call = mock_batch.call_args
+    assert call.kwargs["period"] == ("2005-01-01", "2005-12-31")
+```
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 3: Implement the two functions**
+
+Add to `src/nhf_spatial_targets/aggregate/_driver.py`:
+
+```python
+def per_year_output_path(project: Project, source_key: str, year: int) -> Path:
+    """Return the per-year intermediate NC path."""
+    return (
+        project.workdir
+        / "data"
+        / "aggregated"
+        / "_by_year"
+        / f"{source_key}_{year}_agg.nc"
+    )
+
+
+def _atomic_write_netcdf(ds: xr.Dataset, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".nc.tmp")
+    os.close(tmp_fd)
+    try:
+        ds.to_netcdf(tmp_path)
+        Path(tmp_path).replace(path)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+
+
+def aggregate_year(
+    adapter: "SourceAdapter",
+    project: Project,
+    year: int,
+    source_file: Path,
+    fabric_batched: gpd.GeoDataFrame,
+    id_col: str,
+) -> Path:
+    """Aggregate one year to HRU polygons; idempotent on the intermediate NC.
+
+    Returns the path of the per-year intermediate. If that path already
+    exists, returns immediately without opening the source file.
+    """
+    out_path = per_year_output_path(project, adapter.source_key, year)
+    if out_path.exists():
+        logger.info("%s: year %d: intermediate exists, skipping (%s)",
+                    adapter.source_key, year, out_path)
+        return out_path
+
+    logger.info("%s: year %d: aggregating from %s",
+                adapter.source_key, year, source_file.name)
+    period = (f"{year}-01-01", f"{year}-12-31")
+
+    with xr.open_dataset(source_file) as raw:
+        ds = raw
+        if adapter.pre_aggregate_hook is not None:
+            ds = adapter.pre_aggregate_hook(ds)
+
+        grid_var = adapter.grid_variable or adapter.variables[0]
+        x_coord, y_coord, time_coord = detect_coords(
+            ds,
+            grid_var,
+            x_override=adapter.x_coord,
+            y_override=adapter.y_coord,
+            time_override=adapter.time_coord,
+        )
+
+        datasets: list[xr.Dataset] = []
+        for bid in sorted(fabric_batched["batch_id"].unique()):
+            batch_gdf = fabric_batched[fabric_batched["batch_id"] == bid].drop(
+                columns=["batch_id"]
+            )
+            weights = compute_or_load_weights(
+                batch_gdf=batch_gdf,
+                source_ds=ds,
+                source_var=grid_var,
+                source_crs=adapter.source_crs,
+                x_coord=x_coord,
+                y_coord=y_coord,
+                time_coord=time_coord,
+                id_col=id_col,
+                source_key=adapter.source_key,
+                batch_id=int(bid),
+                workdir=project.workdir,
+                period=period,
+            )
+            batch_ds = aggregate_variables_for_batch(
+                batch_gdf=batch_gdf,
+                source_ds=ds,
+                variables=list(adapter.variables),
+                source_crs=adapter.source_crs,
+                x_coord=x_coord,
+                y_coord=y_coord,
+                time_coord=time_coord,
+                id_col=id_col,
+                weights=weights,
+                period=period,
+            )
+            datasets.append(batch_ds)
+
+        year_ds = xr.concat(datasets, dim=id_col)
+
+    _atomic_write_netcdf(year_ds, out_path)
+    logger.info("%s: year %d: wrote %s", adapter.source_key, year, out_path)
+    return out_path
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_driver.py tests/test_aggregate_driver_per_year.py
+git commit -m "feat: per-year aggregation with idempotent intermediate"
+```
+
+---
+
+## Task 6: `concat_years` — final concat with validation
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_driver.py`
+- Modify: `tests/test_aggregate_driver_per_year.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/test_aggregate_driver_per_year.py`:
+
+```python
+def _write_year_intermediate(path: Path, year: int) -> None:
+    times = pd.date_range(f"{year}-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"v": (["time", "hru_id"], np.ones((12, 2)) * year)},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1],
+        },
+    ).to_netcdf(path)
+
+
+def test_concat_years_orders_by_time(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p2001 = tmp_path / "src_2001_agg.nc"
+    p2000 = tmp_path / "src_2000_agg.nc"
+    _write_year_intermediate(p2001, 2001)
+    _write_year_intermediate(p2000, 2000)
+
+    combined = concat_years([p2001, p2000], time_coord="time")
+    years = pd.DatetimeIndex(combined["time"].values).year
+    assert list(years[:12]) == [2000] * 12
+    assert list(years[-12:]) == [2001] * 12
+
+
+def test_concat_years_raises_on_duplicate_time(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p1 = tmp_path / "src_a_agg.nc"
+    p2 = tmp_path / "src_b_agg.nc"
+    _write_year_intermediate(p1, 2001)
+    _write_year_intermediate(p2, 2001)
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        concat_years([p1, p2], time_coord="time")
+```
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 3: Implement `concat_years`**
+
+Add to `src/nhf_spatial_targets/aggregate/_driver.py`:
+
+```python
+def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
+    """Open per-year intermediates, concat on time, validate monotonic + unique.
+
+    Loads each intermediate into memory and closes the on-disk handle so the
+    returned Dataset is detached from the filesystem (per the project's
+    rioxarray/close convention).
+    """
+    if not paths:
+        raise ValueError("concat_years called with empty paths list")
+    loaded: list[xr.Dataset] = []
+    for p in paths:
+        with xr.open_dataset(p) as ds:
+            loaded.append(ds.load())
+    combined = xr.concat(loaded, dim=time_coord).sortby(time_coord)
+    t = combined[time_coord].values
+    if len(np.unique(t)) != len(t):
+        raise ValueError(
+            f"Duplicate time coords across per-year intermediates: "
+            f"{[p.name for p in paths]}"
+        )
+    return combined
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver_per_year.py
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_driver.py tests/test_aggregate_driver_per_year.py
+git commit -m "feat: concat_years helper for per-year intermediates"
+```
+
+---
+
+## Task 7: Rewrite `aggregate_source` to orchestrate the per-year pipeline
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/_driver.py`
+- Modify: `tests/test_aggregate_driver.py`
+
+- [ ] **Step 1: Update the integration test for the new pipeline**
+
+In `tests/test_aggregate_driver.py`, replace `test_aggregate_source_writes_multi_var_nc_and_manifest` with:
+
+```python
+def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric):
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    datastore = tmp_path / "datastore"
+    (datastore / "merra2").mkdir(parents=True)
+    src_nc = datastore / "merra2" / "merra2_2000_consolidated.nc"
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {
+            "a": (["time", "lat", "lon"], np.ones((12, 2, 2))),
+            "b": (["time", "lat", "lon"], np.ones((12, 2, 2)) * 2.0),
+        },
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_nc)
+
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": str(tiny_fabric), "id_col": "hru_id"},
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["a", "b"],
+    )
+
+    fake_meta = {"access": {"type": "local_nc"}}
+    fake_year_ds = xr.Dataset(
+        {
+            "a": (["time", "hru_id"], np.ones((12, 4))),
+            "b": (["time", "hru_id"], np.ones((12, 4)) * 2.0),
+        },
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1, 2, 3],
+        },
+    )
+
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.catalog_source",
+            return_value=fake_meta,
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=_fake_weights(),
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ),
+    ):
+        out = aggregate_source(
+            adapter,
+            fabric_path=tiny_fabric,
+            id_col="hru_id",
+            workdir=tmp_path,
+            batch_size=500,
+        )
+
+    assert set(out.data_vars) == {"a", "b"}
+    output_nc = tmp_path / "data" / "aggregated" / "merra2_agg.nc"
+    assert output_nc.exists()
+    # Per-year intermediate preserved.
+    assert (tmp_path / "data" / "aggregated" / "_by_year" / "merra2_2000_agg.nc").exists()
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert "merra2" in manifest["sources"]
+    assert manifest["sources"]["merra2"]["output_file"] == (
+        "data/aggregated/merra2_agg.nc"
+    )
+```
+
+Also update `test_aggregate_source_raises_when_variable_missing` (same file): the failure should still surface, but now happens inside `aggregate_year` after opening the first year's file. Amend the assertion so it passes with the new pipeline — change the NC filename to `merra2_2000_consolidated.nc` and keep the `pytest.raises(ValueError, match="BOGUS_VAR")` check. The `aggregate_year` body must raise when a declared variable is absent; add that guard in Step 3.
+
+Delete the now-obsolete `_default_open_hook` tests (entire functions):
+
+- `test_default_open_hook_single_consolidated_nc`
+- `test_default_open_hook_concatenates_multiple_consolidated_ncs`
+- `test_default_open_hook_concat_sorts_when_filename_order_disagrees_with_time`
+- `test_default_open_hook_returned_dataset_detached_from_disk`
+- `test_default_open_hook_single_non_consolidated_nc`
+- `test_default_open_hook_raises_when_multiple_ncs_none_consolidated`
+- `test_default_open_hook_raises_when_no_nc_at_all`
+- `test_default_open_hook_raises_on_duplicate_time_across_consolidated_ncs`
+
+Their semantics are replaced by `enumerate_years` + `aggregate_year` tests from Tasks 4-5.
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py
+```
+
+- [ ] **Step 3: Rewrite `aggregate_source` and delete `_default_open_hook`**
+
+In `src/nhf_spatial_targets/aggregate/_driver.py`:
+
+1. **Delete** `_default_open_hook` entirely.
+2. **Add** the CF global-attr helper:
+
+```python
+def _attach_cf_global_attrs(ds: xr.Dataset, source_key: str, meta: dict) -> None:
+    """Attach CF-1.6 global attrs in place (non-destructive for var attrs)."""
+    access = meta.get("access", {})
+    history = (
+        f"{datetime.now(timezone.utc).isoformat()}: aggregated to HRU fabric "
+        f"by nhf_spatial_targets.aggregate._driver"
+    )
+    ds.attrs.setdefault("Conventions", "CF-1.6")
+    ds.attrs["history"] = history
+    ds.attrs["source"] = source_key
+    if "doi" in access:
+        ds.attrs["source_doi"] = access["doi"]
+    ds.attrs.setdefault("institution", "USGS")
+```
+
+3. **Rewrite** `aggregate_source`:
+
+```python
+def aggregate_source(
+    adapter: SourceAdapter,
+    fabric_path: Path,
+    id_col: str,
+    workdir: Path,
+    batch_size: int = 500,
+) -> xr.Dataset:
+    """Aggregate a source to fabric HRU polygons via the per-year pipeline.
+
+    Enumerates years from ``*_consolidated.nc`` in the datastore, aggregates
+    each year to ``data/aggregated/_by_year/<source_key>_<year>_agg.nc``
+    (idempotent; existing intermediates are reused on restart), then concats
+    on time to ``data/aggregated/<output_name>``. Per-year intermediates
+    are preserved for audit/restart.
+
+    Variables declared by ``adapter.variables`` that are missing from the
+    source NC cause ValueError before any year is aggregated.
+    """
+    workdir = Path(workdir)
+    project = load_project(workdir)
+    meta = catalog_source(adapter.source_key)
+
+    raw_dir = project.raw_dir(adapter.source_key)
+    files = sorted(raw_dir.glob("*_consolidated.nc"))
+    if not files:
+        raise FileNotFoundError(
+            f"No consolidated NC found in {raw_dir}. "
+            f"Run 'nhf-targets fetch {adapter.source_key}' first."
+        )
+
+    # Fail fast on missing declared variables: peek the first file.
+    with xr.open_dataset(files[0]) as peek:
+        missing = [v for v in adapter.variables if v not in peek.data_vars]
+        if missing:
+            raise ValueError(
+                f"{adapter.source_key}: variables {missing} missing from source "
+                f"dataset (have {list(peek.data_vars)})"
+            )
+
+    year_files = enumerate_years(files)
+    fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
+    n_batches = int(fabric_batched["batch_id"].nunique())
+    logger.info(
+        "%s: %d years to aggregate across %d spatial batches",
+        adapter.source_key,
+        len(year_files),
+        n_batches,
+    )
+
+    per_year_paths = [
+        aggregate_year(adapter, project, year, path, fabric_batched, id_col)
+        for year, path in year_files
+    ]
+
+    # Resolve time coord name from the first intermediate for the concat.
+    with xr.open_dataset(per_year_paths[0]) as probe:
+        time_coord = _find_time_coord_name(probe) or "time"
+    combined = concat_years(per_year_paths, time_coord=time_coord)
+
+    if adapter.post_aggregate_hook is not None:
+        combined = adapter.post_aggregate_hook(combined)
+
+    _attach_cf_global_attrs(combined, adapter.source_key, meta)
+
+    output_path = project.aggregated_dir() / adapter.output_name
+    _atomic_write_netcdf(combined, output_path)
+    logger.info("%s: output written to %s", adapter.source_key, output_path)
+
+    t0 = str(combined[time_coord].values[0])[:10]
+    t1 = str(combined[time_coord].values[-1])[:10]
+    update_manifest(
+        project=project,
+        source_key=adapter.source_key,
+        access=meta.get("access", {}),
+        period=f"{t0}/{t1}",
+        output_file=str(Path("data") / "aggregated" / adapter.output_name),
+        weight_files=[
+            str(Path("weights") / f"{adapter.source_key}_batch{i}.csv")
+            for i in range(n_batches)
+        ],
+    )
+    return combined
+```
+
+- [ ] **Step 4: Run the full driver test file**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py tests/test_aggregate_driver_per_year.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/_driver.py tests/test_aggregate_driver.py
+git commit -m "refactor: aggregate_source uses per-year streaming pipeline"
+```
+
+---
+
+## Task 8: Collapse `mod10c1.py` onto the adapter + hooks path
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/mod10c1.py`
+- Modify: `tests/test_aggregate_mod10c1.py`
+
+- [ ] **Step 1: Update tests**
+
+In `tests/test_aggregate_mod10c1.py`:
+
+- **Delete** the import of `_open` and every `_open` test (all six `test_open_*` functions).
+- Keep the `build_masked_source` and `_log_low_valid_coverage` tests.
+- Add a new test verifying the adapter wiring:
+
+```python
+def test_mod10c1_adapter_wires_hooks_and_variables():
+    from nhf_spatial_targets.aggregate.mod10c1 import (
+        ADAPTER,
+        build_masked_source,
+    )
+
+    assert ADAPTER.source_key == "mod10c1_v061"
+    assert ADAPTER.output_name == "mod10c1_agg.nc"
+    assert set(ADAPTER.variables) == {"sca", "ci", "valid_mask"}
+    assert ADAPTER.grid_variable == "sca"
+    assert ADAPTER.pre_aggregate_hook is build_masked_source
+    assert ADAPTER.post_aggregate_hook is not None
+```
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```
+pixi run -e dev test -- tests/test_aggregate_mod10c1.py
+```
+
+- [ ] **Step 3: Rewrite `src/nhf_spatial_targets/aggregate/mod10c1.py`**
+
+Replace the entire file with:
+
+```python
+"""MOD10C1 v061 daily SCA aggregator (CI-masked) — adapter + hooks."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import xarray as xr
+
+from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "mod10c1_v061"
+_CI_THRESHOLD = 0.70  # TM 6-B10: keep cells where CI > 0.70
+_OUTPUT_NAME = "mod10c1_agg.nc"
+_LOW_COVERAGE_WARN_THRESHOLD = 0.10
+
+
+def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
+    """Derive ``sca``, ``ci``, ``valid_mask`` from raw MOD10C1 variables.
+
+    - ``sca``        = Day_CMG_Snow_Cover / 100, NaN where CI <= 0.70.
+    - ``ci``         = Snow_Spatial_QA / 100 (passed through, unmasked).
+    - ``valid_mask`` = 1.0 where CI > 0.70, 0.0 otherwise.
+    """
+    ci = ds["Snow_Spatial_QA"] / 100.0
+    pass_mask = ci > _CI_THRESHOLD
+    sca_raw = ds["Day_CMG_Snow_Cover"] / 100.0
+    sca = sca_raw.where(pass_mask)
+    valid_mask = pass_mask.astype("float64")
+
+    out = xr.Dataset(
+        {"sca": sca, "ci": ci, "valid_mask": valid_mask},
+        coords=ds.coords,
+    )
+    out["sca"].attrs = {"long_name": "fractional snow-covered area", "units": "1"}
+    out["ci"].attrs = {
+        "long_name": "confidence interval (Snow_Spatial_QA/100)",
+        "units": "1",
+    }
+    out["valid_mask"].attrs = {
+        "long_name": "per-cell CI-pass indicator",
+        "units": "1",
+        "ci_threshold": _CI_THRESHOLD,
+    }
+    return out
+
+
+def _log_low_valid_coverage(combined: xr.Dataset) -> None:
+    """Warn if > 10% of (HRU, time) cells have zero valid area."""
+    vaf = combined["valid_area_fraction"]
+    n_total = int(vaf.notnull().sum())
+    if n_total == 0:
+        return
+    n_zero = int(((vaf == 0) & vaf.notnull()).sum())
+    zero_frac = n_zero / n_total
+    if zero_frac > _LOW_COVERAGE_WARN_THRESHOLD:
+        logger.warning(
+            "mod10c1: %.1f%% of (HRU, time) cells had zero valid-area "
+            "after CI>%.2f filter (n=%d of %d finite). Downstream sca "
+            "values are NaN for these cells.",
+            zero_frac * 100,
+            _CI_THRESHOLD,
+            n_zero,
+            n_total,
+        )
+
+
+def _rename_and_warn(combined: xr.Dataset) -> xr.Dataset:
+    combined = combined.rename({"valid_mask": "valid_area_fraction"})
+    combined["valid_area_fraction"].attrs = {
+        "long_name": "fraction of HRU area that passed CI filter",
+        "units": "1",
+        "ci_threshold": _CI_THRESHOLD,
+    }
+    _log_low_valid_coverage(combined)
+    return combined
+
+
+ADAPTER = SourceAdapter(
+    source_key=_SOURCE_KEY,
+    output_name=_OUTPUT_NAME,
+    variables=("sca", "ci", "valid_mask"),
+    grid_variable="sca",
+    source_crs="EPSG:4326",
+    pre_aggregate_hook=build_masked_source,
+    post_aggregate_hook=_rename_and_warn,
+)
+
+
+def aggregate_mod10c1(
+    fabric_path: Path,
+    id_col: str,
+    workdir: Path,
+    batch_size: int = 500,
+) -> xr.Dataset:
+    """Aggregate MOD10C1 v061 daily SCA to HRU polygons with CI masking.
+
+    The CI>0.70 filter is applied per-year inside the driver's per-year loop
+    via ``pre_aggregate_hook``. Final output at
+    ``data/aggregated/mod10c1_agg.nc`` carries ``sca``, ``ci``, and
+    ``valid_area_fraction`` keyed on (time, HRU).
+    """
+    return aggregate_source(ADAPTER, fabric_path, id_col, workdir, batch_size)
+```
+
+**Note:** `ADAPTER.variables` is declared as `("sca", "ci", "valid_mask")`. These variables exist on the output of `build_masked_source`, not on the raw NC. The driver's "fail fast on missing variables" check in `aggregate_source` peeks the raw NC for `adapter.variables` — which would spuriously fail here. **Add a hook-aware check**: if `adapter.pre_aggregate_hook is not None`, skip the peek (the hook constructs the variables). Update Step 3 of Task 7 to wrap the peek:
+
+```python
+if adapter.pre_aggregate_hook is None:
+    with xr.open_dataset(files[0]) as peek:
+        missing = [v for v in adapter.variables if v not in peek.data_vars]
+        if missing:
+            raise ValueError(...)
+```
+
+(Fold this adjustment into `_driver.py` as part of this task.)
+
+- [ ] **Step 4: Run tests**
+
+```
+pixi run -e dev test -- tests/test_aggregate_mod10c1.py tests/test_aggregate_driver.py tests/test_aggregate_driver_per_year.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/mod10c1.py tests/test_aggregate_mod10c1.py src/nhf_spatial_targets/aggregate/_driver.py
+git commit -m "refactor: MOD10C1 uses SourceAdapter + pre/post aggregate hooks"
+```
+
+---
+
+## Task 9: Let MOD16A2 rely on CF coord detection
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/aggregate/mod16a2.py`
+
+MOD16A2 currently sets `x_coord="x", y_coord="y"` explicitly. With Task 2 the adapter accepts `None`, and Task 1's detector resolves `projection_x_coordinate` / `projection_y_coordinate` automatically. Drop the explicit overrides so the detector is exercised in production; keep `source_crs` (the sinusoidal PROJ string) since it's not inferable.
+
+- [ ] **Step 1: Edit `src/nhf_spatial_targets/aggregate/mod16a2.py`**
+
+Remove `x_coord="x"` and `y_coord="y"` from the `ADAPTER` definition:
+
+```python
+ADAPTER = SourceAdapter(
+    source_key="mod16a2_v061",
+    output_name="mod16a2_agg.nc",
+    variables=["ET_500m"],
+    source_crs=MODIS_SINUSOIDAL_PROJ,
+)
+```
+
+- [ ] **Step 2: Run all aggregate tests**
+
+```
+pixi run -e dev test -- tests/test_aggregate_driver.py tests/test_aggregate_driver_per_year.py tests/test_aggregate_mod10c1.py
+```
+
+Expected: all pass (no MOD16A2-specific test exists; this change is covered by the shared driver tests).
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/nhf_spatial_targets/aggregate/mod16a2.py
+git commit -m "refactor: MOD16A2 adapter drops hard-coded x/y coord overrides"
+```
+
+---
+
+## Task 10: Full test sweep, lint/format, and PR update
+
+**Files:**
+- No code changes; verification + housekeeping.
+
+- [ ] **Step 1: Run the full dev test suite**
+
+```
+pixi run -e dev fmt && pixi run -e dev lint && pixi run -e dev test
+```
+
+Expected: format clean, lint clean, all unit tests pass. Fix any issues in place and stage them.
+
+- [ ] **Step 2: Smoke-test on a real project (operator step; skip if no project available)**
+
+If `$NHF_PROJECT_DIR` points to a real project with MOD10C1 or MOD16A2 fetched to the datastore:
+
+```
+pixi run nhf-targets agg mod10c1 --project-dir "$NHF_PROJECT_DIR"
+```
+
+Confirm:
+
+- `data/aggregated/_by_year/mod10c1_v061_<year>_agg.nc` exists for every year covered.
+- `data/aggregated/mod10c1_agg.nc` exists and opens with xarray; has `sca`, `ci`, `valid_area_fraction`.
+- A re-run prints "intermediate exists, skipping" for every year and does not re-invoke `WeightGen` / `AggGen`.
+
+If no project is available, record "smoke test deferred — operator to run before merge" in the PR description.
+
+- [ ] **Step 3: Push and update PR**
+
+```
+git push
+gh pr view --web  # or: gh pr edit <num> --body "..."
+```
+
+Update the PR description with:
+
+- Link to the design spec (`docs/superpowers/specs/2026-04-15-per-year-streaming-aggregation-design.md`).
+- Summary of the refactor (per-year streaming, CF coord detection, restartable intermediates).
+- Note on which smoke tests were run (or deferred).
+
+- [ ] **Step 4: Final commit for any fmt/lint fixups**
+
+```
+git status
+# If anything is staged:
+git commit -m "chore: format / lint cleanup"
+git push
+```
+
+---
+
+## Notes for the implementer
+
+- **Hook-aware variable check** (Task 8 note): if this is missed, the MOD10C1 aggregation raises before ever opening a year because `sca` / `ci` / `valid_mask` are not in the raw NC. Test `test_aggregate_source_raises_when_variable_missing` covers the non-hook path; the MOD10C1 adapter-wiring test exercises the hook path implicitly by not raising at construction.
+- **CF attribute expectations**: the project's consolidated NCs are written CF-1.6 with `axis` and `standard_name` attrs on every coord (see `feedback_cf_netcdf_patterns.md`). The detector fails loudly if those are missing — that's intentional; don't add a bare-name fallback.
+- **Period string format**: `aggregate_year` uses `f"{year}-01-01"` and `f"{year}-12-31"`. gdptools `UserCatData.period` accepts date strings; the year range is inclusive on both ends per gdptools convention. If a year is partially populated (e.g. source ends mid-year), gdptools clips to available data — no special casing needed.
+- **No changes to `fetch/`**: this refactor is purely on the aggregation side.
+- **Manifest schema unchanged**: existing downstream consumers (target builders, audit scripts) keep working.

--- a/docs/superpowers/specs/2026-04-15-per-year-streaming-aggregation-design.md
+++ b/docs/superpowers/specs/2026-04-15-per-year-streaming-aggregation-design.md
@@ -1,0 +1,283 @@
+# Per-Year Streaming Aggregation — Design
+
+**Date:** 2026-04-15
+**Status:** Proposed
+**Related:** PR branch `fix/modis-aggregator-open-consolidated-nc`; builds on commits `d178653`, `fb323c5`, `587f457`.
+
+## Problem
+
+`aggregate_source` in `src/nhf_spatial_targets/aggregate/_driver.py` opens every `*_consolidated.nc` under `project.raw_dir(source_key)`, concatenates them into a single in-memory `xr.Dataset`, then loops spatial batches over the full time range. For MOD16A2 v061 and MOD10C1 v061 (per-year consolidated NCs across 2000–2023) this exceeds available memory on the HPC nodes used by `pixi run nhf-targets agg …` job arrays (array=7 reproduced the failure).
+
+Adapters also hard-code coordinate names (`x_coord="x"`, `y_coord="lat"`, etc.). The MOD10C1 consolidated NCs carry `['time','lat','lon']` but the adapter assumed `time,y,x`. Coordinate resolution must come from the dataset, not the adapter.
+
+## Goals
+
+1. Stream aggregation year-by-year so peak memory is one year of source grid data plus one batch's weights and results.
+2. Detect coordinate names from CF metadata on the opened dataset; fail loudly when detection fails.
+3. Support restart: a killed job resumes at the first year without a per-year intermediate output, without recomputing earlier years.
+4. Apply uniformly to every adapter — including single-file sources (MERRA-2, WaterGAP, NCEP-NCAR), which benefit via gdptools' lazy period clip.
+5. Produce a single CF-1.6 compliant `data/aggregated/<source_key>_agg.nc` identical in schema to today's output.
+
+## Non-Goals
+
+- Changing the fetch layer or consolidated NC filenames.
+- Changing the weight cache layout (`weights/<source_key>_batch<id>.csv`).
+- Changing the manifest schema or CLI surface.
+- Parallelizing across years within a single process (the HPC array scripts already shard by source; per-year parallelism is out of scope).
+
+## Architecture
+
+Four layers, all in `src/nhf_spatial_targets/aggregate/`:
+
+1. **Coordinate detection** — new module `_coords.py`.
+2. **Year enumeration** — `_driver.py`, reads `time` from each consolidated NC lazily.
+3. **Per-year aggregation with intermediate output** — `_driver.py`.
+4. **Final concat + manifest update** — `_driver.py`.
+
+MOD10C1's bespoke masking logic moves into adapter hooks (`pre_aggregate_hook`, `post_aggregate_hook`), so `aggregate/mod10c1.py` collapses to an adapter definition + two small helper functions.
+
+## Components
+
+### `aggregate/_coords.py` (new)
+
+```python
+def detect_coords(
+    ds: xr.Dataset,
+    var: str,
+    x_override: str | None = None,
+    y_override: str | None = None,
+    time_override: str | None = None,
+) -> tuple[str, str, str]:
+    """Resolve (x_coord, y_coord, time_coord) for ``ds[var]``.
+
+    Resolution order per axis:
+      1. Explicit override, if given and present in ``ds[var].dims``.
+      2. Coordinate with CF ``axis`` attribute matching 'X' / 'Y' / 'T'.
+      3. Coordinate with CF ``standard_name`` in:
+           - X: 'longitude', 'projection_x_coordinate'
+           - Y: 'latitude',  'projection_y_coordinate'
+           - T: 'time'
+    Raises ValueError listing ``ds[var].dims`` and their attrs if unresolved.
+    No name-based fallback. Consolidated NCs are CF-1.6 per the project's
+    fetch-layer conventions.
+    """
+```
+
+### `aggregate/_adapter.py` (changed)
+
+`SourceAdapter` changes:
+
+- `x_coord`, `y_coord`, `time_coord` become `str | None = None`. The `__post_init__` CRS/catalog validation stays; coord validation against a variable is deferred to `detect_coords` at run time.
+- New field `pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = None` — applied to each year's opened dataset before weight/aggregation calls. Used by MOD10C1 for CI masking.
+- New field `post_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = None` — applied to the final concatenated dataset before the terminal atomic write. Used by MOD10C1 for the `valid_mask` → `valid_area_fraction` rename plus its low-coverage warning.
+- `open_hook` semantics change: it must return a **lazy** Dataset (no `.load()`) or a mapping of year → lazy Dataset. The default hook globs `*_consolidated.nc` in `project.raw_dir(source_key)` and opens each lazily, keeping them independent (no concat).
+
+### `aggregate/_driver.py` (changed)
+
+New functions:
+
+```python
+def enumerate_years(
+    files: list[Path], time_coord_hint: str | None = None
+) -> list[tuple[int, Path]]:
+    """Open each NC lazily, read the time coord, map covering years → file.
+
+    Returns a sorted list of (year, file_path) with one entry per distinct
+    year across all files. A single-file source may produce many tuples
+    pointing at the same file; a per-year source produces one tuple per file.
+
+    Raises ValueError if two files cover the same year (stale fetch) or if
+    the time coord cannot be located (passes time_coord_hint through to
+    detect_coords when provided; otherwise uses CF axis/standard_name only).
+    """
+
+def per_year_output_path(project: Project, source_key: str, year: int) -> Path:
+    """Return <project>/data/aggregated/_by_year/<source_key>_<year>_agg.nc."""
+
+def aggregate_year(
+    adapter: SourceAdapter,
+    project: Project,
+    year: int,
+    source_file: Path,
+    fabric_batched: gpd.GeoDataFrame,
+    id_col: str,
+) -> Path:
+    """Aggregate one year and atomically write the per-year intermediate.
+
+    Idempotent: returns the per-year path immediately if it exists. Else:
+      - open source_file lazily
+      - apply adapter.pre_aggregate_hook
+      - detect coords via _coords.detect_coords
+      - for each spatial batch: compute-or-load weights, aggregate vars,
+        collect per-batch xr.Dataset
+      - concat on id_col
+      - atomic write (tempfile + rename) to per_year_output_path
+      - close source file, return path
+    """
+
+def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
+    """Open all per-year NCs lazily, concat on time, validate monotonic + unique."""
+```
+
+Refactored `aggregate_source`:
+
+```python
+def aggregate_source(adapter, fabric_path, id_col, workdir, batch_size=500):
+    project = load_project(workdir)
+    meta = catalog_source(adapter.source_key)
+
+    files = sorted(project.raw_dir(adapter.source_key).glob("*_consolidated.nc"))
+    if not files:
+        raise FileNotFoundError(...)
+
+    year_files = enumerate_years(files, time_coord_hint=adapter.time_coord)
+    fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
+
+    per_year_paths = [
+        aggregate_year(adapter, project, year, path, fabric_batched, id_col)
+        for year, path in year_files
+    ]
+
+    combined_lazy = concat_years(per_year_paths, time_coord=<resolved>)
+    if adapter.post_aggregate_hook is not None:
+        combined_lazy = adapter.post_aggregate_hook(combined_lazy)
+
+    combined = combined_lazy.load()
+    _attach_cf_global_attrs(combined, adapter.source_key, meta)
+
+    output_path = project.aggregated_dir() / adapter.output_name
+    _atomic_write_netcdf(combined, output_path)
+
+    update_manifest(project, adapter.source_key, meta.get("access", {}),
+                    period=<t0/t1 from combined>,
+                    output_file=str(Path("data") / "aggregated" / adapter.output_name),
+                    weight_files=[...])
+    return combined
+```
+
+Helpers `compute_or_load_weights` and `aggregate_variables_for_batch` gain an explicit `period: tuple[str, str]` parameter and stop deriving period from `source_ds[time_coord]`. For per-year aggregation, callers pass `(f"{year}-01-01", f"{year}-12-31")`; gdptools' `UserCatData` applies the lazy time clip internally.
+
+### `aggregate/mod10c1.py` (changed)
+
+Collapses to:
+
+```python
+ADAPTER = SourceAdapter(
+    source_key="mod10c1_v061",
+    output_name="mod10c1_agg.nc",
+    variables=("sca", "ci", "valid_mask"),
+    grid_variable="sca",
+    source_crs="EPSG:4326",
+    pre_aggregate_hook=build_masked_source,
+    post_aggregate_hook=_rename_and_warn,
+)
+
+def aggregate_mod10c1(fabric_path, id_col, workdir, batch_size=500):
+    return aggregate_source(ADAPTER, fabric_path, id_col, workdir, batch_size)
+```
+
+`build_masked_source` is unchanged. `_rename_and_warn` wraps the existing
+`valid_mask → valid_area_fraction` rename plus `_log_low_valid_coverage`.
+Custom `_open` hook and the bespoke batch loop are deleted.
+
+### `aggregate/mod16a2.py` (changed)
+
+Unchanged in spirit — still an adapter. The sinusoidal PROJ override stays
+as-is. `x_coord`/`y_coord` can be dropped (CF detection resolves them from
+the consolidated NC's `projection_x_coordinate` / `projection_y_coordinate`
+attrs). Keep them as explicit overrides for safety until the refactor is
+verified against a full run.
+
+### Other adapters
+
+No code changes required — all use `aggregate_source` and inherit the
+per-year pipeline automatically. Single-file sources (MERRA-2, WaterGAP,
+NCEP-NCAR) run through `enumerate_years` producing many `(year, same_file)`
+tuples; gdptools' period clip ensures only one year is read per iteration.
+
+## Data Flow
+
+```
+project.raw_dir(source_key)/*_consolidated.nc
+      │
+      ▼  enumerate_years (lazy open → read time → close)
+[(2000, f0), (2001, f1), … (2023, fN)]    # or many tuples → same file for single-NC sources
+      │
+      ▼  for each year (skip if _by_year/<src>_<year>_agg.nc exists)
+         ├─ open source_file lazily
+         ├─ ds = adapter.pre_aggregate_hook(ds)           # optional
+         ├─ (x,y,t) = detect_coords(ds, adapter.grid_variable, overrides)
+         ├─ for each spatial batch:
+         │     weights = compute_or_load_weights(..., period=(y-01-01, y-12-31))
+         │     per-batch ds = aggregate_variables_for_batch(..., period=...)
+         ├─ concat batches on id_col
+         ├─ atomic write → _by_year/<src>_<year>_agg.nc
+         └─ close source_file
+      │
+      ▼  concat_years (lazy open _by_year/*, concat on time)
+      ▼  adapter.post_aggregate_hook (optional)
+      ▼  attach CF-1.6 global attrs
+      ▼  atomic write → data/aggregated/<src>_agg.nc
+      ▼  update_manifest
+```
+
+## Failure Modes
+
+| Condition | Behavior |
+|---|---|
+| No `*_consolidated.nc` in raw_dir | `FileNotFoundError` pointing at `nhf-targets fetch <source>`. |
+| Two files cover same year | `ValueError` from `enumerate_years` listing both filenames. |
+| `time` coord not resolvable | `ValueError` from `detect_coords` listing dims + attrs. |
+| X/Y coord not resolvable | `ValueError` from `detect_coords` listing dims + attrs. |
+| Per-year intermediate exists but is corrupt | `ValueError` — operator deletes and retries (no silent re-aggregate). |
+| Duplicate / non-monotonic time after `concat_years` | `ValueError` listing offending years. |
+| Atomic-write tempfile survives crash | Replaced on next successful write (existing tempfile+rename pattern). |
+| Final `<src>_agg.nc` already exists | Overwritten atomically; manifest updated. |
+| User wants a full rebuild | `rm -rf <project>/data/aggregated/_by_year/<src>_*` before rerunning. |
+
+## Restart Semantics
+
+- Rerunning `nhf-targets agg <source>` is idempotent: `aggregate_year` skips years whose per-year NC already exists, so a killed job resumes at the first missing year.
+- The weight cache is unchanged and remains restart-safe — grid geometry is year-independent.
+- Per-year intermediates are **preserved** after the final concat (audit trail; small size: HRU × days_in_year). A future `--clean-intermediates` flag may be added; out of scope here.
+
+## Memory Model
+
+Per-year peak state:
+
+- One year of lazily-opened source grid (gdptools clips via `period`).
+- One batch's weight table (already cached on disk).
+- One batch's aggregated Dataset (HRU_batch × time_year × variables).
+
+All previous-year state is closed before the next year begins. Single-file sources benefit identically because `UserCatData(period=...)` triggers a lazy time subset.
+
+## CF Compliance
+
+- Per-year intermediates inherit variable attrs from the adapter / `pre_aggregate_hook`.
+- Final concat preserves those attrs; `_attach_cf_global_attrs` sets top-level `Conventions: "CF-1.6"`, `history` (ISO8601 of the concat), `institution`, `source`, and `source_doi` from `catalog_source(source_key).access`.
+- `to_netcdf` writes with `format="NETCDF4"` (default) and no special encoding changes from today.
+
+## Testing
+
+New tests under `tests/`:
+
+- `test_coords.py` — `detect_coords` resolution order, override precedence, CF `axis` vs `standard_name`, error messages on absent metadata.
+- `test_driver_per_year.py` — `enumerate_years` on per-year and single-file inputs (including duplicate-year error), `aggregate_year` idempotency (rerun does not re-open source), `concat_years` monotonic/unique check.
+- `test_driver_restart.py` — pre-populate `_by_year/<src>_<year>_agg.nc` for a subset of years and assert those years are not re-aggregated on rerun.
+
+Existing tests updated:
+
+- `tests/test_aggregate_driver.py` — adjust fixtures to the per-year interface; assert `period` is passed through to gdptools.
+- `tests/test_aggregate_mod10c1.py` — verify the adapter + hooks path produces the same `sca` / `ci` / `valid_area_fraction` variables as the current implementation on a small synthetic fixture.
+
+Integration tests (`@pytest.mark.integration`) for real MOD16A2 / MOD10C1 data remain out of scope for unit test suites; the HPC array scripts are the integration harness.
+
+## Migration
+
+- No manifest schema change. Existing `data/aggregated/<src>_agg.nc` outputs remain valid; rerunning will overwrite them via the new path.
+- Existing `weights/<src>_batch<id>.csv` caches are reused unchanged.
+- New directory `data/aggregated/_by_year/` appears on first run.
+
+## Open Questions
+
+None at brainstorm time. Any ambiguity surfaced during implementation should be recorded in the implementation plan, not decided silently.

--- a/notebooks/debug_mod16a2_agg.ipynb
+++ b/notebooks/debug_mod16a2_agg.ipynb
@@ -1,0 +1,575 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# MOD16A2 Aggregation Debug Notebook\n",
+    "\n",
+    "Reproduces the aggregation pipeline for a single year + small batch of HRUs so errors\n",
+    "can be isolated and inspected interactively.  Mirrors the logic in\n",
+    "`src/nhf_spatial_targets/aggregate/_driver.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import xarray as xr\n",
+    "\n",
+    "# ── project / datastore paths ──────────────────────────────────────────────\n",
+    "PROJECT_DIR  = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets\")\n",
+    "DATASTORE    = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-datastore\")\n",
+    "FABRIC_PATH  = Path(\"/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/gfv2/fabric/gfv2_nhru_merged.gpkg\")\n",
+    "ID_COL       = \"nat_hru_id\"\n",
+    "\n",
+    "# ── choose one consolidated year for debugging ─────────────────────────────\n",
+    "DEBUG_YEAR   = 2001\n",
+    "NC_PATH      = DATASTORE / \"mod16a2_v061\" / f\"mod16a2_v061_{DEBUG_YEAR}_consolidated.nc\"\n",
+    "BATCH_SIZE   = 5000\n",
+    "\n",
+    "print(f\"NC path:  {NC_PATH}  exists={NC_PATH.exists()}\")\n",
+    "print(f\"Fabric:   {FABRIC_PATH}  exists={FABRIC_PATH.exists()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## 1  Inspect the consolidated source NC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(NC_PATH)\n",
+    "print(ds)\n",
+    "print(\"\\n── coordinate attrs ──\")\n",
+    "for name in ds.coords:\n",
+    "    print(f\"  {name}: axis={ds[name].attrs.get('axis')!r}  \"\n",
+    "          f\"standard_name={ds[name].attrs.get('standard_name')!r}  \"\n",
+    "          f\"shape={ds[name].shape}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check that detect_coords resolves the right coord names\n",
+    "import sys\n",
+    "sys.path.insert(0, str(Path(\"../src\")))\n",
+    "\n",
+    "from nhf_spatial_targets.aggregate._coords import detect_coords\n",
+    "\n",
+    "x, y, t = detect_coords(ds, \"ET_500m\")\n",
+    "print(f\"Detected:  x={x!r}  y={y!r}  t={t!r}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## 2  Load the fabric and create a small test batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nhf_spatial_targets.aggregate._driver import load_and_batch_fabric\n",
+    "\n",
+    "fabric_batched = load_and_batch_fabric(FABRIC_PATH, batch_size=BATCH_SIZE)\n",
+    "print(f\"Fabric rows: {len(fabric_batched)}  batches: {fabric_batched['batch_id'].nunique()}\")\n",
+    "print(f\"CRS: {fabric_batched.crs}\")\n",
+    "fabric_batched.head(3)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grab a single small batch\n",
+    "TEST_BATCH_ID = 0\n",
+    "batch_gdf = fabric_batched[fabric_batched[\"batch_id\"] == TEST_BATCH_ID].drop(columns=[\"batch_id\"])\n",
+    "print(f\"Batch {TEST_BATCH_ID}: {len(batch_gdf)} HRUs\")\n",
+    "print(f\"Bounds: {batch_gdf.total_bounds}\")\n",
+    "batch_gdf.head(3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## 3  Diagnose the CRS mismatch, then reproduce compute_or_load_weights\n",
+    "\n",
+    "`consolidate_mod16a2` reprojects the raw sinusoidal HDF tiles to **WGS84 (EPSG:4326)**\n",
+    "and renames the spatial coords to `lon` / `lat`.  If `UserCatData` is given\n",
+    "`proj_ds=MODIS_SINUSOIDAL_PROJ` (metres), it reprojects the fabric bounds into\n",
+    "sinusoidal metres and tries to slice the `lon` coordinate (±180 °) with those\n",
+    "large metre values → empty spatial subset → `Length of values (0)` downstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdptools import UserCatData, WeightGen\n",
+    "\n",
+    "from nhf_spatial_targets.aggregate.mod16a2 import ADAPTER, MODIS_SINUSOIDAL_PROJ\n",
+    "from nhf_spatial_targets.aggregate._driver import WEIGHT_GEN_CRS\n",
+    "\n",
+    "PERIOD = (f\"{DEBUG_YEAR}-01-01\", f\"{DEBUG_YEAR}-12-31\")\n",
+    "\n",
+    "# ── Show what goes wrong with the sinusoidal CRS ───────────────────────────\n",
+    "from gdptools.utils import _get_shp_bounds_w_buffer\n",
+    "\n",
+    "bad_bounds = _get_shp_bounds_w_buffer(\n",
+    "    gdf=batch_gdf, ds=ds, crs=MODIS_SINUSOIDAL_PROJ, lon=x, lat=y\n",
+    ")\n",
+    "print(f\"Bounds with sinusoidal CRS (metres): {bad_bounds}\")\n",
+    "good_bounds = _get_shp_bounds_w_buffer(\n",
+    "    gdf=batch_gdf, ds=ds, crs=\"EPSG:4326\", lon=x, lat=y\n",
+    ")\n",
+    "print(f\"Bounds with EPSG:4326      (degrees): {good_bounds}\")\n",
+    "print(f\"lon coord range: {float(ds[x].min()):.2f} … {float(ds[x].max()):.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create UserCatData with the CORRECT source CRS (EPSG:4326)\n",
+    "user_data_w = UserCatData(\n",
+    "    ds=ds,\n",
+    "    proj_ds=\"EPSG:4326\",   # consolidated NC is in WGS84, not sinusoidal\n",
+    "    x_coord=x,\n",
+    "    y_coord=y,\n",
+    "    t_coord=t,\n",
+    "    var=[ADAPTER.variables[0]],\n",
+    "    f_feature=batch_gdf,\n",
+    "    proj_feature=WEIGHT_GEN_CRS,\n",
+    "    id_feature=ID_COL,\n",
+    "    period=list(PERIOD),\n",
+    ")\n",
+    "print(\"UserCatData created OK\")\n",
+    "print(f\"source_time_period: {user_data_w.source_time_period}\")\n",
+    "\n",
+    "# Check the subset shape — should be (n_times, n_lat, n_lon), not (n_times, 0, 0)\n",
+    "da_subset = user_data_w.get_source_subset(ADAPTER.variables[0])\n",
+    "print(f\"Source subset shape: {da_subset.shape}\")\n",
+    "print(f\"Time range: {da_subset.time.values[[0, -1]]}\")\n",
+    "print(f\"NaN fraction: {float(da_subset.isnull().mean()):.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.ET_500m.values\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wg = WeightGen(\n",
+    "    user_data=user_data_w,\n",
+    "    method=\"serial\",\n",
+    "    weight_gen_crs=WEIGHT_GEN_CRS,\n",
+    ")\n",
+    "weights = wg.calculate_weights()\n",
+    "print(f\"Weights shape: {weights.shape}\")\n",
+    "print(f\"Weights columns: {list(weights.columns)}\")\n",
+    "print(f\"Unique HRUs in weights: {weights[ID_COL].nunique()}  (batch has {len(batch_gdf)})\")\n",
+    "weights.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Which batch HRUs got NO weights?\n",
+    "hrus_with_weights = set(weights[ID_COL].astype(str).unique())\n",
+    "hrus_in_batch    = set(batch_gdf[ID_COL].astype(str).unique())\n",
+    "missing = hrus_in_batch - hrus_with_weights\n",
+    "print(f\"HRUs with no grid-cell intersection: {len(missing)} → {sorted(missing)[:10]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## 4  Reproduce aggregate_variables_for_batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdptools import AggGen, UserCatData\n",
+    "\n",
+    "user_data_a = UserCatData(\n",
+    "    ds=ds,\n",
+    "    proj_ds=\"EPSG:4326\",   # consolidated NC is in WGS84, not sinusoidal\n",
+    "    x_coord=x,\n",
+    "    y_coord=y,\n",
+    "    t_coord=t,\n",
+    "    var=[ADAPTER.variables[0]],\n",
+    "    f_feature=batch_gdf,\n",
+    "    proj_feature=WEIGHT_GEN_CRS,\n",
+    "    id_feature=ID_COL,\n",
+    "    period=list(PERIOD),\n",
+    ")\n",
+    "\n",
+    "agg = AggGen(\n",
+    "    user_data=user_data_a,\n",
+    "    stat_method=\"mean\",\n",
+    "    agg_engine=\"serial\",\n",
+    "    agg_writer=\"none\",\n",
+    "    weights=weights,\n",
+    ")\n",
+    "gdf, batch_ds = agg.calculate_agg()\n",
+    "print(batch_ds)\n",
+    "print(f\"\\nResult dims: {dict(batch_ds.dims)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Spot-check one HRU time series\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "hru_id = batch_gdf[ID_COL].iloc[0]\n",
+    "ts = batch_ds[\"ET_500m\"].sel({ID_COL: hru_id})\n",
+    "ts.plot(figsize=(12, 3), marker=\"o\", markersize=3)\n",
+    "plt.title(f\"MOD16A2 ET_500m — HRU {hru_id} — {DEBUG_YEAR}\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "## 5  Full aggregate_year for one batch (reuse weights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nhf_spatial_targets.aggregate._driver import aggregate_variables_for_batch\n",
+    "\n",
+    "# Apply the adapter's pre_aggregate_hook (fill-value masking) to match what\n",
+    "# aggregate_year does internally.  Without this, section 5 would aggregate\n",
+    "# the raw values including MODIS special codes (water, cloud, no-data).\n",
+    "ds_masked = ADAPTER.pre_aggregate_hook(ds) if ADAPTER.pre_aggregate_hook else ds\n",
+    "\n",
+    "batch_ds2 = aggregate_variables_for_batch(\n",
+    "    batch_gdf=batch_gdf,\n",
+    "    source_ds=ds_masked,\n",
+    "    variables=list(ADAPTER.variables),\n",
+    "    source_crs=ADAPTER.source_crs,   # \"EPSG:4326\" — use adapter, not the sinusoidal constant\n",
+    "    x_coord=x,\n",
+    "    y_coord=y,\n",
+    "    time_coord=t,\n",
+    "    id_col=ID_COL,\n",
+    "    weights=weights,\n",
+    "    period=PERIOD,\n",
+    ")\n",
+    "print(batch_ds2)\n",
+    "print(f\"\\nET_500m range: {float(batch_ds2['ET_500m'].min()):.2f} … {float(batch_ds2['ET_500m'].max()):.2f}\")\n",
+    "print(f\"ET_500m NaN count: {int(batch_ds2['ET_500m'].isnull().sum())}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## 6  Run aggregate_year end-to-end (writes per-year intermediate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "from pathlib import Path\n",
+    "\n",
+    "log_file = Path(\"../logs/debug_mod16a2_agg.log\")\n",
+    "log_file.parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO,\n",
+    "    format=\"%(asctime)s %(name)s %(levelname)s %(message)s\",\n",
+    "    filename=log_file,\n",
+    "    filemode=\"w\",\n",
+    "    force=True,\n",
+    ")\n",
+    "print(f\"Logging to {log_file.resolve()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nhf_spatial_targets.aggregate._driver import per_year_output_path, weight_cache_path\n",
+    "from nhf_spatial_targets.workspace import load as load_project\n",
+    "\n",
+    "project = load_project(PROJECT_DIR)\n",
+    "\n",
+    "# ── Delete stale per-year intermediate ────────────────────────────────────\n",
+    "# aggregate_year is idempotent; it skips if the file exists.  Any file from\n",
+    "# a pre-fix run (wrong source_crs) must be removed before re-running.\n",
+    "stale_nc = per_year_output_path(project, ADAPTER.source_key, DEBUG_YEAR)\n",
+    "if stale_nc.exists():\n",
+    "    stale_nc.unlink()\n",
+    "    print(f\"Deleted stale intermediate: {stale_nc}\")\n",
+    "else:\n",
+    "    print(f\"No stale intermediate: {stale_nc}\")\n",
+    "\n",
+    "# ── Delete stale weight caches ─────────────────────────────────────────────\n",
+    "# Weights were computed with MODIS_SINUSOIDAL_PROJ — all batches are invalid.\n",
+    "weight_dir = project.workdir / \"weights\"\n",
+    "stale_weights = sorted(weight_dir.glob(f\"{ADAPTER.source_key}_batch*.csv\"))\n",
+    "for w in stale_weights:\n",
+    "    w.unlink()\n",
+    "print(f\"Deleted {len(stale_weights)} stale weight cache(s) from {weight_dir}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nhf_spatial_targets.aggregate._driver import aggregate_year\n",
+    "\n",
+    "out_path = aggregate_year(\n",
+    "    adapter=ADAPTER,\n",
+    "    project=project,\n",
+    "    year=DEBUG_YEAR,\n",
+    "    source_file=NC_PATH,\n",
+    "    fabric_batched=fabric_batched,\n",
+    "    id_col=ID_COL,\n",
+    ")\n",
+    "print(f\"Wrote: {out_path}\")\n",
+    "\n",
+    "with xr.open_dataset(out_path) as result:\n",
+    "    print(result)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.ET_500m.head().values\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
+   "metadata": {},
+   "source": [
+    "## 7  Spatial QC — map of annual-mean ET\n",
+    "\n",
+    "Join aggregated ET back to the fabric geometry and plot as a choropleth.\n",
+    "A spatially coherent result (smooth gradients, no obvious tiling artefacts)\n",
+    "confirms the aggregation worked correctly across HRU batches.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gc\n",
+    "import matplotlib.pyplot as plt\n",
+    "import geopandas as gpd\n",
+    "import xarray as xr\n",
+    "\n",
+    "# ── Load aggregated annual mean (values only, no geometry) ─────────────────\n",
+    "with xr.open_dataset(out_path) as result:\n",
+    "    annual_mean = (\n",
+    "        result[\"ET_500m\"]\n",
+    "        .mean(dim=\"time\")\n",
+    "        .to_dataframe()\n",
+    "        .reset_index()[[ID_COL, \"ET_500m\"]]\n",
+    "    )\n",
+    "\n",
+    "print(f\"ET_500m (annual mean) range: {annual_mean['ET_500m'].min():.2f} … {annual_mean['ET_500m'].max():.2f}\")\n",
+    "print(f\"ET_500m NaN count: {annual_mean['ET_500m'].isna().sum()} / {len(annual_mean)}\")\n",
+    "\n",
+    "# ── Load fabric: id + simplified geometry only ─────────────────────────────\n",
+    "# Simplify to ~1 km tolerance (fabric is EPSG:5070, units = metres).\n",
+    "# This drastically reduces vertex count without affecting visual quality at\n",
+    "# national scale.\n",
+    "fabric_full = gpd.read_file(FABRIC_PATH, columns=[ID_COL, \"geometry\"])\n",
+    "fabric_full[\"geometry\"] = fabric_full.geometry.simplify(1000, preserve_topology=False)\n",
+    "\n",
+    "# ── Join and report coverage ───────────────────────────────────────────────\n",
+    "plot_gdf = fabric_full.merge(annual_mean, on=ID_COL, how=\"left\")\n",
+    "del fabric_full, annual_mean\n",
+    "gc.collect()\n",
+    "\n",
+    "n_matched = plot_gdf[\"ET_500m\"].notna().sum()\n",
+    "n_total   = len(plot_gdf)\n",
+    "print(f\"HRUs with aggregated values: {n_matched} / {n_total}  \"\n",
+    "      f\"({100 * n_matched / n_total:.1f}%)\")\n",
+    "\n",
+    "# ── Plot ───────────────────────────────────────────────────────────────────\n",
+    "# vmax=100 clips the colormap to a physically meaningful range for CONUS\n",
+    "# annual-mean 8-day ET (kg m⁻² 8d⁻¹); fill-value artefacts (>3270) should\n",
+    "# already be masked by the pre_aggregate_hook.\n",
+    "fig, ax = plt.subplots(figsize=(14, 8))\n",
+    "plot_gdf[plot_gdf[\"ET_500m\"].isna()].plot(\n",
+    "    ax=ax, color=\"lightgrey\", linewidth=0,\n",
+    ")\n",
+    "plot_gdf[plot_gdf[\"ET_500m\"].notna()].plot(\n",
+    "    ax=ax,\n",
+    "    column=\"ET_500m\",\n",
+    "    cmap=\"YlGnBu\",\n",
+    "    linewidth=0,\n",
+    "    legend=True,\n",
+    "    vmin=0,\n",
+    "    vmax=100,\n",
+    "    legend_kwds={\"label\": \"Annual mean ET_500m (kg m⁻² 8d⁻¹)\", \"shrink\": 0.6},\n",
+    "    aspect=None,   # skip expensive equal-aspect calculation\n",
+    ")\n",
+    "ax.set_title(f\"MOD16A2 v061 — Annual mean ET_500m — {DEBUG_YEAR}\", fontsize=13)\n",
+    "ax.set_axis_off()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "del plot_gdf\n",
+    "gc.collect()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import geopandas as gpd\n",
+    "\n",
+    "# ── Diagnose join key and geometry ─────────────────────────────────────────\n",
+    "print(f\"Inspecting: {out_path}\")\n",
+    "\n",
+    "with xr.open_dataset(out_path) as result:\n",
+    "    print(result)\n",
+    "    annual_mean_diag = (\n",
+    "        result[\"ET_500m\"]\n",
+    "        .mean(dim=\"time\")\n",
+    "        .to_dataframe()\n",
+    "        .reset_index()[[ID_COL, \"ET_500m\"]]\n",
+    "    )\n",
+    "\n",
+    "fabric_diag = gpd.read_file(FABRIC_PATH, columns=[ID_COL, \"geometry\"], rows=5)\n",
+    "\n",
+    "print(\"\\n=== annual_mean ===\")\n",
+    "print(annual_mean_diag.head())\n",
+    "print(f\"dtype: {annual_mean_diag[ID_COL].dtype}\")\n",
+    "print(f\"sample values: {annual_mean_diag[ID_COL].iloc[:3].tolist()}\")\n",
+    "print(f\"ET_500m range: {annual_mean_diag['ET_500m'].min():.4f} … {annual_mean_diag['ET_500m'].max():.4f}\")\n",
+    "print(f\"ET_500m NaN count: {annual_mean_diag['ET_500m'].isna().sum()} / {len(annual_mean_diag)}\")\n",
+    "\n",
+    "print(\"\\n=== fabric (5 rows) ===\")\n",
+    "print(fabric_diag[[ID_COL]].head())\n",
+    "print(f\"dtype: {fabric_diag[ID_COL].dtype}\")\n",
+    "print(f\"sample values: {fabric_diag[ID_COL].iloc[:3].tolist()}\")\n",
+    "\n",
+    "# Check if a test merge would match\n",
+    "test_merge = fabric_diag.merge(annual_mean_diag.head(5), on=ID_COL, how=\"inner\")\n",
+    "print(f\"\\nTest inner merge rows matched: {len(test_merge)} (expected > 0)\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geoenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/nhf_spatial_targets/aggregate/_adapter.py
+++ b/src/nhf_spatial_targets/aggregate/_adapter.py
@@ -29,12 +29,14 @@ class SourceAdapter:
     source_key: str
     output_name: str
     variables: tuple[str, ...]
-    x_coord: str = "lon"
-    y_coord: str = "lat"
-    time_coord: str = "time"
+    x_coord: str | None = None
+    y_coord: str | None = None
+    time_coord: str | None = None
     source_crs: str = "EPSG:4326"
     grid_variable: str | None = None
     open_hook: Callable[[Project], xr.Dataset] | None = field(default=None)
+    pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
+    post_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
 
     def __post_init__(self) -> None:
         # Coerce list → tuple so callers can pass list literals.

--- a/src/nhf_spatial_targets/aggregate/_adapter.py
+++ b/src/nhf_spatial_targets/aggregate/_adapter.py
@@ -7,23 +7,22 @@ from dataclasses import dataclass, field
 
 import xarray as xr
 
-from nhf_spatial_targets.workspace import Project
-
 
 @dataclass(frozen=True)
 class SourceAdapter:
     """Declarative description of a source for the shared aggregation driver.
 
-    Use for sources whose consolidated NetCDF can be opened directly (optionally
-    via an ``open_hook`` for derived variables or file selection) and handed to
+    Use for sources whose NetCDFs can be opened directly and handed to
     ``aggregate_source`` without per-source batching/weighting logic. Sources
     requiring pre-aggregation masking or post-aggregation rename (e.g. MOD10C1)
     call the driver helpers directly and do not use this adapter.
 
-    ``open_hook`` receives the resolved :class:`Project` and must return an
-    :class:`xarray.Dataset` with CRS set and all ``variables`` present
-    (including any derived variables). When ``None``, the driver opens the
-    single consolidated NetCDF under ``project.raw_dir(source_key)``.
+    ``files_glob`` controls which files are enumerated from the datastore raw
+    directory.  The default ``"*_consolidated.nc"`` matches the standard fetch
+    output; sources with non-standard naming (e.g. ERA5-Land monthly NCs) set
+    this to a tighter pattern.  ``pre_aggregate_hook``, when set, receives each
+    lazily-opened per-year Dataset and may add derived variables before the
+    aggregation loop runs.
     """
 
     source_key: str
@@ -34,7 +33,7 @@ class SourceAdapter:
     time_coord: str | None = None
     source_crs: str = "EPSG:4326"
     grid_variable: str | None = None
-    open_hook: Callable[[Project], xr.Dataset] | None = field(default=None)
+    files_glob: str = "*_consolidated.nc"
     pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
     post_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
 

--- a/src/nhf_spatial_targets/aggregate/_coords.py
+++ b/src/nhf_spatial_targets/aggregate/_coords.py
@@ -1,0 +1,81 @@
+"""CF-based coordinate detection for source datasets."""
+
+from __future__ import annotations
+
+import xarray as xr
+
+_X_STANDARD_NAMES = frozenset({"longitude", "projection_x_coordinate"})
+_Y_STANDARD_NAMES = frozenset({"latitude", "projection_y_coordinate"})
+_T_STANDARD_NAMES = frozenset({"time"})
+
+
+def _find_axis(
+    ds: xr.Dataset,
+    dims: tuple[str, ...],
+    axis_letter: str,
+    standard_names: frozenset[str],
+) -> str | None:
+    # First pass: CF axis attribute.
+    for name in dims:
+        if name in ds.coords and ds.coords[name].attrs.get("axis") == axis_letter:
+            return name
+    # Second pass: CF standard_name.
+    for name in dims:
+        if (
+            name in ds.coords
+            and ds.coords[name].attrs.get("standard_name") in standard_names
+        ):
+            return name
+    return None
+
+
+def detect_coords(
+    ds: xr.Dataset,
+    var: str,
+    x_override: str | None = None,
+    y_override: str | None = None,
+    time_override: str | None = None,
+) -> tuple[str, str, str]:
+    """Return (x_coord, y_coord, time_coord) for ``ds[var]``.
+
+    Resolution order per axis:
+      1. Explicit override (must be one of ``ds[var].dims``).
+      2. Coordinate whose ``axis`` attr is 'X' / 'Y' / 'T'.
+      3. Coordinate whose ``standard_name`` attr matches a CF name for that axis.
+
+    Raises KeyError if ``var`` is not in ``ds``.
+    Raises ValueError if an override is not in ``ds[var].dims`` or if any axis
+    cannot be resolved after overrides + CF passes.
+    """
+    if var not in ds.data_vars:
+        raise KeyError(f"Variable {var!r} not in dataset (have {list(ds.data_vars)})")
+    dims = tuple(ds[var].dims)
+
+    def _resolve(
+        override: str | None,
+        axis_letter: str,
+        standard_names: frozenset[str],
+        label: str,
+    ) -> str:
+        if override is not None:
+            if override not in dims:
+                raise ValueError(
+                    f"{label} override {override!r} is not a dim of {var!r} "
+                    f"(dims={dims})"
+                )
+            return override
+        found = _find_axis(ds, dims, axis_letter, standard_names)
+        if found is None:
+            attrs_by_dim = {d: dict(ds.coords[d].attrs) for d in dims if d in ds.coords}
+            raise ValueError(
+                f"Could not detect {label} coord for {var!r}. "
+                f"No dim has axis={axis_letter!r} or standard_name in "
+                f"{sorted(standard_names)}. "
+                f"dims={dims}, coord attrs={attrs_by_dim}"
+            )
+        return found
+
+    x = _resolve(x_override, "X", _X_STANDARD_NAMES, "x")
+    y = _resolve(y_override, "Y", _Y_STANDARD_NAMES, "y")
+    t = _resolve(time_override, "T", _T_STANDARD_NAMES, "time")
+    return x, y, t

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -6,9 +6,11 @@ import json
 import logging
 import os
 import tempfile
+from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
 
+import numpy as np
 import geopandas as gpd
 import pandas as pd
 import xarray as xr
@@ -284,13 +286,20 @@ def _default_open_hook(project: Project, adapter: SourceAdapter) -> xr.Dataset:
 
     1. Glob all ``*.nc`` files in the raw directory.
     2. If exactly one is found, open it directly (single-file sources such as
-       merra2, watergap22d, ncep_ncar).
+       merra2, watergap22d, ncep_ncar) — handles both ``*_consolidated.nc``
+       and bare names like ``watergap22d_qrdif_cf.nc``.
     3. If multiple are found, narrow to ``*_consolidated.nc`` files (per-year
-       sources such as mod16a2) and concatenate along ``time``.  This avoids
-       accidentally picking up raw per-timestep files that share the directory.
+       sources such as mod16a2) and concatenate along ``time``, then
+       ``sortby("time")`` so the time coord is monotonic regardless of
+       filename order. This avoids accidentally picking up raw per-timestep
+       files that share the directory.
 
-    Raises ``FileNotFoundError`` when no NCs are present, or when the
-    multi-file path finds no ``*_consolidated.nc`` matches.
+    Raises:
+        FileNotFoundError: no NCs are present, or the multi-file path finds
+            no ``*_consolidated.nc`` matches (the error lists the offending
+            filenames so the operator can investigate).
+        ValueError: concatenated time coord contains duplicates (e.g. a
+            re-fetch left both old and new per-year files in place).
     """
     raw_dir = project.raw_dir(adapter.source_key)
     all_ncs = sorted(raw_dir.glob("*.nc"))
@@ -301,27 +310,40 @@ def _default_open_hook(project: Project, adapter: SourceAdapter) -> xr.Dataset:
         )
     if len(all_ncs) == 1:
         ncs = all_ncs
+        logger.info("Opening single NC: %s", ncs[0].name)
+        with ExitStack() as stack:
+            datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
+            loaded = datasets[0].load()
+        return loaded
     else:
         ncs = sorted(raw_dir.glob("*_consolidated.nc"))
         if not ncs:
+            sample = [p.name for p in all_ncs[:5]]
             raise FileNotFoundError(
                 f"Multiple NCs found in {raw_dir} but none match "
-                f"'*_consolidated.nc'. Run "
+                f"'*_consolidated.nc'. Existing files (first 5 of "
+                f"{len(all_ncs)}): {sample}. Run "
                 f"'nhf-targets fetch {adapter.source_key}' to produce "
                 f"consolidated files."
             )
-    datasets = [xr.open_dataset(p) for p in ncs]
-    try:
-        if len(datasets) == 1:
-            loaded = datasets[0].load()
-        else:
-            combined = xr.concat(datasets, dim="time")
-            combined = combined.sortby("time")
-            loaded = combined.load()
-    finally:
-        for d in datasets:
-            d.close()
-    return loaded
+        logger.info(
+            "Concatenating %d consolidated NCs: %s",
+            len(ncs),
+            [p.name for p in ncs],
+        )
+        with ExitStack() as stack:
+            datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
+            loaded = [d.load() for d in datasets]
+            combined = xr.concat(loaded, dim="time").sortby("time")
+        time_values = combined["time"].values
+        if len(np.unique(time_values)) != len(time_values):
+            raise ValueError(
+                f"Duplicate time coords across consolidated files "
+                f"{[p.name for p in ncs]}. Check the datastore for overlapping "
+                f"per-year files (e.g. a re-fetch may have left both the old and "
+                f"new file in place)."
+            )
+        return combined
 
 
 def aggregate_source(

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -130,6 +130,8 @@ def compute_or_load_weights(
     source_key: str,
     batch_id: int,
     workdir: Path,
+    *,
+    period: tuple[str, str],
 ) -> pd.DataFrame:
     """Compute (or load from cache) the per-batch weight table.
 
@@ -188,10 +190,7 @@ def compute_or_load_weights(
         f_feature=batch_gdf,
         proj_feature=batch_gdf.crs.to_string(),
         id_feature=id_col,
-        period=[
-            str(source_ds[time_coord].values[0]),
-            str(source_ds[time_coord].values[-1]),
-        ],
+        period=[period[0], period[1]],
     )
     wg = WeightGen(
         user_data=user_data,
@@ -222,6 +221,8 @@ def aggregate_variables_for_batch(
     time_coord: str,
     id_col: str,
     weights: pd.DataFrame,
+    *,
+    period: tuple[str, str],
 ) -> xr.Dataset:
     """Run gdptools AggGen once per variable, merge results on HRU ID.
 
@@ -263,10 +264,7 @@ def aggregate_variables_for_batch(
             f_feature=batch_gdf,
             proj_feature=batch_gdf.crs.to_string(),
             id_feature=id_col,
-            period=[
-                str(source_ds[time_coord].values[0]),
-                str(source_ds[time_coord].values[-1]),
-            ],
+            period=[period[0], period[1]],
         )
         agg = AggGen(
             user_data=user_data,
@@ -413,6 +411,10 @@ def aggregate_source(
         n_batches,
     )
 
+    t0 = str(source_ds[time_coord].values[0])
+    t1 = str(source_ds[time_coord].values[-1])
+    period_full = (t0, t1)
+
     datasets: list[xr.Dataset] = []
     for bid in sorted(batched["batch_id"].unique()):
         batch_gdf = batched[batched["batch_id"] == bid].drop(columns=["batch_id"])
@@ -428,6 +430,7 @@ def aggregate_source(
             source_key=adapter.source_key,
             batch_id=int(bid),
             workdir=workdir,
+            period=period_full,
         )
         ds = aggregate_variables_for_batch(
             batch_gdf=batch_gdf,
@@ -439,6 +442,7 @@ def aggregate_source(
             time_coord=time_coord,
             id_col=id_col,
             weights=weights,
+            period=period_full,
         )
         datasets.append(ds)
 

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -17,6 +17,7 @@ import xarray as xr
 from gdptools import AggGen, UserCatData, WeightGen
 
 from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+from nhf_spatial_targets.aggregate._coords import detect_coords
 from nhf_spatial_targets.aggregate.batching import spatial_batch
 from nhf_spatial_targets.catalog import source as catalog_source
 from nhf_spatial_targets.workspace import Project, load as load_project
@@ -393,6 +394,17 @@ def aggregate_source(
             f"dataset (have {list(source_ds.data_vars)})"
         )
 
+    # Resolve coordinate names: use adapter overrides when set, else auto-detect
+    # via CF attrs on the grid variable.  This handles both legacy adapters that
+    # hard-code coord names and new adapters that leave coords as None.
+    x_coord, y_coord, time_coord = detect_coords(
+        source_ds,
+        adapter.grid_variable,
+        x_override=adapter.x_coord,
+        y_override=adapter.y_coord,
+        time_override=adapter.time_coord,
+    )
+
     batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
     n_batches = int(batched["batch_id"].nunique())
     logger.info(
@@ -409,9 +421,9 @@ def aggregate_source(
             source_ds=source_ds,
             source_var=adapter.grid_variable,
             source_crs=adapter.source_crs,
-            x_coord=adapter.x_coord,
-            y_coord=adapter.y_coord,
-            time_coord=adapter.time_coord,
+            x_coord=x_coord,
+            y_coord=y_coord,
+            time_coord=time_coord,
             id_col=id_col,
             source_key=adapter.source_key,
             batch_id=int(bid),
@@ -422,9 +434,9 @@ def aggregate_source(
             source_ds=source_ds,
             variables=adapter.variables,
             source_crs=adapter.source_crs,
-            x_coord=adapter.x_coord,
-            y_coord=adapter.y_coord,
-            time_coord=adapter.time_coord,
+            x_coord=x_coord,
+            y_coord=y_coord,
+            time_coord=time_coord,
             id_col=id_col,
             weights=weights,
         )
@@ -434,7 +446,7 @@ def aggregate_source(
     logger.info(
         "%s: combined dataset: %s time steps x %s HRUs",
         adapter.source_key,
-        combined.sizes.get(adapter.time_coord, "?"),
+        combined.sizes.get(time_coord, "?"),
         combined.sizes.get(id_col, "?"),
     )
 
@@ -448,8 +460,8 @@ def aggregate_source(
     loaded = combined.load()
     combined.close()
 
-    t0 = str(loaded[adapter.time_coord].values[0])[:10]
-    t1 = str(loaded[adapter.time_coord].values[-1])[:10]
+    t0 = str(loaded[time_coord].values[0])[:10]
+    t1 = str(loaded[time_coord].values[-1])[:10]
     update_manifest(
         project=project,
         source_key=adapter.source_key,

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -273,6 +273,28 @@ def aggregate_year(
     return out_path
 
 
+def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
+    """Open per-year intermediates, concat on time, validate monotonic + unique.
+
+    Loads each intermediate into memory and closes the on-disk handle so the
+    returned Dataset is detached from the filesystem.
+    """
+    if not paths:
+        raise ValueError("concat_years called with empty paths list")
+    loaded: list[xr.Dataset] = []
+    for p in paths:
+        with xr.open_dataset(p) as ds:
+            loaded.append(ds.load())
+    combined = xr.concat(loaded, dim=time_coord).sortby(time_coord)
+    t = combined[time_coord].values
+    if len(np.unique(t)) != len(t):
+        raise ValueError(
+            f"Duplicate time coords across per-year intermediates: "
+            f"{[p.name for p in paths]}"
+        )
+    return combined
+
+
 def compute_or_load_weights(
     batch_gdf: gpd.GeoDataFrame,
     source_ds: xr.Dataset,

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -278,32 +278,49 @@ def aggregate_variables_for_batch(
 
 
 def _default_open_hook(project: Project, adapter: SourceAdapter) -> xr.Dataset:
-    """Open the single consolidated NC in ``project.raw_dir(adapter.source_key)``.
+    """Open the consolidated NC(s) in ``project.raw_dir(adapter.source_key)``.
 
-    Raises ``FileNotFoundError`` when the datastore has no NCs and
-    ``ValueError`` when it has more than one (ambiguous — the consolidated
-    contract is a single NC per source).
+    Strategy:
+
+    1. Glob all ``*.nc`` files in the raw directory.
+    2. If exactly one is found, open it directly (single-file sources such as
+       merra2, watergap22d, ncep_ncar).
+    3. If multiple are found, narrow to ``*_consolidated.nc`` files (per-year
+       sources such as mod16a2) and concatenate along ``time``.  This avoids
+       accidentally picking up raw per-timestep files that share the directory.
+
+    Raises ``FileNotFoundError`` when no NCs are present, or when the
+    multi-file path finds no ``*_consolidated.nc`` matches.
     """
     raw_dir = project.raw_dir(adapter.source_key)
-    ncs = sorted(raw_dir.glob("*.nc"))
-    if not ncs:
+    all_ncs = sorted(raw_dir.glob("*.nc"))
+    if not all_ncs:
         raise FileNotFoundError(
             f"No consolidated NC found in {raw_dir}. "
             f"Run 'nhf-targets fetch {adapter.source_key}' first."
         )
-    if len(ncs) > 1:
-        names = ", ".join(nc.name for nc in ncs)
-        raise ValueError(
-            f"Multiple consolidated NCs found in {raw_dir}: [{names}]. "
-            "The consolidated-source contract expects exactly one NC per source. "
-            "Check the datastore for duplicate or stale files and remove all but "
-            "the correct consolidated file."
-        )
-    ds = xr.open_dataset(ncs[0])
+    if len(all_ncs) == 1:
+        ncs = all_ncs
+    else:
+        ncs = sorted(raw_dir.glob("*_consolidated.nc"))
+        if not ncs:
+            raise FileNotFoundError(
+                f"Multiple NCs found in {raw_dir} but none match "
+                f"'*_consolidated.nc'. Run "
+                f"'nhf-targets fetch {adapter.source_key}' to produce "
+                f"consolidated files."
+            )
+    datasets = [xr.open_dataset(p) for p in ncs]
     try:
-        loaded = ds.load()
+        if len(datasets) == 1:
+            loaded = datasets[0].load()
+        else:
+            combined = xr.concat(datasets, dim="time")
+            combined = combined.sortby("time")
+            loaded = combined.load()
     finally:
-        ds.close()
+        for d in datasets:
+            d.close()
     return loaded
 
 

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -118,6 +118,48 @@ def weight_cache_path(workdir: Path, source_key: str, batch_id: int) -> Path:
     return Path(workdir) / "weights" / f"{source_key}_batch{batch_id}.csv"
 
 
+def _find_time_coord_name(ds: xr.Dataset) -> str | None:
+    """Return the name of the time coord via CF attrs, or None."""
+    for name in ds.coords:
+        attrs = ds.coords[name].attrs
+        if attrs.get("axis") == "T" or attrs.get("standard_name") == "time":
+            return name
+    # Fall back: any coord literally named 'time' (non-CF legacy NCs).
+    return "time" if "time" in ds.coords else None
+
+
+def enumerate_years(files: list[Path]) -> list[tuple[int, Path]]:
+    """Map each year covered by the files to its source file.
+
+    Opens each NC lazily, reads its time coord, and expands to one
+    ``(year, file)`` tuple per distinct year. Returns results sorted by year.
+
+    Raises:
+        ValueError: two files cover the same year (stale fetch), or a file has
+            no resolvable time coord.
+    """
+    year_to_file: dict[int, Path] = {}
+    for path in files:
+        with xr.open_dataset(path) as ds:
+            time_name = _find_time_coord_name(ds)
+            if time_name is None:
+                attrs_by_coord = {n: dict(ds.coords[n].attrs) for n in ds.coords}
+                raise ValueError(
+                    f"No time coord found in {path.name}. "
+                    f"dims={list(ds.dims)}, coord attrs={attrs_by_coord}"
+                )
+            years = pd.DatetimeIndex(ds[time_name].values).year.unique().tolist()
+        for y in years:
+            if y in year_to_file:
+                raise ValueError(
+                    f"Year {y} overlaps between {year_to_file[y].name} "
+                    f"and {path.name}. Check the datastore for a stale "
+                    f"fetch artifact."
+                )
+            year_to_file[int(y)] = path
+    return sorted(year_to_file.items())
+
+
 def compute_or_load_weights(
     batch_gdf: gpd.GeoDataFrame,
     source_ds: xr.Dataset,

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -364,7 +364,7 @@ def compute_or_load_weights(
         t_coord=time_coord,
         var=[source_var],
         f_feature=batch_gdf,
-        proj_feature=batch_gdf.crs.to_string(),
+        proj_feature=WEIGHT_GEN_CRS,
         id_feature=id_col,
         period=[period[0], period[1]],
     )
@@ -438,13 +438,13 @@ def aggregate_variables_for_batch(
             t_coord=time_coord,
             var=[var],
             f_feature=batch_gdf,
-            proj_feature=batch_gdf.crs.to_string(),
+            proj_feature=WEIGHT_GEN_CRS,
             id_feature=id_col,
             period=[period[0], period[1]],
         )
         agg = AggGen(
             user_data=user_data,
-            stat_method="masked_mean",
+            stat_method="mean",
             agg_engine="serial",
             agg_writer="none",
             weights=weights,

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -160,6 +160,119 @@ def enumerate_years(files: list[Path]) -> list[tuple[int, Path]]:
     return sorted(year_to_file.items())
 
 
+def per_year_output_path(project: Project, source_key: str, year: int) -> Path:
+    """Return the per-year intermediate NC path."""
+    return (
+        project.workdir
+        / "data"
+        / "aggregated"
+        / "_by_year"
+        / f"{source_key}_{year}_agg.nc"
+    )
+
+
+def _atomic_write_netcdf(ds: xr.Dataset, path: Path) -> None:
+    """Atomically write a Dataset to disk via tempfile + rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".nc.tmp")
+    os.close(tmp_fd)
+    try:
+        ds.to_netcdf(tmp_path)
+        Path(tmp_path).replace(path)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+
+
+def aggregate_year(
+    adapter: SourceAdapter,
+    project: Project,
+    year: int,
+    source_file: Path,
+    fabric_batched: gpd.GeoDataFrame,
+    id_col: str,
+) -> Path:
+    """Aggregate one year to HRU polygons; idempotent on the intermediate NC.
+
+    Returns the path of the per-year intermediate. If that path already
+    exists, returns immediately without opening the source file. Otherwise
+    opens the source file lazily, applies ``adapter.pre_aggregate_hook`` if
+    set, detects coords via CF attrs (respecting adapter overrides), runs
+    the batch loop with ``period=(YYYY-01-01, YYYY-12-31)``, concatenates
+    batches on ``id_col``, and writes the intermediate atomically.
+    """
+    out_path = per_year_output_path(project, adapter.source_key, year)
+    if out_path.exists():
+        logger.info(
+            "%s: year %d: intermediate exists, skipping (%s)",
+            adapter.source_key,
+            year,
+            out_path,
+        )
+        return out_path
+
+    logger.info(
+        "%s: year %d: aggregating from %s",
+        adapter.source_key,
+        year,
+        source_file.name,
+    )
+    period = (f"{year}-01-01", f"{year}-12-31")
+
+    with xr.open_dataset(source_file) as raw:
+        ds = raw
+        if adapter.pre_aggregate_hook is not None:
+            ds = adapter.pre_aggregate_hook(ds)
+
+        grid_var = adapter.grid_variable or adapter.variables[0]
+        x_coord, y_coord, time_coord = detect_coords(
+            ds,
+            grid_var,
+            x_override=adapter.x_coord,
+            y_override=adapter.y_coord,
+            time_override=adapter.time_coord,
+        )
+
+        datasets: list[xr.Dataset] = []
+        for bid in sorted(fabric_batched["batch_id"].unique()):
+            batch_gdf = fabric_batched[fabric_batched["batch_id"] == bid].drop(
+                columns=["batch_id"]
+            )
+            weights = compute_or_load_weights(
+                batch_gdf=batch_gdf,
+                source_ds=ds,
+                source_var=grid_var,
+                source_crs=adapter.source_crs,
+                x_coord=x_coord,
+                y_coord=y_coord,
+                time_coord=time_coord,
+                id_col=id_col,
+                source_key=adapter.source_key,
+                batch_id=int(bid),
+                workdir=project.workdir,
+                period=period,
+            )
+            batch_ds = aggregate_variables_for_batch(
+                batch_gdf=batch_gdf,
+                source_ds=ds,
+                variables=list(adapter.variables),
+                source_crs=adapter.source_crs,
+                x_coord=x_coord,
+                y_coord=y_coord,
+                time_coord=time_coord,
+                id_col=id_col,
+                weights=weights,
+                period=period,
+            )
+            datasets.append(batch_ds)
+
+        year_ds = xr.concat(datasets, dim=id_col)
+
+    _atomic_write_netcdf(year_ds, out_path)
+    logger.info("%s: year %d: wrote %s", adapter.source_key, year, out_path)
+    return out_path
+
+
 def compute_or_load_weights(
     batch_gdf: gpd.GeoDataFrame,
     source_ds: xr.Dataset,

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -478,11 +478,12 @@ def aggregate_source(
 ) -> xr.Dataset:
     """Aggregate a source to fabric HRU polygons via the per-year pipeline.
 
-    Enumerates years from ``*_consolidated.nc`` in the datastore, aggregates
-    each year to ``data/aggregated/_by_year/<source_key>_<year>_agg.nc``
-    (idempotent; existing intermediates are reused on restart), then concats
-    on time to ``data/aggregated/<output_name>``. Per-year intermediates
-    are preserved for audit/restart.
+    Enumerates years from files matching ``adapter.files_glob`` in the
+    datastore raw directory, aggregates each year to
+    ``data/aggregated/_by_year/<source_key>_<year>_agg.nc`` (idempotent;
+    existing intermediates are reused on restart), then concats on time to
+    ``data/aggregated/<output_name>``. Per-year intermediates are preserved
+    for audit/restart.
 
     Variables declared by ``adapter.variables`` that are missing from the
     source NC cause ValueError before any year is aggregated — unless the
@@ -494,10 +495,10 @@ def aggregate_source(
     meta = catalog_source(adapter.source_key)
 
     raw_dir = project.raw_dir(adapter.source_key)
-    files = sorted(raw_dir.glob("*_consolidated.nc"))
+    files = sorted(raw_dir.glob(adapter.files_glob))
     if not files:
         raise FileNotFoundError(
-            f"No consolidated NC found in {raw_dir}. "
+            f"No NC matching '{adapter.files_glob}' found in {raw_dir}. "
             f"Run 'nhf-targets fetch {adapter.source_key}' first."
         )
 

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import tempfile
-from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -455,71 +454,19 @@ def aggregate_variables_for_batch(
     return xr.merge(per_var)
 
 
-def _default_open_hook(project: Project, adapter: SourceAdapter) -> xr.Dataset:
-    """Open the consolidated NC(s) in ``project.raw_dir(adapter.source_key)``.
-
-    Strategy:
-
-    1. Glob all ``*.nc`` files in the raw directory.
-    2. If exactly one is found, open it directly (single-file sources such as
-       merra2, watergap22d, ncep_ncar) — handles both ``*_consolidated.nc``
-       and bare names like ``watergap22d_qrdif_cf.nc``.
-    3. If multiple are found, narrow to ``*_consolidated.nc`` files (per-year
-       sources such as mod16a2) and concatenate along ``time``, then
-       ``sortby("time")`` so the time coord is monotonic regardless of
-       filename order. This avoids accidentally picking up raw per-timestep
-       files that share the directory.
-
-    Raises:
-        FileNotFoundError: no NCs are present, or the multi-file path finds
-            no ``*_consolidated.nc`` matches (the error lists the offending
-            filenames so the operator can investigate).
-        ValueError: concatenated time coord contains duplicates (e.g. a
-            re-fetch left both old and new per-year files in place).
-    """
-    raw_dir = project.raw_dir(adapter.source_key)
-    all_ncs = sorted(raw_dir.glob("*.nc"))
-    if not all_ncs:
-        raise FileNotFoundError(
-            f"No consolidated NC found in {raw_dir}. "
-            f"Run 'nhf-targets fetch {adapter.source_key}' first."
-        )
-    if len(all_ncs) == 1:
-        ncs = all_ncs
-        logger.info("Opening single NC: %s", ncs[0].name)
-        with ExitStack() as stack:
-            datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
-            loaded = datasets[0].load()
-        return loaded
-    else:
-        ncs = sorted(raw_dir.glob("*_consolidated.nc"))
-        if not ncs:
-            sample = [p.name for p in all_ncs[:5]]
-            raise FileNotFoundError(
-                f"Multiple NCs found in {raw_dir} but none match "
-                f"'*_consolidated.nc'. Existing files (first 5 of "
-                f"{len(all_ncs)}): {sample}. Run "
-                f"'nhf-targets fetch {adapter.source_key}' to produce "
-                f"consolidated files."
-            )
-        logger.info(
-            "Concatenating %d consolidated NCs: %s",
-            len(ncs),
-            [p.name for p in ncs],
-        )
-        with ExitStack() as stack:
-            datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
-            loaded = [d.load() for d in datasets]
-            combined = xr.concat(loaded, dim="time").sortby("time")
-        time_values = combined["time"].values
-        if len(np.unique(time_values)) != len(time_values):
-            raise ValueError(
-                f"Duplicate time coords across consolidated files "
-                f"{[p.name for p in ncs]}. Check the datastore for overlapping "
-                f"per-year files (e.g. a re-fetch may have left both the old and "
-                f"new file in place)."
-            )
-        return combined
+def _attach_cf_global_attrs(ds: xr.Dataset, source_key: str, meta: dict) -> None:
+    """Attach CF-1.6 global attrs in place (non-destructive for var attrs)."""
+    access = meta.get("access", {})
+    history = (
+        f"{datetime.now(timezone.utc).isoformat()}: aggregated to HRU fabric "
+        f"by nhf_spatial_targets.aggregate._driver"
+    )
+    ds.attrs.setdefault("Conventions", "CF-1.6")
+    ds.attrs["history"] = history
+    ds.attrs["source"] = source_key
+    if "doi" in access:
+        ds.attrs["source_doi"] = access["doi"]
+    ds.attrs.setdefault("institution", "USGS")
 
 
 def aggregate_source(
@@ -529,120 +476,72 @@ def aggregate_source(
     workdir: Path,
     batch_size: int = 500,
 ) -> xr.Dataset:
-    """Aggregate a tier-1 source to fabric HRU polygons.
+    """Aggregate a source to fabric HRU polygons via the per-year pipeline.
 
-    Processes the full temporal range present in the consolidated source NC;
-    no period clipping is applied. Weights are cached per batch under
-    ``workdir/weights/<source_key>_batch<id>.csv``.
+    Enumerates years from ``*_consolidated.nc`` in the datastore, aggregates
+    each year to ``data/aggregated/_by_year/<source_key>_<year>_agg.nc``
+    (idempotent; existing intermediates are reused on restart), then concats
+    on time to ``data/aggregated/<output_name>``. Per-year intermediates
+    are preserved for audit/restart.
 
-    Parameters
-    ----------
-    adapter : SourceAdapter
-        Declarative description of the source (variables, open_hook, CRS, etc).
-    fabric_path : Path
-        Path to the HRU fabric file.
-    id_col : str
-        Name of the HRU identifier column in the fabric.
-    workdir : Path
-        Project working directory (contains config.yml, fabric.json, manifest.json).
-    batch_size : int
-        Target number of HRUs per spatial batch.
-
-    Returns
-    -------
-    xr.Dataset
-        Combined aggregated dataset with all HRUs and time steps.
+    Variables declared by ``adapter.variables`` that are missing from the
+    source NC cause ValueError before any year is aggregated — unless the
+    adapter defines a ``pre_aggregate_hook`` (in which case the declared
+    variables are constructed by the hook, not read from the raw NC).
     """
     workdir = Path(workdir)
     project = load_project(workdir)
     meta = catalog_source(adapter.source_key)
 
-    if adapter.open_hook is not None:
-        source_ds = adapter.open_hook(project)
-    else:
-        source_ds = _default_open_hook(project, adapter)
-
-    missing = [v for v in adapter.variables if v not in source_ds.data_vars]
-    if missing:
-        raise ValueError(
-            f"{adapter.source_key}: variables {missing} missing from source "
-            f"dataset (have {list(source_ds.data_vars)})"
+    raw_dir = project.raw_dir(adapter.source_key)
+    files = sorted(raw_dir.glob("*_consolidated.nc"))
+    if not files:
+        raise FileNotFoundError(
+            f"No consolidated NC found in {raw_dir}. "
+            f"Run 'nhf-targets fetch {adapter.source_key}' first."
         )
 
-    # Resolve coordinate names: use adapter overrides when set, else auto-detect
-    # via CF attrs on the grid variable.  This handles both legacy adapters that
-    # hard-code coord names and new adapters that leave coords as None.
-    x_coord, y_coord, time_coord = detect_coords(
-        source_ds,
-        adapter.grid_variable,
-        x_override=adapter.x_coord,
-        y_override=adapter.y_coord,
-        time_override=adapter.time_coord,
-    )
+    # Fail fast on missing declared variables — but only if there is no
+    # pre_aggregate_hook. Hooked adapters derive their declared variables.
+    if adapter.pre_aggregate_hook is None:
+        with xr.open_dataset(files[0]) as peek:
+            missing = [v for v in adapter.variables if v not in peek.data_vars]
+            if missing:
+                raise ValueError(
+                    f"{adapter.source_key}: variables {missing} missing from "
+                    f"source dataset (have {list(peek.data_vars)})"
+                )
 
-    batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
-    n_batches = int(batched["batch_id"].nunique())
+    year_files = enumerate_years(files)
+    fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
+    n_batches = int(fabric_batched["batch_id"].nunique())
     logger.info(
-        "%s: fabric split into %d spatial batches",
+        "%s: %d years to aggregate across %d spatial batches",
         adapter.source_key,
+        len(year_files),
         n_batches,
     )
 
-    t0 = str(source_ds[time_coord].values[0])
-    t1 = str(source_ds[time_coord].values[-1])
-    period_full = (t0, t1)
+    per_year_paths = [
+        aggregate_year(adapter, project, year, path, fabric_batched, id_col)
+        for year, path in year_files
+    ]
 
-    datasets: list[xr.Dataset] = []
-    for bid in sorted(batched["batch_id"].unique()):
-        batch_gdf = batched[batched["batch_id"] == bid].drop(columns=["batch_id"])
-        weights = compute_or_load_weights(
-            batch_gdf=batch_gdf,
-            source_ds=source_ds,
-            source_var=adapter.grid_variable,
-            source_crs=adapter.source_crs,
-            x_coord=x_coord,
-            y_coord=y_coord,
-            time_coord=time_coord,
-            id_col=id_col,
-            source_key=adapter.source_key,
-            batch_id=int(bid),
-            workdir=workdir,
-            period=period_full,
-        )
-        ds = aggregate_variables_for_batch(
-            batch_gdf=batch_gdf,
-            source_ds=source_ds,
-            variables=adapter.variables,
-            source_crs=adapter.source_crs,
-            x_coord=x_coord,
-            y_coord=y_coord,
-            time_coord=time_coord,
-            id_col=id_col,
-            weights=weights,
-            period=period_full,
-        )
-        datasets.append(ds)
+    with xr.open_dataset(per_year_paths[0]) as probe:
+        time_coord = _find_time_coord_name(probe) or "time"
+    combined = concat_years(per_year_paths, time_coord=time_coord)
 
-    combined = xr.concat(datasets, dim=id_col)
-    logger.info(
-        "%s: combined dataset: %s time steps x %s HRUs",
-        adapter.source_key,
-        combined.sizes.get(time_coord, "?"),
-        combined.sizes.get(id_col, "?"),
-    )
+    if adapter.post_aggregate_hook is not None:
+        combined = adapter.post_aggregate_hook(combined)
 
-    output_dir = project.aggregated_dir()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / adapter.output_name
-    combined.to_netcdf(output_path)
+    _attach_cf_global_attrs(combined, adapter.source_key, meta)
+
+    output_path = project.aggregated_dir() / adapter.output_name
+    _atomic_write_netcdf(combined, output_path)
     logger.info("%s: output written to %s", adapter.source_key, output_path)
-    # Load a detached in-memory copy so callers can use the return value safely
-    # after the on-disk handle is closed.
-    loaded = combined.load()
-    combined.close()
 
-    t0 = str(loaded[time_coord].values[0])[:10]
-    t1 = str(loaded[time_coord].values[-1])[:10]
+    t0 = str(combined[time_coord].values[0])[:10]
+    t1 = str(combined[time_coord].values[-1])[:10]
     update_manifest(
         project=project,
         source_key=adapter.source_key,
@@ -654,5 +553,4 @@ def aggregate_source(
             for i in range(n_batches)
         ],
     )
-
-    return loaded
+    return combined

--- a/src/nhf_spatial_targets/aggregate/era5_land.py
+++ b/src/nhf_spatial_targets/aggregate/era5_land.py
@@ -8,38 +8,15 @@ import xarray as xr
 
 from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 from nhf_spatial_targets.aggregate._driver import aggregate_source
-from nhf_spatial_targets.workspace import Project
-
-
-def _open_monthly(project: Project) -> xr.Dataset:
-    """Open the monthly consolidated ERA5-Land NC in the datastore.
-
-    The ERA5-Land fetch stores both a daily and a monthly NC; this helper
-    selects the monthly one by globbing for the literal ``monthly`` token
-    in the filename (``*monthly*.nc``).
-    """
-    raw_dir = project.raw_dir("era5_land")
-    monthly_ncs = sorted(Path(raw_dir).glob("*monthly*.nc"))
-    if not monthly_ncs:
-        raise FileNotFoundError(
-            f"No monthly ERA5-Land NC found in {raw_dir}. "
-            "Run 'nhf-targets fetch era5-land' first."
-        )
-    ds = xr.open_dataset(monthly_ncs[0])
-    try:
-        loaded = ds.load()
-    finally:
-        ds.close()
-    return loaded
 
 
 ADAPTER = SourceAdapter(
     source_key="era5_land",
     output_name="era5_land_agg.nc",
-    variables=["ro", "sro", "ssro"],
+    variables=("ro", "sro", "ssro"),
     x_coord="longitude",
     y_coord="latitude",
-    open_hook=_open_monthly,
+    files_glob="*monthly*.nc",
 )
 
 

--- a/src/nhf_spatial_targets/aggregate/gldas.py
+++ b/src/nhf_spatial_targets/aggregate/gldas.py
@@ -8,40 +8,28 @@ import xarray as xr
 
 from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 from nhf_spatial_targets.aggregate._driver import aggregate_source
-from nhf_spatial_targets.workspace import Project
 
 _SOURCE_KEY = "gldas_noah_v21_monthly"
 
 
-def _open(project: Project) -> xr.Dataset:
-    """Open the consolidated GLDAS NC and derive ``runoff_total``."""
-    raw_dir = project.raw_dir(_SOURCE_KEY)
-    ncs = sorted(Path(raw_dir).glob("*.nc"))
-    if not ncs:
-        raise FileNotFoundError(
-            f"No GLDAS NC found in {raw_dir}. Run 'nhf-targets fetch gldas' first."
-        )
-    ds = xr.open_dataset(ncs[0])
-    try:
-        loaded = ds.load()
-    finally:
-        ds.close()
-    total = loaded["Qs_acc"] + loaded["Qsb_acc"]
+def _derive_runoff_total(ds: xr.Dataset) -> xr.Dataset:
+    """Add ``runoff_total = Qs_acc + Qsb_acc`` to the dataset."""
+    total = ds["Qs_acc"] + ds["Qsb_acc"]
     total.attrs = {
         "long_name": "total runoff (Qs_acc + Qsb_acc, derived)",
         "units": "kg m-2",
         "cell_methods": "time: sum",
         "derived_from": "Qs_acc + Qsb_acc",
     }
-    loaded["runoff_total"] = total
-    return loaded
+    return ds.assign(runoff_total=total)
 
 
 ADAPTER = SourceAdapter(
     source_key=_SOURCE_KEY,
     output_name="gldas_agg.nc",
-    variables=["Qs_acc", "Qsb_acc", "runoff_total"],
-    open_hook=_open,
+    variables=("Qs_acc", "Qsb_acc", "runoff_total"),
+    files_glob="*.nc",
+    pre_aggregate_hook=_derive_runoff_total,
 )
 
 

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -82,16 +82,23 @@ def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
 
 def _open(project) -> xr.Dataset:
     raw_dir = project.raw_dir(_SOURCE_KEY)
-    ncs = sorted(Path(raw_dir).glob("*.nc"))
+    ncs = sorted(Path(raw_dir).glob("*_consolidated.nc"))
     if not ncs:
         raise FileNotFoundError(
-            f"No MOD10C1 NC found in {raw_dir}. Run 'nhf-targets fetch mod10c1' first."
+            f"No consolidated MOD10C1 NC found in {raw_dir}. "
+            f"Run 'nhf-targets fetch mod10c1' first."
         )
-    ds = xr.open_dataset(ncs[0])
+    datasets = [xr.open_dataset(p) for p in ncs]
     try:
-        loaded = ds.load()
+        if len(datasets) == 1:
+            loaded = datasets[0].load()
+        else:
+            combined = xr.concat(datasets, dim="time")
+            combined = combined.sortby("time")
+            loaded = combined.load()
     finally:
-        ds.close()
+        for d in datasets:
+            d.close()
     return loaded
 
 

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+from contextlib import ExitStack
 from pathlib import Path
 
+import numpy as np
 import xarray as xr
 
 from nhf_spatial_targets.aggregate._driver import (
@@ -81,25 +83,55 @@ def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
 
 
 def _open(project) -> xr.Dataset:
+    """Open MOD10C1 v061 consolidated NC(s) for the project's datastore.
+
+    The fetch step writes one ``mod10c1_v061_<year>_consolidated.nc`` per
+    year alongside the raw ``MOD10C1.A*.conus.nc`` per-day tiles. This
+    helper globs only the ``*_consolidated.nc`` pattern so the per-day
+    files (which sort earlier under POSIX uppercase ordering and lack a
+    ``time`` dimension) are ignored. Multi-year files are loaded into
+    memory and concatenated along ``time``, then ``sortby("time")`` so
+    the time coord is monotonic regardless of filename order.
+
+    Raises:
+        FileNotFoundError: no ``*_consolidated.nc`` files are present.
+        ValueError: concatenated time coord contains duplicates (e.g. a
+            re-fetch left both old and new per-year files in place).
+    """
     raw_dir = project.raw_dir(_SOURCE_KEY)
     ncs = sorted(Path(raw_dir).glob("*_consolidated.nc"))
     if not ncs:
+        all_ncs = sorted(Path(raw_dir).glob("*.nc"))
+        if all_ncs:
+            sample = [p.name for p in all_ncs[:5]]
+            raise FileNotFoundError(
+                f"No consolidated MOD10C1 NC found in {raw_dir} (only "
+                f"raw per-day files present, first 5 of {len(all_ncs)}: "
+                f"{sample}). Run 'nhf-targets fetch mod10c1' to produce "
+                f"the consolidated file."
+            )
         raise FileNotFoundError(
             f"No consolidated MOD10C1 NC found in {raw_dir}. "
             f"Run 'nhf-targets fetch mod10c1' first."
         )
-    datasets = [xr.open_dataset(p) for p in ncs]
-    try:
-        if len(datasets) == 1:
-            loaded = datasets[0].load()
+    logger.info("Opening %d consolidated NC(s): %s", len(ncs), [p.name for p in ncs])
+    with ExitStack() as stack:
+        datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
+        loaded_list = [d.load() for d in datasets]
+        if len(loaded_list) == 1:
+            combined = loaded_list[0]
         else:
-            combined = xr.concat(datasets, dim="time")
-            combined = combined.sortby("time")
-            loaded = combined.load()
-    finally:
-        for d in datasets:
-            d.close()
-    return loaded
+            combined = xr.concat(loaded_list, dim="time").sortby("time")
+    if len(ncs) > 1:
+        time_values = combined["time"].values
+        if len(np.unique(time_values)) != len(time_values):
+            raise ValueError(
+                f"Duplicate time coords across consolidated files "
+                f"{[p.name for p in ncs]}. Check the datastore for overlapping "
+                f"per-year files (e.g. a re-fetch may have left both the old and "
+                f"new file in place)."
+            )
+    return combined
 
 
 def aggregate_mod10c1(

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -1,22 +1,14 @@
-"""MOD10C1 v061 daily snow-covered area aggregator (CI-masked)."""
+"""MOD10C1 v061 daily SCA aggregator (CI-masked) — adapter + hooks."""
 
 from __future__ import annotations
 
 import logging
-from contextlib import ExitStack
 from pathlib import Path
 
-import numpy as np
 import xarray as xr
 
-from nhf_spatial_targets.aggregate._driver import (
-    aggregate_variables_for_batch,
-    compute_or_load_weights,
-    load_and_batch_fabric,
-    update_manifest,
-)
-from nhf_spatial_targets.catalog import source as catalog_source
-from nhf_spatial_targets.workspace import load as load_project
+from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 logger = logging.getLogger(__name__)
 
@@ -26,38 +18,12 @@ _OUTPUT_NAME = "mod10c1_agg.nc"
 _LOW_COVERAGE_WARN_THRESHOLD = 0.10
 
 
-def _log_low_valid_coverage(combined: xr.Dataset) -> None:
-    """Emit a WARNING log line if too many (HRU, time) cells have zero valid area.
-
-    NaN cells are treated as "no data available" and excluded from both
-    numerator and denominator — the threshold compares zero-area cells
-    against cells with any finite valid-area fraction.
-    """
-    vaf = combined["valid_area_fraction"]
-    n_total = int(vaf.notnull().sum())
-    if n_total == 0:
-        return
-    n_zero = int(((vaf == 0) & vaf.notnull()).sum())
-    zero_frac = n_zero / n_total
-    if zero_frac > _LOW_COVERAGE_WARN_THRESHOLD:
-        logger.warning(
-            "mod10c1: %.1f%% of (HRU, time) cells had zero valid-area "
-            "after CI>%.2f filter (n=%d of %d finite). Downstream sca "
-            "values are NaN for these cells.",
-            zero_frac * 100,
-            _CI_THRESHOLD,
-            n_zero,
-            n_total,
-        )
-
-
 def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
     """Derive ``sca``, ``ci``, ``valid_mask`` from raw MOD10C1 variables.
 
     - ``sca``        = Day_CMG_Snow_Cover / 100, NaN where CI <= 0.70.
     - ``ci``         = Snow_Spatial_QA / 100 (passed through, unmasked).
-    - ``valid_mask`` = 1.0 where CI > 0.70, 0.0 otherwise (float so
-                       area-weighted mean gives valid-area fraction per HRU).
+    - ``valid_mask`` = 1.0 where CI > 0.70, 0.0 otherwise.
     """
     ci = ds["Snow_Spatial_QA"] / 100.0
     pass_mask = ci > _CI_THRESHOLD
@@ -82,56 +48,46 @@ def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
     return out
 
 
-def _open(project) -> xr.Dataset:
-    """Open MOD10C1 v061 consolidated NC(s) for the project's datastore.
-
-    The fetch step writes one ``mod10c1_v061_<year>_consolidated.nc`` per
-    year alongside the raw ``MOD10C1.A*.conus.nc`` per-day tiles. This
-    helper globs only the ``*_consolidated.nc`` pattern so the per-day
-    files (which sort earlier under POSIX uppercase ordering and lack a
-    ``time`` dimension) are ignored. Multi-year files are loaded into
-    memory and concatenated along ``time``, then ``sortby("time")`` so
-    the time coord is monotonic regardless of filename order.
-
-    Raises:
-        FileNotFoundError: no ``*_consolidated.nc`` files are present.
-        ValueError: concatenated time coord contains duplicates (e.g. a
-            re-fetch left both old and new per-year files in place).
-    """
-    raw_dir = project.raw_dir(_SOURCE_KEY)
-    ncs = sorted(Path(raw_dir).glob("*_consolidated.nc"))
-    if not ncs:
-        all_ncs = sorted(Path(raw_dir).glob("*.nc"))
-        if all_ncs:
-            sample = [p.name for p in all_ncs[:5]]
-            raise FileNotFoundError(
-                f"No consolidated MOD10C1 NC found in {raw_dir} (only "
-                f"raw per-day files present, first 5 of {len(all_ncs)}: "
-                f"{sample}). Run 'nhf-targets fetch mod10c1' to produce "
-                f"the consolidated file."
-            )
-        raise FileNotFoundError(
-            f"No consolidated MOD10C1 NC found in {raw_dir}. "
-            f"Run 'nhf-targets fetch mod10c1' first."
+def _log_low_valid_coverage(combined: xr.Dataset) -> None:
+    """Warn if > 10% of (HRU, time) cells have zero valid area."""
+    vaf = combined["valid_area_fraction"]
+    n_total = int(vaf.notnull().sum())
+    if n_total == 0:
+        return
+    n_zero = int(((vaf == 0) & vaf.notnull()).sum())
+    zero_frac = n_zero / n_total
+    if zero_frac > _LOW_COVERAGE_WARN_THRESHOLD:
+        logger.warning(
+            "mod10c1: %.1f%% of (HRU, time) cells had zero valid-area "
+            "after CI>%.2f filter (n=%d of %d finite). Downstream sca "
+            "values are NaN for these cells.",
+            zero_frac * 100,
+            _CI_THRESHOLD,
+            n_zero,
+            n_total,
         )
-    logger.info("Opening %d consolidated NC(s): %s", len(ncs), [p.name for p in ncs])
-    with ExitStack() as stack:
-        datasets = [stack.enter_context(xr.open_dataset(p)) for p in ncs]
-        loaded_list = [d.load() for d in datasets]
-        if len(loaded_list) == 1:
-            combined = loaded_list[0]
-        else:
-            combined = xr.concat(loaded_list, dim="time").sortby("time")
-    if len(ncs) > 1:
-        time_values = combined["time"].values
-        if len(np.unique(time_values)) != len(time_values):
-            raise ValueError(
-                f"Duplicate time coords across consolidated files "
-                f"{[p.name for p in ncs]}. Check the datastore for overlapping "
-                f"per-year files (e.g. a re-fetch may have left both the old and "
-                f"new file in place)."
-            )
+
+
+def _rename_and_warn(combined: xr.Dataset) -> xr.Dataset:
+    combined = combined.rename({"valid_mask": "valid_area_fraction"})
+    combined["valid_area_fraction"].attrs = {
+        "long_name": "fraction of HRU area that passed CI filter",
+        "units": "1",
+        "ci_threshold": _CI_THRESHOLD,
+    }
+    _log_low_valid_coverage(combined)
     return combined
+
+
+ADAPTER = SourceAdapter(
+    source_key=_SOURCE_KEY,
+    output_name=_OUTPUT_NAME,
+    variables=("sca", "ci", "valid_mask"),
+    grid_variable="sca",
+    source_crs="EPSG:4326",
+    pre_aggregate_hook=build_masked_source,
+    post_aggregate_hook=_rename_and_warn,
+)
 
 
 def aggregate_mod10c1(
@@ -142,90 +98,8 @@ def aggregate_mod10c1(
 ) -> xr.Dataset:
     """Aggregate MOD10C1 v061 daily SCA to HRU polygons with CI masking.
 
-    Applies the CI > 0.70 filter at source grid cells (cells below threshold
-    become NaN in ``sca``). Writes three variables to
-    ``data/aggregated/mod10c1_agg.nc``:
-
-    - ``sca``: CI-masked fractional snow cover (NaN where CI <= 0.70).
-    - ``ci``:  raw confidence interval as a fraction (no masking).
-    - ``valid_area_fraction``: per-HRU fraction of grid-cell area that
-      passed the CI filter on each day.
-
-    Logs a warning if more than 10% of (HRU, time) cells end up with zero
-    valid area.
+    The CI>0.70 filter is applied per-year inside the driver's per-year loop
+    via ``pre_aggregate_hook``. Final output at ``data/aggregated/mod10c1_agg.nc``
+    carries ``sca``, ``ci``, and ``valid_area_fraction`` keyed on (time, HRU).
     """
-    workdir = Path(workdir)
-    project = load_project(workdir)
-    meta = catalog_source(_SOURCE_KEY)
-
-    raw = _open(project)
-    source_ds = build_masked_source(raw)
-    variables = ["sca", "ci", "valid_mask"]
-
-    batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
-    n_batches = int(batched["batch_id"].nunique())
-    logger.info("mod10c1: fabric split into %d spatial batches", n_batches)
-
-    datasets: list[xr.Dataset] = []
-    for bid in sorted(batched["batch_id"].unique()):
-        batch_gdf = batched[batched["batch_id"] == bid].drop(columns=["batch_id"])
-        weights = compute_or_load_weights(
-            batch_gdf=batch_gdf,
-            source_ds=source_ds,
-            source_var="sca",
-            source_crs="EPSG:4326",
-            x_coord="lon",
-            y_coord="lat",
-            time_coord="time",
-            id_col=id_col,
-            source_key=_SOURCE_KEY,
-            batch_id=int(bid),
-            workdir=workdir,
-        )
-        ds = aggregate_variables_for_batch(
-            batch_gdf=batch_gdf,
-            source_ds=source_ds,
-            variables=variables,
-            source_crs="EPSG:4326",
-            x_coord="lon",
-            y_coord="lat",
-            time_coord="time",
-            id_col=id_col,
-            weights=weights,
-        )
-        datasets.append(ds)
-
-    combined = xr.concat(datasets, dim=id_col)
-    combined = combined.rename({"valid_mask": "valid_area_fraction"})
-    combined["valid_area_fraction"].attrs = {
-        "long_name": "fraction of HRU area that passed CI filter",
-        "units": "1",
-        "ci_threshold": _CI_THRESHOLD,
-    }
-
-    _log_low_valid_coverage(combined)
-
-    output_dir = project.aggregated_dir()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / _OUTPUT_NAME
-    combined.to_netcdf(output_path)
-    logger.info("mod10c1: output written to %s", output_path)
-    # Load a detached in-memory copy so callers can use the return value safely
-    # after the on-disk handle is closed.
-    loaded = combined.load()
-    combined.close()
-
-    t0 = str(loaded["time"].values[0])[:10]
-    t1 = str(loaded["time"].values[-1])[:10]
-    update_manifest(
-        project=project,
-        source_key=_SOURCE_KEY,
-        access=meta.get("access", {}),
-        period=f"{t0}/{t1}",
-        output_file=str(Path("data") / "aggregated" / _OUTPUT_NAME),
-        weight_files=[
-            str(Path("weights") / f"{_SOURCE_KEY}_batch{i}.csv")
-            for i in range(n_batches)
-        ],
-    )
-    return loaded
+    return aggregate_source(ADAPTER, fabric_path, id_col, workdir, batch_size)

--- a/src/nhf_spatial_targets/aggregate/mod16a2.py
+++ b/src/nhf_spatial_targets/aggregate/mod16a2.py
@@ -1,4 +1,15 @@
-"""MOD16A2 v061 AET adapter (sinusoidal MODIS projection)."""
+"""MOD16A2 v061 AET adapter.
+
+consolidate_mod16a2 reprojects the raw sinusoidal HDF tiles to WGS84 geographic
+(EPSG:4326) and renames the spatial coords to ``lon`` / ``lat`` before writing
+the consolidated NC.  The adapter therefore declares EPSG:4326 — using the
+original sinusoidal CRS here would cause gdptools to reproject the fabric bounds
+into sinusoidal metres and attempt to slice the lon/lat coordinate with those
+values, producing an empty spatial subset.
+
+MODIS_SINUSOIDAL_PROJ is retained for reference / tests but is no longer used
+in the adapter.
+"""
 
 from __future__ import annotations
 
@@ -10,18 +21,31 @@ from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 # MODIS Land Tile gridding uses an authalic sphere (not WGS84 ellipsoid).
-# The +R parameter in the PROJ string encodes that sphere radius. See
-# the MODIS Land Products User Guide for the canonical parameter set.
+# Retained for reference; the consolidated NC is reprojected to EPSG:4326.
 MODIS_SINUSOIDAL_PROJ = (
     "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +R=6371007.181 +units=m +no_defs"
 )
+
+
+def _mask_et_fill(ds: xr.Dataset) -> xr.Dataset:
+    """Mask MODIS ET_500m special/fill values before area-weighted aggregation.
+
+    The consolidated NC stores scaled float32 values (raw × 0.1).  MOD16A2
+    valid_range for ET_500m is 0–32700 raw (0–3270.0 scaled).  Values above
+    3270 are special codes (water=32761, barren=32762, snow/ice=32763,
+    cloudy=32764, no-data=32766, not-processed=32767 in raw units) that must
+    be set to NaN so they do not contaminate the weighted mean.
+    """
+    ds["ET_500m"] = ds["ET_500m"].where(ds["ET_500m"] <= 3270.0)
+    return ds
 
 
 ADAPTER = SourceAdapter(
     source_key="mod16a2_v061",
     output_name="mod16a2_agg.nc",
     variables=["ET_500m"],
-    source_crs=MODIS_SINUSOIDAL_PROJ,
+    source_crs="EPSG:4326",  # consolidate_mod16a2 reprojects tiles to WGS84
+    pre_aggregate_hook=_mask_et_fill,
 )
 
 

--- a/src/nhf_spatial_targets/aggregate/mod16a2.py
+++ b/src/nhf_spatial_targets/aggregate/mod16a2.py
@@ -21,8 +21,6 @@ ADAPTER = SourceAdapter(
     source_key="mod16a2_v061",
     output_name="mod16a2_agg.nc",
     variables=["ET_500m"],
-    x_coord="x",
-    y_coord="y",
     source_crs=MODIS_SINUSOIDAL_PROJ,
 )
 

--- a/src/nhf_spatial_targets/aggregate/ssebop.py
+++ b/src/nhf_spatial_targets/aggregate/ssebop.py
@@ -75,7 +75,7 @@ def _process_batch(
     )
     agg = AggGen(
         user_data=stac_data,
-        stat_method="masked_mean",
+        stat_method="mean",
         agg_engine="serial",
         agg_writer="none",
         weights=weights,

--- a/src/nhf_spatial_targets/aggregate/watergap22d.py
+++ b/src/nhf_spatial_targets/aggregate/watergap22d.py
@@ -14,6 +14,7 @@ ADAPTER = SourceAdapter(
     source_key="watergap22d",
     output_name="watergap22d_agg.nc",
     variables=["qrdif"],
+    files_glob="*_cf.nc",
 )
 
 

--- a/tests/test_aggregate_coords.py
+++ b/tests/test_aggregate_coords.py
@@ -1,0 +1,91 @@
+"""Tests for CF-based coordinate detection."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from nhf_spatial_targets.aggregate._coords import detect_coords
+
+
+def _ds_with_axis_attrs() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["t", "y", "x"], np.zeros((1, 2, 2)))},
+        coords={
+            "t": ("t", [0], {"axis": "T", "standard_name": "time"}),
+            "y": ("y", [0.0, 1.0], {"axis": "Y", "standard_name": "latitude"}),
+            "x": ("x", [0.0, 1.0], {"axis": "X", "standard_name": "longitude"}),
+        },
+    )
+    return ds
+
+
+def _ds_with_standard_names_only() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.0, 1.0], {"standard_name": "longitude"}),
+        },
+    )
+    return ds
+
+
+def _ds_projected() -> xr.Dataset:
+    ds = xr.Dataset(
+        {"v": (["time", "y", "x"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "y": ("y", [0.0, 1.0], {"standard_name": "projection_y_coordinate"}),
+            "x": ("x", [0.0, 1.0], {"standard_name": "projection_x_coordinate"}),
+        },
+    )
+    return ds
+
+
+def test_detects_via_axis_attrs():
+    x, y, t = detect_coords(_ds_with_axis_attrs(), "v")
+    assert (x, y, t) == ("x", "y", "t")
+
+
+def test_detects_via_standard_name_when_axis_missing():
+    x, y, t = detect_coords(_ds_with_standard_names_only(), "v")
+    assert (x, y, t) == ("lon", "lat", "time")
+
+
+def test_detects_projected_xy():
+    x, y, t = detect_coords(_ds_projected(), "v")
+    assert (x, y, t) == ("x", "y", "time")
+
+
+def test_override_takes_precedence():
+    ds = _ds_with_axis_attrs()
+    x, y, t = detect_coords(ds, "v", x_override="x", y_override="y", time_override="t")
+    assert (x, y, t) == ("x", "y", "t")
+
+
+def test_override_must_be_in_var_dims():
+    ds = _ds_with_axis_attrs()
+    with pytest.raises(ValueError, match="override"):
+        detect_coords(ds, "v", x_override="bogus")
+
+
+def test_raises_when_axis_unresolvable():
+    ds = xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.zeros((1, 2, 2)))},
+        coords={
+            "time": ("time", [0], {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0]),  # no attrs
+            "lon": ("lon", [0.0, 1.0]),  # no attrs
+        },
+    )
+    with pytest.raises(ValueError, match=r"(x|X)"):
+        detect_coords(ds, "v")
+
+
+def test_raises_when_var_missing():
+    ds = _ds_with_axis_attrs()
+    with pytest.raises(KeyError):
+        detect_coords(ds, "not_a_var")

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -195,7 +195,7 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
     datastore = tmp_path / "datastore"
     (datastore / "merra2").mkdir(parents=True)
     # write a placeholder consolidated NC so default open_hook has something
-    src_nc = datastore / "merra2" / "merra2.nc"
+    src_nc = datastore / "merra2" / "merra2_consolidated.nc"
     times = pd.date_range("2000-01-01", periods=2, freq="MS")
     xr.Dataset(
         {
@@ -351,7 +351,7 @@ def test_aggregate_source_raises_when_variable_missing(tmp_path, tiny_fabric):
     xr.Dataset(
         {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
         coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(datastore / "merra2" / "merra2.nc")
+    ).to_netcdf(datastore / "merra2" / "merra2_consolidated.nc")
 
     (tmp_path / "config.yml").write_text(
         yaml.dump(
@@ -378,18 +378,20 @@ def test_aggregate_source_raises_when_variable_missing(tmp_path, tiny_fabric):
         )
 
 
-def test_default_open_hook_raises_on_multiple_ncs(tmp_path):
-    """Multiple NCs in the datastore for a source is a user-facing error."""
+def test_default_open_hook_single_consolidated_nc(tmp_path):
+    """Single *_consolidated.nc file is opened and returned with time coord."""
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
     from nhf_spatial_targets.aggregate._driver import _default_open_hook
 
     src_dir = tmp_path / "datastore" / "merra2"
     src_dir.mkdir(parents=True)
-    times = pd.date_range("2000-01-01", periods=1, freq="MS")
-    for name in ("a.nc", "b.nc"):
-        xr.Dataset({"x": (["time"], [1.0])}, coords={"time": times}).to_netcdf(
-            src_dir / name
-        )
+    times = pd.date_range("2000-01-01", periods=2, freq="MS")
+    xr.Dataset(
+        {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
+        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+    ).to_netcdf(src_dir / "merra2_consolidated.nc")
+    # Non-consolidated file should be ignored
+    (src_dir / "stale.nc").write_bytes(b"not a real nc")
 
     class _FakeProject:
         def raw_dir(self, key):
@@ -400,7 +402,112 @@ def test_default_open_hook_raises_on_multiple_ncs(tmp_path):
         output_name="merra2_agg.nc",
         variables=["GWETTOP"],
     )
-    with pytest.raises(ValueError, match="Multiple"):
+    result = _default_open_hook(_FakeProject(), adapter)
+    assert "time" in result.coords
+    assert len(result["time"]) == 2
+
+
+def test_default_open_hook_concatenates_multiple_consolidated_ncs(tmp_path):
+    """Multiple *_consolidated.nc files (one per year) are concatenated on time."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+    for year, t0 in ((2000, "2000-01-01"), (2001, "2001-01-01")):
+        times = pd.date_range(t0, periods=2, freq="MS")
+        xr.Dataset(
+            {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
+            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+        ).to_netcdf(src_dir / f"merra2_{year}_consolidated.nc")
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    result = _default_open_hook(_FakeProject(), adapter)
+    assert "time" in result.coords
+    assert len(result["time"]) == 4
+    assert result["time"].values[0] < result["time"].values[-1]
+
+
+def test_default_open_hook_single_non_consolidated_nc(tmp_path):
+    """Single *.nc with no _consolidated suffix is opened directly (watergap22d pattern)."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "watergap22d"
+    src_dir.mkdir(parents=True)
+    times = pd.date_range("1901-01-01", periods=3, freq="MS")
+    xr.Dataset(
+        {"qrdif": (["time", "lat", "lon"], np.ones((3, 2, 2)))},
+        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+    ).to_netcdf(src_dir / "watergap22d_qrdif_cf.nc")
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="watergap22d",
+        output_name="watergap22d_agg.nc",
+        variables=["qrdif"],
+    )
+    result = _default_open_hook(_FakeProject(), adapter)
+    assert "time" in result.coords
+    assert len(result["time"]) == 3
+
+
+def test_default_open_hook_raises_when_multiple_ncs_none_consolidated(tmp_path):
+    """FileNotFoundError when multiple NCs exist but none match *_consolidated.nc."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+    times = pd.date_range("2000-01-01", periods=1, freq="MS")
+    for name in ("raw_2000.nc", "raw_2001.nc"):
+        xr.Dataset(
+            {"GWETTOP": (["time", "lat", "lon"], np.ones((1, 2, 2)))},
+            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+        ).to_netcdf(src_dir / name)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    with pytest.raises(FileNotFoundError, match="consolidated"):
+        _default_open_hook(_FakeProject(), adapter)
+
+
+def test_default_open_hook_raises_when_no_nc_at_all(tmp_path):
+    """FileNotFoundError when the raw directory is empty."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    with pytest.raises(FileNotFoundError):
         _default_open_hook(_FakeProject(), adapter)
 
 

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -184,6 +184,7 @@ def test_aggregate_variables_for_batch_merges_variables(tiny_fabric):
             time_coord="time",
             id_col="hru_id",
             weights=_fake_weights(),
+            period=("2000-01-01", "2000-02-01"),
         )
     assert set(result.data_vars) == {"a", "b"}
     assert result.sizes["hru_id"] == 4
@@ -657,6 +658,7 @@ def test_compute_or_load_weights_writes_cache_on_miss(tmp_path, tiny_fabric):
             source_key="toy",
             batch_id=0,
             workdir=tmp_path,
+            period=("2000-01-01", "2000-02-01"),
         )
     assert mock_wg.called
     cache_path = tmp_path / "weights" / "toy_batch0.csv"
@@ -695,6 +697,7 @@ def test_compute_or_load_weights_uses_cache_on_hit(tmp_path, tiny_fabric):
             source_key="toy",
             batch_id=0,
             workdir=tmp_path,
+            period=("2000-01-01", "2000-02-01"),
         )
     assert not mock_wg.called
     pd.testing.assert_frame_equal(weights, cached)
@@ -782,6 +785,7 @@ def test_compute_or_load_weights_ignores_stray_tmp_from_crashed_run(
             source_key="toy",
             batch_id=0,
             workdir=tmp_path,
+            period=("2000-01-01", "2000-02-01"),
         )
 
     # Final-name CSV present and equals the fresh computation.
@@ -810,3 +814,40 @@ def test_source_adapter_accepts_hooks():
     )
     assert adapter.pre_aggregate_hook is _pre
     assert adapter.post_aggregate_hook is _post
+
+
+def test_aggregate_variables_for_batch_passes_period_through(tiny_fabric):
+    from nhf_spatial_targets.aggregate._driver import aggregate_variables_for_batch
+
+    batch_gdf = gpd.read_file(tiny_fabric)
+    batch_gdf["batch_id"] = 0
+    times = pd.date_range("2005-01-01", periods=12, freq="MS")
+    source_ds = xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+    )
+
+    with (
+        patch("nhf_spatial_targets.aggregate._driver.AggGen") as mock_agg,
+        patch("nhf_spatial_targets.aggregate._driver.UserCatData") as mock_ucd,
+    ):
+        mock_ucd.return_value = _fake_user_data()
+        inst = MagicMock()
+        mock_agg.return_value = inst
+        inst.calculate_agg.side_effect = [_fake_agg_result("a", [0, 1, 2, 3])]
+
+        aggregate_variables_for_batch(
+            batch_gdf=batch_gdf,
+            source_ds=source_ds,
+            variables=["a"],
+            source_crs="EPSG:4326",
+            x_coord="lon",
+            y_coord="lat",
+            time_coord="time",
+            id_col="hru_id",
+            weights=_fake_weights(),
+            period=("2005-01-01", "2005-12-01"),
+        )
+
+    call_kwargs = mock_ucd.call_args.kwargs
+    assert call_kwargs["period"] == ["2005-01-01", "2005-12-01"]

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -81,27 +81,8 @@ def test_source_adapter_defaults():
     assert adapter.x_coord is None
     assert adapter.y_coord is None
     assert adapter.time_coord is None
-    assert adapter.open_hook is None
     assert adapter.pre_aggregate_hook is None
     assert adapter.post_aggregate_hook is None
-
-
-def test_source_adapter_open_hook_invocable(project):
-    import xarray as xr
-
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-
-    def _open(proj):
-        return xr.Dataset({"a": (("time",), [1.0])}, coords={"time": [0]})
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-        open_hook=_open,
-    )
-    ds = adapter.open_hook(project)
-    assert "a" in ds
 
 
 @pytest.fixture()

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -194,18 +194,20 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
     from nhf_spatial_targets.aggregate._driver import aggregate_source
 
-    # --- minimal project ---
     datastore = tmp_path / "datastore"
     (datastore / "merra2").mkdir(parents=True)
-    # write a placeholder consolidated NC so default open_hook has something
-    src_nc = datastore / "merra2" / "merra2_consolidated.nc"
-    times = pd.date_range("2000-01-01", periods=2, freq="MS")
+    src_nc = datastore / "merra2" / "merra2_2000_consolidated.nc"
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
     xr.Dataset(
         {
-            "a": (["time", "lat", "lon"], np.ones((2, 2, 2))),
-            "b": (["time", "lat", "lon"], np.ones((2, 2, 2)) * 2.0),
+            "a": (["time", "lat", "lon"], np.ones((12, 2, 2))),
+            "b": (["time", "lat", "lon"], np.ones((12, 2, 2)) * 2.0),
         },
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
     ).to_netcdf(src_nc)
 
     (tmp_path / "config.yml").write_text(
@@ -225,13 +227,19 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
         source_key="merra2",
         output_name="merra2_agg.nc",
         variables=["a", "b"],
-        x_coord="lon",
-        y_coord="lat",
-        time_coord="time",
     )
 
-    # Patch catalog.source to supply access metadata for the manifest
     fake_meta = {"access": {"type": "local_nc"}}
+    fake_year_ds = xr.Dataset(
+        {
+            "a": (["time", "hru_id"], np.ones((12, 4))),
+            "b": (["time", "hru_id"], np.ones((12, 4)) * 2.0),
+        },
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1, 2, 3],
+        },
+    )
 
     with (
         patch(
@@ -243,17 +251,10 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
             return_value=_fake_weights(),
         ),
         patch(
-            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch"
-        ) as mock_agg_batch,
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ),
     ):
-        times = pd.date_range("2000-01-01", periods=2, freq="MS")
-        mock_agg_batch.return_value = xr.Dataset(
-            {
-                "a": (["time", "hru_id"], np.ones((2, 4))),
-                "b": (["time", "hru_id"], np.ones((2, 4)) * 2.0),
-            },
-            coords={"time": times, "hru_id": [0, 1, 2, 3]},
-        )
         out = aggregate_source(
             adapter,
             fabric_path=tiny_fabric,
@@ -265,6 +266,9 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
     assert set(out.data_vars) == {"a", "b"}
     output_nc = tmp_path / "data" / "aggregated" / "merra2_agg.nc"
     assert output_nc.exists()
+    assert (
+        tmp_path / "data" / "aggregated" / "_by_year" / "merra2_2000_agg.nc"
+    ).exists()
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert "merra2" in manifest["sources"]
     assert manifest["sources"]["merra2"]["output_file"] == (
@@ -357,7 +361,7 @@ def test_aggregate_source_raises_when_variable_missing(tmp_path, tiny_fabric):
     xr.Dataset(
         {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
         coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(datastore / "merra2" / "merra2_consolidated.nc")
+    ).to_netcdf(datastore / "merra2" / "merra2_2000_consolidated.nc")
 
     (tmp_path / "config.yml").write_text(
         yaml.dump(
@@ -385,245 +389,6 @@ def test_aggregate_source_raises_when_variable_missing(tmp_path, tiny_fabric):
             id_col="hru_id",
             workdir=tmp_path,
         )
-
-
-def test_default_open_hook_single_consolidated_nc(tmp_path):
-    """Single *_consolidated.nc file is opened and returned with time coord."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-    times = pd.date_range("2000-01-01", periods=2, freq="MS")
-    xr.Dataset(
-        {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(src_dir / "merra2_consolidated.nc")
-    # Non-consolidated file should be ignored
-    (src_dir / "stale.nc").write_bytes(b"not a real nc")
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    result = _default_open_hook(_FakeProject(), adapter)
-    assert "time" in result.coords
-    assert len(result["time"]) == 2
-
-
-def test_default_open_hook_concatenates_multiple_consolidated_ncs(tmp_path):
-    """Multiple *_consolidated.nc files (one per year) are concatenated on time."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-    for year, t0 in ((2000, "2000-01-01"), (2001, "2001-01-01")):
-        times = pd.date_range(t0, periods=2, freq="MS")
-        xr.Dataset(
-            {"GWETTOP": (["time", "lat", "lon"], np.ones((2, 2, 2)))},
-            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-        ).to_netcdf(src_dir / f"merra2_{year}_consolidated.nc")
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    result = _default_open_hook(_FakeProject(), adapter)
-    assert "time" in result.coords
-    assert len(result["time"]) == 4
-    assert result["time"].values[0] < result["time"].values[-1]
-    # Both input years must be represented (catches a regression that drops
-    # a file silently); use pandas to extract the year from the time coord.
-    years_present = set(pd.DatetimeIndex(result["time"].values).year)
-    assert years_present == {2000, 2001}
-
-
-def test_default_open_hook_concat_sorts_when_filename_order_disagrees_with_time(
-    tmp_path,
-):
-    """sortby('time') must run even when filename glob order is non-chronological."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-
-    # Filenames sort partA < partB lexically, but partA covers 2001 and
-    # partB covers 2000 — chronological order disagrees with glob order.
-    times_partA = pd.date_range("2001-01-01", periods=2, freq="MS")
-    times_partB = pd.date_range("2000-01-01", periods=2, freq="MS")
-    for name, times in (
-        ("merra2_partA_consolidated.nc", times_partA),
-        ("merra2_partB_consolidated.nc", times_partB),
-    ):
-        xr.Dataset(
-            {"GWETTOP": (["time"], np.ones(2))},
-            coords={"time": times},
-        ).to_netcdf(src_dir / name)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    result = _default_open_hook(_FakeProject(), adapter)
-    times = pd.DatetimeIndex(result["time"].values)
-    assert list(times.year) == [2000, 2000, 2001, 2001]
-
-
-def test_default_open_hook_returned_dataset_detached_from_disk(tmp_path):
-    """Returned Dataset must be in-memory; deleting source NCs must not break it.
-
-    Guards against a future refactor that drops .load() and returns a lazy
-    view tied to the on-disk handle (per memory feedback_rioxarray_close.md).
-    """
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-    times = pd.date_range("2001-01-01", periods=3, freq="MS")
-    nc_path = src_dir / "merra2_2001_consolidated.nc"
-    xr.Dataset(
-        {"GWETTOP": (["time"], np.array([0.1, 0.2, 0.3]))},
-        coords={"time": times},
-    ).to_netcdf(nc_path)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    result = _default_open_hook(_FakeProject(), adapter)
-    nc_path.unlink()  # delete source file; the in-memory copy must survive
-    np.testing.assert_array_equal(result["GWETTOP"].values, [0.1, 0.2, 0.3])
-
-
-def test_default_open_hook_single_non_consolidated_nc(tmp_path):
-    """Single *.nc with no _consolidated suffix is opened directly (watergap22d pattern)."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "watergap22d"
-    src_dir.mkdir(parents=True)
-    times = pd.date_range("1901-01-01", periods=3, freq="MS")
-    xr.Dataset(
-        {"qrdif": (["time", "lat", "lon"], np.ones((3, 2, 2)))},
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(src_dir / "watergap22d_qrdif_cf.nc")
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="watergap22d",
-        output_name="watergap22d_agg.nc",
-        variables=["qrdif"],
-    )
-    result = _default_open_hook(_FakeProject(), adapter)
-    assert "time" in result.coords
-    assert len(result["time"]) == 3
-
-
-def test_default_open_hook_raises_when_multiple_ncs_none_consolidated(tmp_path):
-    """FileNotFoundError when multiple NCs exist but none match *_consolidated.nc."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-    times = pd.date_range("2000-01-01", periods=1, freq="MS")
-    for name in ("raw_2000.nc", "raw_2001.nc"):
-        xr.Dataset(
-            {"GWETTOP": (["time", "lat", "lon"], np.ones((1, 2, 2)))},
-            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-        ).to_netcdf(src_dir / name)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    with pytest.raises(FileNotFoundError, match="consolidated"):
-        _default_open_hook(_FakeProject(), adapter)
-
-
-def test_default_open_hook_raises_when_no_nc_at_all(tmp_path):
-    """FileNotFoundError when the raw directory is empty."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    with pytest.raises(FileNotFoundError):
-        _default_open_hook(_FakeProject(), adapter)
-
-
-def test_default_open_hook_raises_on_duplicate_time_across_consolidated_ncs(tmp_path):
-    """Overlapping per-year consolidated NCs must raise, not silently concat."""
-    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
-    from nhf_spatial_targets.aggregate._driver import _default_open_hook
-
-    src_dir = tmp_path / "datastore" / "merra2"
-    src_dir.mkdir(parents=True)
-
-    # Two NCs whose time ranges overlap at 2001-06
-    times_a = pd.date_range("2001-01-01", periods=12, freq="MS")
-    times_b = pd.date_range("2001-06-01", periods=12, freq="MS")
-    for name, times in (
-        ("merra2_2001a_consolidated.nc", times_a),
-        ("merra2_2001b_consolidated.nc", times_b),
-    ):
-        xr.Dataset(
-            {"GWETTOP": (["time"], np.ones(12))},
-            coords={"time": times},
-        ).to_netcdf(src_dir / name)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return src_dir
-
-    adapter = SourceAdapter(
-        source_key="merra2",
-        output_name="merra2_agg.nc",
-        variables=["GWETTOP"],
-    )
-    with pytest.raises(ValueError, match="Duplicate"):
-        _default_open_hook(_FakeProject(), adapter)
 
 
 def test_compute_or_load_weights_writes_cache_on_miss(tmp_path, tiny_fabric):

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -78,10 +78,12 @@ def test_source_adapter_defaults():
         variables=["GWETTOP", "GWETROOT"],
     )
     assert adapter.source_crs == "EPSG:4326"
-    assert adapter.x_coord == "lon"
-    assert adapter.y_coord == "lat"
-    assert adapter.time_coord == "time"
+    assert adapter.x_coord is None
+    assert adapter.y_coord is None
+    assert adapter.time_coord is None
     assert adapter.open_hook is None
+    assert adapter.pre_aggregate_hook is None
+    assert adapter.post_aggregate_hook is None
 
 
 def test_source_adapter_open_hook_invocable(project):
@@ -222,6 +224,9 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
         source_key="merra2",
         output_name="merra2_agg.nc",
         variables=["a", "b"],
+        x_coord="lon",
+        y_coord="lat",
+        time_coord="time",
     )
 
     # Patch catalog.source to supply access metadata for the manifest
@@ -368,6 +373,9 @@ def test_aggregate_source_raises_when_variable_missing(tmp_path, tiny_fabric):
         source_key="merra2",
         output_name="merra2_agg.nc",
         variables=["GWETTOP", "BOGUS_VAR"],
+        x_coord="lon",
+        y_coord="lat",
+        time_coord="time",
     )
     with pytest.raises(ValueError, match="BOGUS_VAR"):
         aggregate_source(
@@ -782,3 +790,23 @@ def test_compute_or_load_weights_ignores_stray_tmp_from_crashed_run(
     pd.testing.assert_frame_equal(weights, fake)
     # WeightGen was invoked — cache was NOT short-circuited by the stray tmp.
     assert mock_wg.called
+
+
+def test_source_adapter_accepts_hooks():
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+
+    def _pre(ds):
+        return ds
+
+    def _post(ds):
+        return ds
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+        pre_aggregate_hook=_pre,
+        post_aggregate_hook=_post,
+    )
+    assert adapter.pre_aggregate_hook is _pre
+    assert adapter.post_aggregate_hook is _post

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -434,6 +434,79 @@ def test_default_open_hook_concatenates_multiple_consolidated_ncs(tmp_path):
     assert "time" in result.coords
     assert len(result["time"]) == 4
     assert result["time"].values[0] < result["time"].values[-1]
+    # Both input years must be represented (catches a regression that drops
+    # a file silently); use pandas to extract the year from the time coord.
+    years_present = set(pd.DatetimeIndex(result["time"].values).year)
+    assert years_present == {2000, 2001}
+
+
+def test_default_open_hook_concat_sorts_when_filename_order_disagrees_with_time(
+    tmp_path,
+):
+    """sortby('time') must run even when filename glob order is non-chronological."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+
+    # Filenames sort partA < partB lexically, but partA covers 2001 and
+    # partB covers 2000 — chronological order disagrees with glob order.
+    times_partA = pd.date_range("2001-01-01", periods=2, freq="MS")
+    times_partB = pd.date_range("2000-01-01", periods=2, freq="MS")
+    for name, times in (
+        ("merra2_partA_consolidated.nc", times_partA),
+        ("merra2_partB_consolidated.nc", times_partB),
+    ):
+        xr.Dataset(
+            {"GWETTOP": (["time"], np.ones(2))},
+            coords={"time": times},
+        ).to_netcdf(src_dir / name)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    result = _default_open_hook(_FakeProject(), adapter)
+    times = pd.DatetimeIndex(result["time"].values)
+    assert list(times.year) == [2000, 2000, 2001, 2001]
+
+
+def test_default_open_hook_returned_dataset_detached_from_disk(tmp_path):
+    """Returned Dataset must be in-memory; deleting source NCs must not break it.
+
+    Guards against a future refactor that drops .load() and returns a lazy
+    view tied to the on-disk handle (per memory feedback_rioxarray_close.md).
+    """
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+    times = pd.date_range("2001-01-01", periods=3, freq="MS")
+    nc_path = src_dir / "merra2_2001_consolidated.nc"
+    xr.Dataset(
+        {"GWETTOP": (["time"], np.array([0.1, 0.2, 0.3]))},
+        coords={"time": times},
+    ).to_netcdf(nc_path)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    result = _default_open_hook(_FakeProject(), adapter)
+    nc_path.unlink()  # delete source file; the in-memory copy must survive
+    np.testing.assert_array_equal(result["GWETTOP"].values, [0.1, 0.2, 0.3])
 
 
 def test_default_open_hook_single_non_consolidated_nc(tmp_path):
@@ -508,6 +581,39 @@ def test_default_open_hook_raises_when_no_nc_at_all(tmp_path):
         variables=["GWETTOP"],
     )
     with pytest.raises(FileNotFoundError):
+        _default_open_hook(_FakeProject(), adapter)
+
+
+def test_default_open_hook_raises_on_duplicate_time_across_consolidated_ncs(tmp_path):
+    """Overlapping per-year consolidated NCs must raise, not silently concat."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _default_open_hook
+
+    src_dir = tmp_path / "datastore" / "merra2"
+    src_dir.mkdir(parents=True)
+
+    # Two NCs whose time ranges overlap at 2001-06
+    times_a = pd.date_range("2001-01-01", periods=12, freq="MS")
+    times_b = pd.date_range("2001-06-01", periods=12, freq="MS")
+    for name, times in (
+        ("merra2_2001a_consolidated.nc", times_a),
+        ("merra2_2001b_consolidated.nc", times_b),
+    ):
+        xr.Dataset(
+            {"GWETTOP": (["time"], np.ones(12))},
+            coords={"time": times},
+        ).to_netcdf(src_dir / name)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return src_dir
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=["GWETTOP"],
+    )
+    with pytest.raises(ValueError, match="Duplicate"):
         _default_open_hook(_FakeProject(), adapter)
 
 

--- a/tests/test_aggregate_driver_per_year.py
+++ b/tests/test_aggregate_driver_per_year.py
@@ -1,0 +1,64 @@
+"""Unit tests for per-year streaming aggregation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+
+def _write_nc(path: Path, times: pd.DatetimeIndex) -> None:
+    xr.Dataset(
+        {"v": (["time", "lat", "lon"], np.ones((len(times), 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.0, 1.0], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.0, 1.0], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(path)
+
+
+def test_enumerate_years_per_year_files(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f2000 = tmp_path / "src_2000_consolidated.nc"
+    f2001 = tmp_path / "src_2001_consolidated.nc"
+    _write_nc(f2000, pd.date_range("2000-01-01", periods=12, freq="MS"))
+    _write_nc(f2001, pd.date_range("2001-01-01", periods=12, freq="MS"))
+
+    year_files = enumerate_years([f2000, f2001])
+    assert year_files == [(2000, f2000), (2001, f2001)]
+
+
+def test_enumerate_years_single_multi_year_file(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f = tmp_path / "src_consolidated.nc"
+    _write_nc(f, pd.date_range("2000-01-01", periods=36, freq="MS"))
+
+    year_files = enumerate_years([f])
+    assert year_files == [(2000, f), (2001, f), (2002, f)]
+
+
+def test_enumerate_years_raises_on_year_overlap(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    fa = tmp_path / "src_a_consolidated.nc"
+    fb = tmp_path / "src_b_consolidated.nc"
+    _write_nc(fa, pd.date_range("2001-01-01", periods=12, freq="MS"))
+    _write_nc(fb, pd.date_range("2001-06-01", periods=12, freq="MS"))
+
+    with pytest.raises(ValueError, match="overlap"):
+        enumerate_years([fa, fb])
+
+
+def test_enumerate_years_raises_when_no_time_coord(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import enumerate_years
+
+    f = tmp_path / "no_time_consolidated.nc"
+    xr.Dataset({"v": (["y", "x"], np.zeros((2, 2)))}).to_netcdf(f)
+    with pytest.raises(ValueError, match="time"):
+        enumerate_years([f])

--- a/tests/test_aggregate_driver_per_year.py
+++ b/tests/test_aggregate_driver_per_year.py
@@ -185,3 +185,39 @@ def test_aggregate_year_writes_intermediate_when_missing(project, tiny_batched_f
     assert path.exists()
     call = mock_batch.call_args
     assert call.kwargs["period"] == ("2005-01-01", "2005-12-31")
+
+
+def _write_year_intermediate(path: Path, year: int) -> None:
+    times = pd.date_range(f"{year}-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"v": (["time", "hru_id"], np.ones((12, 2)) * year)},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1],
+        },
+    ).to_netcdf(path)
+
+
+def test_concat_years_orders_by_time(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p2001 = tmp_path / "src_2001_agg.nc"
+    p2000 = tmp_path / "src_2000_agg.nc"
+    _write_year_intermediate(p2001, 2001)
+    _write_year_intermediate(p2000, 2000)
+
+    combined = concat_years([p2001, p2000], time_coord="time")
+    years = pd.DatetimeIndex(combined["time"].values).year
+    assert list(years[:12]) == [2000] * 12
+    assert list(years[-12:]) == [2001] * 12
+
+
+def test_concat_years_raises_on_duplicate_time(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p1 = tmp_path / "src_a_agg.nc"
+    p2 = tmp_path / "src_b_agg.nc"
+    _write_year_intermediate(p1, 2001)
+    _write_year_intermediate(p2, 2001)
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        concat_years([p1, p2], time_coord="time")

--- a/tests/test_aggregate_driver_per_year.py
+++ b/tests/test_aggregate_driver_per_year.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+import yaml
+from shapely.geometry import box
+
+from nhf_spatial_targets.workspace import load as load_project
 
 
 def _write_nc(path: Path, times: pd.DatetimeIndex) -> None:
@@ -62,3 +69,119 @@ def test_enumerate_years_raises_when_no_time_coord(tmp_path):
     xr.Dataset({"v": (["y", "x"], np.zeros((2, 2)))}).to_netcdf(f)
     with pytest.raises(ValueError, match="time"):
         enumerate_years([f])
+
+
+@pytest.fixture()
+def project(tmp_path):
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": "", "id_col": "hru_id"},
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "abc"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+    return load_project(tmp_path)
+
+
+@pytest.fixture()
+def tiny_batched_fabric():
+    polys = [box(i, 0, i + 1, 1) for i in range(2)]
+    gdf = gpd.GeoDataFrame(
+        {"hru_id": range(2), "batch_id": [0, 0]}, geometry=polys, crs="EPSG:4326"
+    )
+    return gdf
+
+
+def test_per_year_output_path(project):
+    from nhf_spatial_targets.aggregate._driver import per_year_output_path
+
+    p = per_year_output_path(project, "foo", 2005)
+    assert p == project.workdir / "data" / "aggregated" / "_by_year" / "foo_2005_agg.nc"
+
+
+def test_aggregate_year_skips_when_intermediate_exists(project, tiny_batched_fabric):
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import (
+        aggregate_year,
+        per_year_output_path,
+    )
+
+    out_path = per_year_output_path(project, "merra2", 2005)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    times = pd.date_range("2005-01-01", periods=1, freq="MS")
+    xr.Dataset(
+        {"GWETTOP": (["time", "hru_id"], np.ones((1, 2)))},
+        coords={"time": times, "hru_id": [0, 1]},
+    ).to_netcdf(out_path)
+
+    src_dir = project.raw_dir("merra2")
+    src_dir.mkdir(parents=True, exist_ok=True)
+    src_file = src_dir / "src_2005_consolidated.nc"
+    _write_nc(src_file, pd.date_range("2005-01-01", periods=12, freq="MS"))
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["v"]
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch"
+    ) as mock_batch:
+        path = aggregate_year(
+            adapter, project, 2005, src_file, tiny_batched_fabric, "hru_id"
+        )
+    assert path == out_path
+    assert not mock_batch.called, "existing intermediate must skip aggregation"
+
+
+def test_aggregate_year_writes_intermediate_when_missing(project, tiny_batched_fabric):
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import (
+        aggregate_year,
+        per_year_output_path,
+    )
+
+    src_dir = project.raw_dir("merra2")
+    src_dir.mkdir(parents=True, exist_ok=True)
+    src_file = src_dir / "src_2005_consolidated.nc"
+    _write_nc(src_file, pd.date_range("2005-01-01", periods=12, freq="MS"))
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["v"]
+    )
+
+    fake_weights = pd.DataFrame({"i": [0], "j": [0], "wght": [1.0], "hru_id": [0]})
+    fake_year_ds = xr.Dataset(
+        {"v": (["time", "hru_id"], np.ones((1, 2)))},
+        coords={
+            "time": (
+                "time",
+                pd.date_range("2005-01-01", periods=1, freq="MS"),
+                {"standard_name": "time"},
+            ),
+            "hru_id": [0, 1],
+        },
+    )
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=fake_weights,
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ) as mock_batch,
+    ):
+        path = aggregate_year(
+            adapter, project, 2005, src_file, tiny_batched_fabric, "hru_id"
+        )
+
+    assert path == per_year_output_path(project, "merra2", 2005)
+    assert path.exists()
+    call = mock_batch.call_args
+    assert call.kwargs["period"] == ("2005-01-01", "2005-12-31")

--- a/tests/test_aggregate_era5_land.py
+++ b/tests/test_aggregate_era5_land.py
@@ -2,33 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-import numpy as np
-import pandas as pd
-import pytest
-import xarray as xr
-
-from nhf_spatial_targets.aggregate.era5_land import ADAPTER, _open_monthly
-
-
-@pytest.fixture()
-def monthly_nc(tmp_path):
-    ds_dir = tmp_path / "era5_land"
-    ds_dir.mkdir()
-    times = pd.date_range("2000-01-01", periods=3, freq="MS")
-    ds = xr.Dataset(
-        {
-            "ro": (["time", "lat", "lon"], np.ones((3, 2, 2))),
-            "sro": (["time", "lat", "lon"], np.ones((3, 2, 2)) * 0.5),
-            "ssro": (["time", "lat", "lon"], np.ones((3, 2, 2)) * 0.5),
-        },
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    )
-    # Distinguishable from any daily neighbour by the "monthly" token.
-    ds.to_netcdf(ds_dir / "era5_land_monthly_2000_2002.nc")
-    ds.to_netcdf(ds_dir / "era5_land_daily_2000_2002.nc")
-    return ds_dir
+from nhf_spatial_targets.aggregate.era5_land import ADAPTER
 
 
 def test_adapter_declares_runoff_vars():
@@ -37,9 +11,5 @@ def test_adapter_declares_runoff_vars():
     assert set(ADAPTER.variables) == {"ro", "sro", "ssro"}
 
 
-def test_open_monthly_selects_monthly_nc(monthly_nc):
-    project = MagicMock()
-    project.raw_dir.return_value = monthly_nc
-    ds = _open_monthly(project)
-    assert "ro" in ds
-    assert ds.sizes["time"] == 3
+def test_adapter_uses_monthly_files_glob():
+    assert ADAPTER.files_glob == "*monthly*.nc"

--- a/tests/test_aggregate_gldas.py
+++ b/tests/test_aggregate_gldas.py
@@ -2,66 +2,62 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
-
-from nhf_spatial_targets.aggregate.gldas import ADAPTER, _open
-
-
-@pytest.fixture()
-def gldas_nc(tmp_path):
-    ds_dir = tmp_path / "gldas_noah_v21_monthly"
-    ds_dir.mkdir()
-    times = pd.date_range("2000-01-01", periods=2, freq="MS")
-    xr.Dataset(
-        {
-            "Qs_acc": (["time", "lat", "lon"], np.ones((2, 2, 2))),
-            "Qsb_acc": (["time", "lat", "lon"], np.ones((2, 2, 2)) * 3.0),
-        },
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(ds_dir / "gldas_noah_v21_monthly.nc")
-    return ds_dir
 
 
 def test_adapter_declares_runoff_vars():
+    from nhf_spatial_targets.aggregate.gldas import ADAPTER
+
     assert ADAPTER.source_key == "gldas_noah_v21_monthly"
     assert ADAPTER.output_name == "gldas_agg.nc"
     assert set(ADAPTER.variables) == {"Qs_acc", "Qsb_acc", "runoff_total"}
 
 
-def test_open_adds_runoff_total(gldas_nc):
-    project = MagicMock()
-    project.raw_dir.return_value = gldas_nc
-    ds = _open(project)
-    assert "runoff_total" in ds
-    np.testing.assert_allclose(ds["runoff_total"].values, 4.0)
-    assert ds["runoff_total"].attrs["units"] == "kg m-2"
+def test_derive_runoff_total():
+    from nhf_spatial_targets.aggregate.gldas import _derive_runoff_total
 
-
-def test_open_preserves_nan_in_runoff_total(tmp_path):
-    """If either Qs_acc or Qsb_acc is NaN at a cell, runoff_total is NaN there."""
-    ds_dir = tmp_path / "gldas_noah_v21_monthly"
-    ds_dir.mkdir()
-    times = pd.date_range("2000-01-01", periods=1, freq="MS")
-    qs = np.array([[[1.0, np.nan], [1.0, 1.0]]])
-    qsb = np.array([[[2.0, 2.0], [np.nan, 2.0]]])
-    xr.Dataset(
+    ds = xr.Dataset(
         {
-            "Qs_acc": (["time", "lat", "lon"], qs),
-            "Qsb_acc": (["time", "lat", "lon"], qsb),
+            "Qs_acc": (["time"], np.array([1.0, 2.0])),
+            "Qsb_acc": (["time"], np.array([3.0, 4.0])),
         },
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    ).to_netcdf(ds_dir / "gldas_noah_v21_monthly.nc")
+        coords={"time": pd.date_range("2000-01-01", periods=2, freq="MS")},
+    )
+    out = _derive_runoff_total(ds)
+    np.testing.assert_array_equal(out["runoff_total"].values, np.array([4.0, 6.0]))
+    assert out["runoff_total"].attrs["derived_from"] == "Qs_acc + Qsb_acc"
 
-    project = MagicMock()
-    project.raw_dir.return_value = ds_dir
-    ds = _open(project)
-    rt = ds["runoff_total"].isel(time=0).values
+
+def test_derive_runoff_total_preserves_nan():
+    """NaN in either component propagates to runoff_total."""
+    from nhf_spatial_targets.aggregate.gldas import _derive_runoff_total
+
+    ds = xr.Dataset(
+        {
+            "Qs_acc": (["time", "lat", "lon"], np.array([[[1.0, np.nan], [1.0, 1.0]]])),
+            "Qsb_acc": (
+                ["time", "lat", "lon"],
+                np.array([[[2.0, 2.0], [np.nan, 2.0]]]),
+            ),
+        },
+        coords={
+            "time": pd.date_range("2000-01-01", periods=1, freq="MS"),
+            "lat": [0.25, 0.75],
+            "lon": [0.5, 1.5],
+        },
+    )
+    out = _derive_runoff_total(ds)
+    rt = out["runoff_total"].isel(time=0).values
     assert np.isnan(rt[0, 1])  # Qs NaN -> total NaN
     assert np.isnan(rt[1, 0])  # Qsb NaN -> total NaN
     assert rt[0, 0] == 3.0
     assert rt[1, 1] == 3.0
+
+
+def test_adapter_sets_files_glob_and_pre_hook():
+    from nhf_spatial_targets.aggregate.gldas import ADAPTER, _derive_runoff_total
+
+    assert ADAPTER.files_glob == "*.nc"
+    assert ADAPTER.pre_aggregate_hook is _derive_runoff_total

--- a/tests/test_aggregate_mod10c1.py
+++ b/tests/test_aggregate_mod10c1.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from nhf_spatial_targets.aggregate.mod10c1 import build_masked_source
+from nhf_spatial_targets.aggregate.mod10c1 import _open, build_masked_source
 
 
 @pytest.fixture()
@@ -126,3 +126,74 @@ def test_log_low_valid_coverage_silent_below_threshold(caplog):
     ):
         _log_low_valid_coverage(combined)
     assert not any("zero valid-area" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _open: consolidated NC selection
+# ---------------------------------------------------------------------------
+
+
+def _make_consolidated_nc(path, times):
+    """Write a minimal consolidated MOD10C1 NC with a time coordinate."""
+    snow = np.ones((len(times), 2, 2)) * 50.0
+    qa = np.ones((len(times), 2, 2)) * 80.0
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (["time", "lat", "lon"], snow),
+            "Snow_Spatial_QA": (["time", "lat", "lon"], qa),
+        },
+        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+    )
+    ds.to_netcdf(path)
+
+
+def test_open_loads_single_consolidated_nc(tmp_path):
+    """`_open` returns a Dataset with a 'time' coordinate from one consolidated file."""
+    raw_dir = tmp_path / "mod10c1_v061"
+    raw_dir.mkdir()
+    times = pd.date_range("2000-03-01", periods=3, freq="D")
+    _make_consolidated_nc(raw_dir / "mod10c1_v061_2000_consolidated.nc", times)
+    # Also put a .conus.nc file in the dir to confirm it is ignored
+    (raw_dir / "MOD10C1.A2000061.061.conus.nc").write_bytes(b"not a real nc")
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return raw_dir
+
+    result = _open(_FakeProject())
+    assert "time" in result.coords
+    assert len(result["time"]) == 3
+
+
+def test_open_concatenates_multiple_consolidated_ncs(tmp_path):
+    """`_open` merges multi-year consolidated files into one Dataset along time."""
+    raw_dir = tmp_path / "mod10c1_v061"
+    raw_dir.mkdir()
+    times_2000 = pd.date_range("2000-01-01", periods=2, freq="D")
+    times_2001 = pd.date_range("2001-01-01", periods=2, freq="D")
+    _make_consolidated_nc(raw_dir / "mod10c1_v061_2000_consolidated.nc", times_2000)
+    _make_consolidated_nc(raw_dir / "mod10c1_v061_2001_consolidated.nc", times_2001)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return raw_dir
+
+    result = _open(_FakeProject())
+    assert "time" in result.coords
+    assert len(result["time"]) == 4
+    # Verify time is sorted (2000 before 2001)
+    assert result["time"].values[0] < result["time"].values[-1]
+
+
+def test_open_raises_when_no_consolidated_nc_found(tmp_path):
+    """`_open` raises FileNotFoundError when only .conus.nc files exist."""
+    raw_dir = tmp_path / "mod10c1_v061"
+    raw_dir.mkdir()
+    (raw_dir / "MOD10C1.A2000061.061.conus.nc").write_bytes(b"not a real nc")
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return raw_dir
+
+    with pytest.raises(FileNotFoundError, match="consolidated"):
+        _open(_FakeProject())

--- a/tests/test_aggregate_mod10c1.py
+++ b/tests/test_aggregate_mod10c1.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from nhf_spatial_targets.aggregate.mod10c1 import _open, build_masked_source
+from nhf_spatial_targets.aggregate.mod10c1 import build_masked_source
 
 
 @pytest.fixture()
@@ -128,122 +128,12 @@ def test_log_low_valid_coverage_silent_below_threshold(caplog):
     assert not any("zero valid-area" in rec.message for rec in caplog.records)
 
 
-# ---------------------------------------------------------------------------
-# _open: consolidated NC selection
-# ---------------------------------------------------------------------------
+def test_mod10c1_adapter_wires_hooks_and_variables():
+    from nhf_spatial_targets.aggregate.mod10c1 import ADAPTER, build_masked_source
 
-
-def _make_consolidated_nc(path, times):
-    """Write a minimal consolidated MOD10C1 NC with a time coordinate."""
-    snow = np.ones((len(times), 2, 2)) * 50.0
-    qa = np.ones((len(times), 2, 2)) * 80.0
-    ds = xr.Dataset(
-        {
-            "Day_CMG_Snow_Cover": (["time", "lat", "lon"], snow),
-            "Snow_Spatial_QA": (["time", "lat", "lon"], qa),
-        },
-        coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-    )
-    ds.to_netcdf(path)
-
-
-def test_open_loads_single_consolidated_nc(tmp_path):
-    """`_open` returns a Dataset with a 'time' coordinate from one consolidated file."""
-    raw_dir = tmp_path / "mod10c1_v061"
-    raw_dir.mkdir()
-    times = pd.date_range("2000-03-01", periods=3, freq="D")
-    _make_consolidated_nc(raw_dir / "mod10c1_v061_2000_consolidated.nc", times)
-    # Also put a .conus.nc file in the dir to confirm it is ignored
-    (raw_dir / "MOD10C1.A2000061.061.conus.nc").write_bytes(b"not a real nc")
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return raw_dir
-
-    result = _open(_FakeProject())
-    assert "time" in result.coords
-    assert len(result["time"]) == 3
-
-
-def test_open_concatenates_multiple_consolidated_ncs(tmp_path):
-    """`_open` merges multi-year consolidated files into one Dataset along time."""
-    raw_dir = tmp_path / "mod10c1_v061"
-    raw_dir.mkdir()
-    times_2000 = pd.date_range("2000-01-01", periods=2, freq="D")
-    times_2001 = pd.date_range("2001-01-01", periods=2, freq="D")
-    _make_consolidated_nc(raw_dir / "mod10c1_v061_2000_consolidated.nc", times_2000)
-    _make_consolidated_nc(raw_dir / "mod10c1_v061_2001_consolidated.nc", times_2001)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return raw_dir
-
-    result = _open(_FakeProject())
-    assert "time" in result.coords
-    assert len(result["time"]) == 4
-    # Verify time is sorted (2000 before 2001)
-    assert result["time"].values[0] < result["time"].values[-1]
-    # Both years must be represented (catches a regression that drops a file)
-    years_present = set(pd.DatetimeIndex(result["time"].values).year)
-    assert years_present == {2000, 2001}
-
-
-def test_open_concat_sorts_when_filename_order_disagrees_with_time(tmp_path):
-    """sortby('time') must run even when filename glob order is non-chronological."""
-    raw_dir = tmp_path / "mod10c1_v061"
-    raw_dir.mkdir()
-
-    # partA covers 2001, partB covers 2000 — filename order is reversed
-    times_partA = pd.date_range("2001-01-01", periods=2, freq="D")
-    times_partB = pd.date_range("2000-01-01", periods=2, freq="D")
-    _make_consolidated_nc(raw_dir / "mod10c1_v061_partA_consolidated.nc", times_partA)
-    _make_consolidated_nc(raw_dir / "mod10c1_v061_partB_consolidated.nc", times_partB)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return raw_dir
-
-    result = _open(_FakeProject())
-    times = pd.DatetimeIndex(result["time"].values)
-    assert list(times.year) == [2000, 2000, 2001, 2001]
-
-
-def test_open_raises_when_no_consolidated_nc_found(tmp_path):
-    """`_open` raises FileNotFoundError when only .conus.nc files exist."""
-    raw_dir = tmp_path / "mod10c1_v061"
-    raw_dir.mkdir()
-    (raw_dir / "MOD10C1.A2000061.061.conus.nc").write_bytes(b"not a real nc")
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return raw_dir
-
-    with pytest.raises(FileNotFoundError, match="consolidated"):
-        _open(_FakeProject())
-
-
-def test_open_raises_on_duplicate_time_across_consolidated_ncs(tmp_path):
-    """Overlapping-time mod10c1 consolidated NCs must raise."""
-    raw_dir = tmp_path / "mod10c1_v061"
-    raw_dir.mkdir()
-
-    times_a = pd.date_range("2001-01-01", periods=10, freq="D")
-    times_b = pd.date_range("2001-01-05", periods=10, freq="D")  # overlaps
-    for name, times in (
-        ("mod10c1_v061_2001a_consolidated.nc", times_a),
-        ("mod10c1_v061_2001b_consolidated.nc", times_b),
-    ):
-        xr.Dataset(
-            {
-                "Day_CMG_Snow_Cover": (["time", "lat", "lon"], np.ones((10, 2, 2))),
-                "Snow_Spatial_QA": (["time", "lat", "lon"], np.ones((10, 2, 2)) * 90),
-            },
-            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
-        ).to_netcdf(raw_dir / name)
-
-    class _FakeProject:
-        def raw_dir(self, key):
-            return raw_dir
-
-    with pytest.raises(ValueError, match="Duplicate"):
-        _open(_FakeProject())
+    assert ADAPTER.source_key == "mod10c1_v061"
+    assert ADAPTER.output_name == "mod10c1_agg.nc"
+    assert set(ADAPTER.variables) == {"sca", "ci", "valid_mask"}
+    assert ADAPTER.grid_variable == "sca"
+    assert ADAPTER.pre_aggregate_hook is build_masked_source
+    assert ADAPTER.post_aggregate_hook is not None

--- a/tests/test_aggregate_mod10c1.py
+++ b/tests/test_aggregate_mod10c1.py
@@ -183,6 +183,29 @@ def test_open_concatenates_multiple_consolidated_ncs(tmp_path):
     assert len(result["time"]) == 4
     # Verify time is sorted (2000 before 2001)
     assert result["time"].values[0] < result["time"].values[-1]
+    # Both years must be represented (catches a regression that drops a file)
+    years_present = set(pd.DatetimeIndex(result["time"].values).year)
+    assert years_present == {2000, 2001}
+
+
+def test_open_concat_sorts_when_filename_order_disagrees_with_time(tmp_path):
+    """sortby('time') must run even when filename glob order is non-chronological."""
+    raw_dir = tmp_path / "mod10c1_v061"
+    raw_dir.mkdir()
+
+    # partA covers 2001, partB covers 2000 — filename order is reversed
+    times_partA = pd.date_range("2001-01-01", periods=2, freq="D")
+    times_partB = pd.date_range("2000-01-01", periods=2, freq="D")
+    _make_consolidated_nc(raw_dir / "mod10c1_v061_partA_consolidated.nc", times_partA)
+    _make_consolidated_nc(raw_dir / "mod10c1_v061_partB_consolidated.nc", times_partB)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return raw_dir
+
+    result = _open(_FakeProject())
+    times = pd.DatetimeIndex(result["time"].values)
+    assert list(times.year) == [2000, 2000, 2001, 2001]
 
 
 def test_open_raises_when_no_consolidated_nc_found(tmp_path):
@@ -196,4 +219,31 @@ def test_open_raises_when_no_consolidated_nc_found(tmp_path):
             return raw_dir
 
     with pytest.raises(FileNotFoundError, match="consolidated"):
+        _open(_FakeProject())
+
+
+def test_open_raises_on_duplicate_time_across_consolidated_ncs(tmp_path):
+    """Overlapping-time mod10c1 consolidated NCs must raise."""
+    raw_dir = tmp_path / "mod10c1_v061"
+    raw_dir.mkdir()
+
+    times_a = pd.date_range("2001-01-01", periods=10, freq="D")
+    times_b = pd.date_range("2001-01-05", periods=10, freq="D")  # overlaps
+    for name, times in (
+        ("mod10c1_v061_2001a_consolidated.nc", times_a),
+        ("mod10c1_v061_2001b_consolidated.nc", times_b),
+    ):
+        xr.Dataset(
+            {
+                "Day_CMG_Snow_Cover": (["time", "lat", "lon"], np.ones((10, 2, 2))),
+                "Snow_Spatial_QA": (["time", "lat", "lon"], np.ones((10, 2, 2)) * 90),
+            },
+            coords={"time": times, "lat": [0.25, 0.75], "lon": [0.5, 1.5]},
+        ).to_netcdf(raw_dir / name)
+
+    class _FakeProject:
+        def raw_dir(self, key):
+            return raw_dir
+
+    with pytest.raises(ValueError, match="Duplicate"):
         _open(_FakeProject())

--- a/tests/test_aggregate_mod16a2.py
+++ b/tests/test_aggregate_mod16a2.py
@@ -1,17 +1,50 @@
-"""Tests for MOD16A2 aggregation adapter (sinusoidal CRS)."""
+"""Tests for MOD16A2 aggregation adapter."""
 
 from __future__ import annotations
+
+import numpy as np
+import xarray as xr
 
 from nhf_spatial_targets.aggregate.mod16a2 import ADAPTER, MODIS_SINUSOIDAL_PROJ
 
 
-def test_adapter_declares_sinusoidal_crs():
+def test_adapter_declares_wgs84_crs():
+    # consolidate_mod16a2 reprojects tiles to EPSG:4326; the adapter must
+    # match so gdptools slices lon/lat correctly (not sinusoidal metres).
     assert ADAPTER.source_key == "mod16a2_v061"
     assert ADAPTER.output_name == "mod16a2_agg.nc"
     assert ADAPTER.variables == ("ET_500m",)
-    assert ADAPTER.source_crs == MODIS_SINUSOIDAL_PROJ
-    assert "+proj=sinu" in ADAPTER.source_crs
+    assert ADAPTER.source_crs == "EPSG:4326"
+    # MODIS_SINUSOIDAL_PROJ is retained for reference but NOT used as source_crs.
+    assert "+proj=sinu" in MODIS_SINUSOIDAL_PROJ
     # x_coord / y_coord are None — resolved at runtime via CF attrs on the
-    # consolidated NC (projection_x_coordinate / projection_y_coordinate).
+    # consolidated NC.
     assert ADAPTER.x_coord is None
     assert ADAPTER.y_coord is None
+
+
+def test_adapter_has_fill_value_hook():
+    assert ADAPTER.pre_aggregate_hook is not None
+
+
+def test_mask_et_fill_masks_special_codes():
+    """_mask_et_fill replaces MODIS special codes (>3270) with NaN."""
+    from nhf_spatial_targets.aggregate.mod16a2 import _mask_et_fill
+
+    # Simulate a tiny dataset: one valid pixel, one fill-value pixel.
+    # MODIS ET_500m valid_range_max = 32700 raw = 3270.0 scaled.
+    # Fill codes (water, barren, cloudy, etc.) range from 32761–32767 raw
+    # = 3276.1–3276.7 scaled.
+    et = xr.DataArray(
+        np.array([[10.0, 50.0], [3270.0, 3276.6]], dtype=np.float32),
+        dims=["time", "space"],
+    )
+    ds = xr.Dataset({"ET_500m": et})
+
+    result = _mask_et_fill(ds)
+
+    # Values at or below 3270 are preserved; above are NaN.
+    assert float(result["ET_500m"].values[0, 0]) == 10.0
+    assert float(result["ET_500m"].values[0, 1]) == 50.0
+    assert float(result["ET_500m"].values[1, 0]) == 3270.0  # boundary kept
+    assert np.isnan(result["ET_500m"].values[1, 1])  # fill → NaN

--- a/tests/test_aggregate_mod16a2.py
+++ b/tests/test_aggregate_mod16a2.py
@@ -11,5 +11,7 @@ def test_adapter_declares_sinusoidal_crs():
     assert ADAPTER.variables == ("ET_500m",)
     assert ADAPTER.source_crs == MODIS_SINUSOIDAL_PROJ
     assert "+proj=sinu" in ADAPTER.source_crs
-    assert ADAPTER.x_coord == "x"
-    assert ADAPTER.y_coord == "y"
+    # x_coord / y_coord are None — resolved at runtime via CF attrs on the
+    # consolidated NC (projection_x_coordinate / projection_y_coordinate).
+    assert ADAPTER.x_coord is None
+    assert ADAPTER.y_coord is None


### PR DESCRIPTION
## Summary

Refactors the spatial aggregation driver to stream year-by-year, fixing MOD16A2/MOD10C1 OOM and the `time,lat,lon` vs `time,y,x` coord mismatch seen on HPC array=7.

- **Per-year pipeline** — `aggregate_source` now enumerates years from `*_consolidated.nc` via CF time coord, aggregates each year idempotently to `data/aggregated/_by_year/<src>_<year>_agg.nc` (restartable), then concats on time into `data/aggregated/<src>_agg.nc`. Peak memory is one year + one batch.
- **CF coord detection** — new `_coords.detect_coords` resolves x/y/time via `axis` / `standard_name` attrs; `SourceAdapter` coord fields are now optional overrides.
- **Adapter model simplified** — `open_hook` removed. Adapters use `files_glob` for file-pattern override, `pre_aggregate_hook` for derivation, `post_aggregate_hook` for final rename/warn.
- **MOD10C1** collapses to an adapter with `pre_aggregate_hook=build_masked_source` + `post_aggregate_hook=_rename_and_warn`.
- **ERA5-Land / GLDAS / WaterGAP** migrated to the new model (file-glob override; GLDAS derives `runoff_total` via pre-hook).
- **MOD16A2** drops hard-coded `x`/`y` overrides (CF detection resolves `projection_x_coordinate` / `projection_y_coordinate`).

Design: docs/superpowers/specs/2026-04-15-per-year-streaming-aggregation-design.md
Plan:   docs/superpowers/plans/2026-04-15-per-year-streaming-aggregation.md

## Test plan

- [x] 420 unit tests pass (pixi run -e dev test); fmt + lint clean
- [ ] Smoke test on a real project: pixi run nhf-targets agg mod10c1 --project-dir <dir> — verify _by_year/ per year, final mod10c1_agg.nc has sca/ci/valid_area_fraction, re-run logs intermediate exists for every year
- [ ] Same smoke test for MOD16A2 (sinusoidal CRS path exercises CF projection_*_coordinate detection)
- [ ] Confirm ERA5-Land / GLDAS / WaterGAP still aggregate correctly against the datastore (new files_glob values)

## Notes for reviewer

Commit 71afc7d accidentally bundled docs/strategy-deck.html and a .claude/settings.local.json tweak alongside the MOD16A2 change. These are unrelated to this PR and should be split out or reverted before merge.