### PR TITLE
fix: canonical id_col-sorted HRU coords in target builder

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -102,6 +102,12 @@ def read_aggregated_source(
             f"Variable '{var}' not found in aggregated NCs for source "
             f"'{source_key}'. Available variables: {available}."
         )
+    # Canonical row order: HRU dim ascending by id_col. The aggregator (gdptools)
+    # writes rows in whatever order its upstream geometry table happens to use
+    # (often VPU-grouped); sorting here gives downstream code a stable invariant
+    # so positional checks against the fabric do not break on order alone.
+    # Tracked for emission-time enforcement in #93.
+    ds = ds.sortby(project.id_col)
     sliced = ds[var].sel(time=slice(period[0], period[1]))
     if sliced.sizes.get("time", 0) == 0:
         # Years parsed from sorted filenames -- avoids triggering dask compute
@@ -262,7 +268,7 @@ def compute_hru_area_and_centroids(project: Project) -> "pd.DataFrame":
     df["centroid_y"] = centroids_eq.y.astype(float)
     df["centroid_lon"] = centroids_ll.x.astype(float)
     df["centroid_lat"] = centroids_ll.y.astype(float)
-    df = df.set_index(id_col)
+    df = df.set_index(id_col).sort_index()
     return df
 
 

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -190,14 +190,32 @@ def build(project: Project) -> None:
         )
         # Validate that the source's HRU IDs match the fabric before any
         # arithmetic that would silently broadcast/intersect mismatched coords.
+        # Both sides are canonically sorted ascending by id_col upstream
+        # (compute_hru_area_and_centroids and read_aggregated_source); a
+        # remaining mismatch is therefore a true set difference, not an
+        # ordering artifact. Distinguish the two cases in the error so a
+        # regression in the canonical-sort invariant is diagnosable from the
+        # log alone.
         src_hru_ids = da_native[id_col].values
         if not np.array_equal(src_hru_ids, fabric_hru_ids):
+            same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
+                np.sort(src_hru_ids), np.sort(fabric_hru_ids)
+            )
+            if same_set:
+                raise ValueError(
+                    f"HRU coords for source '{src}' have the same set as the "
+                    f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
+                    f"order. Both sides are expected to be sorted ascending by "
+                    f"id_col='{id_col}' — this indicates a regression in the "
+                    f"canonical-sort invariant in targets/_common.py."
+                )
             raise ValueError(
-                f"HRU coords differ between fabric and source '{src}'. "
-                f"Fabric has {len(fabric_hru_ids)} HRUs "
-                f"({fabric_hru_ids[0]}..{fabric_hru_ids[-1]}); source has "
-                f"{len(src_hru_ids)}. Re-aggregate '{src}' against the "
-                f"current fabric."
+                f"HRU coords differ between fabric and source '{src}' as "
+                f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
+                f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
+                f"source has {len(src_hru_ids)} "
+                f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
+                f"Re-aggregate '{src}' against the current fabric."
             )
         da_mm = _TO_MM[src](da_native)
         da_cfs = mm_per_month_to_cfs(da_mm, hru_area_da)

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -384,6 +384,98 @@ def test_reindex_to_month_start_rejects_non_ms_freq():
         reindex_to_month_start(da, bad)
 
 
+def _write_year_nc_unsorted(
+    path: Path,
+    year: int,
+    var: str,
+    hrus: list[int],
+    id_col: str = "nhm_id",
+):
+    """Write a per-year NC with HRUs in caller-specified (possibly unsorted) order."""
+    times = pd.date_range(f"{year}-01-01", f"{year}-12-01", freq="MS")
+    data = np.arange(len(times) * len(hrus), dtype=np.float32).reshape(
+        len(times), len(hrus)
+    )
+    ds = xr.Dataset(
+        {var: (("time", id_col), data)},
+        coords={"time": times, id_col: hrus},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def test_read_aggregated_source_sorts_hru_ascending(tmp_path: Path):
+    """Source NCs written in non-monotonic HRU order come back canonically sorted.
+
+    Mirrors the GFv2 era5_land case (#94) where gdptools wrote rows in a VPU-
+    grouped (non-monotonic) order; downstream alignment against a sorted
+    fabric requires the reader to canonicalise the order.
+    """
+    from nhf_spatial_targets.targets._common import read_aggregated_source
+
+    workdir = make_minimal_project(tmp_path)
+    src = "era5_land"
+    var = "ro"
+    src_dir = workdir / "data" / "aggregated" / src
+    _write_year_nc_unsorted(src_dir / f"{src}_2000_agg.nc", 2000, var, hrus=[3, 1, 2])
+
+    project = load(workdir)
+    da = read_aggregated_source(
+        project, src, var, period=("2000-01-01", "2000-12-31"), chunks={"time": 12}
+    )
+    np.testing.assert_array_equal(da["nhm_id"].values, [1, 2, 3])
+    # Values must follow the coord — i.e. rows are reordered, not just relabelled.
+    # Original month-0 row was [0, 1, 2] (HRUs [3, 1, 2]); after sort it should
+    # be [1, 2, 0] (values for HRUs [1, 2, 3]).
+    np.testing.assert_array_equal(da.values[0], [1.0, 2.0, 0.0])
+
+
+def test_compute_hru_area_and_centroids_returns_sorted_index(tmp_path: Path):
+    """A fabric with rows in non-monotonic id_col order returns a sorted DataFrame.
+
+    Mirrors gfv2_nhru_merged.gpkg (#94), which is a permutation of 1..N with
+    a handful of out-of-order rows in the middle.
+    """
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    from nhf_spatial_targets.targets._common import compute_hru_area_and_centroids
+
+    fabric_path = tmp_path / "fabric.gpkg"
+    gdf = gpd.GeoDataFrame(
+        {"nhm_id": [3, 1, 2]},  # deliberately unsorted
+        geometry=[
+            box(-104.8, 40.0, -104.7, 40.1),
+            box(-105.0, 40.0, -104.9, 40.1),
+            box(-104.9, 40.0, -104.8, 40.1),
+        ],
+        crs="EPSG:4326",
+    )
+    fabric_path.parent.mkdir(parents=True, exist_ok=True)
+    gdf.to_file(fabric_path, driver="GPKG")
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    (workdir / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "datastore": str(tmp_path / "store"),
+                "fabric": {"path": str(fabric_path), "id_col": "nhm_id"},
+            }
+        )
+    )
+    (workdir / "fabric.json").write_text(json.dumps({"id_col": "nhm_id"}))
+
+    project = load(workdir)
+    df = compute_hru_area_and_centroids(project)
+    np.testing.assert_array_equal(df.index.values, [1, 2, 3])
+    # The centroid_lon for HRU 1 should match the polygon at lon ~-104.95
+    # (the second row of the input GeoDataFrame).
+    assert -105.0 < df.loc[1, "centroid_lon"] < -104.9
+    assert -104.9 < df.loc[2, "centroid_lon"] < -104.8
+    assert -104.8 < df.loc[3, "centroid_lon"] < -104.7
+
+
 def test_compute_hru_area_and_centroids_raises_on_duplicate_id_col(tmp_path: Path):
     """A fabric with duplicate HRU IDs must raise, not silently produce a
     non-unique-index DataFrame."""

--- a/tests/test_targets_run.py
+++ b/tests/test_targets_run.py
@@ -175,8 +175,70 @@ def test_build_hru_mismatch_raises(tmp_path: Path):
     ds.to_netcdf(bad)
 
     project = load(workdir)
-    with pytest.raises(ValueError, match="HRU coords differ"):
+    with pytest.raises(ValueError, match="HRU coords differ.*as sets"):
         build(project)
+
+
+def test_build_succeeds_when_source_hru_order_differs_from_fabric(tmp_path: Path):
+    """Source NCs with HRUs in non-monotonic order must not break the build.
+
+    Regression test for #94: gfv2's era5_land aggregated NCs ship rows in a
+    VPU-grouped order while the fabric is (near-)sorted by nat_hru_id. The
+    target builder must canonicalise both sides via id_col-ascending sort
+    rather than relying on positional alignment.
+
+    All per-year NCs for a single source share the same (permuted) order in
+    production (one gdptools run per source); the test mirrors that — a
+    cross-year ordering mismatch would trip xr.open_mfdataset before the
+    sort could run.
+    """
+    from nhf_spatial_targets.targets.run import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_runoff_project(
+        tmp_path,
+        period="2000-01-01/2000-12-31",
+        sources_per_year={
+            "era5_land": {2000: ("ro", 0.05)},
+            "gldas_noah_v21_monthly": {2000: ("runoff_total", 6.25)},
+            "mwbm_climgrid": {2000: ("runoff", 30.0)},
+        },
+        nn_fill=False,
+    )
+    # Rewrite the era5_land NC with HRUs in a permuted (non-monotonic) order.
+    # Per-HRU values are distinct so a positional misalignment produces a wrong
+    # answer rather than just rearranged metadata.
+    bad = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    times = pd.date_range("2000-01-01", "2000-12-01", freq="MS")
+    permuted_hrus = [3, 1, 2]
+    per_hru_value = {1: 0.05, 2: 0.10, 3: 0.20}  # m/month
+    arr = np.array(
+        [[per_hru_value[h] for h in permuted_hrus]] * len(times), dtype=np.float32
+    )
+    ds = xr.Dataset(
+        {"ro": (("time", "nhm_id"), arr)},
+        coords={"time": times, "nhm_id": permuted_hrus},
+    )
+    bad.unlink()
+    ds.to_netcdf(bad)
+
+    project = load(workdir)
+    build(project)
+
+    out = project.targets_dir() / "runoff_targets.nc"
+    assert out.exists()
+    with xr.open_dataset(out) as got:
+        # HRU dim must be canonically sorted in the target output, regardless
+        # of input order.
+        np.testing.assert_array_equal(got["nhm_id"].values, [1, 2, 3])
+        # ERA5-Land contributes the lower bound here (gldas/mwbm are scaled to
+        # ~roughly the same cfs magnitude, but HRU-3's ERA5 value of 0.20
+        # m/month is the largest of the three; HRU-1's 0.05 is the smallest).
+        # If positional alignment had silently mismatched, HRU-3's bound would
+        # not reflect 0.20 m/month.
+        lb = got["lower_bound"].sel(nhm_id=[1, 2, 3]).isel(time=0).values
+        assert (lb > 0).all()
+        assert lb[2] > lb[0]  # HRU 3 ERA5 (0.20) > HRU 1 (0.05) m/month
 
 
 def test_build_source_attr_reflects_active_sources(tmp_path: Path):


### PR DESCRIPTION
Closes #94. Partial groundwork for #93.

## Summary

- `targets/_common.py`: sort fabric to `id_col` ascending in `compute_hru_area_and_centroids` (`.sort_index()`); sort the lazy mfdataset in `read_aggregated_source` (`ds.sortby(project.id_col)`).
- `targets/run.py`: keep the existing `np.array_equal` guard (now correct by construction) but rework its error to distinguish "set differs" (legit re-aggregate situation) from "same set, different order" (canonical-sort invariant regression — a code bug).
- Tests: two unit tests in `test_targets_common.py` for the canonicalisation of fabric and source independently; one end-to-end regression in `test_targets_run.py` that mirrors the GFv2 bug — per-year ERA5-Land NCs written with `nhm_id=[3,1,2]` are read, aligned, and combined correctly, and the target NC emerges with `nhm_id=[1,2,3]`.

## Why now

The runoff target builder failed on the GFv2 fabric with `HRU coords differ between fabric and source 'era5_land'` even though both sides carried the same 361,471 `nat_hru_id` values. Aggregated NCs from `gdptools` come in a (likely VPU-grouped) row order; the fabric is a near-monotonic permutation of `1..N`. The order-sensitive `np.array_equal` check tripped on the ordering mismatch and emitted a misleading "re-aggregate" suggestion that would not have helped.

## Out of scope

Emission-time enforcement of canonical sort across `validate`, the aggregator, and target output is the broader concern tracked in #93. This PR fixes the immediate runtime symptom without touching upstream stages.

## Test plan

- [x] `pixi run -e dev fmt` — clean
- [x] `pixi run -e dev lint` — clean
- [x] `pixi run -e dev test` — 644 passed, 16 deselected
- [x] Re-run `pixi run run-runoff --project-dir /caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets` and confirm the runoff target builds end-to-end against the existing aggregated NCs (no re-aggregation required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)