### PR TITLE
feat(agg): --period flag to clip per-year aggregation window

### DIFF
--- a/agg_all.slurm
+++ b/agg_all.slurm
@@ -61,17 +61,41 @@ AGG_TASKS=(
     "agg-mwbm-climgrid" # 10 — USGS MWBM (ClimGrid) (2.5 arcmin monthly, 4 vars)
 )
 
+# Optional --period override per task. Empty string means "no clip"; the
+# aggregator iterates every year present in the source files. Used by
+# monolithic single-file sources (mwbm-climgrid: 1895-2020 in one NC)
+# where the fetch period is provenance-only and can't subset bytes —
+# clip at agg time instead. Indices align with AGG_TASKS.
+AGG_PERIODS=(
+    ""              # 0  era5-land
+    ""              # 1  gldas
+    ""              # 2  merra2
+    ""              # 3  ncep-ncar
+    ""              # 4  nldas-mosaic
+    ""              # 5  nldas-noah
+    ""              # 6  watergap22d
+    ""              # 7  reitz2017
+    ""              # 8  mod16a2
+    ""              # 9  mod10c1
+    "1979/2020"     # 10 mwbm-climgrid (publisher: 1895-2020; clip to NHM window, drop spinup)
+)
+
 if (( SLURM_ARRAY_TASK_ID < 0 || SLURM_ARRAY_TASK_ID >= ${#AGG_TASKS[@]} )); then
     echo "ERROR: SLURM_ARRAY_TASK_ID=$SLURM_ARRAY_TASK_ID out of range [0, ${#AGG_TASKS[@]})" >&2
     exit 2
 fi
 
 TASK="${AGG_TASKS[$SLURM_ARRAY_TASK_ID]}"
-echo "=== Array task $SLURM_ARRAY_TASK_ID: $TASK  batch_size=$BATCH_SIZE ==="
+PERIOD="${AGG_PERIODS[$SLURM_ARRAY_TASK_ID]}"
+echo "=== Array task $SLURM_ARRAY_TASK_ID: $TASK  batch_size=$BATCH_SIZE  period=${PERIOD:-<none>} ==="
 echo "=== Project: $PROJECT_DIR ==="
 echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 echo "=== Host:    $(hostname) ==="
 
-pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --batch-size "$BATCH_SIZE"
+if [ -n "$PERIOD" ]; then
+    pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --batch-size "$BATCH_SIZE" --period "$PERIOD"
+else
+    pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --batch-size "$BATCH_SIZE"
+fi
 
 echo "=== Done:  $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/docs/sources/mwbm_climgrid.md
+++ b/docs/sources/mwbm_climgrid.md
@@ -43,11 +43,22 @@ provenance in `manifest.json`.
    `mwbm_climgrid` entry to `manifest.json`. Subsequent invocations
    re-verify the fingerprint and short-circuit if it matches.
 
-6. Aggregate to the HRU fabric as usual:
+6. Aggregate to the HRU fabric. The publisher distributes a single
+   1895–2020 NetCDF, so the aggregator processes every year in the
+   file by default. Pass `--period` to clip the per-year output to the
+   window you actually want (e.g. drop the publisher's 1895–1899
+   spinup and anything outside the NHM run window):
 
    ```bash
-   pixi run nhf-targets agg mwbm-climgrid --project-dir /data/nhf-runs/my-run
+   pixi run nhf-targets agg mwbm-climgrid \
+       --project-dir /data/nhf-runs/my-run \
+       --period 1979/2020
    ```
+
+   Without `--period`, ~125 per-year aggregated NetCDFs are written
+   (1895/96 through 2020). The HPC SLURM script `agg_all.slurm`
+   passes `1979/2020` for the mwbm-climgrid task by default; edit
+   `AGG_PERIODS[10]` to change it.
 
 ## Sharing across projects
 

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -610,6 +610,7 @@ def aggregate_source(
     id_col: str,
     workdir: Path,
     batch_size: int = 500,
+    period: str | None = None,
 ) -> None:
     """Aggregate a source to fabric HRU polygons; emit per-year NCs.
 
@@ -688,6 +689,31 @@ def aggregate_source(
                 )
 
     year_files = enumerate_years(files)
+    if period is not None:
+        # Filter year_files to the operator-requested window. Useful for
+        # monolithic single-file sources (mwbm_climgrid: 1895-2020 in one
+        # NC) where the fetch period is provenance-only and can't subset
+        # bytes — the operator clips here at agg time instead.
+        from nhf_spatial_targets.fetch._period import parse_period
+
+        parse_period(period)  # validate format
+        start_year, end_year = (int(p) for p in period.split("/"))
+        before = len(year_files)
+        all_years = [y for y, _ in year_files]
+        year_files = [(y, p) for y, p in year_files if start_year <= y <= end_year]
+        if not year_files:
+            raise ValueError(
+                f"{adapter.source_key}: --period {period!r} excludes every "
+                f"year in the source files. Source covers "
+                f"{min(all_years)}-{max(all_years)}."
+            )
+        logger.info(
+            "%s: --period %s clipped %d → %d years",
+            adapter.source_key,
+            period,
+            before,
+            len(year_files),
+        )
     fabric_batched = load_and_batch_fabric(fabric_path, batch_size=batch_size)
     n_batches = int(fabric_batched["batch_id"].nunique())
     logger.info(

--- a/src/nhf_spatial_targets/aggregate/mwbm_climgrid.py
+++ b/src/nhf_spatial_targets/aggregate/mwbm_climgrid.py
@@ -17,12 +17,25 @@ ADAPTER = SourceAdapter(
 
 
 def aggregate_mwbm_climgrid(
-    fabric_path: Path, id_col: str, workdir: Path, batch_size: int = 500
+    fabric_path: Path,
+    id_col: str,
+    workdir: Path,
+    batch_size: int = 500,
+    period: str | None = None,
 ) -> None:
+    """Aggregate the MWBM ClimGrid source to HRU polygons.
+
+    The publisher distributes a single 1895-2020 NetCDF; pass ``period``
+    (e.g. ``"1979/2020"``) to clip the per-year output to a specific
+    window, otherwise every year in the file is aggregated. The
+    publisher's 1895-1899 spinup is not auto-skipped — clip it via
+    ``period`` if you don't want it.
+    """
     aggregate_source(
         ADAPTER,
         fabric_path,
         id_col,
         workdir,
         batch_size,
+        period=period,
     )

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -1091,8 +1091,14 @@ def _run_tier_agg(
     label: str,
     workdir: Path,
     batch_size: int,
+    period: str | None = None,
 ) -> None:
-    """Common boilerplate for tier-1/tier-2 aggregator CLI wrappers."""
+    """Common boilerplate for tier-1/tier-2 aggregator CLI wrappers.
+
+    ``period`` is forwarded to ``aggregate_fn`` only when set, so
+    aggregators that don't accept it (most sources, where fetch already
+    clips by file) are unaffected.
+    """
     from rich.console import Console
 
     if not workdir.exists():
@@ -1115,14 +1121,20 @@ def _run_tier_agg(
     id_col = cfg["fabric"].get("id_col", "nhm_id")
 
     console = Console()
-    console.print(f"[bold]Aggregating {label} (batch_size={batch_size})...[/bold]")
+    period_suffix = f", period={period}" if period is not None else ""
+    console.print(
+        f"[bold]Aggregating {label} (batch_size={batch_size}{period_suffix})...[/bold]"
+    )
     try:
-        aggregate_fn(
-            fabric_path=fabric_path,
-            id_col=id_col,
-            workdir=workdir,
-            batch_size=batch_size,
-        )
+        kwargs = {
+            "fabric_path": fabric_path,
+            "id_col": id_col,
+            "workdir": workdir,
+            "batch_size": batch_size,
+        }
+        if period is not None:
+            kwargs["period"] = period
+        aggregate_fn(**kwargs)
     except (ValueError, FileNotFoundError, RuntimeError) as exc:
         print(f"Error ({type(exc).__name__}): {exc}", file=sys.stderr)
         sys.exit(1)
@@ -1233,9 +1245,28 @@ def agg_mod10c1_cmd(
 def agg_mwbm_climgrid_cmd(
     workdir: Annotated[Path, Parameter(name=["--project-dir"])],
     batch_size: Annotated[int, Parameter(name="--batch-size")] = 500,
+    period: Annotated[
+        str | None,
+        Parameter(
+            name=["--period", "-p"],
+            help=(
+                "Optional 'YYYY/YYYY' clip applied to the per-year output. "
+                "ClimGrid_WBM.nc spans 1895-2020 in a single file; pass e.g. "
+                "'1979/2020' to skip the publisher's spinup years and "
+                "anything outside the NHM run window. Omit to aggregate "
+                "every year in the file."
+            ),
+        ),
+    ] = None,
 ):
     """Aggregate USGS MWBM (ClimGrid-forced) monthly outputs to HRU polygons."""
-    _run_tier_agg(aggregate_mwbm_climgrid, "MWBM (ClimGrid)", workdir, batch_size)
+    _run_tier_agg(
+        aggregate_mwbm_climgrid,
+        "MWBM (ClimGrid)",
+        workdir,
+        batch_size,
+        period=period,
+    )
 
 
 @agg_app.command(name="all")

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -262,6 +262,150 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
     ]
 
 
+def test_aggregate_source_period_filter_clips_year_files(tmp_path, tiny_fabric):
+    """`period` filters multi-year sources to the requested window only.
+
+    Pins the contract for monolithic single-file sources (mwbm_climgrid:
+    1895-2020 in one NC) where the operator clips at agg time.
+    """
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    datastore = tmp_path / "datastore"
+    (datastore / "merra2").mkdir(parents=True)
+    src_nc = datastore / "merra2" / "merra2_consolidated.nc"
+    # 4 years × 12 months: 2000-2003.
+    times = pd.date_range("2000-01-01", periods=48, freq="MS")
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((48, 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_nc)
+
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": str(tiny_fabric), "id_col": "hru_id"},
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["a"]
+    )
+    fake_meta = {"access": {"type": "local_nc"}}
+
+    def _make_year_ds(year: int) -> xr.Dataset:
+        yt = pd.date_range(f"{year}-01-01", periods=12, freq="MS")
+        return xr.Dataset(
+            {"a": (["time", "hru_id"], np.ones((12, 4)))},
+            coords={
+                "time": ("time", yt, {"standard_name": "time"}),
+                "hru_id": [0, 1, 2, 3],
+            },
+        )
+
+    # Side-effect: each call to aggregate_variables_for_batch returns the
+    # year-appropriate Dataset, keyed off the year embedded in the time
+    # axis the driver passes through.
+    call_years: list[int] = []
+
+    def _fake_agg(*_args, **kwargs):
+        # The year-specific time slice is built upstream; recover the
+        # year from the slice the driver opens. Easier: peek the file
+        # the driver passed and report the year via the recorded list.
+        # We rely on the year being threaded via the call ordering
+        # established by enumerate_years (sorted ascending).
+        year = 2000 + len(call_years)
+        call_years.append(year)
+        return _make_year_ds(year)
+
+    with (
+        patch(
+            "nhf_spatial_targets.aggregate._driver.catalog_source",
+            return_value=fake_meta,
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.compute_or_load_weights",
+            return_value=_fake_weights(),
+        ),
+        patch(
+            "nhf_spatial_targets.aggregate._driver.aggregate_variables_for_batch",
+            side_effect=_fake_agg,
+        ),
+    ):
+        aggregate_source(
+            adapter,
+            fabric_path=tiny_fabric,
+            id_col="hru_id",
+            workdir=tmp_path,
+            batch_size=500,
+            period="2001/2002",
+        )
+
+    per_source_dir = tmp_path / "data" / "aggregated" / "merra2"
+    written = sorted(p.name for p in per_source_dir.glob("merra2_*_agg.nc"))
+    # 2000 and 2003 must be excluded; 2001 and 2002 must be present.
+    assert written == ["merra2_2001_agg.nc", "merra2_2002_agg.nc"]
+
+
+def test_aggregate_source_period_filter_excludes_all_raises(tmp_path, tiny_fabric):
+    """`period` outside the file's coverage raises rather than silently no-op."""
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import aggregate_source
+
+    datastore = tmp_path / "datastore"
+    (datastore / "merra2").mkdir(parents=True)
+    src_nc = datastore / "merra2" / "merra2_consolidated.nc"
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    xr.Dataset(
+        {"a": (["time", "lat", "lon"], np.ones((12, 2, 2)))},
+        coords={
+            "time": ("time", times, {"standard_name": "time"}),
+            "lat": ("lat", [0.25, 0.75], {"standard_name": "latitude"}),
+            "lon": ("lon", [0.5, 1.5], {"standard_name": "longitude"}),
+        },
+    ).to_netcdf(src_nc)
+
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {"path": str(tiny_fabric), "id_col": "hru_id"},
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
+    (tmp_path / "data" / "aggregated").mkdir(parents=True)
+    (tmp_path / "weights").mkdir()
+
+    adapter = SourceAdapter(
+        source_key="merra2", output_name="merra2_agg.nc", variables=["a"]
+    )
+    with patch(
+        "nhf_spatial_targets.aggregate._driver.catalog_source",
+        return_value={"access": {"type": "local_nc"}},
+    ):
+        with pytest.raises(ValueError, match="excludes every year"):
+            aggregate_source(
+                adapter,
+                fabric_path=tiny_fabric,
+                id_col="hru_id",
+                workdir=tmp_path,
+                batch_size=500,
+                period="2010/2011",
+            )
+
+
 def test_source_adapter_rejects_empty_variables():
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 


### PR DESCRIPTION
## Summary

The aggregation driver enumerates every year in a source's files. For
monolithic single-file sources (mwbm_climgrid: 1895–2020 in one NC),
the fetch period is provenance-only and can't subset bytes, so without
an agg-time clip you get ~125 per-year files including the publisher's
1895–1899 spinup and everything outside the NHM run window. Add an
optional `--period` to `agg mwbm-climgrid` and an aligned `AGG_PERIODS`
array in the SLURM script, threading the value into the driver as a
`(year, file)` filter.

- New parameter: `aggregate_source(..., period: str | None = None)`.
  After `enumerate_years`, filter to `start_year <= y <= end_year`.
  Empty intersection raises a clear error including the source's
  actual covered range.
- `aggregate_mwbm_climgrid` and the `agg mwbm-climgrid` CLI both
  accept `period`. `_run_tier_agg` forwards it only when set, so
  other aggregators are unaffected.
- `agg_all.slurm` grows `AGG_PERIODS` parallel to `AGG_TASKS`;
  mwbm-climgrid (task 10) defaults to `1979/2020`. The script passes
  `--period` only for tasks with a non-empty entry.
- `docs/sources/mwbm_climgrid.md` updated with the new flag.

## Test plan

- [x] `pixi run -e dev fmt-check`
- [x] `pixi run -e dev lint`
- [x] `pixi run -e dev test` — 517 passed (was 515; two new tests
      cover the clip path and the exclude-everything error)
- [ ] On HPC: `sbatch --array=10 agg_all.slurm`; expect per-year files
      `mwbm_climgrid_1979_agg.nc`–`mwbm_climgrid_2020_agg.nc` only,
      and a log line `mwbm_climgrid: --period 1979/2020 clipped 125 → 42 years`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)