### PR TITLE
chore: replace broad PreToolUse if: filter with standalone guard

### DIFF
--- a/.claude/hooks/git-commit-guard.py
+++ b/.claude/hooks/git-commit-guard.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PreToolUse guard that blocks bare `git commit` and directs Claude to use `pixi run git commit`.
+
+The repo's pre-commit config runs ruff and pytest via `pixi run`. Invoking
+`git commit` outside an activated pixi shell forces every hook to re-resolve
+the pixi environment, which is slow and has intermittently stalled the
+pytest hook. Running the commit via `pixi run git commit` keeps the pre-
+commit invocations inside the already-resolved pixi environment.
+
+Reads the hook payload on stdin. If the tool_input.command begins with
+`git commit` at a word boundary, prints the permission-deny JSON to
+stdout and exits 0. Otherwise exits silently so the tool call proceeds.
+
+Matches (blocked):
+  git commit
+  git commit -m "msg"
+  <leading whitespace>git commit --amend
+
+Does NOT match (allowed):
+  pixi run git commit ...          (doesn't start with `git`)
+  cat <<EOF ... git commit ... EOF (doesn't start with `git`)
+  git branch -D foo                (second token isn't `commit`)
+  for b in ...; do git branch ...  (doesn't start with `git`)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+PATTERN = re.compile(r"^\s*git\s+commit(\s|$)")
+
+REASON = (
+    "This repo runs git commit through pixi so pre-commit hooks "
+    "(ruff, pytest) resolve inside the pixi dev env instead of the "
+    "parent shell. Re-run the same command with pixi run prepended "
+    "(pixi run git commit -m ...). See CLAUDE.md -> Pre-commit Quality Gate."
+)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return
+    cmd = payload.get("tool_input", {}).get("command", "")
+    if not PATTERN.match(cmd):
+        return
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": REASON,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,8 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit*)",
-            "command": "printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This repo runs git commit through pixi so pre-commit hooks (ruff, pytest) resolve inside the pixi dev env instead of the parent shell. Re-run the same command with pixi run prepended (pixi run git commit -m ...). See CLAUDE.md -> Pre-commit Quality Gate.\"}}\\n'"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/git-commit-guard.py\""
           }
         ]
       }


### PR DESCRIPTION
Closes #66.

## Summary

The PreToolUse hook added in #65 (block bare `git commit`, redirect to `pixi run git commit`) used `if: "Bash(git commit*)"` as its pre-filter. In practice the `if:` matcher does substring matching against the command text, so any Bash command whose payload contains the literal `git commit` — including JSON test fixtures for the guard itself — trips the hook. False positives observed during the post-merge session:

- `git fetch --prune origin; for b in ...; do gh pr list --head "$b" ...; done`
- `for b in <list>; do git branch -D "$b"; done`
- any pipe-test with `"command":"git commit ..."` as JSON payload

## Fix

- **New file** `.claude/hooks/git-commit-guard.py` — standalone Python guard. Reads the PreToolUse payload from stdin, regex-matches `^\s*git\s+commit(\s|$)` against `tool_input.command`, emits the deny JSON if matched, exits silently otherwise.
- **`.claude/settings.json`** — Bash PreToolUse hook now just invokes the script; the `if:` filter is removed.

## Verification

10 pipe-tests pass:

| Case | Expect |
|---|---|
| `git commit -m test`                           | deny  |
| `git commit` (no args)                          | deny  |
| `   git commit --amend` (leading whitespace)    | deny  |
| `pixi run git commit -m foo`                    | allow |
| `git branch -D some/branch`                     | allow |
| `git fetch --prune origin`                      | allow |
| `for b in x y; do git branch -D "$b"; done`     | allow |
| `cat <<EOF\ntalking about git commit here\nEOF` | allow |
| `gitfoo commit`                                 | allow |

Live in-session checks:
- `git commit --dry-run` → still blocked with the expected deny reason (new hook invocation shown in system reminder: `python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/git-commit-guard.py"`).
- `git fetch --dry-run` → now passes through cleanly (previously tripped the old filter).

## Out of scope

No hook unit tests shipped — the 10 cases live as an ephemeral `/tmp/guard_test.sh` during development. Worth adding `tests/test_git_commit_guard.py` if the hook grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)