### PR TITLE
Fix #54: normalize NCEP/NCAR 0-360 longitude in consolidation

### DIFF
--- a/docs/superpowers/plans/2026-04-17-ncep-ncar-longitude-fix.md
+++ b/docs/superpowers/plans/2026-04-17-ncep-ncar-longitude-fix.md
@@ -1,0 +1,136 @@
+# NCEP/NCAR Longitude Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `consolidate_ncep_ncar()` to produce a consolidated NetCDF with monotonic -180..180 longitude so gdptools aggregation can slice the coordinate without KeyError.
+
+**Architecture:** Add longitude normalization (wrap 0-360 → -180..180 + sort) inside `consolidate_ncep_ncar()` after `apply_cf_metadata()` and before `_write_netcdf()`. The CF `axis="X"` attribute (set by `apply_cf_metadata`) is used to detect the longitude coordinate name. A guard (`max > 180`) skips normalization for data already in -180..180.
+
+**Tech Stack:** xarray, numpy, pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-17-ncep-ncar-longitude-fix-design.md`
+
+---
+
+### Task 1: Write failing test for longitude normalization
+
+**Files:**
+- Modify: `tests/test_consolidate.py` (add new fixture + test after line ~393)
+
+- [ ] **Step 1: Write test fixture and test**
+
+Add a new fixture that creates synthetic NCEP/NCAR files with 0-360 longitude (matching the real T62 Gaussian grid convention), and a test asserting the consolidated output has -180..180 monotonic longitude.
+
+Add after the `test_ncep_cf_metadata` test (~line 393):
+
+```python
+@pytest.fixture
+def ncep_dir_0_360(tmp_path: Path) -> Path:
+    """Create synthetic NCEP/NCAR monthly files with 0-360 longitude."""
+    out = tmp_path / "ncep_ncar"
+    out.mkdir(parents=True)
+
+    lat = np.arange(-90, 91, 45.0)
+    lon = np.arange(0, 360, 60.0)  # 0-360 convention
+
+    for month in range(1, 4):
+        time = np.array([f"2010-{month:02d}-15T00:00:00"], dtype="datetime64[ns]")
+        ds = xr.Dataset(
+            {
+                "soilw": (
+                    ["time", "lat", "lon"],
+                    np.random.rand(1, len(lat), len(lon)).astype(np.float32),
+                ),
+            },
+            coords={"time": time, "lat": lat, "lon": lon},
+        )
+        fname = f"soilw.0-10cm.gauss.2010-{month:02d}.monthly.nc"
+        ds.to_netcdf(out / fname, format="NETCDF3_CLASSIC")
+
+    return out
+
+
+def test_ncep_longitude_normalization(ncep_dir_0_360):
+    """NCEP/NCAR 0-360 longitude is normalized to -180..180 and sorted."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_ncep_ncar
+
+    consolidate_ncep_ncar(source_dir=ncep_dir_0_360, variables=["soilw"])
+
+    ds = xr.open_dataset(ncep_dir_0_360 / "ncep_ncar_consolidated.nc")
+    lon_vals = ds.lon.values
+    ds.close()
+
+    # All values in -180..180
+    assert float(lon_vals.min()) >= -180.0
+    assert float(lon_vals.max()) <= 180.0
+
+    # Monotonically increasing
+    assert all(lon_vals[i] < lon_vals[i + 1] for i in range(len(lon_vals) - 1))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev test -- tests/test_consolidate.py::test_ncep_longitude_normalization -v`
+
+Expected: FAIL — the consolidated file will have 0-360 longitude values (not normalized) because `consolidate_ncep_ncar()` does not yet normalize. The `assert float(lon_vals.max()) <= 180.0` assertion should fail.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add tests/test_consolidate.py
+git commit -m "test: add failing test for NCEP/NCAR 0-360 longitude normalization (#54)"
+```
+
+### Task 2: Implement longitude normalization
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/consolidate.py:1159-1161`
+
+- [ ] **Step 1: Add normalization after `apply_cf_metadata()`**
+
+In `consolidate_ncep_ncar()`, between the `apply_cf_metadata()` call (line 1159) and the `out_path` assignment (line 1161), add:
+
+```python
+        ds = apply_cf_metadata(ds, "ncep_ncar", "monthly")
+
+        lon_name = next(
+            (c for c in ds.coords if ds[c].attrs.get("axis") == "X"),
+            "lon",
+        )
+        if float(ds[lon_name].max()) > 180:
+            ds.coords[lon_name] = ((ds.coords[lon_name] + 180) % 360) - 180
+            ds = ds.sortby(lon_name)
+
+        out_path = source_dir / "ncep_ncar_consolidated.nc"
+```
+
+- [ ] **Step 2: Run the new test to verify it passes**
+
+Run: `pixi run -e dev test -- tests/test_consolidate.py::test_ncep_longitude_normalization -v`
+
+Expected: PASS
+
+- [ ] **Step 3: Run the full NCEP/NCAR test suite to check for regressions**
+
+Run: `pixi run -e dev test -- tests/test_consolidate.py -k ncep -v`
+
+Expected: All NCEP/NCAR consolidation tests pass. The existing `ncep_dir` fixture uses -180..180 longitude, so the `max > 180` guard skips normalization and existing behavior is preserved.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `pixi run -e dev test`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Run lint and format**
+
+Run: `pixi run -e dev fmt && pixi run -e dev lint`
+
+Expected: Clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/consolidate.py tests/test_consolidate.py
+git commit -m "fix: normalize NCEP/NCAR 0-360 longitude to -180..180 in consolidation (#54)"
+```

--- a/docs/superpowers/specs/2026-04-17-ncep-ncar-longitude-fix-design.md
+++ b/docs/superpowers/specs/2026-04-17-ncep-ncar-longitude-fix-design.md
@@ -1,0 +1,70 @@
+# NCEP/NCAR Non-Monotonic Longitude Fix
+
+**Date:** 2026-04-17
+**Issue:** #54
+**Status:** Design
+
+## Problem
+
+`nhf-targets agg ncep-ncar` fails with `KeyError: "Cannot get left slice bound for non-monotonic index"` because the NCEP/NCAR T62 Gaussian grid uses 0-360 longitude convention. When gdptools rotates values >180 by subtracting 360, the coordinate becomes non-monotonic (values wrap from ~358.125 → -1.875 at the seam), and xarray's `.sel(lon=slice(...))` raises a KeyError.
+
+A secondary gdptools bug (in-place mutation of shared dataset coordinates) means the rotation corrupts the dataset for subsequent spatial batches even if the first batch succeeds. That bug will be reported upstream separately.
+
+## Fix
+
+Normalize longitude to -180..180 and sort in `consolidate_ncep_ncar()` so the consolidated file is correct on disk for all consumers.
+
+### Location
+
+`src/nhf_spatial_targets/fetch/consolidate.py`, inside `consolidate_ncep_ncar()`, after the `apply_cf_metadata()` call (line 1159) and before `_write_netcdf()` (line 1163).
+
+### Change
+
+```python
+ds = apply_cf_metadata(ds, "ncep_ncar", "monthly")
+
+# Normalize 0-360 longitude to -180..180 and sort for monotonic indexing
+lon_name = next(
+    (c for c in ds.coords if ds[c].attrs.get("axis") == "X"),
+    "lon",
+)
+if float(ds[lon_name].max()) > 180:
+    ds.coords[lon_name] = ((ds.coords[lon_name] + 180) % 360) - 180
+    ds = ds.sortby(lon_name)
+
+out_path = source_dir / "ncep_ncar_consolidated.nc"
+```
+
+The CF-detected coordinate name lookup via `axis="X"` is consistent with how `apply_cf_metadata()` sets the attribute. The guard `max > 180` avoids a no-op sort on data already in -180..180.
+
+### Why not fix in the aggregation adapter?
+
+- Leaves a known-bad file on disk that would trip up any non-gdptools consumer.
+- The GLDAS fetch module already normalizes longitude at consolidation time (`fetch/gldas.py:90-94`), establishing a precedent.
+- The consolidated file is the contract between fetch and aggregation; it should be self-consistent.
+
+### Why not generalize in `apply_cf_metadata()`?
+
+- Only NCEP/NCAR uses 0-360 in this project. Generalizing risks unintended effects on future sources that may legitimately use 0-360.
+- If more sources need this, it can be promoted to `apply_cf_metadata()` later.
+
+## Testing
+
+Add a test in `tests/test_consolidate.py` that:
+
+1. Creates synthetic NCEP/NCAR monthly files with 0-360 longitude (e.g., `np.arange(0, 360, 1.875)`)
+2. Runs `consolidate_ncep_ncar()`
+3. Asserts the output longitude is in -180..180 and monotonically increasing
+
+## Scope
+
+- 2 production lines + coordinate lookup in `consolidate.py`
+- 1 new test in `test_consolidate.py`
+- No changes to aggregation adapters, `_driver.py`, or `apply_cf_metadata()`
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/nhf_spatial_targets/fetch/consolidate.py` | Normalize longitude after `apply_cf_metadata()` in `consolidate_ncep_ncar()` |
+| `tests/test_consolidate.py` | Add test for 0-360 → -180..180 normalization |

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -1163,6 +1163,7 @@ def consolidate_ncep_ncar(
             "lon",
         )
         if float(ds[lon_name].max()) > 180:
+            logger.info("Normalizing %s from 0..360 to -180..180 range", lon_name)
             ds.coords[lon_name] = ((ds.coords[lon_name] + 180) % 360) - 180
             ds = ds.sortby(lon_name)
 

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -1158,6 +1158,14 @@ def consolidate_ncep_ncar(
         ds = ds[variables]
         ds = apply_cf_metadata(ds, "ncep_ncar", "monthly")
 
+        lon_name = next(
+            (c for c in ds.coords if ds[c].attrs.get("axis") == "X"),
+            "lon",
+        )
+        if float(ds[lon_name].max()) > 180:
+            ds.coords[lon_name] = ((ds.coords[lon_name] + 180) % 360) - 180
+            ds = ds.sortby(lon_name)
+
         out_path = source_dir / "ncep_ncar_consolidated.nc"
         logger.info("Writing consolidated file: %s", out_path)
         _write_netcdf(ds, out_path)

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -394,6 +394,47 @@ def test_ncep_cf_metadata(ncep_dir):
 
 
 @pytest.fixture()
+def ncep_dir_0_360(tmp_path: Path) -> Path:
+    """Create synthetic NCEP/NCAR monthly files with 0-360 longitude."""
+    out = tmp_path / "ncep_ncar"
+    out.mkdir(parents=True)
+
+    lat = np.arange(-90, 91, 45.0)
+    lon = np.arange(0, 360, 60.0)
+
+    for month in range(1, 4):
+        time = np.array([f"2010-{month:02d}-15T00:00:00"], dtype="datetime64[ns]")
+        ds = xr.Dataset(
+            {
+                "soilw": (
+                    ["time", "lat", "lon"],
+                    np.random.rand(1, len(lat), len(lon)).astype(np.float32),
+                ),
+            },
+            coords={"time": time, "lat": lat, "lon": lon},
+        )
+        fname = f"soilw.0-10cm.gauss.2010-{month:02d}.monthly.nc"
+        ds.to_netcdf(out / fname, format="NETCDF3_CLASSIC")
+
+    return out
+
+
+def test_ncep_longitude_normalization(ncep_dir_0_360):
+    """NCEP/NCAR 0-360 longitude is normalized to -180..180 and sorted."""
+    from nhf_spatial_targets.fetch.consolidate import consolidate_ncep_ncar
+
+    consolidate_ncep_ncar(source_dir=ncep_dir_0_360, variables=["soilw"])
+
+    ds = xr.open_dataset(ncep_dir_0_360 / "ncep_ncar_consolidated.nc")
+    lon_vals = ds.lon.values
+    ds.close()
+
+    assert float(lon_vals.min()) >= -180.0
+    assert float(lon_vals.max()) <= 180.0
+    assert all(lon_vals[i] < lon_vals[i + 1] for i in range(len(lon_vals) - 1))
+
+
+@pytest.fixture()
 def merra2_dir_unsorted(tmp_path: Path) -> Path:
     """Create MERRA-2 files in reverse chronological order."""
     out = tmp_path / "merra2"

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -402,14 +402,17 @@ def ncep_dir_0_360(tmp_path: Path) -> Path:
     lat = np.arange(-90, 91, 45.0)
     lon = np.arange(0, 360, 60.0)
 
+    # Deterministic values: each cell encodes its longitude so we can verify
+    # data-coordinate alignment survives the shift+sort.
+    values = np.broadcast_to(
+        lon[np.newaxis, np.newaxis, :], (1, len(lat), len(lon))
+    ).astype(np.float32)
+
     for month in range(1, 4):
         time = np.array([f"2010-{month:02d}-15T00:00:00"], dtype="datetime64[ns]")
         ds = xr.Dataset(
             {
-                "soilw": (
-                    ["time", "lat", "lon"],
-                    np.random.rand(1, len(lat), len(lon)).astype(np.float32),
-                ),
+                "soilw": (["time", "lat", "lon"], values.copy()),
             },
             coords={"time": time, "lat": lat, "lon": lon},
         )
@@ -427,11 +430,18 @@ def test_ncep_longitude_normalization(ncep_dir_0_360):
 
     ds = xr.open_dataset(ncep_dir_0_360 / "ncep_ncar_consolidated.nc")
     lon_vals = ds.lon.values
+    data = ds["soilw"].isel(time=0, lat=0).values
     ds.close()
 
+    # Range and monotonicity
     assert float(lon_vals.min()) >= -180.0
     assert float(lon_vals.max()) <= 180.0
     assert all(lon_vals[i] < lon_vals[i + 1] for i in range(len(lon_vals) - 1))
+
+    # Data-coordinate alignment: each cell's value should equal its original
+    # 0-360 longitude, which is (normalized_lon % 360).
+    expected_original = np.array([v % 360 for v in lon_vals], dtype=np.float32)
+    np.testing.assert_array_equal(data, expected_original)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- Normalize 0-360 longitude to -180..180 and sort in `consolidate_ncep_ncar()` so the consolidated NetCDF has monotonic longitude for gdptools/xarray `.sel()` slicing
- Add test with synthetic 0-360 longitude fixture to verify normalization
- Also identified an upstream gdptools bug where in-place longitude rotation corrupts shared datasets across spatial batches (to be filed separately)

Closes #54

## Test Plan

- [x] New `test_ncep_longitude_normalization` passes — verifies output longitude is in -180..180 and monotonically increasing
- [x] All existing NCEP/NCAR consolidation tests pass (existing fixture uses -180..180, guard skips normalization)
- [x] Full test suite: 448 passed, 14 deselected
- [x] ruff fmt + lint clean
- [ ] Run `nhf-targets agg ncep-ncar` on HPC against real consolidated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)