### PR TITLE
fix: harden per-year aggregation driver (PR #51 followups)

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_adapter.py
+++ b/src/nhf_spatial_targets/aggregate/_adapter.py
@@ -33,6 +33,7 @@ class SourceAdapter:
     time_coord: str | None = None
     source_crs: str = "EPSG:4326"
     grid_variable: str | None = None
+    raw_grid_variable: str | None = None
     files_glob: str = "*_consolidated.nc"
     pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
     post_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
@@ -56,6 +57,15 @@ class SourceAdapter:
                 f"SourceAdapter.grid_variable {self.grid_variable!r} must be one of "
                 f"variables={self.variables}"
             )
+        # raw_grid_variable names the pre-hook raw-NC variable used to detect
+        # grid-shape invariance across source files. For non-hooked adapters it
+        # defaults to grid_variable (which is itself a raw var). For adapters
+        # whose pre_aggregate_hook synthesizes all declared variables from
+        # raw inputs (e.g. MOD10C1), raw_grid_variable must be set explicitly
+        # to a variable that exists in the raw NC; otherwise the driver cannot
+        # enforce the cross-year grid invariant.
+        if self.raw_grid_variable is None:
+            object.__setattr__(self, "raw_grid_variable", self.grid_variable)
         # Catalog-typo check. If the catalog is unavailable at construction
         # time (e.g. test harness, repackaged install), defer the check until
         # the driver runs. Do NOT swallow KeyError — that's the typo case we

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -271,11 +271,15 @@ def aggregate_year(
                     period=period,
                 )
             except Exception as exc:
-                raise RuntimeError(
+                # Preserve the original exception type (FileNotFoundError,
+                # PermissionError, gdptools errors, etc.) so callers can still
+                # except on concrete types; attach provenance via a note.
+                exc.add_note(
                     f"{adapter.source_key}: aggregation failed for "
-                    f"year={year} batch={int(bid)} source_file={source_file.name}: "
-                    f"{exc}"
-                ) from exc
+                    f"year={year} batch={int(bid)} "
+                    f"source_file={source_file.name}"
+                )
+                raise
             datasets.append(batch_ds)
 
         year_ds = xr.concat(datasets, dim=id_col)
@@ -306,7 +310,10 @@ def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
             f"Duplicate time coords across per-year intermediates: "
             f"{[p.name for p in paths]}"
         )
-    years_present = set(pd.DatetimeIndex(t).year.unique().tolist())
+    # Use the xarray .dt accessor rather than pd.DatetimeIndex: the latter
+    # raises TypeError on cftime calendars (noleap, 360_day, etc.), which
+    # some upstream sources ship with.
+    years_present = set(int(y) for y in combined[time_coord].dt.year.values)
     expected = set(range(min(years_present), max(years_present) + 1))
     missing_years = sorted(expected - years_present)
     if missing_years:
@@ -535,7 +542,7 @@ def aggregate_source(
     # check is skipped in that case. The grid-shape check always runs: weight
     # caches are keyed per (source_key, batch_id) — not per year — and reused
     # across years, so every file must share the same source grid.
-    grid_var = adapter.grid_variable or adapter.variables[0]
+    raw_grid_var = adapter.raw_grid_variable
     reference_grid: tuple | None = None
     for f in files:
         with xr.open_dataset(f) as peek:
@@ -546,21 +553,36 @@ def aggregate_source(
                         f"{adapter.source_key}: variables {missing} missing from "
                         f"{f.name} (have {list(peek.data_vars)})"
                     )
-            if grid_var in peek.data_vars:
-                shape = tuple(
-                    peek[grid_var].sizes[d]
-                    for d in peek[grid_var].dims
-                    if d != adapter.time_coord and d != "time"
+            if raw_grid_var not in peek.data_vars:
+                raise ValueError(
+                    f"{adapter.source_key}: raw_grid_variable "
+                    f"{raw_grid_var!r} missing from {f.name} "
+                    f"(have {list(peek.data_vars)}). For adapters whose "
+                    f"pre_aggregate_hook synthesizes declared variables, set "
+                    f"SourceAdapter.raw_grid_variable to a variable that exists "
+                    f"in the raw NC so the cross-year grid invariant can be "
+                    f"enforced."
                 )
-                if reference_grid is None:
-                    reference_grid = shape
-                elif shape != reference_grid:
-                    raise ValueError(
-                        f"{adapter.source_key}: grid shape drift across source "
-                        f"files — {f.name} has {shape}, expected {reference_grid}. "
-                        f"Weight caches are reused across years and require a "
-                        f"stable source grid."
-                    )
+            # Exclude the CF-detected time dim from the grid shape so that
+            # per-file timestep differences (leap years, partial-year
+            # fetches) don't masquerade as grid drift. Name-based filtering
+            # would false-positive on sources whose time dim is not named
+            # literally "time" (e.g. ERA5-Land "valid_time").
+            time_name = _find_time_coord_name(peek)
+            shape = tuple(
+                peek[raw_grid_var].sizes[d]
+                for d in peek[raw_grid_var].dims
+                if d != time_name
+            )
+            if reference_grid is None:
+                reference_grid = shape
+            elif shape != reference_grid:
+                raise ValueError(
+                    f"{adapter.source_key}: grid shape drift across source "
+                    f"files — {f.name} has {shape}, expected {reference_grid}. "
+                    f"Weight caches are reused across years and require a "
+                    f"stable source grid."
+                )
 
     year_files = enumerate_years(files)
     fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -9,8 +9,8 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-import numpy as np
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 import xarray as xr
 from gdptools import AggGen, UserCatData, WeightGen
@@ -79,7 +79,7 @@ def update_manifest(
         with os.fdopen(tmp_fd, "w") as f:
             json.dump(manifest, f, indent=2)
         Path(tmp_path).replace(manifest_path)
-    except BaseException:
+    except Exception:
         Path(tmp_path).unlink(missing_ok=True)
         raise
 
@@ -118,13 +118,19 @@ def weight_cache_path(workdir: Path, source_key: str, batch_id: int) -> Path:
 
 
 def _find_time_coord_name(ds: xr.Dataset) -> str | None:
-    """Return the name of the time coord via CF attrs, or None."""
-    for name in ds.coords:
+    """Return the name of the time coord via CF ``axis=T`` / ``standard_name=time``.
+
+    Returns ``None`` only if no dim carries either CF attribute. Callers
+    should raise with context rather than guessing a literal name — a coord
+    literally named ``"time"`` without CF attrs could be a non-time axis.
+    """
+    for name in ds.dims:
+        if name not in ds.coords:
+            continue
         attrs = ds.coords[name].attrs
         if attrs.get("axis") == "T" or attrs.get("standard_name") == "time":
             return name
-    # Fall back: any coord literally named 'time' (non-CF legacy NCs).
-    return "time" if "time" in ds.coords else None
+    return None
 
 
 def enumerate_years(files: list[Path]) -> list[tuple[int, Path]]:
@@ -178,7 +184,7 @@ def _atomic_write_netcdf(ds: xr.Dataset, path: Path) -> None:
     try:
         ds.to_netcdf(tmp_path)
         Path(tmp_path).replace(path)
-    except BaseException:
+    except Exception:
         Path(tmp_path).unlink(missing_ok=True)
         raise
 
@@ -237,32 +243,39 @@ def aggregate_year(
             batch_gdf = fabric_batched[fabric_batched["batch_id"] == bid].drop(
                 columns=["batch_id"]
             )
-            weights = compute_or_load_weights(
-                batch_gdf=batch_gdf,
-                source_ds=ds,
-                source_var=grid_var,
-                source_crs=adapter.source_crs,
-                x_coord=x_coord,
-                y_coord=y_coord,
-                time_coord=time_coord,
-                id_col=id_col,
-                source_key=adapter.source_key,
-                batch_id=int(bid),
-                workdir=project.workdir,
-                period=period,
-            )
-            batch_ds = aggregate_variables_for_batch(
-                batch_gdf=batch_gdf,
-                source_ds=ds,
-                variables=list(adapter.variables),
-                source_crs=adapter.source_crs,
-                x_coord=x_coord,
-                y_coord=y_coord,
-                time_coord=time_coord,
-                id_col=id_col,
-                weights=weights,
-                period=period,
-            )
+            try:
+                weights = compute_or_load_weights(
+                    batch_gdf=batch_gdf,
+                    source_ds=ds,
+                    source_var=grid_var,
+                    source_crs=adapter.source_crs,
+                    x_coord=x_coord,
+                    y_coord=y_coord,
+                    time_coord=time_coord,
+                    id_col=id_col,
+                    source_key=adapter.source_key,
+                    batch_id=int(bid),
+                    workdir=project.workdir,
+                    period=period,
+                )
+                batch_ds = aggregate_variables_for_batch(
+                    batch_gdf=batch_gdf,
+                    source_ds=ds,
+                    variables=list(adapter.variables),
+                    source_crs=adapter.source_crs,
+                    x_coord=x_coord,
+                    y_coord=y_coord,
+                    time_coord=time_coord,
+                    id_col=id_col,
+                    weights=weights,
+                    period=period,
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    f"{adapter.source_key}: aggregation failed for "
+                    f"year={year} batch={int(bid)} source_file={source_file.name}: "
+                    f"{exc}"
+                ) from exc
             datasets.append(batch_ds)
 
         year_ds = xr.concat(datasets, dim=id_col)
@@ -276,7 +289,9 @@ def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
     """Open per-year intermediates, concat on time, validate monotonic + unique.
 
     Loads each intermediate into memory and closes the on-disk handle so the
-    returned Dataset is detached from the filesystem.
+    returned Dataset is detached from the filesystem. Raises if duplicate
+    time coords appear across inputs or if the covered calendar years have
+    interior gaps (i.e. a year between min and max is not represented).
     """
     if not paths:
         raise ValueError("concat_years called with empty paths list")
@@ -290,6 +305,14 @@ def concat_years(paths: list[Path], time_coord: str) -> xr.Dataset:
         raise ValueError(
             f"Duplicate time coords across per-year intermediates: "
             f"{[p.name for p in paths]}"
+        )
+    years_present = set(pd.DatetimeIndex(t).year.unique().tolist())
+    expected = set(range(min(years_present), max(years_present) + 1))
+    missing_years = sorted(expected - years_present)
+    if missing_years:
+        raise ValueError(
+            f"concat_years: year gap(s) in per-year intermediates: "
+            f"missing={missing_years}, covered={sorted(years_present)}"
         )
     return combined
 
@@ -380,7 +403,7 @@ def compute_or_load_weights(
         with os.fdopen(tmp_fd, "w") as f:
             weights.to_csv(f, index=False)
         Path(tmp_path).replace(wp)
-    except BaseException:
+    except Exception:
         Path(tmp_path).unlink(missing_ok=True)
         raise
     logger.info("Batch %d: weights saved to %s", batch_id, wp)
@@ -455,14 +478,19 @@ def aggregate_variables_for_batch(
 
 
 def _attach_cf_global_attrs(ds: xr.Dataset, source_key: str, meta: dict) -> None:
-    """Attach CF-1.6 global attrs in place (non-destructive for var attrs)."""
+    """Attach CF-1.6 global attrs in place (non-destructive for var attrs).
+
+    Appends to any existing ``history`` rather than overwriting, preserving
+    provenance carried on the consolidated source NC.
+    """
     access = meta.get("access", {})
-    history = (
+    entry = (
         f"{datetime.now(timezone.utc).isoformat()}: aggregated to HRU fabric "
         f"by nhf_spatial_targets.aggregate._driver"
     )
     ds.attrs.setdefault("Conventions", "CF-1.6")
-    ds.attrs["history"] = history
+    existing = ds.attrs.get("history", "")
+    ds.attrs["history"] = f"{existing}\n{entry}" if existing else entry
     ds.attrs["source"] = source_key
     if "doi" in access:
         ds.attrs["source_doi"] = access["doi"]
@@ -502,16 +530,37 @@ def aggregate_source(
             f"Run 'nhf-targets fetch {adapter.source_key}' first."
         )
 
-    # Fail fast on missing declared variables — but only if there is no
-    # pre_aggregate_hook. Hooked adapters derive their declared variables.
-    if adapter.pre_aggregate_hook is None:
-        with xr.open_dataset(files[0]) as peek:
-            missing = [v for v in adapter.variables if v not in peek.data_vars]
-            if missing:
-                raise ValueError(
-                    f"{adapter.source_key}: variables {missing} missing from "
-                    f"source dataset (have {list(peek.data_vars)})"
+    # Fail fast on missing declared variables and on source-grid drift across
+    # files. Hooked adapters derive their declared variables, so the missing-var
+    # check is skipped in that case. The grid-shape check always runs: weight
+    # caches are keyed per (source_key, batch_id) — not per year — and reused
+    # across years, so every file must share the same source grid.
+    grid_var = adapter.grid_variable or adapter.variables[0]
+    reference_grid: tuple | None = None
+    for f in files:
+        with xr.open_dataset(f) as peek:
+            if adapter.pre_aggregate_hook is None:
+                missing = [v for v in adapter.variables if v not in peek.data_vars]
+                if missing:
+                    raise ValueError(
+                        f"{adapter.source_key}: variables {missing} missing from "
+                        f"{f.name} (have {list(peek.data_vars)})"
+                    )
+            if grid_var in peek.data_vars:
+                shape = tuple(
+                    peek[grid_var].sizes[d]
+                    for d in peek[grid_var].dims
+                    if d != adapter.time_coord and d != "time"
                 )
+                if reference_grid is None:
+                    reference_grid = shape
+                elif shape != reference_grid:
+                    raise ValueError(
+                        f"{adapter.source_key}: grid shape drift across source "
+                        f"files — {f.name} has {shape}, expected {reference_grid}. "
+                        f"Weight caches are reused across years and require a "
+                        f"stable source grid."
+                    )
 
     year_files = enumerate_years(files)
     fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
@@ -529,7 +578,13 @@ def aggregate_source(
     ]
 
     with xr.open_dataset(per_year_paths[0]) as probe:
-        time_coord = _find_time_coord_name(probe) or "time"
+        time_coord = _find_time_coord_name(probe)
+    if time_coord is None:
+        raise ValueError(
+            f"{adapter.source_key}: could not detect CF time coord on "
+            f"per-year intermediate {per_year_paths[0].name}. Expected a "
+            f"coord with axis='T' or standard_name='time'."
+        )
     combined = concat_years(per_year_paths, time_coord=time_coord)
 
     if adapter.post_aggregate_hook is not None:

--- a/src/nhf_spatial_targets/aggregate/era5_land.py
+++ b/src/nhf_spatial_targets/aggregate/era5_land.py
@@ -16,7 +16,7 @@ ADAPTER = SourceAdapter(
     variables=("ro", "sro", "ssro"),
     x_coord="longitude",
     y_coord="latitude",
-    files_glob="*monthly*.nc",
+    files_glob="era5_land_monthly_*.nc",
 )
 
 

--- a/src/nhf_spatial_targets/aggregate/gldas.py
+++ b/src/nhf_spatial_targets/aggregate/gldas.py
@@ -28,7 +28,7 @@ ADAPTER = SourceAdapter(
     source_key=_SOURCE_KEY,
     output_name="gldas_agg.nc",
     variables=("Qs_acc", "Qsb_acc", "runoff_total"),
-    files_glob="*.nc",
+    files_glob="gldas_noah_v21_monthly*.nc",
     pre_aggregate_hook=_derive_runoff_total,
 )
 

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -84,6 +84,7 @@ ADAPTER = SourceAdapter(
     output_name=_OUTPUT_NAME,
     variables=("sca", "ci", "valid_mask"),
     grid_variable="sca",
+    raw_grid_variable="Day_CMG_Snow_Cover",
     source_crs="EPSG:4326",
     pre_aggregate_hook=build_masked_source,
     post_aggregate_hook=_rename_and_warn,

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -597,3 +597,235 @@ def test_aggregate_variables_for_batch_passes_period_through(tiny_fabric):
 
     call_kwargs = mock_ucd.call_args.kwargs
     assert call_kwargs["period"] == ["2005-01-01", "2005-12-01"]
+
+
+def _setup_aggregate_source_project(tmp_path, tiny_fabric, source_key):
+    """Helper: create project + datastore dir for aggregate_source integration tests."""
+    datastore = tmp_path / "datastore"
+    (datastore / source_key).mkdir(parents=True)
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": str(tiny_fabric), "id_col": "hru_id"},
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+    return datastore / source_key
+
+
+def test_aggregate_source_invokes_pre_aggregate_hook(tmp_path, tiny_fabric):
+    """pre_aggregate_hook must run before the missing-variable check."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(
+        tmp_path, tiny_fabric, "gldas_noah_v21_monthly"
+    )
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    # Raw NC lacks 'derived' — hook injects it. Missing-var check must be skipped.
+    xr.Dataset(
+        {"raw": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "gldas_noah_v21_monthly.nc")
+
+    hook_calls = []
+
+    def hook(ds):
+        hook_calls.append(1)
+        return ds.assign(derived=ds["raw"] * 2.0)
+
+    adapter = SourceAdapter(
+        source_key="gldas_noah_v21_monthly",
+        output_name="gldas_agg.nc",
+        variables=("derived",),
+        files_glob="gldas_noah_v21_monthly*.nc",
+        pre_aggregate_hook=hook,
+    )
+
+    fake_year_ds = xr.Dataset(
+        {"derived": (["time", "hru_id"], np.ones((12, 4)) * 2.0)},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1, 2, 3],
+        },
+    )
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.catalog_source",
+            return_value={"access": {"type": "local_nc"}},
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=_fake_weights(),
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ),
+    ):
+        out = aggregate_source(
+            adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+        )
+
+    assert hook_calls, "pre_aggregate_hook was not invoked"
+    assert "derived" in out.data_vars
+
+
+def test_aggregate_source_invokes_post_aggregate_hook(tmp_path, tiny_fabric):
+    """post_aggregate_hook must run on the concatenated dataset before write."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "merra2")
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2000_consolidated.nc")
+
+    def post_hook(ds):
+        return ds.rename({"a": "a_renamed"})
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=("a",),
+        post_aggregate_hook=post_hook,
+    )
+    fake_year_ds = xr.Dataset(
+        {"a": (["time", "hru_id"], np.ones((12, 4)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "hru_id": [0, 1, 2, 3],
+        },
+    )
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.catalog_source",
+            return_value={"access": {"type": "local_nc"}},
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=_fake_weights(),
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            return_value=fake_year_ds,
+        ),
+    ):
+        out = aggregate_source(
+            adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+        )
+
+    assert "a_renamed" in out.data_vars
+    assert "a" not in out.data_vars
+    written = xr.open_dataset(tmp_path / "data" / "aggregated" / "merra2_agg.nc")
+    try:
+        assert "a_renamed" in written.data_vars
+    finally:
+        written.close()
+
+
+def test_aggregate_source_raises_on_grid_drift_across_files(tmp_path, tiny_fabric):
+    """Differing grid shape across per-year files must fail before aggregation."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "merra2")
+    t0 = pd.date_range("2000-01-01", periods=12, freq="MS")
+    t1 = pd.date_range("2001-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", t0, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2000_consolidated.nc")
+    # Second year has a different grid shape (3x3 instead of 2x2).
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 3, 3)))},
+        coords={
+            "time": ("time", t1, {"standard_name": "time"}),
+            "lat": ("lat", [0.2, 0.5, 0.8], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.2, 0.5, 0.8], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2001_consolidated.nc")
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=("a",)
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.catalog_source",
+        return_value={"access": {"type": "local_nc"}},
+    ):
+        with pytest.raises(ValueError, match="grid shape drift"):
+            aggregate_source(
+                adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+            )
+
+
+def test_aggregate_source_missing_var_check_scans_all_files(tmp_path, tiny_fabric):
+    """Missing variable in any input file (not just files[0]) must raise."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "merra2")
+    t0 = pd.date_range("2000-01-01", periods=12, freq="MS")
+    t1 = pd.date_range("2001-01-01", periods=12, freq="MS")
+    # First file has both a and b; second file is missing b.
+    xr.Dataset(
+        {
+            "a": (["time", "lat", "lon"], np.ones((12, 2, 2))),
+            "b": (["time", "lat", "lon"], np.ones((12, 2, 2))),
+        },
+        coords={
+            "time": ("time", t0, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2000_consolidated.nc")
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", t1, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2001_consolidated.nc")
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=("a", "b")
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.catalog_source",
+        return_value={"access": {"type": "local_nc"}},
+    ):
+        with pytest.raises(ValueError, match="b.*missing.*2001"):
+            aggregate_source(
+                adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+            )
+
+
+def test_attach_cf_global_attrs_appends_to_existing_history():
+    """Existing history attr on consolidated NC must be preserved, not overwritten."""
+    from nhf_spatial_targets.aggregate._driver import _attach_cf_global_attrs
+
+    ds = xr.Dataset({"v": (["x"], [1.0])})
+    ds.attrs["history"] = "2024-01-01: fetched from provider"
+    _attach_cf_global_attrs(ds, "src", {"access": {}})
+    assert "2024-01-01: fetched from provider" in ds.attrs["history"]
+    assert "aggregated to HRU fabric" in ds.attrs["history"]

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -321,6 +321,44 @@ def test_source_adapter_accepts_valid_grid_variable():
     assert adapter.grid_variable == "GWETROOT"
 
 
+def test_source_adapter_raw_grid_variable_defaults_to_grid_variable():
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=("GWETTOP", "GWETROOT"),
+        grid_variable="GWETROOT",
+    )
+    assert adapter.raw_grid_variable == "GWETROOT"
+
+
+def test_source_adapter_raw_grid_variable_can_differ_from_declared_vars():
+    """Hooked adapters whose declared variables are all derived must be able to
+    name a raw-NC variable for the grid-shape invariant."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+
+    adapter = SourceAdapter(
+        source_key="mod10c1_v061",
+        output_name="mod10c1_agg.nc",
+        variables=("sca", "ci", "valid_mask"),
+        grid_variable="sca",
+        raw_grid_variable="Day_CMG_Snow_Cover",
+        pre_aggregate_hook=lambda ds: ds,
+    )
+    assert adapter.raw_grid_variable == "Day_CMG_Snow_Cover"
+    assert "Day_CMG_Snow_Cover" not in adapter.variables
+
+
+def test_mod10c1_adapter_declares_raw_grid_variable():
+    """Regression: MOD10C1 must set raw_grid_variable so the grid-drift check
+    is not silently skipped (it used to short-circuit on ``sca not in raw``)."""
+    from nhf_spatial_targets.aggregate.mod10c1 import ADAPTER
+
+    assert ADAPTER.raw_grid_variable == "Day_CMG_Snow_Cover"
+    assert ADAPTER.raw_grid_variable not in ADAPTER.variables
+
+
 def test_source_adapter_coerces_list_to_tuple():
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 
@@ -647,6 +685,7 @@ def test_aggregate_source_invokes_pre_aggregate_hook(tmp_path, tiny_fabric):
         source_key="gldas_noah_v21_monthly",
         output_name="gldas_agg.nc",
         variables=("derived",),
+        raw_grid_variable="raw",
         files_glob="gldas_noah_v21_monthly*.nc",
         pre_aggregate_hook=hook,
     )
@@ -778,6 +817,40 @@ def test_aggregate_source_raises_on_grid_drift_across_files(tmp_path, tiny_fabri
             )
 
 
+def test_aggregate_source_raises_when_raw_grid_variable_missing(tmp_path, tiny_fabric):
+    """Hooked adapter whose raw_grid_variable is absent from the raw NC must
+    raise — the prior silent-skip left the cross-year grid invariant un-enforced."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "merra2")
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"raw_present": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2000_consolidated.nc")
+
+    adapter = SourceAdapter(
+        source_key="merra2",
+        output_name="merra2_agg.nc",
+        variables=("derived",),
+        raw_grid_variable="raw_missing",
+        pre_aggregate_hook=lambda ds: ds.assign(derived=ds["raw_present"] * 2.0),
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.catalog_source",
+        return_value={"access": {"type": "local_nc"}},
+    ):
+        with pytest.raises(ValueError, match="raw_grid_variable.*raw_missing"):
+            aggregate_source(
+                adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+            )
+
+
 def test_aggregate_source_missing_var_check_scans_all_files(tmp_path, tiny_fabric):
     """Missing variable in any input file (not just files[0]) must raise."""
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
@@ -829,3 +902,86 @@ def test_attach_cf_global_attrs_appends_to_existing_history():
     _attach_cf_global_attrs(ds, "src", {"access": {}})
     assert "2024-01-01: fetched from provider" in ds.attrs["history"]
     assert "aggregated to HRU fabric" in ds.attrs["history"]
+
+
+def test_find_time_coord_name_detects_non_standard_name():
+    """Time dim named anything (not literally 'time') is found via axis='T'."""
+    from nhf_spatial_targets.aggregate._driver import _find_time_coord_name
+
+    times = pd.date_range("2000-01-01", periods=3, freq="MS")
+    ds = xr.Dataset(
+        {"v": (["valid_time", "y"], np.ones((3, 2)))},
+        coords={
+            "valid_time": ("valid_time", times, {"axis": "T"}),
+            "y": [0.0, 1.0],
+        },
+    )
+    assert _find_time_coord_name(ds) == "valid_time"
+
+
+def test_aggregate_source_grid_drift_check_uses_cf_time_detection(
+    tmp_path, tiny_fabric
+):
+    """Grid-drift check must exclude the CF-detected time dim regardless of name.
+
+    Regression: if the filter used literal "time" / adapter.time_coord to
+    exclude the time axis, a source whose time dim is named ``valid_time``
+    (ERA5-Land) with different per-file timestep counts would be reported
+    as a spurious grid shape drift.
+    """
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "merra2")
+    t0 = pd.date_range("2000-01-01", periods=11, freq="MS")  # 11 timesteps
+    t1 = pd.date_range("2001-01-01", periods=12, freq="MS")  # 12 timesteps
+    # Same spatial grid (2x2), different time lengths, CF time named 'valid_time'.
+    xr.Dataset(
+        {"a": (["valid_time", "lat", "lon"], np.ones((11, 2, 2)))},
+        coords={
+            "valid_time": ("valid_time", t0, {"axis": "T"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2000_consolidated.nc")
+    xr.Dataset(
+        {"a": (["valid_time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "valid_time": ("valid_time", t1, {"axis": "T"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "merra2_2001_consolidated.nc")
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=("a",)
+    )
+
+    def _year_ds(times):
+        return xr.Dataset(
+            {"a": (["valid_time", "hru_id"], np.ones((len(times), 4)))},
+            coords={
+                "valid_time": ("valid_time", times, {"axis": "T"}),
+                "hru_id": [0, 1, 2, 3],
+            },
+        )
+
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.catalog_source",
+            return_value={"access": {"type": "local_nc"}},
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=_fake_weights(),
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            side_effect=[_year_ds(t0), _year_ds(t1)],
+        ),
+    ):
+        # Must NOT raise "grid shape drift" — the name-based filter would have
+        # incorrectly included valid_time in the shape tuple.
+        aggregate_source(
+            adapter, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+        )

--- a/tests/test_aggregate_driver_per_year.py
+++ b/tests/test_aggregate_driver_per_year.py
@@ -234,6 +234,63 @@ def test_concat_years_raises_on_year_gap(tmp_path):
         concat_years([p2000, p2002], time_coord="time")
 
 
+def test_concat_years_handles_cftime_calendar(tmp_path):
+    """Year-gap detection must not crash when time coord is cftime (noleap etc.)."""
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    def _write_cftime_year(path: Path, year: int) -> None:
+        times = xr.date_range(
+            f"{year}-01-01",
+            periods=12,
+            freq="MS",
+            calendar="noleap",
+            use_cftime=True,
+        )
+        xr.Dataset(
+            {"v": (["time", "hru_id"], np.ones((12, 2)) * year)},
+            coords={
+                "time": ("time", times, {"standard_name": "time"}),
+                "hru_id": [0, 1],
+            },
+        ).to_netcdf(path)
+
+    p2000 = tmp_path / "src_2000_agg.nc"
+    p2001 = tmp_path / "src_2001_agg.nc"
+    _write_cftime_year(p2000, 2000)
+    _write_cftime_year(p2001, 2001)
+
+    combined = concat_years([p2000, p2001], time_coord="time")
+    assert combined["v"].values.shape == (24, 2)
+
+
+def test_concat_years_cftime_year_gap_still_detected(tmp_path):
+    """Even on cftime calendars, interior year gaps must raise."""
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    def _write_cftime_year(path: Path, year: int) -> None:
+        times = xr.date_range(
+            f"{year}-01-01",
+            periods=12,
+            freq="MS",
+            calendar="noleap",
+            use_cftime=True,
+        )
+        xr.Dataset(
+            {"v": (["time", "hru_id"], np.ones((12, 2)))},
+            coords={
+                "time": ("time", times, {"standard_name": "time"}),
+                "hru_id": [0, 1],
+            },
+        ).to_netcdf(path)
+
+    p2000 = tmp_path / "src_2000_agg.nc"
+    p2002 = tmp_path / "src_2002_agg.nc"
+    _write_cftime_year(p2000, 2000)
+    _write_cftime_year(p2002, 2002)
+    with pytest.raises(ValueError, match="year gap"):
+        concat_years([p2000, p2002], time_coord="time")
+
+
 def test_concat_years_detaches_from_disk(tmp_path):
     """Returned Dataset must remain usable after source intermediates deleted."""
     from nhf_spatial_targets.aggregate._driver import concat_years
@@ -263,10 +320,11 @@ def test_find_time_coord_returns_none_without_cf_attrs(tmp_path):
     assert _find_time_coord_name(ds) is None
 
 
-def test_aggregate_year_wraps_batch_failure_with_context(
+def test_aggregate_year_preserves_exception_type_and_adds_context_note(
     project, tiny_batched_fabric, tmp_path
 ):
-    """gdptools failures inside a batch must surface with year/batch/file context."""
+    """Batch failures must surface with original exception type and a note
+    carrying year/batch/source_file provenance."""
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
     from nhf_spatial_targets.aggregate._driver import aggregate_year
 
@@ -280,12 +338,21 @@ def test_aggregate_year_wraps_batch_failure_with_context(
         variables=("v",),
     )
 
+    class GdptoolsSentinel(RuntimeError):
+        pass
+
     def boom(**_kwargs):
-        raise RuntimeError("gdptools exploded")
+        raise GdptoolsSentinel("gdptools exploded")
 
     with patch(
         "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
         side_effect=boom,
     ):
-        with pytest.raises(RuntimeError, match=r"year=2005.*batch=0"):
+        with pytest.raises(GdptoolsSentinel) as excinfo:
             aggregate_year(adapter, project, 2005, src, tiny_batched_fabric, "hru_id")
+
+    notes = getattr(excinfo.value, "__notes__", [])
+    assert any(
+        "year=2005" in n and "batch=0" in n and "era5_land_monthly_2005.nc" in n
+        for n in notes
+    ), f"Expected provenance note; got notes={notes}"

--- a/tests/test_aggregate_driver_per_year.py
+++ b/tests/test_aggregate_driver_per_year.py
@@ -221,3 +221,71 @@ def test_concat_years_raises_on_duplicate_time(tmp_path):
     _write_year_intermediate(p2, 2001)
     with pytest.raises(ValueError, match="[Dd]uplicate"):
         concat_years([p1, p2], time_coord="time")
+
+
+def test_concat_years_raises_on_year_gap(tmp_path):
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p2000 = tmp_path / "src_2000_agg.nc"
+    p2002 = tmp_path / "src_2002_agg.nc"
+    _write_year_intermediate(p2000, 2000)
+    _write_year_intermediate(p2002, 2002)
+    with pytest.raises(ValueError, match="year gap"):
+        concat_years([p2000, p2002], time_coord="time")
+
+
+def test_concat_years_detaches_from_disk(tmp_path):
+    """Returned Dataset must remain usable after source intermediates deleted."""
+    from nhf_spatial_targets.aggregate._driver import concat_years
+
+    p2000 = tmp_path / "src_2000_agg.nc"
+    p2001 = tmp_path / "src_2001_agg.nc"
+    _write_year_intermediate(p2000, 2000)
+    _write_year_intermediate(p2001, 2001)
+
+    combined = concat_years([p2000, p2001], time_coord="time")
+    p2000.unlink()
+    p2001.unlink()
+    assert combined["v"].values.shape == (24, 2)
+
+
+def test_find_time_coord_returns_none_without_cf_attrs(tmp_path):
+    """Legacy literal-name fallback is removed — return None for non-CF coord."""
+    from nhf_spatial_targets.aggregate._driver import _find_time_coord_name
+
+    ds = xr.Dataset(
+        {"v": (["time", "x"], np.zeros((3, 2)))},
+        coords={
+            "time": ("time", pd.date_range("2000-01-01", periods=3, freq="D")),
+            "x": ("x", [0.0, 1.0]),
+        },
+    )
+    assert _find_time_coord_name(ds) is None
+
+
+def test_aggregate_year_wraps_batch_failure_with_context(
+    project, tiny_batched_fabric, tmp_path
+):
+    """gdptools failures inside a batch must surface with year/batch/file context."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_year
+
+    src = tmp_path / "datastore" / "era5_land" / "era5_land_monthly_2005.nc"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    _write_nc(src, pd.date_range("2005-01-01", periods=12, freq="MS"))
+
+    adapter = SourceAdapter(
+        source_key="era5_land",
+        output_name="era5_land_agg.nc",
+        variables=("v",),
+    )
+
+    def boom(**_kwargs):
+        raise RuntimeError("gdptools exploded")
+
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+        side_effect=boom,
+    ):
+        with pytest.raises(RuntimeError, match=r"year=2005.*batch=0"):
+            aggregate_year(adapter, project, 2005, src, tiny_batched_fabric, "hru_id")

--- a/tests/test_aggregate_era5_land.py
+++ b/tests/test_aggregate_era5_land.py
@@ -12,4 +12,4 @@ def test_adapter_declares_runoff_vars():
 
 
 def test_adapter_uses_monthly_files_glob():
-    assert ADAPTER.files_glob == "*monthly*.nc"
+    assert ADAPTER.files_glob == "era5_land_monthly_*.nc"

--- a/tests/test_aggregate_gldas.py
+++ b/tests/test_aggregate_gldas.py
@@ -59,5 +59,5 @@ def test_derive_runoff_total_preserves_nan():
 def test_adapter_sets_files_glob_and_pre_hook():
     from nhf_spatial_targets.aggregate.gldas import ADAPTER, _derive_runoff_total
 
-    assert ADAPTER.files_glob == "*.nc"
+    assert ADAPTER.files_glob == "gldas_noah_v21_monthly*.nc"
     assert ADAPTER.pre_aggregate_hook is _derive_runoff_total


### PR DESCRIPTION
## Summary

Two rounds of review-driven hardening for the per-year streaming aggregation driver introduced in #51. All fixes land behind the existing `SourceAdapter` / `aggregate_source` contract — no API surface changes beyond one new optional adapter field.

### Round 1 (`5aa2975`) — initial hardening
- Replace `except BaseException` with `except Exception` in atomic-write paths so `KeyboardInterrupt` / `SystemExit` propagate cleanly.
- Remove legacy literal-\"time\" fallback in `_find_time_coord_name`; require CF `axis=T` / `standard_name=time`, and raise explicitly in `aggregate_source` if a per-year intermediate lacks one.
- Wrap per-batch aggregation with an error carrying year/batch/source-file context so gdptools failures surface with provenance.
- `concat_years`: detect interior year gaps, not just duplicates.
- `aggregate_source`: scan every input file for missing declared variables and validate grid-shape invariance across years (weight caches are keyed per-batch and reused across years, so mixed grids were a silent footgun).
- `_attach_cf_global_attrs`: append to existing `history` rather than overwriting.
- Tighten `files_glob` for ERA5-Land and GLDAS to avoid matching stray NCs.

### Round 2 (`545f95b`) — review followups on round 1
- Grid-shape drift check now uses CF-based time detection (`_find_time_coord_name`) rather than name-matching against `adapter.time_coord` / literal `\"time\"`. Fixes false positives/negatives when the time dim is named `valid_time` (ERA5-Land).
- `aggregate_year` per-batch wrap now attaches provenance via `exc.add_note()` and re-raises bare. Preserves original exception type instead of flattening everything to `RuntimeError`.
- New `SourceAdapter.raw_grid_variable` field names the pre-hook raw-NC variable used for the grid-shape invariant. Defaults to `grid_variable` for non-hooked adapters. MOD10C1 declares `raw_grid_variable=\"Day_CMG_Snow_Cover\"` so the grid-drift check actually runs for it (it was silently skipping because `sca` is not in the raw NC). Driver now raises explicitly when the raw grid variable is missing.
- `concat_years` year-gap detection uses the xarray `.dt.year` accessor instead of `pd.DatetimeIndex`, which raises `TypeError` on cftime calendars (noleap, 360_day).

## Test plan

- [x] `pixi run -e dev pytest tests/test_aggregate_driver.py tests/test_aggregate_driver_per_year.py tests/test_aggregate_mod10c1.py tests/test_aggregate_mod16a2.py tests/test_aggregate_gldas.py tests/test_aggregate_era5_land.py` — 66 passed
- [x] `pixi run -e dev fmt-check && pixi run -e dev lint` — clean
- [x] Full non-integration suite passes locally
- [ ] CI passes
- [ ] Smoke-test against a real datastore before merge (deferred — ERA5-Land fetch is still in progress; separate issue tracks glob-vs-fetch-layout verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)