### PR TITLE
MOD10C1 A2 policy: PR #78 review follow-ups

### DIFF
--- a/docs/architecture/transformation-pipeline.md
+++ b/docs/architecture/transformation-pipeline.md
@@ -85,18 +85,30 @@ aggregation is a different operation:
   high- and low-confidence pixels, and you can't recover the
   high-confidence-only mean from the result.
 
-Worked example: HRU with 50% high-CI snowy pixels (snow=80, ci=0.9) and 50%
-low-CI cloud pixels (snow=20, ci=0.3):
+Worked example (CI in native 0–100 scale, threshold > 70): HRU with 50%
+high-CI snowy pixels (snow=80, ci=90) and 50% low-CI cloud pixels (snow=20,
+ci=30):
 
 - Pre-aggregation gating: only high-CI pixels survive, mean snow = 80,
-  mean ci = 0.9. ✅ The half of the HRU we can see is snowy.
-- Post-aggregation gating with threshold ci > 0.70: HRU-mean snow = 50,
-  HRU-mean ci = 0.6 → masked NaN. ❌ We've thrown away the trustworthy
+  mean ci = 90. ✅ The half of the HRU we can see is snowy.
+- Post-aggregation gating with threshold ci > 70: HRU-mean snow = 50,
+  HRU-mean ci = 60 → masked NaN. ❌ We've thrown away the trustworthy
   half *and* the untrustworthy half.
 
 The information loss is asymmetric: pre-aggregation gating preserves the
 valid signal even when an HRU is partly contaminated; post-aggregation
 gating either contaminates the mean or discards the whole HRU.
+
+**Anti-pattern to watch for.** Once `valid_area_fraction` exists in the
+aggregated NC, it is tempting to use it as a downstream gate
+(`drop HRUs where valid_area_fraction < 0.7`) on the assumption that this
+is equivalent to the pre-aggregation per-pixel gate. It is not. The
+per-pixel gate has already run, so `valid_area_fraction` reports how
+much of the HRU's source-grid area passed CI > 70 — gating on it again
+discards trustworthy partial-coverage HRUs that the pre-gate already
+selected for. Treat `valid_area_fraction` as a coverage diagnostic, not
+a re-applied threshold. If you need to handle low-coverage HRUs, the
+intended path is `normalize/methods.py` NN-fill.
 
 Concrete cases in this repo:
 

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -66,10 +66,22 @@ def build_masked_source(ds: xr.Dataset) -> xr.Dataset:
       values *or* where pixel CI ≤ 70.
     - ``Day_CMG_Clear_Index`` — native 0–100 integer scale, NaN at flag
       values only.
-    - ``valid_mask`` — 1.0 where pixel CI > 70, else 0.0. After
-      area-weighted aggregation this becomes ``valid_area_fraction``,
-      the HRU fraction with valid CI-passing observations.
+    - ``valid_mask`` — 1.0 where pixel CI > 70, else 0.0 (including
+      flag-coded and fill cells, since ``NaN > 70`` is False). After
+      area-weighted aggregation this becomes ``valid_area_fraction``:
+      the fraction of the HRU's source-grid area whose pixels passed
+      the CI gate, counting unobserved (flag/fill/ocean) cells as
+      failing. Downstream NN-fill in ``normalize/methods.py`` is the
+      intended path for handling HRUs where this is too low.
     """
+    for var in ("Day_CMG_Snow_Cover", "Day_CMG_Clear_Index"):
+        if var not in ds.data_vars:
+            raise KeyError(
+                f"{_SOURCE_KEY}: pre_aggregate_hook expected raw variable "
+                f"{var!r}, found {list(ds.data_vars)}. The v006 → v061 "
+                f"rename is the most likely cause; check the consolidated "
+                f"NC layer in <datastore>/{_SOURCE_KEY}/."
+            )
     snow_masked = ds["Day_CMG_Snow_Cover"].where(ds["Day_CMG_Snow_Cover"] <= 100)
     ci_masked = ds["Day_CMG_Clear_Index"].where(ds["Day_CMG_Clear_Index"] <= 100)
     pass_mask = ci_masked > _CI_THRESHOLD_NATIVE
@@ -121,8 +133,12 @@ def _rename_valid_mask(year_ds: xr.Dataset) -> xr.Dataset:
 
     After area-weighted aggregation, the per-pixel 0/1 ``valid_mask``
     becomes a per-HRU fraction in [0, 1] — the share of HRU area whose
-    pixels passed the CI filter. The rename makes the post-aggregation
-    semantic explicit.
+    pixels passed the CI filter. Unobserved cells (flag/fill/ocean) are
+    counted as failing, so a partly-ocean HRU and a fully-cloudy HRU
+    can present the same low ``valid_area_fraction``; the downstream
+    NN-fill step in ``normalize/methods.py`` is the path that
+    distinguishes them. The rename makes the post-aggregation semantic
+    explicit.
     """
     year_ds = year_ds.rename({"valid_mask": "valid_area_fraction"})
     year_ds["valid_area_fraction"].attrs = {

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -368,6 +368,50 @@ def test_mod10c1_adapter_declares_raw_grid_variable():
     assert ADAPTER.raw_grid_variable == ADAPTER.grid_variable
 
 
+def test_mod10c1_adapter_triggers_grid_drift_on_shape_mismatch(tmp_path, tiny_fabric):
+    """Behavioral teeth for the MOD10C1 ADAPTER: under A2 the pre-hook
+    runs and ``raw_grid_variable`` overlaps ``variables``. The unit-level
+    relaxed assertion above pins the wiring; this integration check
+    proves the wiring actually reaches the cross-year drift check."""
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+    from nhf_spatial_targets.aggregate.mod10c1 import ADAPTER
+
+    src_dir = _setup_aggregate_source_project(tmp_path, tiny_fabric, "mod10c1_v061")
+    t0 = pd.date_range("2000-01-01", periods=2, freq="D")
+    t1 = pd.date_range("2001-01-01", periods=2, freq="D")
+    xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (["time", "lat", "lon"], np.zeros((2, 2, 2))),
+            "Day_CMG_Clear_Index": (["time", "lat", "lon"], np.ones((2, 2, 2)) * 100),
+        },
+        coords={
+            "time": ("time", t0, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "mod10c1_2000_consolidated.nc")
+    xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (["time", "lat", "lon"], np.zeros((2, 3, 3))),
+            "Day_CMG_Clear_Index": (["time", "lat", "lon"], np.ones((2, 3, 3)) * 100),
+        },
+        coords={
+            "time": ("time", t1, {"standard_name": "time"}),
+            "lat": ("lat", [0.2, 0.5, 0.8], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.2, 0.5, 0.8], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_dir / "mod10c1_2001_consolidated.nc")
+
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.catalog_source",
+        return_value={"access": {"type": "local_nc"}},
+    ):
+        with pytest.raises(ValueError, match="grid shape drift"):
+            aggregate_source(
+                ADAPTER, fabric_path=tiny_fabric, id_col="hru_id", workdir=tmp_path
+            )
+
+
 def test_source_adapter_coerces_list_to_tuple():
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 

--- a/tests/test_aggregate_mod10c1.py
+++ b/tests/test_aggregate_mod10c1.py
@@ -82,6 +82,38 @@ def test_build_masked_source_strict_threshold_at_70():
     assert out["valid_mask"].isel(time=0).values[0, 0] == 0.0
 
 
+def test_build_masked_source_ci_just_above_threshold_passes():
+    """Symmetric to the CI=70 test: CI=71 must pass. Catches a `>=` slip
+    that would change the keep-side semantics on integer CI inputs."""
+    times = pd.date_range("2000-01-01", periods=1, freq="D")
+    snow = np.array([[[50.0]]])
+    ci = np.array([[[71.0]]])  # just above threshold -> keep
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (["time", "lat", "lon"], snow),
+            "Day_CMG_Clear_Index": (["time", "lat", "lon"], ci),
+        },
+        coords={"time": times, "lat": [0.25], "lon": [0.5]},
+    )
+    out = build_masked_source(ds)
+    assert np.isclose(out["Day_CMG_Snow_Cover"].isel(time=0).values[0, 0], 50.0)
+    assert out["valid_mask"].isel(time=0).values[0, 0] == 1.0
+
+
+def test_build_masked_source_raises_on_missing_input_variable():
+    """If the raw NC is missing the expected variable (e.g. a future
+    product rename like v006 → v061), the pre-hook must raise with
+    source-key context — not let xarray's bare KeyError surface from
+    deep inside the per-year aggregation loop."""
+    times = pd.date_range("2000-01-01", periods=1, freq="D")
+    ds = xr.Dataset(
+        {"Day_CMG_Snow_Cover": (["time", "lat", "lon"], np.zeros((1, 1, 1)))},
+        coords={"time": times, "lat": [0.25], "lon": [0.5]},
+    )
+    with pytest.raises(KeyError, match="mod10c1_v061.*Day_CMG_Clear_Index"):
+        build_masked_source(ds)
+
+
 def test_build_masked_source_day_with_all_low_ci_yields_all_nan_snow_cover():
     """If every cell fails the CI filter, Day_CMG_Snow_Cover is entirely NaN
     and valid_mask is 0."""


### PR DESCRIPTION
Closes #79.

## Summary

Cherry-pick of `dab5866` (originally on the PR #78 branch but unpushed at squash-merge time). Lands the review findings from `/pr-review-toolkit:review-pr` against the merged A2 work.

- Doc: rewrite the `transformation-pipeline.md` worked example in native 0–100 CI scale to match the rest of the doc and the code (was fractional `0.9` / `0.3`).
- Doc: add an anti-pattern note warning against using `valid_area_fraction > 0.7` as a downstream substitute for the per-pixel CI gate; point at `normalize/methods.py` NN-fill as the intended path for low-coverage HRUs.
- Code: raise `KeyError` with source-key + datastore-path context if `Day_CMG_Snow_Cover` / `Day_CMG_Clear_Index` is missing from the raw NC, so a future v06x → v07x rename fails loud rather than surfacing a bare xarray KeyError from inside the per-year aggregation loop.
- Code: docstring clarification — `valid_area_fraction` counts unobserved cells (flag/fill/ocean) as failing.
- Tests (+3, 489 total): CI=71 keep-side boundary, missing-input-variable contextual KeyError, MOD10C1 ADAPTER integration check that the A2-era `raw_grid_variable in variables` configuration still reaches the cross-year grid-drift check.

## Behavioral impact

None on aggregated values. The new `KeyError` guard fires only on absent variables (which v061 raw NCs have), the doc edits are text, and the new tests are pytest-only. Re-aggregation is **not** required.

## Test plan

- [x] `pixi run -e dev fmt-check` — clean.
- [x] `pixi run -e dev lint` — clean.
- [x] `pixi run -e dev test` — 489 passed, 15 deselected (integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)