### PR TITLE
docs: refresh after PR fix/83 + add lessons-learned page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ See `catalog/sources.yml` `status:` and `notes:` fields for per-source gaps.
 
 **Still open:**
 - SCA CI-bounds formula — PRMSobjfun.f not publicly available; formula unconfirmed
+- MOD16A2 v061 flat-on-CONUS+ seasonality — July 2000 inspection (`notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb`) shows Jul/Jan = 1.12× vs SSEBop / MWBM 6–11× expected. Inclusion in the AET multi-source min/max bound is **pending collaborator consensus**; see `docs/references/lessons-learned.md` § MOD16A2 v061 flat-on-CONUS+.
 
 **Resolved (previously open):**
 - SSEBop — accessed via USGS NHGF STAC catalog (collection `ssebopeta_monthly`, doi:10.5066/P9L2YMV, 2000–2023 monthly, 1km). Aggregated directly to HRU fabric via gdptools — no local download. See PR #34.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ Builds the five baseline calibration targets documented in [Hay and others (2022
 | Target | PRMS Variable | Sources | Method | Time Step |
 |---|---|---|---|---|
 | Runoff | `basin_cfs` | ERA5-Land (`ro`) + GLDAS-2.1 NOAH (`Qs_acc + Qsb_acc`) | Multi-source min/max | Monthly |
-| AET | `hru_actet` | MOD16A2 v061 + SSEBop | Multi-source min/max | Monthly |
+| AET | `hru_actet` | SSEBop + MWBM (ClimGrid) + MOD16A2 v061¹ | Multi-source min/max | Monthly |
 | Recharge | `recharge` | Reitz 2017 + WaterGAP 2.2d + ERA5-Land (`ssro`) | Normalized min/max | Annual |
 | Soil Moisture | `soil_rechr` | MERRA-2 + NCEP/NCAR + NLDAS-MOSAIC + NLDAS-NOAH | Normalized min/max | Monthly + Annual |
 | Snow Cover | `snowcov_area` | MOD10C1 v061 | MODIS CI bounds | Daily |
+
+¹ MOD16A2 v061 inclusion in the AET bound is **pending collaborator consensus** —
+the July 2000 inspection found it reads essentially flat across the seasonal
+cycle on CONUS+ while SSEBop and MWBM swing 6–11×. See
+[`docs/references/lessons-learned.md`](docs/references/lessons-learned.md)
+§ MOD16A2 v061 flat-on-CONUS+ for the full finding.
 
 ## Quick Start
 
@@ -173,6 +179,7 @@ Each `fetch` command downloads source granules and consolidates them into a sing
 | MOD10C1 v061 | `fetch mod10c1` | earthaccess (daily HDF4, 0.05&deg;) | `mod10c1_v061_{year}_consolidated.nc` |
 | WaterGAP 2.2d | `fetch watergap22d` | pangaeapy (single NC4) | `watergap22d_qrdif_cf.nc` |
 | Reitz 2017 | `fetch reitz2017` | sciencebasepy (annual GeoTIFF) | `reitz2017_consolidated.nc` |
+| MWBM (ClimGrid) | `fetch mwbm-climgrid` | manual download (ScienceBase, CAPTCHA-gated 7.5 GB NC) | `ClimGrid_WBM.nc` |
 
 All fetch commands support **incremental download** — periods already recorded in `manifest.json` are skipped.
 

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -161,6 +161,13 @@ sources:
     units: kg/m2/8day
     license: public domain (NASA)
     status: current
+    notes: >
+      July 2000 cross-check (notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb)
+      shows essentially flat seasonality at both gridded and aggregated CONUS+
+      scales (Jul/Jan = 1.12x) while SSEBop and MWBM swing 6-11x as expected
+      for CONUS ET. The flatness is already in the consolidated NC, not an
+      aggregation artefact. Inclusion in the AET target is pending collaborator
+      consensus; see docs/references/lessons-learned.md (MOD16A2 v061 flat-on-CONUS+).
 
   ssebop:
     name: SSEBop Actual Evapotranspiration

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -64,7 +64,11 @@ variables:
       mwbm_climgrid contributes the MWBM-family AET trace
       (Wieczorek et al. 2024, mm/month native). Consumption by the
       AET target builder is gated on targets/aet.py being implemented
-      (currently a NotImplementedError stub).
+      (currently a NotImplementedError stub). MOD16A2 v061 inclusion
+      in the bound is pending collaborator consensus per the July 2000
+      inspection finding (see docs/references/lessons-learned.md);
+      targets/aet.py should accept a `sources` override from project
+      config until that decision is finalised.
     normalize: false
     output_format: netcdf
 

--- a/docs/references/calibration-target-recipes.md
+++ b/docs/references/calibration-target-recipes.md
@@ -132,6 +132,23 @@ Per-HRU per-month: `lower_bound = min(ssebop, mod16a2, mwbm)`,
   error propagates straight into the `min` bound. Use the overlap-weighted
   formula above; do not skip it.
 
+**Open decisions (pending collaborator consensus)**
+
+- **MOD16A2 v061 inclusion.** The July 2000 cross-check in
+  `notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb` shows MOD16A2 v061
+  is essentially flat across the seasonal cycle on the CONUS+ aggregation
+  (Jul/Jan = 1.12×) while SSEBop and MWBM swing 6–11× as expected for CONUS
+  ET. The flatness is present at both gridded and aggregated scales, so it is
+  already in the consolidated NC, not an aggregation artefact. In both January
+  and July MOD16A2 sets one end of the multi-source min/max bound and pulls
+  it away from where SSEBop and MWBM agree — the opposite of what the bound
+  is meant to do. Whether to keep MOD16A2 in the bound, drop it, or wait for
+  v062 / a v061 reprocess is **pending collaborator consensus**. Until then,
+  `targets/aet.py` should accept a `sources` override from project config so
+  the decision can be applied without a code change. See
+  `docs/references/lessons-learned.md` § MOD16A2 v061 flat-on-CONUS+ for the
+  full finding and the per-month evidence.
+
 ---
 
 ### 3. Recharge (RCH)
@@ -164,6 +181,15 @@ ERA5-Land: monthly, end-of-month.
 Reitz is CONUS-only at 0.0083° (1 km). WaterGAP and ERA5-Land are global / CONUS+. For
 inspection, the recharge notebook clips all three to ERA5-Land's footprint; the target
 builder should aggregate each to HRUs and then operate per-HRU.
+
+**Datastore files**
+
+- Reitz: `<datastore>/reitz2017/reitz2017_consolidated.nc` (annual, time mid-year).
+- WaterGAP: `<datastore>/watergap22d/watergap22d_qrdif_cf.nc` — CF-conformant rewrite
+  of the PANGAEA NC4 (`watergap_22d_WFDEI-GPCC_histsoc_qrdif_monthly_1901_2016.nc4`)
+  with decoded time so `sel(time=str(year))` works without manual cftime handling.
+- ERA5-Land: `<datastore>/era5_land/monthly/era5_land_monthly_{year}.nc` (per-year
+  monthly NCs, end-of-month timestamps).
 
 **Combination rule (TM 6-B10)**
 

--- a/docs/references/lessons-learned.md
+++ b/docs/references/lessons-learned.md
@@ -1,0 +1,197 @@
+# Lessons Learned
+
+Findings and operational notes accumulated while building the
+`nhf-spatial-targets` pipeline that don't fit cleanly into the per-target
+recipes (`calibration-target-recipes.md`) or the per-source catalog
+(`catalog/sources.yml`). Each entry documents *what we found* and *where
+the consequence lives in the code* so a future maintainer can re-evaluate
+the finding when the underlying data product changes.
+
+---
+
+## MOD16A2 v061 flat-on-CONUS+
+
+**Status:** open — pending collaborator consensus on whether to keep
+MOD16A2 v061 in the AET multi-source `min/max` bound.
+
+### What we found
+
+The July 2000 cross-check in
+`notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb` (commit
+`cce4ed6`, finding cell `55a87e3a`) compared the three AET sources at
+calendar-month cadence on a CONUS+ subset:
+
+| Source | Jan 2000 (mm/month) | Jul 2000 (mm/month) | Jul/Jan |
+|---|---|---|---|
+| SSEBop | 9.0 | 101.1 | **11.2×** |
+| MWBM (ClimGrid) | 12.5 | 77.8 | **6.2×** |
+| MOD16A2 v061 | 33.3 | 37.4 | **1.12×** |
+
+MOD16A2 v061 is essentially flat across the seasonal cycle while the
+other two products swing 6–11× as expected for CONUS ET. The flatness is
+present at both the gridded level (Jan 65.5 → Jul 70.0 = 1.07×) and the
+HRU-aggregated level, so it is already in the consolidated NC, not an
+aggregation artefact.
+
+### Why it matters
+
+The AET target uses `multi_source_minmax` over **absolute** mm/month —
+no 0–1 normalisation. In both January and July MOD16A2 sets one end of
+the bound and pulls it away from where SSEBop and MWBM agree:
+
+- January: `min = SSEBop (9), max = MOD16A2 (33)` → MOD16A2 sets the upper bound.
+- July: `min = MOD16A2 (37), max = SSEBop (101)` → MOD16A2 sets the lower bound.
+
+That is the opposite of what a multi-source error envelope is meant to
+do. SSEBop and MWBM agree to within ~30% in both seasons, and dropping
+MOD16A2 would give a tighter but more honest bound.
+
+### Possible causes (not yet investigated)
+
+- Over-eager flag masking on the consolidated NC (the `<= 3270` threshold
+  in `aggregate/mod16a2.py:_mask_et_fill` may be removing real low-ET
+  pixels that the v061 GF gap-fill marks as flag-coded).
+- Consolidate-step averaging that homogenises composites across the year.
+- Genuine v061 GF behaviour on our CONUS+ tile selection, possibly fixed
+  in a future v061 reprocess or a v062 release.
+
+### Where to look in the code
+
+- Inspection notebook: `notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb`
+  (cells `38002926` for the time-series analysis, `55a87e3a` for the
+  finding).
+- Aggregation adapter: `src/nhf_spatial_targets/aggregate/mod16a2.py`.
+- Catalog entry: `catalog/sources.yml` → `mod16a2_v061` (`notes:` block).
+- Target builder (stub): `src/nhf_spatial_targets/targets/aet.py` —
+  should accept a `sources` override from project config until the
+  decision is finalised.
+
+---
+
+## WaterGAP gridded vs aggregated bbox mismatch
+
+**Status:** documented — no fix needed.
+
+The recharge inspection notebook's validation cell reports a ~41% gap
+between WaterGAP's HRU-aggregated mean and its native-grid mean for
+2000. This is much larger than the 5–30% gap we treat as "normal" for
+gridded vs aggregated cross-checks, but it is *intrinsic to a global
+0.5° grid clipped to a CONUS+ window*:
+
+- The unweighted gridded mean still includes a wide non-CONUS buffer.
+- After area-weighting to fabric HRUs, the dry interior US (low recharge)
+  is over-represented and the value drops well below the gridded number.
+
+A gap above 30% is not automatically a bug for global-grid sources. The
+check that *does* matter for absolute-magnitude comparability is the
+per-source order-of-magnitude sanity (Reitz CONUS-mean ≈ 123 mm/year vs
+the published 162 mm/year; WaterGAP ≈ 61 mm/year plausible for a
+diffuse-only flux; ERA5-Land `ssro` ≈ 100 mm/year plausible as a recharge
+proxy).
+
+The recharge target normalises each source 0–1 over the calibration
+window before computing per-HRU `min/max`, so absolute-magnitude
+divergence between the three is *not* a problem for the target — the
+optimisation targets relative year-to-year change.
+
+---
+
+## MOD16A2 flag-mask convention
+
+**Status:** stable convention; documented for cross-pipeline consistency.
+
+MOD16A2 v061 ET_500m stores int16-packed values 0–32700 (decoded 0–3270
+mm/8-day after `scale_factor=0.1`), with values **above 32700** reserved
+for special codes:
+
+| Raw value | Meaning |
+|---|---|
+| 32761 | water |
+| 32762 | barren |
+| 32763 | snow / ice |
+| 32764 | cloudy |
+| 32765 | (reserved) |
+| 32766 | no-data |
+| 32767 | not-processed |
+
+After `decode_cf=True` these become ~3276.x — not physical ET. The
+aggregation pipeline drops them via:
+
+```python
+ds["ET_500m"] = ds["ET_500m"].where(ds["ET_500m"] <= 3270.0)
+```
+
+(see `src/nhf_spatial_targets/aggregate/mod16a2.py:_mask_et_fill`).
+
+The same threshold is applied in the inspection notebook's gridded
+helper (`_mod16a2_target_month_gridded_mm` in
+`notebooks/inspect_aggregated/inspect_aggregated_aet.ipynb`); without
+it, ~37% of CONUS+ pixels in a typical January composite carry flag
+codes ≈ 3276 mm and the gridded mean reads ~10× too high. The mask is
+the same threshold in both paths so the two columns of the AET
+validation table compare like-for-like.
+
+---
+
+## MWBM is gridded, not polygon
+
+**Status:** corrected.
+
+Earlier wording in `calibration-target-recipes.md` §2 implied MWBM was
+distributed as a 1 km polygon mesh. It is in fact a regular gridded
+NetCDF: CONUS at ~0.042° (2.5 arcminute) on a lat/lon grid, in
+`<datastore>/mwbm_climgrid/ClimGrid_WBM.nc`, covering 1895–2020
+monthly. The recipe and inspection-notebook code now reflect this.
+
+---
+
+## Validation-cell limits
+
+**Status:** kept as a smoke test, not a quantitative validator.
+
+The `_gridded_mean_*` validation cells in the inspection notebooks
+compare the HRU-area-weighted fabric mean against an unweighted mean
+over the source's consolidated-NC bbox. Two systematic biases mean
+this is *not* like-for-like:
+
+1. **Bbox mismatch.** The consolidated bbox typically extends past the
+   fabric (CONUS+, global clip, etc.); the unweighted mean includes
+   non-fabric land that has different climate/recharge/ET than the
+   fabric mean.
+2. **Weighting mismatch.** The aggregated mean is Albers-area-weighted
+   over fabric HRUs; the gridded mean is unweighted.
+
+For CONUS-bounded sources whose bbox closely tracks the fabric (SSEBop,
+MWBM) the two columns agree to within a few percent — that's a
+meaningful correctness check. For global-grid sources clipped to a
+CONUS+ window (WaterGAP, MOD16A2 v061) the gap is dominated by the
+geometry mismatch and is not informative as a correctness check.
+
+A more diagnostic future cross-check would be a **per-HRU residual
+map** comparing the same aggregation run two ways (e.g.
+`stat_method="mean"` vs `stat_method="masked_mean"`, or two different
+weight CRSs). That would isolate aggregation-pipeline issues from
+geometry differences. The current validation cells were sufficient to
+catch the bugs we've actually had (MOD16A2 flag mask, recharge path
+errors), so the upgrade is a "next time" item, not an urgent fix.
+
+---
+
+## Per-source documentation gap
+
+**Status:** open follow-up.
+
+`docs/sources/` currently contains only `mwbm_climgrid.md`. The other
+nine source modules (`era5_land`, `gldas_noah`, `merra2`, `mod10c1_v061`,
+`mod16a2_v061`, `ncep_ncar`, `nldas_mosaic`, `nldas_noah`, `reitz2017`,
+`watergap22d`) have catalog entries with `notes:` blocks but no
+standalone `docs/sources/<source>.md`. This is fine for current
+contributors — the catalog is authoritative — but a new operator
+onboarding to the project will benefit from per-source quick-start
+docs that include manual-download procedures, expected disk size,
+license / credentials needed, and known consolidation gotchas.
+
+The `mwbm_climgrid.md` template is the model: title / description,
+manual-download steps, fingerprinting / placement, expected file
+layout in the datastore, and any gotchas. Track this work in a future
+issue rather than blocking on it for the current PR.


### PR DESCRIPTION
## Summary

- Bring `catalog/`, `docs/references/calibration-target-recipes.md`, `README.md`, and `CLAUDE.md` back in sync with the work merged in PR fix/83-ssebop-per-year-output (MOD16A2 8-day → monthly resample, MWBM gridded comparison, recharge validation paths, July cross-check finding).
- Add a new `docs/references/lessons-learned.md` page consolidating findings: MOD16A2 v061 flat-on-CONUS+ (pending consensus), WaterGAP gridded-vs-aggregated bbox mismatch, MOD16A2 flag-mask convention, MWBM-is-gridded correction, validation-cell limits, and the open per-source-docs gap.
- MOD16A2 v061 is **flagged as pending collaborator consensus** in the catalog, recipes, README, and CLAUDE.md — not pre-decided.

## Test plan

- [x] `pixi run -e dev fmt && lint && test` (551 passing, lint clean)
- [x] `cat.source('mod16a2_v061')['notes']` surfaces via the catalog Python API
- [x] `cat.variable('aet')['range_notes']` includes the MOD16A2 caveat
- [x] Reviewer eyeballs the new `lessons-learned.md` for tone / accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)