### PR TITLE
fix(fetch): mwbm_climgrid — warn when publisher omits cell_methods

### DIFF
--- a/src/nhf_spatial_targets/fetch/mwbm_climgrid.py
+++ b/src/nhf_spatial_targets/fetch/mwbm_climgrid.py
@@ -130,6 +130,23 @@ def _validate_nc(nc_path: Path, meta: dict) -> None:
             if expected is None:
                 continue
             actual = ds[name].attrs.get("cell_methods")
+            if actual is None:
+                # Publisher omitted the attr (confirmed for ClimGrid_WBM.nc:
+                # all four variables ship with units / long_name /
+                # standard_name but no cell_methods). The catalog
+                # declaration stands as documented provenance — MWBM
+                # runoff IS a monthly sum — but we don't enforce against
+                # a silent file.
+                logger.warning(
+                    "%s: variable %r has no cell_methods attribute; "
+                    "catalog declares %r. Treating catalog as "
+                    "authoritative provenance (publisher metadata gap, "
+                    "not a contradiction).",
+                    nc_path.name,
+                    name,
+                    expected,
+                )
+                continue
             if actual != expected:
                 raise RuntimeError(
                     f"{nc_path.name}: variable {name!r} has "

--- a/tests/test_fetch_mwbm_climgrid.py
+++ b/tests/test_fetch_mwbm_climgrid.py
@@ -288,7 +288,7 @@ def _write_dummy_nc_with_bad_cell_methods(path: Path) -> None:
 
 
 def test_rejects_mismatched_cell_methods(tmp_path):
-    """Publisher metadata divergence from catalog raises a clear error."""
+    """Non-None publisher cell_methods that disagrees with catalog raises."""
     workdir = _make_project(tmp_path)
     nc_dir = workdir / "datastore" / "mwbm_climgrid"
     nc_dir.mkdir(parents=True)
@@ -298,6 +298,82 @@ def test_rejects_mismatched_cell_methods(tmp_path):
         fetch_mwbm_climgrid(workdir=workdir, period="1900/1900")
     # Manifest must NOT exist — failed validation must not write provenance.
     assert not (workdir / "manifest.json").exists()
+
+
+def _write_dummy_nc_without_cell_methods(path: Path) -> None:
+    """Like _write_dummy_nc but strips cell_methods on every variable.
+
+    Mirrors the real ClimGrid_WBM.nc, where the publisher ships units /
+    standard_name / long_name but omits cell_methods.
+    """
+    import pandas as pd
+
+    times = pd.date_range("1900-01-01", periods=2, freq="MS")
+    lats = np.array([40.0, 40.5], dtype=np.float64)
+    lons = np.array([-105.0, -104.5], dtype=np.float64)
+    rng = np.random.default_rng(0)
+    attrs_no_cm = {"units": "mm", "long_name": "x", "standard_name": "x"}
+    ds = xr.Dataset(
+        data_vars={
+            "runoff": (
+                ("time", "latitude", "longitude"),
+                rng.random((2, 2, 2)),
+                attrs_no_cm,
+            ),
+            "aet": (
+                ("time", "latitude", "longitude"),
+                rng.random((2, 2, 2)),
+                attrs_no_cm,
+            ),
+            "soilstorage": (
+                ("time", "latitude", "longitude"),
+                rng.random((2, 2, 2)),
+                attrs_no_cm,
+            ),
+            "swe": (
+                ("time", "latitude", "longitude"),
+                rng.random((2, 2, 2)),
+                attrs_no_cm,
+            ),
+        },
+        coords={
+            "time": ("time", times),
+            "latitude": ("latitude", lats, {"units": "degrees_north", "axis": "Y"}),
+            "longitude": ("longitude", lons, {"units": "degrees_east", "axis": "X"}),
+        },
+    )
+    ds["time"].attrs.update({"axis": "T", "standard_name": "time"})
+    ds.to_netcdf(path)
+    ds.close()
+
+
+def test_missing_cell_methods_warns_does_not_raise(tmp_path, caplog):
+    """Silent cell_methods (publisher gap) → warn + register, do NOT raise.
+
+    Mirrors the real ClimGrid_WBM.nc: the publisher ships units and
+    standard_name but no cell_methods. The catalog declaration of
+    `time: sum` etc. is documented provenance, not a hard claim about
+    file attrs, so a silent file is acceptable as long as variables
+    and units check out.
+    """
+    workdir = _make_project(tmp_path)
+    nc_dir = workdir / "datastore" / "mwbm_climgrid"
+    nc_dir.mkdir(parents=True)
+    nc_path = nc_dir / "ClimGrid_WBM.nc"
+    _write_dummy_nc_without_cell_methods(nc_path)
+
+    with caplog.at_level("WARNING", logger="nhf_spatial_targets.fetch.mwbm_climgrid"):
+        result = fetch_mwbm_climgrid(workdir=workdir, period="1900/1900")
+
+    # Manifest WAS written — the file is acceptable.
+    assert (workdir / "manifest.json").exists()
+    assert result["file"]["sha256"]
+
+    # Each declared variable that lost its cell_methods got a warning.
+    warning_text = "\n".join(r.getMessage() for r in caplog.records)
+    for var in ("runoff", "aet", "soilstorage", "swe"):
+        assert var in warning_text, f"missing warning for {var!r}"
+    assert "no cell_methods attribute" in warning_text
 
 
 def test_rejects_missing_variable(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #76. The squash-merge of #76 did not include the
cell_methods-softening commit that landed on the branch after the
HPC dry run uncovered the issue. Re-applies that fix here.

The real `ClimGrid_WBM.nc` ships `units`, `long_name`, and
`standard_name` on every variable but no `cell_methods`. The catalog's
`cell_methods: time: sum` (etc.) is documented provenance — MWBM
runoff IS a monthly sum — not a hard claim about on-disk attrs.

`_validate_nc` now treats a `None` attr as a publisher gap (logs a
warning, continues). A non-`None` attr that disagrees with the
catalog still raises (real divergence, not a gap).

## Test plan

- [x] `pixi run -e dev fmt-check`
- [x] `pixi run -e dev lint`
- [x] `pixi run -e dev test` — 516 passed (was 515; new test
      `test_missing_cell_methods_warns_does_not_raise` pins the
      new behaviour against a fixture mirroring the publisher's
      actual metadata shape)
- [ ] On HPC: re-run `sbatch --array=10 fetch_all.slurm`; expect
      four warning lines (one per variable) and a successful
      manifest entry write rather than the prior RuntimeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)