### PR TITLE
feat(swe): fetch scaffolding for SWE calibration target (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ tests/
 - `catalog.py` is the single Python interface to both YAML files — do not read YAML directly elsewhere
 - When adding a new source, add it to `catalog/sources.yml` first, then write the fetch module
 - Mark superseded sources with `superseded_by:` key and `status: superseded`
+- Fabric-restricted sources (e.g. Margulis WUS-SR for Oregon) carry an optional `fabric_scope: {fabrics: [<token>], notes: ...}` block. Allowed fabric tokens are enumerated by `catalog.FABRIC_SCOPE_TOKENS` and validated by `catalog.validate_fabric_scope`; adding a new fabric means extending that set and the matching check in target builders. Raw downloads remain reusable across projects sharing a datastore — `fabric_scope` is enforced at the target-build stage, not at fetch time
 
 ## Aggregation Transformation Policy
 

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -53,11 +53,23 @@ sources:
         cf_units: "m"
         cell_methods: "time: sum"
         notes: Used as recharge proxy in recharge target.
+      - name: sd
+        long_name: snow depth water equivalent
+        cf_units: "m"
+        cell_methods: "time: point"
+        notes: >
+          Instantaneous snowpack water equivalent (NOT accumulated like
+          ro/sro/ssro). The midnight reset and diff-of-accumulations
+          logic that produces the runoff vars does not apply here.
+          Hourly→daily consolidation uses .mean() rather than .sum();
+          daily→monthly likewise uses .mean(). See
+          fetch/era5_land.py `_VARIABLE_KIND` for the dispatch table.
+          Used for the snow water equivalent calibration target.
     time_step: hourly (aggregated to daily and monthly)
     period: "1979/present"
     spatial_extent: CONUS+contributing-watersheds
     spatial_resolution: 0.1 degree
-    units: m of water equivalent
+    units: m of water equivalent (ro/sro/ssro) and m water equivalent (sd)
     license: Copernicus license (free, attribution)
     status: current
 
@@ -653,4 +665,160 @@ sources:
     units: percent (convert to fraction 0-1)
     ci_threshold: 70
     license: public domain (NASA)
+    status: current
+
+  # ---------------------------------------------------------------------------
+  # SNOW WATER EQUIVALENT
+  # ---------------------------------------------------------------------------
+  daymet:
+    name: Daymet V4 R1 Daily Surface Weather and Climatological Summaries
+    description: >
+      ORNL DAAC Daymet V4 R1 daily 1 km gridded surface weather over
+      three regional domains: North America (na), Hawaii (hi), and
+      Puerto Rico (pr). Used as a source for the snow water equivalent
+      calibration target ('swe'). All six native variables are documented
+      below for completeness; only 'swe' is consumed by default.
+    citations:
+      - "Thornton, M.M., Shrestha, R., Wei, Y., Thornton, P.E., Kao, S.-C., and Wilson, B.E., 2022, doi:10.3334/ORNLDAAC/2129"
+    doi: "10.3334/ORNLDAAC/2129"
+    access:
+      type: zarr_verify
+      url: https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=2129
+      stores:
+        na: "{daymet_root}/daymet_na.zarr"
+        hi: "{daymet_root}/daymet_hi.zarr"
+        pr: "{daymet_root}/daymet_pr.zarr"
+      notes: >
+        Three regional zarr stores are pre-staged on the shared filesystem
+        (e.g. `/caldera/.../data_creation/daymet/source/zarr/`). The fetch
+        module does NOT download or copy data; it verifies each zarr opens
+        cleanly, records sha256 of the `.zmetadata` file plus the total
+        on-disk byte count, and writes a per-region manifest entry. The
+        root path is configurable via `config.yml -> daymet_root` or the
+        `--source-path` CLI flag. Operator places the zarrs once; fetch
+        is then idempotent (matching fingerprint = no-op).
+    variables:
+      - name: swe
+        long_name: snow water equivalent
+        cf_units: "kg m-2"
+        cell_methods: "time: point"
+        notes: Used for snow water equivalent target.
+      - name: prcp
+        long_name: daily total precipitation
+        cf_units: "kg m-2"
+        cell_methods: "time: sum"
+        notes: Available in source; not aggregated by default.
+      - name: tmax
+        long_name: daily maximum 2 m air temperature
+        cf_units: "degC"
+        cell_methods: "time: maximum"
+      - name: tmin
+        long_name: daily minimum 2 m air temperature
+        cf_units: "degC"
+        cell_methods: "time: minimum"
+      - name: srad
+        long_name: daylight-average shortwave radiation
+        cf_units: "W m-2"
+        cell_methods: "time: mean"
+      - name: vp
+        long_name: daily water vapor pressure
+        cf_units: "Pa"
+        cell_methods: "time: mean"
+    time_step: daily
+    period: "1980/2024"
+    spatial_extent: "North America (NA), Hawaii (HI), Puerto Rico (PR)"
+    spatial_resolution: 1 km (Lambert Conformal Conic)
+    units: "kg m-2 (swe, prcp); degC (tmax, tmin); W m-2 (srad); Pa (vp)"
+    license: public domain (NASA / ORNL DAAC)
+    status: current
+
+  snodas:
+    name: SNODAS Snow Data Assimilation System Data Products (NSIDC G02158)
+    description: >
+      NOAA NOHRSC SNODAS daily snow products distributed by NSIDC
+      (collection G02158). Daily 1 km CONUS analysis combining
+      satellite observations, ground stations, and an energy-balance
+      snow model. Used as one source for the SWE calibration target.
+    citations:
+      - "National Operational Hydrologic Remote Sensing Center, 2004, doi:10.7265/N5TB14TC"
+    doi: "10.7265/N5TB14TC"
+    access:
+      type: nasa_nsidc
+      short_name: G02158
+      version: "1"
+      url: https://nsidc.org/data/g02158
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      notes: >
+        Access via earthaccess (NASA Earthdata login required). Daily
+        granules are tar/gz bundles containing flat int16 binary files
+        plus ENVI-style `.Hdr` headers; the SWE field is in mm with a
+        fill value of -9999 (scale_factor 1). Apply scale + fill mask
+        before any quantitative aggregation. The masked product is used
+        (CONUS only); the unmasked variant covering parts of southern
+        Canada is NOT used. Short_name/version should be confirmed via
+        an earthaccess CMR query at implementation time.
+    variables:
+      - name: swe
+        long_name: snow water equivalent
+        cf_units: "kg m-2"
+        cell_methods: "time: point"
+        notes: >
+          Native SNODAS SWE is a flat int16 field in mm (≡ kg m-2 of
+          water at density 1000) with fill value -9999. Apply fill
+          mask before any HRU aggregation.
+    time_step: daily
+    period: "2003/present"
+    spatial_extent: CONUS
+    spatial_resolution: 30 arcsec (~1 km)
+    units: kg m-2 (mm water equivalent)
+    license: public domain (NSIDC / NOAA)
+    status: current
+
+  margulis_wus_sr:
+    name: Margulis Western US Snow Reanalysis (NSIDC-0719)
+    description: >
+      UCLA/Margulis Western US Snow Reanalysis, daily 90 m posterior
+      snow water equivalent over the Sierra Nevada, Cascades, Rockies
+      and adjacent ranges for water years 1985-2021. Used as a SWE
+      calibration source for the Oregon fabric only; for other fabrics
+      the SWE target builder excludes this source (see fabric_scope).
+    citations:
+      - "Fang, Y., Liu, Y., and Margulis, S.A., 2022, doi:10.5067/PP7T2GBI52I2"
+    doi: "10.5067/PP7T2GBI52I2"
+    access:
+      type: nasa_nsidc
+      short_name: WUS_UCLA_SR
+      version: "1"
+      url: https://nsidc.org/data/nsidc-0719
+      notes: >
+        Access via earthaccess (NASA Earthdata login required).
+        Granules are per-water-year per-tile NetCDFs covering the
+        Western US domain; the fetch module subsets to the fabric
+        bounding box at search time. Confirm short_name via an
+        earthaccess CMR query at implementation time — historically
+        the NSIDC-0719 short_name has been WUS_UCLA_SR but the value
+        is subject to NSIDC bookkeeping.
+    fabric_scope:
+      fabrics: [or]
+      notes: >
+        Spatial extent is the Western US (CA, OR, WA, ID, NV, UT, and
+        parts of MT, WY, CO, AZ, NM). This catalog scopes the source
+        to fabric "or" because the SWE target builder is keyed on the
+        Oregon HRU set in the current pipeline; enforcement happens at
+        target-build time, not at fetch time. Raw downloads remain
+        reusable by any project pointing at the same datastore.
+    variables:
+      - name: SWE
+        long_name: posterior snow water equivalent
+        cf_units: "m"
+        cell_methods: "time: point"
+        notes: >
+          Posterior SWE in meters water equivalent. Convert to mm
+          before harmonisation with the other SWE sources.
+    time_step: daily
+    period: "1985/2021"
+    spatial_extent: Western US (Oregon-fabric only in this pipeline)
+    spatial_resolution: 90 m
+    units: m water equivalent
+    license: public domain (NASA NSIDC)
     status: current

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -13,10 +13,11 @@ sources:
     name: ECMWF ERA5-Land Reanalysis
     description: >
       ECMWF ERA5-Land hourly reanalysis. Total runoff (ro), surface runoff
-      (sro), and sub-surface runoff (ssro) downloaded for CONUS plus
-      contributing watersheds (Canada/Mexico). Used as a source for the
-      runoff calibration target (ro) and the recharge calibration target
-      (ssro, as drainage proxy).
+      (sro), sub-surface runoff (ssro), and snow depth water equivalent
+      (sd) downloaded for CONUS plus contributing watersheds (Canada/
+      Mexico). Used as a source for the runoff calibration target (ro),
+      the recharge calibration target (ssro, as drainage proxy), and the
+      snow water equivalent calibration target (sd).
     citations:
       - "Muñoz-Sabater, J., and others, 2021, doi:10.5194/essd-13-4349-2021"
     access:
@@ -69,7 +70,7 @@ sources:
     period: "1979/present"
     spatial_extent: CONUS+contributing-watersheds
     spatial_resolution: 0.1 degree
-    units: m of water equivalent (ro/sro/ssro) and m water equivalent (sd)
+    units: m of water equivalent
     license: Copernicus license (free, attribution)
     status: current
 
@@ -799,7 +800,11 @@ sources:
         the NSIDC-0719 short_name has been WUS_UCLA_SR but the value
         is subject to NSIDC bookkeeping.
     fabric_scope:
-      fabrics: [or]
+      # `fabrics:` is the list of fabric tokens for which this source
+      # should be aggregated. Allowed tokens (kept in sync with the
+      # known fabric set this pipeline targets): "or" (Oregon).
+      # Token names quoted to avoid YAML reserved-word edge cases.
+      fabrics: ["or"]
       notes: >
         Spatial extent is the Western US (CA, OR, WA, ID, NV, UT, and
         parts of MT, WY, CO, AZ, NM). This catalog scopes the source
@@ -817,7 +822,7 @@ sources:
           before harmonisation with the other SWE sources.
     time_step: daily
     period: "1985/2021"
-    spatial_extent: Western US (Oregon-fabric only in this pipeline)
+    spatial_extent: Western US (Sierra Nevada, Cascades, Rockies and adjacent ranges)
     spatial_resolution: 90 m
     units: m water equivalent
     license: public domain (NASA NSIDC)

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -192,8 +192,12 @@ variables:
       three sources. Absolute values used (not normalized).
     prms_reference: "TM 6-B7 (Markstrom et al. 2015)"
     time_step: daily
+    # SNODAS-limited: intersection of all four sources. Non-Oregon
+    # fabrics use a 3-source bound (daymet 1980+, era5_land 1979+,
+    # snodas 2003+), so the intersection is still 2003-present.
     period: "2003/present"
-    units: mm water equivalent
+    units: inches
+    original_units: varies by source (mm water-eq, m water-eq)
     sources:
       - daymet
       - snodas
@@ -203,7 +207,9 @@ variables:
     range_notes: >
       Daymet 'swe' (kg/m² ≡ mm), SNODAS 'swe' (kg/m² ≡ mm), ERA5-Land 'sd'
       (m water-eq → mm), Margulis WUS-SR 'SWE' (m water-eq → mm) are
-      aggregated to HRU polygons via gdptools and harmonized to mm.
+      aggregated to HRU polygons via gdptools and harmonized to mm,
+      then converted to inches in the target builder to match the PRMS
+      variable pkwater_equiv (per TM 6-B7).
       Per-HRU per-day:
         lower_bound = nanmin(daymet, snodas, era5_sd, margulis),
         upper_bound = nanmax(daymet, snodas, era5_sd, margulis).
@@ -213,7 +219,5 @@ variables:
       Oregon (see catalog/sources.yml fabric_scope); for non-OR fabrics
       it is excluded by the target builder so the bound reduces to a
       3-source min/max.
-      PRMS variable pkwater_equiv (per TM 6-B7) is in inches; conversion
-      from mm to inches is applied in the target builder.
     normalize: false
     output_format: netcdf

--- a/catalog/variables.yml
+++ b/catalog/variables.yml
@@ -181,3 +181,39 @@ variables:
     ci_threshold: 0.70
     normalize: false
     output_format: netcdf
+
+  snow_water_equivalent:
+    prms_variable: pkwater_equiv
+    description: >
+      Daily basin snow water equivalent. Range is min/max across four
+      independent SWE sources per HRU and time step. Margulis Western US
+      Snow Reanalysis is fabric-scoped to Oregon only (see fabric_scope in
+      catalog/sources.yml); non-Oregon fabrics are bounded by the remaining
+      three sources. Absolute values used (not normalized).
+    prms_reference: "TM 6-B7 (Markstrom et al. 2015)"
+    time_step: daily
+    period: "2003/present"
+    units: mm water equivalent
+    sources:
+      - daymet
+      - snodas
+      - era5_land            # 'sd' (snow depth water equivalent)
+      - margulis_wus_sr      # Oregon fabric only
+    range_method: multi_source_minmax
+    range_notes: >
+      Daymet 'swe' (kg/m² ≡ mm), SNODAS 'swe' (kg/m² ≡ mm), ERA5-Land 'sd'
+      (m water-eq → mm), Margulis WUS-SR 'SWE' (m water-eq → mm) are
+      aggregated to HRU polygons via gdptools and harmonized to mm.
+      Per-HRU per-day:
+        lower_bound = nanmin(daymet, snodas, era5_sd, margulis),
+        upper_bound = nanmax(daymet, snodas, era5_sd, margulis).
+      nanmin/nanmax (xr.concat([...]).min(skipna=True)) means a bound is
+      defined whenever >=1 source is finite at that (HRU, time); only
+      all-NaN cells produce NaN. Margulis WUS-SR is fabric-scoped to
+      Oregon (see catalog/sources.yml fabric_scope); for non-OR fabrics
+      it is excluded by the target builder so the bound reduces to a
+      3-source min/max.
+      PRMS variable pkwater_equiv (per TM 6-B7) is in inches; conversion
+      from mm to inches is applied in the target builder.
+    normalize: false
+    output_format: netcdf

--- a/docs/sources/daymet.md
+++ b/docs/sources/daymet.md
@@ -1,0 +1,82 @@
+# Daymet V4 R1 (operator-staged zarr)
+
+The ORNL DAAC Daymet V4 R1 daily 1 km gridded surface weather product
+(Thornton et al., 2022; doi:10.3334/ORNLDAAC/2129) is distributed as
+three regional zarr stores covering North America (`na`), Hawaii
+(`hi`), and Puerto Rico (`pr`). Each regional zarr exposes
+`prcp, srad, swe, tmax, tmin, vp` plus the `lambert_conformal_conic`
+CRS spec. Only `swe` is consumed by the SWE calibration target;
+the other variables are documented for completeness.
+
+The publisher distributes the zarrs in hundreds-of-GB per region.
+We do **not** download them — the operator pre-stages the zarrs on a
+shared filesystem and `nhf-targets fetch daymet` fingerprints each
+region (sha256 over `.zgroup` / `.zarray` / `.zattrs` / `.zmetadata`
+files plus the directory's total byte count) and writes a per-region
+manifest entry. The fingerprint design and its residual gaps are
+documented in [`src/nhf_spatial_targets/fetch/daymet.py`](../../src/nhf_spatial_targets/fetch/daymet.py).
+
+## Procedure
+
+1. Obtain the three regional zarrs from the publisher
+   <https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=2129> and stage
+   them on a shared filesystem location, e.g.:
+
+   ```
+   /<shared>/daymet/source/zarr/
+     daymet_na.zarr/
+     daymet_hi.zarr/
+     daymet_pr.zarr/
+   ```
+
+   Operators on the Hovenweep HPC cluster can point at the existing
+   `/caldera/hovenweep/projects/usgs/water/impd/nhgf/data_creation/daymet/source/zarr`
+   tree rather than re-staging.
+
+2. Configure the project to find the zarrs. Either:
+
+   - Add `daymet_root: /<shared>/daymet/source/zarr` to `config.yml`, **or**
+   - Pass `--source-path /<shared>/daymet/source/zarr` on the CLI.
+
+   The `--source-path` flag wins if both are present.
+
+3. Run the fetch:
+
+   ```bash
+   nhf-targets fetch daymet --project-dir <project> --period 1980/2024
+   ```
+
+   Optional flags:
+
+   - `--region {na|hi|pr|all}` (default `all`). Use `--region na` for
+     CONUS-only fabrics.
+
+   The command verifies each present zarr opens cleanly, asserts the
+   required variables are exposed, fingerprints the structural
+   metadata, and records per-region entries under
+   `manifest.json` → `sources.daymet.regions.{na,hi,pr}`. Subsequent
+   runs against unchanged zarrs are a no-op (matching fingerprint =
+   skip re-validation).
+
+4. Parallel runs across regions are safe: the manifest update takes an
+   exclusive `flock` on a `manifest.json.lock` sibling, so
+   `fetch daymet --region na` and `fetch daymet --region hi` can run
+   concurrently without losing each other's records.
+
+## Troubleshooting
+
+- `FileNotFoundError: Daymet zarr root is not configured` — either
+  `--source-path` was not passed or `daymet_root:` is missing from
+  `config.yml`. Fix one and re-run.
+
+- `RuntimeError: <zroot> is missing required variables [...]` — the
+  staged zarr is incomplete. Re-stage from the publisher.
+
+- `RuntimeError: <zroot> is being modified concurrently` — another
+  process is writing to the zarr while fetch tries to fingerprint it.
+  Wait for the writer to finish, then re-run.
+
+- Fingerprint residual risk: a chunk file overwritten in place with
+  identical compressed length but different bytes is invisible to the
+  structural-metadata sha256 + directory byte count. Re-stage from
+  the publisher if chunk-level tampering is suspected.

--- a/docs/sources/margulis_wus_sr.md
+++ b/docs/sources/margulis_wus_sr.md
@@ -1,0 +1,82 @@
+# Margulis Western US Snow Reanalysis (NSIDC-0719)
+
+The UCLA/Margulis Western US Snow Reanalysis is a daily 90 m posterior
+SWE product over the Sierra Nevada, Cascades, Rockies and adjacent
+ranges for water years 1985-2021 (Fang, Liu & Margulis, 2022;
+doi:10.5067/PP7T2GBI52I2). NSIDC distributes it as collection
+NSIDC-0719 (short_name `WUS_UCLA_SR`).
+
+This source is **fabric-scoped to Oregon only** in this pipeline (see
+[`catalog/sources.yml`](../../catalog/sources.yml)
+`margulis_wus_sr.fabric_scope`). Raw downloads are reusable by any
+project pointing at the same datastore, but the SWE target builder
+excludes this source for non-Oregon fabrics — a Mississippi-fabric
+calibration run will not consume Margulis WUS-SR data even if it
+exists in the shared datastore. The fetch step warns when invoked
+against a non-Oregon fabric so operators don't mistake the empty
+search results for an upstream outage.
+
+The fetch step ships the **search-and-download** path: granules land
+in `<datastore>/margulis_wus_sr/raw/<year>/`. Concatenating the
+per-water-year per-tile NetCDFs into a per-year CF NetCDF (and the
+fabric_scope enforcement at target-build time) is **deferred** to the
+Margulis aggregate follow-up issue.
+
+## Prerequisites
+
+- NASA Earthdata account with credentials materialized into `~/.netrc`
+  (`nhf-targets materialize-credentials --project-dir <project>`).
+- Project's `fabric.json` present with a `bbox_buffered` covering the
+  Oregon HRU set. The fetch reads this bbox and passes it as the CMR
+  `bounding_box` constraint, so only granules overlapping the Oregon
+  domain are downloaded.
+
+## Procedure
+
+```bash
+nhf-targets fetch margulis-wus-sr \
+    --project-dir <project> \
+    --period 1985/2021
+```
+
+The command:
+
+1. Logs in to NASA EDL via `earthaccess`.
+2. Reads the publisher window from `sources.yml[margulis_wus_sr].period`
+   and rejects out-of-range years before any network work.
+3. If the project's fabric is not in
+   `sources.yml[margulis_wus_sr].fabric_scope.fabrics` (currently
+   `["or"]`), emits a one-line warning. Fetch proceeds anyway — raw
+   data is datastore-shared and a future Oregon-fabric run can reuse
+   it — but expect zero granules per year.
+4. Pre-filters years against the existing manifest (years with
+   `n_granules > 0` are skipped on re-runs; zero-granule years are
+   retried in case CMR coverage filled in).
+5. For each pending year, searches CMR for granules overlapping the
+   buffered fabric bbox and downloads them into
+   `<datastore>/margulis_wus_sr/raw/<year>/`. Zero-byte downloads are
+   dropped before the per-year tally is recorded.
+6. The manifest update is flock-protected (parallel workers safe).
+
+## Known follow-ups
+
+- **CMR short_name verification.** `WUS_UCLA_SR` is the documented
+  short_name on the NSIDC-0719 product page; confirm against an
+  `earthaccess.search_data` smoke before the first production run.
+- **Aggregate adapter + fabric_scope enforcement** are filed as the
+  Margulis aggregate follow-up issue.
+
+## Troubleshooting
+
+- `ValueError: fabric.json has no 'bbox_buffered' key` — the project's
+  fabric metadata is stale. Re-run
+  `nhf-targets validate --project-dir <project>` to regenerate
+  `fabric.json`.
+
+- `RuntimeError: partial download` — a granule failed mid-run. Re-run
+  the same command to retry only the missing files.
+
+- Repeated `no granules found for year YYYY` log entries with an
+  accompanying scope warning — the project's fabric is not in
+  `fabric_scope.fabrics`. This is expected for non-Oregon fabrics;
+  the SWE target builder will exclude this source automatically.

--- a/docs/sources/snodas.md
+++ b/docs/sources/snodas.md
@@ -1,0 +1,76 @@
+# SNODAS (NSIDC G02158)
+
+The NOAA NOHRSC Snow Data Assimilation System (SNODAS) daily 1 km
+CONUS snow products are distributed by NSIDC as collection
+[G02158](https://nsidc.org/data/g02158)
+(doi:10.7265/N5TB14TC). Daily tar/gz bundles contain flat int16
+binary fields plus ENVI-style `.Hdr` headers. SWE is the variable of
+interest for the snow water equivalent calibration target.
+
+This PR ships the **fetch-only** path: download raw bundles via
+`earthaccess` (NASA Earthdata login) into
+`<datastore>/snodas/raw/<year>/` and record a per-year manifest
+entry. Decoding the int16 binary into a CF NetCDF, and clipping or
+re-projecting it for HRU aggregation, is **deferred** to the SNODAS
+aggregate follow-up issue — the native format needs operator
+characterisation in a notebook (per CLAUDE.md "characterise the data
+first") before a robust parser is committed.
+
+## Prerequisites
+
+- NASA Earthdata account with credentials materialized into `~/.netrc`
+  (run `nhf-targets materialize-credentials --project-dir <project>`
+  after editing `.credentials.yml`).
+- Project's `fabric.json` present with a `bbox_buffered` covering the
+  CONUS footprint of interest. (The catalog also carries a CONUS-wide
+  fallback `bbox_nwse` at `sources.yml[snodas].access.bbox_nwse`.)
+
+## Procedure
+
+```bash
+nhf-targets fetch snodas \
+    --project-dir <project> \
+    --period 2003/2024 \
+    [--worker-index 0 --n-workers 1]
+```
+
+The command:
+
+1. Logs in to NASA EDL via `earthaccess`.
+2. Reads `sources.yml[snodas].period` for the publisher window and
+   rejects out-of-window years before any network work.
+3. Pre-filters years against the existing manifest — years recorded
+   with `n_granules > 0` are skipped on re-runs (years with
+   `n_granules: 0` are retried because CMR coverage can fill in
+   retroactively).
+4. Round-robin assigns the remaining years to `--worker-index` of
+   `--n-workers` so parallel SLURM array jobs cover the period
+   without overlap or gaps.
+5. For each assigned year, searches CMR (`short_name: G02158`,
+   `version: "1"`) inside the catalog bbox, downloads matching
+   granules into `<datastore>/snodas/raw/<year>/`, and records the
+   per-year tally in `manifest.json` → `sources.snodas.years`.
+6. The manifest update is flock-protected so parallel workers do not
+   lose each other's year records.
+
+## Known follow-ups
+
+- **CMR short_name/version verification.** `G02158` / `"1"` is the
+  best-guess pair; confirm against an `earthaccess.search_data` smoke
+  test before the first production run.
+- **Binary decoding.** Filed as the SNODAS aggregate follow-up issue:
+  characterise the flat int16 + `.Hdr` layout in a notebook, then
+  write the decoder, then write the aggregate adapter.
+
+## Troubleshooting
+
+- `RuntimeError: snodas: earthaccess.download returned no files` —
+  Earthdata credentials are missing or wrong, or the CMR endpoint is
+  unreachable. Re-run `nhf-targets materialize-credentials`.
+
+- `RuntimeError: snodas: partial download` — a granule failed mid-run.
+  Re-run the same command to retry only the missing files.
+
+- `ValueError: outside the SNODAS publisher window` — the requested
+  `--period` includes years before the catalog's start year. SNODAS
+  daily archives begin 2003-09-30.

--- a/docs/superpowers/plans/2026-05-12-swe-fetch-scaffolding.md
+++ b/docs/superpowers/plans/2026-05-12-swe-fetch-scaffolding.md
@@ -1,0 +1,299 @@
+# Plan: SWE Calibration Target — Fetch-Layer Scaffolding
+
+> Tracking issue: #99
+> Plan saved 2026-05-12.
+
+## Context
+
+The nhf-spatial-targets pipeline currently builds five calibration targets
+(runoff, AET, recharge, soil moisture, snow-covered area). We are adding a
+sixth: **snow water equivalent (SWE)**. Four sources are in scope:
+
+1. **Daymet** — V4 R1 daily 1 km zarr stores, already on disk at
+   `/caldera/hovenweep/projects/usgs/water/impd/nhgf/data_creation/daymet/source/zarr/{daymet_na.zarr,daymet_hi.zarr,daymet_pr.zarr}`.
+   Each zarr exposes `swe` plus prcp/srad/tmax/tmin/vp.
+2. **SNODAS** — NSIDC G02158, daily CONUS 1 km, via `earthaccess`.
+3. **ERA5-Land `sd`** — snow depth water equivalent. Extend the *existing*
+   `fetch/era5_land.py`; same CDS, same module, additional variable.
+4. **Margulis Western US Snow Reanalysis** (NSIDC-0719) — daily 90 m posterior
+   SWE, water years 1985–2021. **Oregon-fabric only** (carries a new
+   `fabric_scope:` catalog field; enforcement deferred to the target builder).
+
+**This PR scope: fetch routines + catalog wiring + tests only.** Aggregate,
+target builder, defaults block, and full target wiring are deferred to four
+follow-up issues filed at merge time. Per the user direction: "start with the
+fetch routines and then create separate issues to finish the workflow for
+each dataset."
+
+## Critical files to modify
+
+- `catalog/sources.yml` — extend `era5_land`, add `daymet`, `snodas`,
+  `margulis_wus_sr`.
+- `catalog/variables.yml` — add `snow_water_equivalent` target entry.
+- `src/nhf_spatial_targets/fetch/era5_land.py` — add `sd` variable +
+  instantaneous-vs-accumulated dispatch.
+- `src/nhf_spatial_targets/fetch/daymet.py` — **new**, verify-only.
+- `src/nhf_spatial_targets/fetch/snodas.py` — **new**, earthaccess.
+- `src/nhf_spatial_targets/fetch/margulis_wus_sr.py` — **new**, earthaccess.
+- `src/nhf_spatial_targets/cli.py` — imports + `fetch all` tuple + 3 new
+  per-source `@fetch_app.command(...)` blocks + skip list.
+- `tests/test_fetch_daymet.py`, `tests/test_fetch_snodas.py`,
+  `tests/test_fetch_margulis_wus_sr.py` — **new**.
+- `tests/test_era5_land.py`, `tests/test_catalog.py`, `tests/test_cli.py` —
+  extend.
+
+## Reference patterns to reuse (file paths)
+
+- **Verify-only** (Daymet): mirror
+  [`src/nhf_spatial_targets/fetch/mwbm_climgrid.py`](../../../src/nhf_spatial_targets/fetch/mwbm_climgrid.py)
+  — stability check, sha256 fingerprint, manifest registration, idempotency
+  fast-path.
+- **earthaccess + per-year consolidation + flock manifest** (SNODAS,
+  Margulis): mirror
+  [`src/nhf_spatial_targets/fetch/era5_land.py`](../../../src/nhf_spatial_targets/fetch/era5_land.py)
+  (manifest flock `_update_manifest` lines 710–810) and
+  [`src/nhf_spatial_targets/fetch/gldas.py`](../../../src/nhf_spatial_targets/fetch/gldas.py)
+  (earthaccess search/download).
+- **Auth**: `from nhf_spatial_targets.fetch._auth import earthdata_login`.
+- **Period parsing/clamping**:
+  `nhf_spatial_targets.fetch._period.years_in_period`.
+- **CF metadata + write helpers**: `fetch/consolidate.py` —
+  `apply_cf_metadata`, `resolve_license`, `_write_netcdf`.
+- **SourceAdapter / catalog**: `from nhf_spatial_targets import catalog as
+  _catalog; _catalog.source(key)` — never read YAML directly elsewhere.
+
+## Implementation steps
+
+### Step 1 — Catalog edits
+
+**`catalog/variables.yml`** — append `snow_water_equivalent` block after
+`snow_covered_area` (after line 183). `range_method: multi_source_minmax`,
+`normalize: false`, `time_step: daily`, sources list = `[daymet, snodas,
+era5_land, margulis_wus_sr]`. Document in `range_notes:` that Margulis WUS-SR
+is fabric-scoped to Oregon and excluded for non-OR fabrics at target build
+time. PRMS variable: `pkwater_equiv` (confirm in target-builder follow-up).
+
+**`catalog/sources.yml`** — four edits:
+
+1. Add `SNOW WATER EQUIVALENT` section banner (style mirrors lines 8–10).
+2. **Extend `era5_land`** (lines 12–62): append a fourth variable `sd` with
+   `long_name: snow depth water equivalent`, `cf_units: "m"`,
+   `cell_methods: "time: point"`, and a note that this is instantaneous
+   (NOT accumulated; uses the `.mean()` reducer, not diff-of-accumulations).
+3. **Add `daymet`** with `access.type: zarr_verify`, three regional store
+   paths under `stores: {na, hi, pr}` keyed via `{daymet_root}` template,
+   `period: "1980/2023"`, all six variables (`swe, prcp, tmax, tmin, srad,
+   vp`). Operator-staged location, no download.
+4. **Add `snodas`** with `access.type: nasa_nsidc`, `short_name: G02158`,
+   `version: "1"`, `period: "2003/present"`, bbox NWSE clipped to
+   CONUS+contributing. Single variable `swe`.
+5. **Add `margulis_wus_sr`** with `access.type: nasa_nsidc`,
+   `short_name: WUS_UCLA_SR` (verify at impl time),
+   `doi: 10.5067/PP7T2GBI52I2`, `period: "1985/2021"`. **New optional field
+   `fabric_scope: {fabrics: [or], notes: ...}`** documenting Oregon-only
+   scope; enforcement is at target-build time.
+
+### Step 2 — ERA5-Land `sd` extension (small, isolated)
+
+In `fetch/era5_land.py`:
+
+- Line 41: `VARIABLES = ("ro", "sro", "ssro", "sd")`.
+- Lines 104–108: add `"sd": "snow_depth_water_equivalent"` to
+  `_VARIABLE_REQUEST_NAME`.
+- Add `_VARIABLE_KIND = {"ro": "accumulated", "sro": "accumulated",
+  "ssro": "accumulated", "sd": "instantaneous"}` after that table.
+- Add `hourly_to_daily_instantaneous(da)`: `da.resample(time="1D").mean()`,
+  preserve attrs. Short docstring contrasts with the accumulated path.
+- Refactor `daily_to_monthly` to take `kind: str = "accumulated"`; branch
+  `.sum()` vs `.mean()`. Update the existing call site in `consolidate_year`
+  to pass `kind=_VARIABLE_KIND[var]`.
+- In `consolidate_year` (lines 408–429), dispatch
+  `hourly_to_daily` vs `hourly_to_daily_instantaneous` by `_VARIABLE_KIND[var]`.
+- Update title strings at lines 434 / 477 to "ERA5-Land daily runoff and snow".
+- **No CLI changes** — `nhf-targets fetch era5-land` picks up `sd`
+  automatically because it iterates `VARIABLES`.
+
+### Step 3 — `fetch/daymet.py` (new, verify-only)
+
+```python
+def fetch_daymet(
+    workdir: Path,
+    period: str,
+    *,
+    source_path: Path | None = None,
+    region: str = "all",  # "na" | "hi" | "pr" | "all"
+) -> dict
+```
+
+Resolution order for zarr root: `source_path` arg → `config.yml: daymet_root`
+→ raise `FileNotFoundError` with operator instructions. Per region: open
+zarr via `xarray.open_zarr`, assert `swe`/`time`/`x`/`y`/
+`lambert_conformal_conic` present, validate time coord within `period`,
+compute cheap fingerprint (sha256 of `.zmetadata` + total directory byte
+count — NOT a full-data hash, the zarrs are 100s of GB), record under
+`manifest["sources"]["daymet"]["regions"][region]`. Idempotent: identical
+fingerprint = no-op. Stability check pattern from mwbm_climgrid.
+
+### Step 4 — `fetch/snodas.py` (new, earthaccess)
+
+```python
+def fetch_snodas(
+    workdir: Path,
+    period: str,
+    *,
+    worker_index: int = 0,
+    n_workers: int = 1,
+) -> dict
+```
+
+`earthdata_login` → year-sharded round-robin (copy era5_land's helper
+pattern) → `earthaccess.search_data(short_name=G02158, temporal=..., bounding_box=bbox)`
+→ download tarballs to `<datastore>/snodas/raw/<year>/` → extract SWE
+binary+`.Hdr`, build `xr.DataArray` (with scale + fill mask per SNODAS data
+dictionary) → daily NC `<datastore>/snodas/daily/snodas_daily_{year}.nc` →
+monthly NC `<datastore>/snodas/monthly/snodas_monthly_{year}.nc`. Use
+`apply_cf_metadata` + atomic write. **Flock-protected `_update_manifest`**
+(copy from era5_land).
+
+> The SNODAS native format (int16 binary + ENVI-style `.Hdr`) needs
+> characterisation in a notebook before consolidation logic is finalised —
+> per CLAUDE.md "characterise the data first". The fetch PR may stage just
+> the search/download/manifest path and defer consolidation to a follow-up
+> sub-step within the same PR, with the notebook checked into
+> `notebooks/`.
+
+### Step 5 — `fetch/margulis_wus_sr.py` (new, earthaccess)
+
+```python
+def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict
+```
+
+`earthdata_login` → `parse_period` clamped to `(1985, 2021)` →
+`earthaccess.search_data(short_name="WUS_UCLA_SR", bounding_box=ws.fabric["bbox_buffered"], temporal=...)`
+→ download to `<datastore>/margulis_wus_sr/raw/`, drop zero-byte files →
+per-year NC at `<datastore>/margulis_wus_sr/daily/margulis_wus_sr_daily_{year}.nc`.
+Flock-protected manifest update. Module docstring + manifest entry record
+`fabric_scope` per the catalog. Fetch does not enforce the scope (raw
+downloads are reusable); the target builder will.
+
+### Step 6 — CLI wiring (`src/nhf_spatial_targets/cli.py`)
+
+- Imports near lines 372–382 (alphabetical): `fetch_daymet`,
+  `fetch_margulis_wus_sr`, `fetch_snodas`.
+- `fetch all` sources tuple (lines 385–397): add `("daymet", "daymet",
+  fetch_daymet)`, `("snodas", "snodas", fetch_snodas)`,
+  `("margulis-wus-sr", "margulis_wus_sr", fetch_margulis_wus_sr)`.
+- Skip-list at ~line 432 (currently `mwbm-climgrid`): add `daymet` and
+  `margulis-wus-sr` so `FileNotFoundError` yields a yellow "skipped" instead
+  of failing `fetch all` (relevant for non-OR projects and Daymet not yet
+  staged).
+- Three new `@fetch_app.command(...)` blocks following the
+  `fetch_mwbm_climgrid_cmd` pattern at lines 1021+:
+  - `fetch daymet` — `--source-path`, `--region`.
+  - `fetch snodas` — `--worker-index`, `--n-workers`.
+  - `fetch wus-sr` (CLI name kebab; catalog key `margulis_wus_sr`).
+- `fetch era5-land` docstring (line 809) updated to mention `sd`.
+
+### Step 7 — Tests
+
+All hermetic — no network, no real Earthdata creds. Mock `cdsapi`,
+`earthaccess`, and any file-format readers.
+
+- **`tests/test_fetch_daymet.py`** (mirrors test_fetch_mwbm_climgrid.py):
+  missing-zarr error message, period rejection, region=all/single,
+  initial-registration, idempotency on second call, re-fingerprint after
+  replacement, missing `swe` variable rejected, `--source-path` overrides
+  config, corrupt manifest fails fast.
+- **`tests/test_fetch_snodas.py`** (mirrors test_gldas.py + test_modis.py):
+  empty-search error, partial-download error, per-year daily+monthly
+  produced, consolidation idempotent on mtime, period<2003 rejected,
+  manifest accumulates years, worker partitioning.
+- **`tests/test_fetch_margulis_wus_sr.py`**: period clamping, empty search,
+  partial download, zero-byte drop, per-year NC, manifest records
+  `fabric_scope: ["or"]`, auth failure surfaces cleanly.
+- **`tests/test_era5_land.py`** (extend): `hourly_to_daily_instantaneous`
+  means-per-day + attrs, `consolidate_year` kind dispatch produces sum for
+  ro and mean for sd, `daily_to_monthly` kind branch, defensive check that
+  every entry in `VARIABLES` is keyed in `_VARIABLE_KIND`.
+- **`tests/test_catalog.py`** (extend): `snow_water_equivalent` variable
+  present with 4 sources; `daymet`, `snodas`, `margulis_wus_sr` source
+  entries with expected fields; `era5_land.variables` now contains `sd`
+  with `cell_methods: "time: point"`; `margulis_wus_sr.fabric_scope.fabrics
+  == ["or"]`.
+- **`tests/test_cli.py`** (extend if pattern exists): `--help` smoke for the
+  three new commands.
+
+## Verification
+
+```bash
+pixi run -e dev fmt
+pixi run -e dev lint
+pixi run -e dev test
+
+# Catalog inspection
+pixi run catalog-sources   | grep -E "daymet|snodas|margulis|sd"
+pixi run catalog-variables | grep -i snow_water
+
+# CLI help smoke (no network)
+pixi run nhf-targets fetch daymet --help
+pixi run nhf-targets fetch snodas --help
+pixi run nhf-targets fetch wus-sr --help
+pixi run nhf-targets fetch era5-land --help   # docstring now mentions sd
+```
+
+Manual end-to-end smoke on a real project (separate from automated tests):
+
+```bash
+# In an existing nhf-runs project with credentials materialized:
+pixi run nhf-targets fetch daymet --project-dir /path/to/project \
+    --source-path /caldera/hovenweep/projects/usgs/water/impd/nhgf/data_creation/daymet/source/zarr \
+    --region na --period 1980/2023
+# Verify: manifest.json gains a sources.daymet.regions.na entry.
+
+pixi run nhf-targets fetch era5-land --project-dir /path/to/project --period 2020/2020
+# Verify: <datastore>/era5_land/daily/era5_land_daily_2020.nc and
+# <datastore>/era5_land/monthly/era5_land_monthly_2020.nc each contain
+# variables ro, sro, ssro, sd.
+```
+
+## Follow-up issues to file at merge
+
+1. **SWE: Daymet aggregate + target wiring.** `aggregate/daymet.py` (3
+   regional zarrs → per-region per-year HRU NCs, concat in target builder),
+   `defaults.py` SWE block, `cli.py` agg dispatch.
+2. **SWE: SNODAS aggregate + target wiring.**
+3. **SWE: ERA5-Land `sd` aggregate + target wiring.** Extend
+   `aggregate/era5_land.py` to emit `sd` alongside `ro/sro/ssro`.
+4. **SWE: Margulis WUS-SR aggregate + target wiring with `fabric_scope`
+   enforcement.** Wire Oregon-only check (skip-or-raise for non-OR fabrics).
+5. **SWE target builder (`targets/swe.py`).** Multi-source minmax over the
+   four sources; honours `fabric_scope`; emits `swe.nc` and (optional)
+   `swe_nn_filled.nc`. Open question whether normalisation matches
+   `runoff` (none) or `soil_moisture` (calendar-month) — confirm against
+   TM 6-B10 §SWE during this issue.
+
+## Risks / open questions
+
+- **SNODAS short_name/version + masked-vs-unmasked.** Confirm `G02158` vs
+  `G02158_unmasked` against NSIDC before SNODAS consolidation lands.
+- **SNODAS native format.** Int16 binary + ENVI `.Hdr` — consolidation code
+  is non-trivial. Characterise in a notebook before finalising.
+- **Margulis short_name.** `WUS_UCLA_SR` is a best guess from the NSIDC-0719
+  page; verify via earthaccess CMR query.
+- **Daymet fingerprint scope.** Sha256 of `.zmetadata` is cheap but could
+  miss a structure-only change. Acceptable for verify-only; documented in
+  module docstring.
+- **ERA5-Land `sd` daily reducer = mean.** Defensible for slowly-varying
+  snowpack; some operators may prefer 12 UTC point sampling. Document in
+  catalog `notes`; revisit if the target builder needs different semantics.
+- **`fabric_scope` enforcement is deferred.** This PR introduces the field
+  and records it in manifests but does not enforce it on aggregate/target
+  paths. The Margulis follow-up issue (#4) carries the enforcement.
+- **`fetch all` silent skips.** Adding daymet + margulis-wus-sr to the
+  "missing-file = skip" list means a misconfigured datastore proceeds with
+  fewer sources than intended. Mitigation: log a summary tally at the end
+  of `fetch all` distinguishing successes from skips.
+- **No new dependencies expected.** xarray (existing) handles zarr;
+  earthaccess (existing) handles NSIDC. If SNODAS binary parsing requires
+  features not already in our rasterio stack, raise during implementation
+  rather than this scaffolding PR.

--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -47,3 +47,58 @@ def variable(name: str) -> dict:
     if name not in all_vars:
         raise KeyError(f"Variable '{name}' not found in catalog/variables.yml")
     return all_vars[name]
+
+
+# Allowed `fabric_scope.fabrics` tokens. Keep this set in sync with the
+# fabrics this pipeline targets — adding a new fabric should be
+# accompanied by extending this allow-list and the matching
+# enforcement in the target builders.
+FABRIC_SCOPE_TOKENS: frozenset[str] = frozenset({"or"})
+
+
+def validate_fabric_scope(source_key: str, scope: dict | None) -> None:
+    """Raise ValueError if a source's ``fabric_scope`` block is malformed.
+
+    The check is intentionally narrow:
+
+    - ``scope`` may be ``None`` (no scope, source available everywhere).
+    - When present, ``scope`` must be a mapping with a non-empty list
+      ``fabrics`` whose entries are all in :data:`FABRIC_SCOPE_TOKENS`.
+
+    This catches typos (`fabrics: [oregon]`) that would otherwise
+    silently disable scoping at the target-builder boundary.
+
+    Parameters
+    ----------
+    source_key : str
+        Catalog source key (for error messages).
+    scope : dict or None
+        The value of ``sources[source_key].fabric_scope``.
+
+    Raises
+    ------
+    ValueError
+        ``scope`` is not a mapping, ``fabrics`` is missing/empty/not a
+        list, or contains tokens outside :data:`FABRIC_SCOPE_TOKENS`.
+    """
+    if scope is None:
+        return
+    if not isinstance(scope, dict):
+        raise ValueError(
+            f"sources[{source_key!r}].fabric_scope must be a mapping; "
+            f"got {type(scope).__name__}."
+        )
+    fabrics = scope.get("fabrics")
+    if not isinstance(fabrics, list) or not fabrics:
+        raise ValueError(
+            f"sources[{source_key!r}].fabric_scope.fabrics must be a "
+            f"non-empty list; got {fabrics!r}."
+        )
+    unknown = [f for f in fabrics if f not in FABRIC_SCOPE_TOKENS]
+    if unknown:
+        raise ValueError(
+            f"sources[{source_key!r}].fabric_scope.fabrics contains "
+            f"unknown token(s) {unknown}. Allowed: "
+            f"{sorted(FABRIC_SCOPE_TOKENS)}. If you intended to add a "
+            f"new fabric, extend FABRIC_SCOPE_TOKENS in catalog.py."
+        )

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -1193,8 +1193,8 @@ def fetch_snodas_cmd(
     console.print(json_mod.dumps(result, indent=2))
 
 
-@fetch_app.command(name="wus-sr")
-def fetch_wus_sr_cmd(
+@fetch_app.command(name="margulis-wus-sr")
+def fetch_margulis_wus_sr_cmd(
     workdir: Annotated[
         Path,
         Parameter(

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -371,8 +371,10 @@ def fetch_all_cmd(
     # Import all fetch functions
     import nhf_spatial_targets.catalog as _catalog
     from nhf_spatial_targets.fetch._period import clamp_period
+    from nhf_spatial_targets.fetch.daymet import fetch_daymet
     from nhf_spatial_targets.fetch.era5_land import fetch_era5_land
     from nhf_spatial_targets.fetch.gldas import fetch_gldas
+    from nhf_spatial_targets.fetch.margulis_wus_sr import fetch_margulis_wus_sr
     from nhf_spatial_targets.fetch.merra2 import fetch_merra2
     from nhf_spatial_targets.fetch.modis import fetch_mod10c1, fetch_mod16a2
     from nhf_spatial_targets.fetch.mwbm_climgrid import fetch_mwbm_climgrid
@@ -380,6 +382,7 @@ def fetch_all_cmd(
     from nhf_spatial_targets.fetch.nldas import fetch_nldas_mosaic, fetch_nldas_noah
     from nhf_spatial_targets.fetch.pangaea import fetch_watergap22d
     from nhf_spatial_targets.fetch.reitz2017 import fetch_reitz2017
+    from nhf_spatial_targets.fetch.snodas import fetch_snodas
 
     # (display name, catalog source key, fetch function)
     sources = [
@@ -394,6 +397,11 @@ def fetch_all_cmd(
         ("watergap22d", "watergap22d", fetch_watergap22d),
         ("reitz2017", "reitz2017", fetch_reitz2017),
         ("mwbm-climgrid", "mwbm_climgrid", fetch_mwbm_climgrid),
+        # SWE category (issue #99) — fetch scaffolding only; aggregate +
+        # target wiring deferred to per-source follow-up issues.
+        ("daymet", "daymet", fetch_daymet),
+        ("snodas", "snodas", fetch_snodas),
+        ("margulis-wus-sr", "margulis_wus_sr", fetch_margulis_wus_sr),
     ]
 
     results = {}
@@ -425,14 +433,20 @@ def fetch_all_cmd(
             results[name] = result
             console.print(f"[green]{name}: downloaded to datastore[/green]")
         except FileNotFoundError as exc:
-            # mwbm-climgrid requires a manual (CAPTCHA-gated) download;
-            # treat its absence as a skip rather than a fatal error so
-            # the rest of the pipeline can still run when the operator
-            # hasn't placed the file yet.
-            if name == "mwbm-climgrid":
+            # Manual-placement / operator-staged sources can legitimately
+            # be missing on a freshly-bootstrapped project — skip them
+            # rather than fail the whole `fetch all` run so the rest of
+            # the pipeline can proceed. Operators inspect the per-source
+            # skip lines and stage the missing inputs as needed.
+            #   - mwbm-climgrid: CAPTCHA-gated ScienceBase download.
+            #   - daymet: pre-staged zarr root not yet configured.
+            #   - margulis-wus-sr: Oregon-only; legitimately absent for
+            #     non-Oregon projects.
+            manual_skip = {"mwbm-climgrid", "daymet", "margulis-wus-sr"}
+            if name in manual_skip:
                 console.print(
                     f"[yellow]{name}: skipped (manual download not yet "
-                    f"placed; see docs/sources/mwbm_climgrid.md)[/yellow]"
+                    f"placed; see docs/sources/{name.replace('-', '_')}.md)[/yellow]"
                 )
                 continue
             print(f"Error fetching {name}: {exc}", file=sys.stderr)
@@ -836,7 +850,12 @@ def fetch_era5_land_cmd(
         ),
     ] = 1,
 ):
-    """Download ERA5-Land hourly runoff (ro, sro, ssro) via CDS API and consolidate to daily/monthly NetCDFs."""
+    """Download ERA5-Land hourly fields (ro, sro, ssro, sd) via CDS API and consolidate to daily/monthly NetCDFs.
+
+    The runoff variables (ro/sro/ssro) are accumulated and aggregated as
+    daily/monthly sums; sd (snow depth water equivalent) is instantaneous
+    and aggregated as daily/monthly means.
+    """
     import json as json_mod
 
     from rich.console import Console
@@ -1018,6 +1037,209 @@ def fetch_mwbm_climgrid_cmd(
         sys.exit(1)
 
     console.print("[green]MWBM ClimGrid: registered in manifest[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# SWE category (issue #99) — fetch scaffolding
+# Aggregate + target wiring deferred to per-source follow-up issues.
+# ---------------------------------------------------------------------------
+
+
+@fetch_app.command(name="daymet")
+def fetch_daymet_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "1980/2024",
+    source_path: Annotated[
+        Path | None,
+        Parameter(
+            name=["--source-path"],
+            help="Directory containing daymet_{na,hi,pr}.zarr. Overrides "
+            "'daymet_root' from config.yml.",
+        ),
+    ] = None,
+    region: Annotated[
+        str,
+        Parameter(
+            name=["--region"],
+            help="One of 'na' | 'hi' | 'pr' | 'all' (default: all).",
+        ),
+    ] = "all",
+):
+    """Register operator-staged Daymet V4 R1 regional zarr stores.
+
+    Daymet zarrs are pre-staged on a shared filesystem; this command
+    fingerprints the structural metadata of each region and records a
+    per-region manifest entry. No downloading or copying. See
+    docs/sources/daymet.md for the staging procedure.
+    """
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.daymet import fetch_daymet
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    console.print(
+        f"[bold]Registering Daymet (region={region}, period {period})...[/bold]"
+    )
+
+    try:
+        result = fetch_daymet(
+            workdir=workdir,
+            period=period,
+            source_path=source_path,
+            region=region,
+        )
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during Daymet registration")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]Daymet: registered in manifest[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+@fetch_app.command(name="snodas")
+def fetch_snodas_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "2003/2024",
+    worker_index: Annotated[
+        int,
+        Parameter(
+            name=["--worker-index"],
+            help="0-based index of this worker within the pool (default 0).",
+        ),
+    ] = 0,
+    n_workers: Annotated[
+        int,
+        Parameter(
+            name=["--n-workers"],
+            help="Total number of parallel workers (default 1 = serial).",
+        ),
+    ] = 1,
+):
+    """Download SNODAS daily SWE granules from NSIDC (G02158) via earthaccess.
+
+    Fetch-only: raw tar/.Hdr bundles land in <datastore>/snodas/raw/<year>/.
+    Decoding into CF NetCDFs is deferred to the SNODAS aggregate follow-up.
+    """
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.snodas import fetch_snodas
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    if n_workers > 1:
+        console.print(
+            f"[bold]Fetching SNODAS for period {period} "
+            f"(worker {worker_index}/{n_workers})...[/bold]"
+        )
+    else:
+        console.print(f"[bold]Fetching SNODAS for period {period}...[/bold]")
+
+    try:
+        result = fetch_snodas(
+            workdir=workdir,
+            period=period,
+            worker_index=worker_index,
+            n_workers=n_workers,
+        )
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during SNODAS fetch")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]SNODAS: downloaded to datastore[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+@fetch_app.command(name="wus-sr")
+def fetch_wus_sr_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "1985/2021",
+):
+    """Download Margulis Western US Snow Reanalysis (NSIDC-0719) via earthaccess.
+
+    Fabric-scoped to Oregon only (catalog `fabric_scope`); the scope is
+    recorded in manifest.json but not enforced at fetch time. Fetch-only:
+    consolidation is deferred to the Margulis aggregate follow-up.
+    """
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.margulis_wus_sr import fetch_margulis_wus_sr
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    console.print(f"[bold]Fetching Margulis WUS-SR for period {period}...[/bold]")
+
+    try:
+        result = fetch_margulis_wus_sr(workdir=workdir, period=period)
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during Margulis WUS-SR fetch")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]Margulis WUS-SR: downloaded to datastore[/green]")
     console.print(json_mod.dumps(result, indent=2))
 
 

--- a/src/nhf_spatial_targets/fetch/_period.py
+++ b/src/nhf_spatial_targets/fetch/_period.py
@@ -44,6 +44,46 @@ def years_in_period(period: str) -> list[int]:
     return list(range(start_year, end_year + 1))
 
 
+def period_bounds(period: str) -> tuple[int, int]:
+    """Return ``(start_year, end_year)`` integers for a catalog period string.
+
+    Accepts both ``"YYYY/YYYY"`` and ``"YYYY/present"``. ``"present"`` is
+    treated as year 9999 so callers can use the value as an inclusive
+    upper bound on user-requested years without further branching.
+
+    This helper lets fetch modules read their valid year range from the
+    catalog (the source of truth for source metadata) rather than
+    hardcoding it. Use it in place of module-level ``_DATA_PERIOD``
+    constants.
+    """
+    parts = period.split("/")
+    if len(parts) != 2:
+        raise ValueError(
+            f"period must be 'YYYY/YYYY' or 'YYYY/present', got: {period!r}"
+        )
+    try:
+        start = int(parts[0])
+    except ValueError:
+        raise ValueError(
+            f"period start year must be an integer, got: {period!r}"
+        ) from None
+    if parts[1] == "present":
+        end = 9999
+    else:
+        try:
+            end = int(parts[1].split("-")[0])
+        except ValueError:
+            raise ValueError(
+                f"period end year must be an integer or 'present', got: {period!r}"
+            ) from None
+    if end < start:
+        raise ValueError(
+            f"period end year ({parts[1]}) is before start year ({parts[0]}). "
+            f"Use 'YYYY/YYYY' (or 'YYYY/present') with start <= end."
+        )
+    return (start, end)
+
+
 def clamp_period(requested: str, available: str) -> str | None:
     """Clamp *requested* period to the *available* range from the catalog.
 

--- a/src/nhf_spatial_targets/fetch/daymet.py
+++ b/src/nhf_spatial_targets/fetch/daymet.py
@@ -14,6 +14,22 @@ the metadata already encodes (every chunk rewrite changes either a
 ``.zarray`` shape/dtype/chunks block, an attribute file, or the
 directory's total byte count).
 
+**Residual risk in the fingerprint.** A chunk file rewritten in place
+with **identical compressed length** but different content bytes (e.g.
+the operator re-ran the publisher's converter and got a different
+floating-point shuffle, or an ``rsync --inplace`` overlaid a
+same-length corruption) is invisible to both the metadata hash and
+the directory byte count. In practice this is improbable for V4 R1
+(blosc-shuffled chunks producing the exact same compressed length
+from different input is statistically rare), and zarr v2 records no
+per-chunk checksums. Operators who suspect chunk-level tampering
+should re-stage the zarrs from the ORNL DAAC distribution.
+
+Concurrent invocation: ``fetch daymet --region <r>`` is safe to run
+in parallel across regions; the per-region manifest update takes an
+exclusive ``flock`` on a ``manifest.json.lock`` sibling so two
+processes never lose each other's region records.
+
 See ``docs/sources/daymet.md`` for the operator workflow.
 """
 
@@ -28,20 +44,27 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:  # Windows fallback (not used on HPC).
+    _HAVE_FLOCK = False
+
 import xarray as xr
 
 import nhf_spatial_targets.catalog as _catalog
-from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.fetch._period import (
+    parse_period,
+    period_bounds,
+    years_in_period,
+)
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
 
 _SOURCE_KEY = "daymet"
 _REGIONS = ("na", "hi", "pr")
-# Publisher-usable window; the catalog declares "1980/2024" but the
-# fetch step records whatever the staged zarrs actually carry. The
-# clamp here just rejects obvious operator typos before any work runs.
-_DATA_PERIOD = (1980, 2024)
 # Stability window for detecting concurrent writes: stat the .zmetadata
 # file twice, sleep, compare. Tunable for tests.
 _STABILITY_SECONDS = 0.5
@@ -156,8 +179,10 @@ def _validate_zarr(zroot: Path, region: str) -> dict:
             f"or corrupt; verify the operator staging step completed."
         ) from exc
     try:
-        present_vars = set(ds.data_vars) | set(ds.coords)
-        missing = _REQUIRED_VARS - present_vars
+        # Required vars must be data_vars, not coords. A coord coincidentally
+        # named "swe" should not mask a missing data variable.
+        present_data_vars = set(ds.data_vars)
+        missing = _REQUIRED_VARS - present_data_vars
         if missing:
             raise RuntimeError(
                 f"{zroot} (region={region}) is missing required variables "
@@ -176,7 +201,9 @@ def _validate_zarr(zroot: Path, region: str) -> dict:
                     f"{zroot}: zarr has no '{axis}' coordinate; "
                     f"Daymet uses (time, y, x) projected coords."
                 )
-        if "lambert_conformal_conic" not in present_vars:
+        # The CRS spec is a scalar var that can show up under data_vars or
+        # coords depending on how the zarr was written; check both.
+        if "lambert_conformal_conic" not in (present_data_vars | set(ds.coords)):
             logger.warning(
                 "%s (region=%s): missing CRS variable "
                 "'lambert_conformal_conic'. Aggregation steps will likely "
@@ -288,11 +315,14 @@ def fetch_daymet(
         missing required variables.
     """
     parse_period(period)
+    meta = _catalog.source(_SOURCE_KEY)
+    data_lo, data_hi = period_bounds(meta["period"])
     for y in years_in_period(period):
-        if y < _DATA_PERIOD[0] or y > _DATA_PERIOD[1]:
+        if y < data_lo or y > data_hi:
             raise ValueError(
                 f"Year {y} is outside the Daymet V4 R1 publisher window "
-                f"({_DATA_PERIOD[0]}-{_DATA_PERIOD[1]}). Adjust --period."
+                f"({data_lo}-{data_hi}, from catalog `sources.yml[{_SOURCE_KEY}]"
+                f".period`). Adjust --period."
             )
 
     if region not in (*_REGIONS, "all"):
@@ -329,7 +359,6 @@ def fetch_daymet(
             region_paths[r],
         )
 
-    meta = _catalog.source(_SOURCE_KEY)
     license_str = meta.get("license", "unknown")
     now_utc = datetime.now(timezone.utc).isoformat()
 
@@ -407,49 +436,72 @@ def _update_manifest(
     license_str: str,
     region_records: dict[str, dict],
 ) -> None:
-    """Merge daymet provenance into manifest.json (per-region entries)."""
+    """Merge daymet provenance into manifest.json (per-region entries).
+
+    Operators may invoke ``fetch daymet --region na`` and
+    ``fetch daymet --region hi`` concurrently; the read-merge-write
+    cycle takes an exclusive ``flock`` on a ``manifest.json.lock``
+    sibling so parallel processes never lose each other's region
+    records.
+    """
     ws = _load_project(workdir)
     manifest_path = ws.manifest_path
-    if manifest_path.exists():
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _do_update() -> None:
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"manifest.json in {workdir} is corrupt and cannot be "
+                    f"parsed. Delete it and re-run the fetch step. "
+                    f"Original error: {exc}"
+                ) from exc
+        else:
+            manifest = {"sources": {}, "steps": []}
+
+        manifest.setdefault("sources", {})
+        entry = manifest["sources"].get(_SOURCE_KEY, {})
+        existing_regions = entry.get("regions", {}) or {}
+        # Merge: keep regions we didn't touch this run, overwrite the ones we did.
+        merged_regions = {**existing_regions, **region_records}
+        access = meta["access"]
+        entry.update(
+            {
+                "source_key": _SOURCE_KEY,
+                "access_url": access["url"],
+                "doi": meta.get("doi"),
+                "license": license_str,
+                "period": period,
+                "spatial_extent": meta.get("spatial_extent"),
+                "variables": [v["name"] for v in meta["variables"]],
+                "regions": merged_regions,
+            }
+        )
+        manifest["sources"][_SOURCE_KEY] = entry
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=manifest_path.parent, suffix=".json.tmp"
+        )
         try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupt and cannot be "
-                f"parsed. Delete it and re-run the fetch step. "
-                f"Original error: {exc}"
-            ) from exc
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump(manifest, f, indent=2)
+            Path(tmp_path).replace(manifest_path)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+    if _HAVE_FLOCK:
+        with open(lock_path, "a") as _lock_f:
+            _fcntl.flock(_lock_f, _fcntl.LOCK_EX)
+            try:
+                _do_update()
+            finally:
+                _fcntl.flock(_lock_f, _fcntl.LOCK_UN)
     else:
-        manifest = {"sources": {}, "steps": []}
-
-    manifest.setdefault("sources", {})
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    existing_regions = entry.get("regions", {}) or {}
-    # Merge: keep regions we didn't touch this run, overwrite the ones we did.
-    merged_regions = {**existing_regions, **region_records}
-    access = meta["access"]
-    entry.update(
-        {
-            "source_key": _SOURCE_KEY,
-            "access_url": access["url"],
-            "doi": meta.get("doi"),
-            "license": license_str,
-            "period": period,
-            "spatial_extent": meta.get("spatial_extent"),
-            "variables": [v["name"] for v in meta["variables"]],
-            "regions": merged_regions,
-        }
-    )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
+        _do_update()
     logger.info(
         "Updated manifest.json with daymet provenance for regions %s",
         sorted(region_records.keys()),

--- a/src/nhf_spatial_targets/fetch/daymet.py
+++ b/src/nhf_spatial_targets/fetch/daymet.py
@@ -1,0 +1,456 @@
+"""Register operator-staged Daymet V4 R1 regional zarr stores.
+
+Daymet V4 R1 is distributed by ORNL DAAC as three regional zarr stores —
+North America (na), Hawaii (hi), and Puerto Rico (pr) — totalling hundreds
+of gigabytes per region. We do not download or copy them: the operator
+pre-stages the zarrs at a shared filesystem location, and this module
+fingerprints each region (sha256 over the zarr's structural metadata
+files: ``.zattrs``, ``.zgroup``, and every per-array ``.zarray`` and
+``.zattrs``, walked in sorted order — plus the total on-disk byte
+count) and records the result in ``manifest.json`` for downstream
+provenance. The fingerprint is intentionally cheap; a full-data hash
+would take many hours per region and add no defensive value beyond what
+the metadata already encodes (every chunk rewrite changes either a
+``.zarray`` shape/dtype/chunks block, an attribute file, or the
+directory's total byte count).
+
+See ``docs/sources/daymet.md`` for the operator workflow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import xarray as xr
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "daymet"
+_REGIONS = ("na", "hi", "pr")
+# Publisher-usable window; the catalog declares "1980/2024" but the
+# fetch step records whatever the staged zarrs actually carry. The
+# clamp here just rejects obvious operator typos before any work runs.
+_DATA_PERIOD = (1980, 2024)
+# Stability window for detecting concurrent writes: stat the .zmetadata
+# file twice, sleep, compare. Tunable for tests.
+_STABILITY_SECONDS = 0.5
+# Variables every Daymet regional zarr is expected to expose. Mirrors
+# the catalog `variables:` block; checked at registration time.
+_REQUIRED_VARS = {"swe", "prcp", "tmax", "tmin", "srad", "vp"}
+
+
+def _metadata_files(zroot: Path) -> list[Path]:
+    """Return all zarr structural metadata files in deterministic order.
+
+    Includes ``.zgroup`` / ``.zattrs`` at the top level and every
+    ``.zarray`` / ``.zattrs`` / ``.zgroup`` underneath. If a
+    ``.zmetadata`` (consolidated metadata) file is present, it is
+    included too — it is the cheapest single-file authoritative
+    summary. Walking metadata is fast (kilobytes per region) so this
+    cost is negligible compared to a chunk hash.
+    """
+    names = {".zgroup", ".zattrs", ".zarray", ".zmetadata"}
+    out: list[Path] = []
+    for child in zroot.rglob("*"):
+        if child.is_file() and child.name in names:
+            out.append(child)
+    out.sort(key=lambda p: str(p.relative_to(zroot)))
+    return out
+
+
+def _verify_zarr_stable(zroot: Path) -> None:
+    """Raise RuntimeError if any structural metadata file is being written."""
+    files = _metadata_files(zroot)
+    if not files:
+        raise RuntimeError(
+            f"{zroot}: zarr has no .zgroup / .zarray / .zattrs metadata "
+            f"files; this is not a valid zarr v2 store."
+        )
+    snap = [(p, p.stat().st_size, p.stat().st_mtime) for p in files]
+    time.sleep(_STABILITY_SECONDS)
+    for p, size, mtime in snap:
+        st = p.stat()
+        if st.st_size != size or st.st_mtime != mtime:
+            raise RuntimeError(
+                f"{p} is being modified concurrently (size or mtime "
+                f"changed during the {_STABILITY_SECONDS:.2f}s stability "
+                f"window). Wait for the writer to finish, then re-run."
+            )
+
+
+def _hash_zarr_metadata(zroot: Path) -> str:
+    """sha256 over the zarr's structural metadata files, sorted by path.
+
+    The hash incorporates each file's relative path AND content so that
+    adding/removing arrays changes the digest even when the per-file
+    bytes would otherwise reshuffle.
+    """
+    sha = hashlib.sha256()
+    for p in _metadata_files(zroot):
+        sha.update(str(p.relative_to(zroot)).encode("utf-8"))
+        sha.update(b"\0")
+        with p.open("rb") as f:
+            for chunk in iter(lambda: f.read(64 * 1024), b""):
+                sha.update(chunk)
+        sha.update(b"\0")
+    return sha.hexdigest()
+
+
+def _zarr_directory_size(zroot: Path) -> int:
+    """Total on-disk byte count of all files inside the zarr store.
+
+    Used alongside the metadata sha256 as a defensive fingerprint: a
+    chunk file rewritten without touching ``.zarray`` / ``.zattrs`` is
+    unusual but possible (e.g. rsync --inplace), and the directory size
+    will diverge in that case.
+    """
+    total = 0
+    for child in zroot.rglob("*"):
+        if child.is_file():
+            total += child.stat().st_size
+    return total
+
+
+def _read_manifest_entry(workdir: Path) -> dict | None:
+    """Return the daymet manifest entry, or None if absent."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"manifest.json in {workdir} is corrupt and cannot be parsed. "
+            f"Delete it and re-run the fetch step. Original error: {exc}"
+        ) from exc
+    return manifest.get("sources", {}).get(_SOURCE_KEY)
+
+
+def _validate_zarr(zroot: Path, region: str) -> dict:
+    """Open the zarr, assert required vars + dims, return time-range info.
+
+    Returns ``{"time_min": iso, "time_max": iso, "time_steps": int}``.
+
+    Raises RuntimeError if the zarr is missing the SWE variable, the
+    canonical CF coords (time/x/y), or the CRS spec
+    (``lambert_conformal_conic``).
+    """
+    try:
+        # Real Daymet zarrs are v2 without consolidated metadata.
+        ds = xr.open_zarr(zroot, consolidated=False)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot open zarr {zroot}: {exc}. The store may be incomplete "
+            f"or corrupt; verify the operator staging step completed."
+        ) from exc
+    try:
+        present_vars = set(ds.data_vars) | set(ds.coords)
+        missing = _REQUIRED_VARS - present_vars
+        if missing:
+            raise RuntimeError(
+                f"{zroot} (region={region}) is missing required variables "
+                f"{sorted(missing)}. Daymet V4 R1 should expose "
+                f"{sorted(_REQUIRED_VARS)} on every regional zarr. "
+                f"Re-stage the publisher's zarr before re-running."
+            )
+        if "time" not in ds.coords and "time" not in ds.dims:
+            raise RuntimeError(
+                f"{zroot}: zarr has no 'time' coordinate; cannot use as a "
+                f"calibration source."
+            )
+        for axis in ("x", "y"):
+            if axis not in ds.coords and axis not in ds.dims:
+                raise RuntimeError(
+                    f"{zroot}: zarr has no '{axis}' coordinate; "
+                    f"Daymet uses (time, y, x) projected coords."
+                )
+        if "lambert_conformal_conic" not in present_vars:
+            logger.warning(
+                "%s (region=%s): missing CRS variable "
+                "'lambert_conformal_conic'. Aggregation steps will likely "
+                "fail to identify the projection.",
+                zroot,
+                region,
+            )
+        times = ds["time"].values
+        if len(times) == 0:
+            raise RuntimeError(f"{zroot}: time coord is empty.")
+        return {
+            "time_min": str(times[0]),
+            "time_max": str(times[-1]),
+            "time_steps": int(len(times)),
+        }
+    finally:
+        ds.close()
+
+
+def _resolve_root(
+    workdir: Path,
+    source_path: Path | None,
+) -> Path:
+    """Return the absolute path to the directory containing the three zarrs.
+
+    Order of precedence: ``source_path`` arg → ``config.yml: daymet_root``
+    → raise ``FileNotFoundError`` with operator instructions. The catalog
+    `access.stores` values use a ``{daymet_root}`` template placeholder
+    that is substituted with the resolved root.
+    """
+    if source_path is not None:
+        return Path(source_path).resolve()
+    ws = _load_project(workdir)
+    cfg_root = ws.config.get("daymet_root")
+    if cfg_root:
+        return Path(cfg_root).resolve()
+    raise FileNotFoundError(
+        "Daymet zarr root is not configured. Either pass "
+        "--source-path <dir> on the CLI, or add `daymet_root: /path/to/...` "
+        "to config.yml. The directory must contain daymet_na.zarr, "
+        "daymet_hi.zarr, and/or daymet_pr.zarr. See docs/sources/daymet.md."
+    )
+
+
+def _resolve_region_paths(root: Path, regions: tuple[str, ...]) -> dict[str, Path]:
+    """Apply the ``{daymet_root}`` template from the catalog to ``root``."""
+    meta = _catalog.source(_SOURCE_KEY)
+    template = meta["access"]["stores"]
+    out: dict[str, Path] = {}
+    for region in regions:
+        try:
+            tmpl = template[region]
+        except KeyError as exc:
+            raise ValueError(
+                f"region {region!r} is not declared in catalog "
+                f"sources.yml[daymet].access.stores; known: "
+                f"{sorted(template.keys())}"
+            ) from exc
+        out[region] = Path(tmpl.format(daymet_root=str(root)))
+    return out
+
+
+def fetch_daymet(
+    workdir: Path,
+    period: str,
+    *,
+    source_path: Path | None = None,
+    region: str = "all",
+) -> dict:
+    """Register pre-staged Daymet V4 R1 regional zarr stores in manifest.json.
+
+    The three regional zarrs (NA, HI, PR) live on a shared filesystem; this
+    module verifies each one opens cleanly, fingerprints it, and records a
+    per-region entry under ``manifest["sources"]["daymet"]["regions"]``.
+    No download and no copy: the catalog's ``access.stores`` map carries
+    a ``{daymet_root}`` template that is filled with the resolved root.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory.
+    period : str
+        Temporal window ``"YYYY/YYYY"``. Validated against the publisher-
+        usable window (1980/2024) and recorded in the manifest entry.
+    source_path : Path or None
+        Directory containing the regional zarrs. If ``None``, falls back
+        to ``config.yml -> daymet_root``.
+    region : str
+        One of ``"na" | "hi" | "pr" | "all"``. ``"all"`` registers every
+        region present at ``source_path``; missing regions are reported
+        but do not raise (operators frequently stage only NA).
+
+    Returns
+    -------
+    dict
+        Provenance summary with one entry per registered region.
+
+    Raises
+    ------
+    FileNotFoundError
+        Neither ``source_path`` nor ``daymet_root`` resolves to an
+        existing directory, or none of the requested regional zarrs
+        are present.
+    ValueError
+        Period falls outside the publisher window or ``region`` is
+        not one of the documented values.
+    RuntimeError
+        A zarr is being written concurrently, fails to open, or is
+        missing required variables.
+    """
+    parse_period(period)
+    for y in years_in_period(period):
+        if y < _DATA_PERIOD[0] or y > _DATA_PERIOD[1]:
+            raise ValueError(
+                f"Year {y} is outside the Daymet V4 R1 publisher window "
+                f"({_DATA_PERIOD[0]}-{_DATA_PERIOD[1]}). Adjust --period."
+            )
+
+    if region not in (*_REGIONS, "all"):
+        raise ValueError(
+            f"region={region!r} is not recognised; expected one of "
+            f"{(*_REGIONS, 'all')}."
+        )
+
+    root = _resolve_root(workdir, source_path)
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(
+            f"Daymet zarr root does not exist or is not a directory: {root}. "
+            f"Pass --source-path or set `daymet_root:` in config.yml to "
+            f"a directory containing daymet_na.zarr / daymet_hi.zarr / "
+            f"daymet_pr.zarr."
+        )
+
+    requested = _REGIONS if region == "all" else (region,)
+    region_paths = _resolve_region_paths(root, requested)
+    present: dict[str, Path] = {
+        r: p for r, p in region_paths.items() if p.exists() and p.is_dir()
+    }
+    missing = [r for r in requested if r not in present]
+    if not present:
+        raise FileNotFoundError(
+            f"None of the requested Daymet regional zarrs exist under {root}. "
+            f"Looked for {[str(p) for p in region_paths.values()]}. "
+            f"See docs/sources/daymet.md for the staging procedure."
+        )
+    for r in missing:
+        logger.warning(
+            "daymet: region %r not present at %s; skipping.",
+            r,
+            region_paths[r],
+        )
+
+    meta = _catalog.source(_SOURCE_KEY)
+    license_str = meta.get("license", "unknown")
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    # Idempotency fast path: if every requested-and-present region's
+    # manifest entry already matches (zmetadata sha256 + directory size),
+    # return cached records without re-hashing.
+    existing = _read_manifest_entry(workdir) or {}
+    existing_regions = existing.get("regions", {}) if isinstance(existing, dict) else {}
+
+    region_records: dict[str, dict] = {}
+    fingerprinted_any = False
+    for r, zroot in present.items():
+        # Quick structural check: the zarr must have a .zgroup at the
+        # root, otherwise it's not a valid zarr v2 hierarchy.
+        if not (zroot / ".zgroup").exists():
+            raise RuntimeError(
+                f"{zroot}: not a valid zarr v2 store (missing .zgroup at "
+                f"root). Re-stage the publisher zarr."
+            )
+        size_bytes = _zarr_directory_size(zroot)
+        recorded = existing_regions.get(r) or {}
+        if (
+            recorded.get("size_bytes") == size_bytes
+            and recorded.get("zmetadata_sha256")
+            and _hash_zarr_metadata(zroot) == recorded["zmetadata_sha256"]
+        ):
+            logger.info(
+                "daymet: region %r matches manifest (size + metadata "
+                "sha256); skipping re-fingerprint.",
+                r,
+            )
+            region_records[r] = recorded
+            continue
+
+        _verify_zarr_stable(zroot)
+        sha_hex = _hash_zarr_metadata(zroot)
+        time_info = _validate_zarr(zroot, region=r)
+        region_records[r] = {
+            "region": r,
+            "path": str(zroot),
+            "size_bytes": size_bytes,
+            # Stored under the legacy key ``zmetadata_sha256`` for
+            # operator-facing continuity; the value is a hash over all
+            # zarr structural metadata, not just ``.zmetadata``.
+            "zmetadata_sha256": sha_hex,
+            "time_min": time_info["time_min"],
+            "time_max": time_info["time_max"],
+            "time_steps": time_info["time_steps"],
+            "registered_utc": now_utc,
+            "manual_staging": True,
+        }
+        fingerprinted_any = True
+
+    if fingerprinted_any:
+        _update_manifest(workdir, period, meta, license_str, region_records)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": meta["access"]["url"],
+        "doi": meta.get("doi"),
+        "license": license_str,
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "spatial_extent": meta.get("spatial_extent"),
+        "download_timestamp": now_utc if fingerprinted_any else None,
+        "regions": region_records,
+        "missing_regions": missing,
+    }
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    meta: dict,
+    license_str: str,
+    region_records: dict[str, dict],
+) -> None:
+    """Merge daymet provenance into manifest.json (per-region entries)."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"manifest.json in {workdir} is corrupt and cannot be "
+                f"parsed. Delete it and re-run the fetch step. "
+                f"Original error: {exc}"
+            ) from exc
+    else:
+        manifest = {"sources": {}, "steps": []}
+
+    manifest.setdefault("sources", {})
+    entry = manifest["sources"].get(_SOURCE_KEY, {})
+    existing_regions = entry.get("regions", {}) or {}
+    # Merge: keep regions we didn't touch this run, overwrite the ones we did.
+    merged_regions = {**existing_regions, **region_records}
+    access = meta["access"]
+    entry.update(
+        {
+            "source_key": _SOURCE_KEY,
+            "access_url": access["url"],
+            "doi": meta.get("doi"),
+            "license": license_str,
+            "period": period,
+            "spatial_extent": meta.get("spatial_extent"),
+            "variables": [v["name"] for v in meta["variables"]],
+            "regions": merged_regions,
+        }
+    )
+    manifest["sources"][_SOURCE_KEY] = entry
+
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp_path).replace(manifest_path)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+    logger.info(
+        "Updated manifest.json with daymet provenance for regions %s",
+        sorted(region_records.keys()),
+    )

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -229,7 +229,7 @@ def download_month_variable(
     year : int
     month : int
         Calendar month (1–12).
-    variable : {"ro", "sro", "ssro"}
+    variable : {"ro", "sro", "ssro", "sd"}
     output_path : Path
         Target NetCDF file. Parent directory is created if missing.
 
@@ -326,7 +326,7 @@ def download_year_variable(
     Parameters
     ----------
     year : int
-    variable : {"ro", "sro", "ssro"}
+    variable : {"ro", "sro", "ssro", "sd"}
     output_path : Path
         Target per-year NetCDF file. Parent directory is created if missing.
 

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -1,9 +1,12 @@
-"""Fetch ERA5-Land hourly runoff from Copernicus CDS.
+"""Fetch ERA5-Land hourly fields from Copernicus CDS.
 
-Downloads hourly accumulated runoff variables (ro, sro, ssro) for the
-CONUS+contributing-watersheds bbox, then aggregates hourly→daily and
-daily→monthly. Both daily and monthly consolidated NetCDFs are written
-to the shared datastore.
+Downloads hourly accumulated runoff variables (ro, sro, ssro) and the
+instantaneous snow depth water equivalent (sd) for the CONUS+contributing-
+watersheds bbox, then aggregates hourly→daily and daily→monthly. Both
+daily and monthly consolidated NetCDFs are written to the shared
+datastore. The accumulated and instantaneous variables use different
+reducers (see :data:`_VARIABLE_KIND` and the dispatch in
+:func:`consolidate_year` and :func:`daily_to_monthly`).
 """
 
 from __future__ import annotations
@@ -38,7 +41,23 @@ logger = logging.getLogger(__name__)
 # Encompasses CONUS contributing watersheds (Canada/Mexico) + ~10 km buffer.
 BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
 
-VARIABLES = ("ro", "sro", "ssro")
+VARIABLES = ("ro", "sro", "ssro", "sd")
+
+# Variable semantics for hourly→daily and daily→monthly aggregation.
+#   accumulated : midnight-resetting accumulation; aggregate via the
+#                 diff-of-accumulations sum (see hourly_to_daily) and
+#                 daily→monthly sum.
+#   instantaneous : point-in-time field with no midnight reset; aggregate
+#                   via .mean() at both hourly→daily and daily→monthly.
+# The accumulated reducer applied to an instantaneous field would produce
+# physically meaningless values; the dispatch in consolidate_year and
+# daily_to_monthly is keyed on this table.
+_VARIABLE_KIND = {
+    "ro": "accumulated",
+    "sro": "accumulated",
+    "ssro": "accumulated",
+    "sd": "instantaneous",
+}
 
 
 def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
@@ -85,17 +104,59 @@ def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:
     return daily
 
 
-def daily_to_monthly(da: xr.DataArray) -> xr.DataArray:
-    """Sum daily totals to monthly totals.
+def hourly_to_daily_instantaneous(da: xr.DataArray) -> xr.DataArray:
+    """Aggregate ERA5-Land hourly instantaneous fields to daily means.
+
+    For point-in-time fields like ``sd`` (snow depth water equivalent) which
+    carry no midnight reset and are NOT accumulated, the daily aggregation
+    is a simple ``.resample("1D").mean()``. The accumulated counterpart
+    :func:`hourly_to_daily` must NOT be used for these fields — its
+    diff-of-accumulations sum would produce nonsense.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Hourly instantaneous values with a 'time' dimension.
+
+    Returns
+    -------
+    xr.DataArray
+        Daily-mean values. Time coordinate is the date (00:00) of each
+        complete day. Original attrs are preserved.
+    """
+    daily = da.resample(time="1D").mean()
+    daily.attrs = dict(da.attrs)
+    return daily
+
+
+def daily_to_monthly(da: xr.DataArray, kind: str = "accumulated") -> xr.DataArray:
+    """Aggregate daily values to monthly.
 
     Uses month-end frequency ('1ME') so the time coordinate marks the
     last day of each month — consistent with other monthly products in
     this codebase. Original attrs are preserved.
 
+    Parameters
+    ----------
+    da : xr.DataArray
+    kind : str, default "accumulated"
+        ``"accumulated"`` uses ``.sum()`` (appropriate for ro/sro/ssro
+        whose daily values are within-day totals). ``"instantaneous"``
+        uses ``.mean()`` (appropriate for ``sd``).
+
     Note: called by ``consolidate_year``, which also deletes any stale
     monthly NCs whose filenames fall outside the updated year range.
     """
-    monthly = da.resample(time="1ME").sum()
+    resampler = da.resample(time="1ME")
+    if kind == "instantaneous":
+        monthly = resampler.mean()
+    elif kind == "accumulated":
+        monthly = resampler.sum()
+    else:
+        raise ValueError(
+            f"daily_to_monthly: unknown kind {kind!r}; expected 'accumulated' "
+            f"or 'instantaneous'."
+        )
     monthly.attrs = dict(da.attrs)
     return monthly
 
@@ -105,6 +166,7 @@ _VARIABLE_REQUEST_NAME = {
     "ro": "runoff",
     "sro": "surface_runoff",
     "ssro": "sub_surface_runoff",
+    "sd": "snow_depth_water_equivalent",
 }
 
 
@@ -425,13 +487,16 @@ def consolidate_year(
                 )
             da = ds[var].load()
             ds.close()
-            daily_arrays[var] = hourly_to_daily(da)
+            if _VARIABLE_KIND[var] == "instantaneous":
+                daily_arrays[var] = hourly_to_daily_instantaneous(da)
+            else:
+                daily_arrays[var] = hourly_to_daily(da)
 
         daily_ds = xr.Dataset(daily_arrays)
         daily_ds = apply_cf_metadata(daily_ds, _SOURCE_KEY, "daily")
         daily_ds.attrs.update(
             {
-                "title": f"ERA5-Land daily runoff (CONUS+ buffered) {year}",
+                "title": f"ERA5-Land daily runoff and snow (CONUS+ buffered) {year}",
                 "institution": "ECMWF",
                 "source": "reanalysis-era5-land",
                 "references": "doi:10.5194/essd-13-4349-2021",
@@ -469,12 +534,14 @@ def consolidate_year(
         with xr.open_dataset(daily_path) as ds_year:
             monthly_arrays: dict[str, xr.DataArray] = {}
             for var in VARIABLES:
-                monthly_arrays[var] = daily_to_monthly(ds_year[var].load())
+                monthly_arrays[var] = daily_to_monthly(
+                    ds_year[var].load(), kind=_VARIABLE_KIND[var]
+                )
         monthly_ds = xr.Dataset(monthly_arrays)
         monthly_ds = apply_cf_metadata(monthly_ds, _SOURCE_KEY, "monthly")
         monthly_ds.attrs.update(
             {
-                "title": f"ERA5-Land monthly runoff (CONUS+ buffered) {year}",
+                "title": f"ERA5-Land monthly runoff and snow (CONUS+ buffered) {year}",
                 "institution": "ECMWF",
                 "source": "reanalysis-era5-land",
                 "references": "doi:10.5194/essd-13-4349-2021",

--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -1,0 +1,259 @@
+"""Fetch Margulis Western US Snow Reanalysis (NSIDC-0719) via earthaccess.
+
+NSIDC-0719 is a daily 90 m posterior SWE reanalysis over the Western US
+for water years 1985-2021. This source is **fabric-scoped to Oregon
+only** in this pipeline (see ``catalog/sources.yml ->
+margulis_wus_sr.fabric_scope``). The fetch step does not enforce that
+scope — raw downloads stay in the shared datastore and remain usable
+by any project pointing at the same store — but the manifest entry
+records the scope so downstream aggregate/target code can honour it.
+
+This is the **fetch-only** scaffolding: search NSIDC via earthaccess,
+download granules to ``<datastore>/margulis_wus_sr/raw/<year>/``,
+flock-protect the manifest update. Per-year consolidation into CF
+NetCDFs is deferred to the Margulis aggregate follow-up issue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:  # Windows fallback.
+    _HAVE_FLOCK = False
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "margulis_wus_sr"
+_DATA_PERIOD = (1985, 2021)
+
+
+def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
+    """Download Margulis WUS-SR daily granules to the shared datastore.
+
+    Fetch-only path: search NSIDC for granules covering ``period`` within
+    the project's fabric bbox, download to
+    ``<datastore>/margulis_wus_sr/raw/<year>/``, and write a flock-protected
+    manifest entry recording the fabric scope from the catalog. NSIDC-0719
+    granules are per-water-year per-tile NetCDFs; the consolidation step
+    that concatenates and re-projects them is deferred to a follow-up.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory. The project's fabric bbox is used as the
+        ``bounding_box`` constraint on the CMR search.
+    period : str
+        Temporal window ``"YYYY/YYYY"``. Clamped to the publisher window
+        (1985/2021) — out-of-range years raise ValueError.
+
+    Returns
+    -------
+    dict
+        Provenance summary.
+
+    Raises
+    ------
+    ValueError
+        Period falls outside the publisher window.
+    RuntimeError
+        ``earthaccess.download`` returned fewer files than the CMR
+        result count.
+    """
+    import earthaccess
+
+    parse_period(period)
+    years = years_in_period(period)
+    for y in years:
+        if y < _DATA_PERIOD[0] or y > _DATA_PERIOD[1]:
+            raise ValueError(
+                f"Year {y} is outside the Margulis WUS-SR publisher window "
+                f"({_DATA_PERIOD[0]}-{_DATA_PERIOD[1]}). Adjust --period."
+            )
+
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    access = meta["access"]
+    fabric_scope = meta.get("fabric_scope", {})
+
+    raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
+    raw_root.mkdir(parents=True, exist_ok=True)
+
+    bbox_buffered = ws.fabric.get("bbox_buffered") or {}
+    if not bbox_buffered:
+        raise ValueError(
+            "Margulis WUS-SR fetch needs a buffered fabric bbox; "
+            "fabric.json has no 'bbox_buffered' key. Re-run "
+            "`nhf-targets validate` to regenerate fabric.json."
+        )
+    bounding_box = (
+        float(bbox_buffered["minx"]),
+        float(bbox_buffered["miny"]),
+        float(bbox_buffered["maxx"]),
+        float(bbox_buffered["maxy"]),
+    )
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+    earthaccess.login(strategy="netrc")
+
+    year_records: list[dict] = []
+    for year in years:
+        year_dir = raw_root / f"{year}"
+        year_dir.mkdir(parents=True, exist_ok=True)
+        logger.info("margulis_wus_sr: searching CMR for year %d", year)
+        results = earthaccess.search_data(
+            short_name=access["short_name"],
+            version=access.get("version"),
+            temporal=(f"{year}-01-01", f"{year}-12-31"),
+            bounding_box=bounding_box,
+        )
+        n_found = len(results)
+        if n_found == 0:
+            logger.warning(
+                "margulis_wus_sr: no granules found for year %d (bbox %s); skipping",
+                year,
+                bounding_box,
+            )
+            year_records.append(
+                {
+                    "year": year,
+                    "raw_dir": str(year_dir),
+                    "n_granules": 0,
+                    "downloaded_utc": now_utc,
+                    "note": "no_granules_in_CMR",
+                }
+            )
+            continue
+        downloaded = earthaccess.download(results, str(year_dir))
+        if not downloaded:
+            raise RuntimeError(
+                f"margulis_wus_sr: earthaccess.download returned no files for "
+                f"year {year}; check network connectivity and Earthdata "
+                f"credentials."
+            )
+        # Drop zero-byte downloads (NSIDC occasionally returns truncated
+        # granules; the consolidation step would later trip on them).
+        usable = []
+        for f in downloaded:
+            p = Path(f)
+            if p.exists() and p.stat().st_size > 0:
+                usable.append(str(p))
+            else:
+                logger.warning("margulis_wus_sr: dropping zero-byte download %s", p)
+                if p.exists():
+                    p.unlink()
+        if len(usable) < n_found:
+            raise RuntimeError(
+                f"margulis_wus_sr: partial download for year {year}: "
+                f"{len(usable)}/{n_found} usable granules. Re-run to retry."
+            )
+        year_records.append(
+            {
+                "year": year,
+                "raw_dir": str(year_dir),
+                "n_granules": len(usable),
+                "downloaded_utc": now_utc,
+            }
+        )
+
+    _update_manifest(workdir, period, meta, year_records, fabric_scope, bounding_box)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": access["url"],
+        "doi": meta.get("doi"),
+        "license": meta.get("license", "public domain (NSIDC)"),
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": bounding_box,
+        "fabric_scope": fabric_scope,
+        "years": year_records,
+        "download_timestamp": now_utc,
+    }
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    meta: dict,
+    year_records: list[dict],
+    fabric_scope: dict,
+    bounding_box: tuple[float, float, float, float],
+) -> None:
+    """Merge Margulis provenance into manifest.json (flock-protected)."""
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _do_update() -> None:
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"manifest.json in {workdir} is corrupt and cannot be "
+                    f"parsed. Delete it and re-run the fetch step. "
+                    f"Original error: {exc}"
+                ) from exc
+        else:
+            manifest = {"sources": {}, "steps": []}
+
+        manifest.setdefault("sources", {})
+        entry = manifest["sources"].get(_SOURCE_KEY, {})
+        existing_by_year = {int(y["year"]): y for y in entry.get("years", [])}
+        for rec in year_records:
+            existing_by_year[int(rec["year"])] = rec
+        merged_years = [existing_by_year[y] for y in sorted(existing_by_year)]
+        access = meta["access"]
+        entry.update(
+            {
+                "source_key": _SOURCE_KEY,
+                "access_url": access["url"],
+                "doi": meta.get("doi"),
+                "license": meta.get("license", "public domain (NSIDC)"),
+                "period": period,
+                "bbox": list(bounding_box),
+                "fabric_scope": fabric_scope,
+                "variables": [v["name"] for v in meta["variables"]],
+                "years": merged_years,
+            }
+        )
+        manifest["sources"][_SOURCE_KEY] = entry
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=manifest_path.parent, suffix=".json.tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump(manifest, f, indent=2)
+            Path(tmp_path).replace(manifest_path)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+    if _HAVE_FLOCK:
+        with open(lock_path, "a") as _lock_f:
+            _fcntl.flock(_lock_f, _fcntl.LOCK_EX)
+            try:
+                _do_update()
+            finally:
+                _fcntl.flock(_lock_f, _fcntl.LOCK_UN)
+    else:
+        _do_update()
+    logger.info(
+        "Updated manifest.json with margulis_wus_sr provenance for years %s",
+        [r["year"] for r in year_records],
+    )

--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -31,13 +31,16 @@ except ImportError:  # Windows fallback.
     _HAVE_FLOCK = False
 
 import nhf_spatial_targets.catalog as _catalog
-from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.fetch._period import (
+    parse_period,
+    period_bounds,
+    years_in_period,
+)
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
 
 _SOURCE_KEY = "margulis_wus_sr"
-_DATA_PERIOD = (1985, 2021)
 
 
 def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
@@ -50,6 +53,12 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
     granules are per-water-year per-tile NetCDFs; the consolidation step
     that concatenates and re-projects them is deferred to a follow-up.
 
+    The source is fabric-scoped to Oregon via the catalog's
+    ``fabric_scope`` block; calling on a non-Oregon project still runs
+    (raw downloads are reusable across projects sharing a datastore)
+    but emits a warning that the search bbox is unlikely to overlap
+    NSIDC-0719's Western US domain.
+
     Parameters
     ----------
     workdir : Path
@@ -57,7 +66,8 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
         ``bounding_box`` constraint on the CMR search.
     period : str
         Temporal window ``"YYYY/YYYY"``. Clamped to the publisher window
-        (1985/2021) — out-of-range years raise ValueError.
+        recorded in ``catalog/sources.yml`` — out-of-range years raise
+        ValueError.
 
     Returns
     -------
@@ -67,7 +77,8 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
     Raises
     ------
     ValueError
-        Period falls outside the publisher window.
+        Period falls outside the publisher window, or the project
+        fabric lacks a buffered bbox.
     RuntimeError
         ``earthaccess.download`` returned fewer files than the CMR
         result count.
@@ -75,18 +86,39 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
     import earthaccess
 
     parse_period(period)
-    years = years_in_period(period)
-    for y in years:
-        if y < _DATA_PERIOD[0] or y > _DATA_PERIOD[1]:
-            raise ValueError(
-                f"Year {y} is outside the Margulis WUS-SR publisher window "
-                f"({_DATA_PERIOD[0]}-{_DATA_PERIOD[1]}). Adjust --period."
-            )
-
     ws = _load_project(workdir)
     meta = _catalog.source(_SOURCE_KEY)
     access = meta["access"]
     fabric_scope = meta.get("fabric_scope", {})
+    data_lo, data_hi = period_bounds(meta["period"])
+    years = years_in_period(period)
+    for y in years:
+        if y < data_lo or y > data_hi:
+            raise ValueError(
+                f"Year {y} is outside the Margulis WUS-SR publisher window "
+                f"({data_lo}-{data_hi}, from catalog `sources.yml[{_SOURCE_KEY}]"
+                f".period`). Adjust --period."
+            )
+
+    # Operator hint: warn (don't fail) if the project's fabric isn't in
+    # the source's `fabric_scope.fabrics` list. Raw downloads are still
+    # useful (reusable by any project pointing at the same datastore),
+    # but a non-Oregon CMR search will return 0 granules on every year
+    # and the operator deserves a hint about why.
+    scope_fabrics = list(fabric_scope.get("fabrics") or [])
+    fabric_id = (ws.config.get("fabric") or {}).get("id") or (
+        (ws.config.get("fabric") or {}).get("name")
+    )
+    if scope_fabrics and fabric_id and fabric_id not in scope_fabrics:
+        logger.warning(
+            "margulis_wus_sr is scoped to fabrics %s in the catalog; this "
+            "project's fabric is %r, which is outside that scope. "
+            "Fetching anyway (raw downloads are datastore-shared), but "
+            "expect zero granules per year. See docs/sources/"
+            "margulis_wus_sr.md.",
+            scope_fabrics,
+            fabric_id,
+        )
 
     raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
     raw_root.mkdir(parents=True, exist_ok=True)
@@ -98,7 +130,7 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
             "fabric.json has no 'bbox_buffered' key. Re-run "
             "`nhf-targets validate` to regenerate fabric.json."
         )
-    bounding_box = (
+    search_bbox = (
         float(bbox_buffered["minx"]),
         float(bbox_buffered["miny"]),
         float(bbox_buffered["maxx"]),
@@ -108,8 +140,19 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
     now_utc = datetime.now(timezone.utc).isoformat()
     earthaccess.login(strategy="netrc")
 
+    # Pre-filter against the manifest: years already fully downloaded
+    # in a prior run are skipped before any CMR search work.
+    completed = _completed_years_from_manifest(workdir)
+    pending = [y for y in years if y not in completed]
+    if completed:
+        logger.info(
+            "margulis_wus_sr: skipping %d year(s) already in manifest: %s",
+            len(completed & set(years)),
+            sorted(completed & set(years)),
+        )
+
     year_records: list[dict] = []
-    for year in years:
+    for year in pending:
         year_dir = raw_root / f"{year}"
         year_dir.mkdir(parents=True, exist_ok=True)
         logger.info("margulis_wus_sr: searching CMR for year %d", year)
@@ -117,14 +160,14 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
             short_name=access["short_name"],
             version=access.get("version"),
             temporal=(f"{year}-01-01", f"{year}-12-31"),
-            bounding_box=bounding_box,
+            bounding_box=search_bbox,
         )
         n_found = len(results)
         if n_found == 0:
             logger.warning(
                 "margulis_wus_sr: no granules found for year %d (bbox %s); skipping",
                 year,
-                bounding_box,
+                search_bbox,
             )
             year_records.append(
                 {
@@ -168,7 +211,7 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
             }
         )
 
-    _update_manifest(workdir, period, meta, year_records, fabric_scope, bounding_box)
+    _update_manifest(workdir, period, meta, year_records, fabric_scope, search_bbox)
 
     return {
         "source_key": _SOURCE_KEY,
@@ -177,10 +220,39 @@ def fetch_margulis_wus_sr(workdir: Path, period: str) -> dict:
         "license": meta.get("license", "public domain (NSIDC)"),
         "variables": [v["name"] for v in meta["variables"]],
         "period": period,
-        "bbox": bounding_box,
+        "search_bbox": search_bbox,
         "fabric_scope": fabric_scope,
         "years": year_records,
         "download_timestamp": now_utc,
+    }
+
+
+def _completed_years_from_manifest(workdir: Path) -> set[int]:
+    """Return the set of years with ``n_granules > 0`` in manifest.json.
+
+    Years recorded with ``n_granules: 0`` (no CMR hits) are NOT
+    considered complete — re-runs will retry them, which is intentional
+    because CMR coverage can fill in retroactively. Missing/corrupt
+    manifest yields an empty set so the caller falls through to a clean
+    fresh fetch.
+    """
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if not manifest_path.exists():
+        return set()
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError:
+        logger.warning(
+            "margulis_wus_sr: manifest.json could not be parsed; treating "
+            "all years as pending."
+        )
+        return set()
+    entry = manifest.get("sources", {}).get(_SOURCE_KEY, {})
+    return {
+        int(rec["year"])
+        for rec in entry.get("years", [])
+        if int(rec.get("n_granules", 0)) > 0
     }
 
 
@@ -190,7 +262,7 @@ def _update_manifest(
     meta: dict,
     year_records: list[dict],
     fabric_scope: dict,
-    bounding_box: tuple[float, float, float, float],
+    search_bbox: tuple[float, float, float, float],
 ) -> None:
     """Merge Margulis provenance into manifest.json (flock-protected)."""
     ws = _load_project(workdir)
@@ -225,7 +297,7 @@ def _update_manifest(
                 "doi": meta.get("doi"),
                 "license": meta.get("license", "public domain (NSIDC)"),
                 "period": period,
-                "bbox": list(bounding_box),
+                "search_bbox": list(search_bbox),
                 "fabric_scope": fabric_scope,
                 "variables": [v["name"] for v in meta["variables"]],
                 "years": merged_years,

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -31,19 +31,16 @@ except ImportError:  # Windows fallback (not used on HPC).
     _HAVE_FLOCK = False
 
 import nhf_spatial_targets.catalog as _catalog
-from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.fetch._period import (
+    parse_period,
+    period_bounds,
+    years_in_period,
+)
 from nhf_spatial_targets.workspace import load as _load_project
 
 logger = logging.getLogger(__name__)
 
 _SOURCE_KEY = "snodas"
-# Publisher-usable window. SNODAS daily archives begin 2003-09-30; the
-# year-level gate uses 2003 as the lower bound and accepts "present"
-# years up to the current calendar year + 1 (the plan records "present"
-# in the catalog rather than a fixed terminal year).
-_DATA_PERIOD_START = 2003
-# CONUS+contributing-watersheds bbox; matches the project convention.
-BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
 
 
 def _assign_worker_years(
@@ -110,17 +107,24 @@ def fetch_snodas(
     import earthaccess
 
     parse_period(period)
-    years = years_in_period(period)
-    for y in years:
-        if y < _DATA_PERIOD_START:
-            raise ValueError(
-                f"Year {y} is before the SNODAS publisher start "
-                f"({_DATA_PERIOD_START}). Adjust --period."
-            )
-
     ws = _load_project(workdir)
     meta = _catalog.source(_SOURCE_KEY)
     access = meta["access"]
+    data_lo, data_hi = period_bounds(meta["period"])
+    years = years_in_period(period)
+    for y in years:
+        if y < data_lo or y > data_hi:
+            raise ValueError(
+                f"Year {y} is outside the SNODAS publisher window "
+                f"({data_lo}-{data_hi}, from catalog `sources.yml[{_SOURCE_KEY}]"
+                f".period`). Adjust --period."
+            )
+    bbox_nwse = access.get("bbox_nwse")
+    if not bbox_nwse:
+        raise ValueError(
+            f"catalog `sources.yml[{_SOURCE_KEY}].access.bbox_nwse` is missing. "
+            f"Add a [N, W, S, E] bbox before running the SNODAS fetch."
+        )
 
     raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
     raw_root.mkdir(parents=True, exist_ok=True)
@@ -128,7 +132,17 @@ def fetch_snodas(
     now_utc = datetime.now(timezone.utc).isoformat()
 
     earthaccess.login(strategy="netrc")
-    assigned = _assign_worker_years(years, worker_index, n_workers)
+    # Pre-filter against the manifest: years already fully downloaded
+    # in a prior run are skipped before any CMR search/download work.
+    completed = _completed_years_from_manifest(workdir)
+    pending = [y for y in years if y not in completed]
+    if completed:
+        logger.info(
+            "snodas: skipping %d year(s) already in manifest: %s",
+            len(completed & set(years)),
+            sorted(completed & set(years)),
+        )
+    assigned = _assign_worker_years(pending, worker_index, n_workers)
     if not assigned:
         logger.info(
             "snodas: worker %d/%d has no years to process for period %s",
@@ -143,7 +157,7 @@ def fetch_snodas(
             "license": meta.get("license", "public domain (NSIDC)"),
             "variables": [v["name"] for v in meta["variables"]],
             "period": period,
-            "bbox": BBOX_NWSE,
+            "bbox": bbox_nwse,
             "worker_index": worker_index,
             "n_workers": n_workers,
             "years": [],
@@ -159,7 +173,7 @@ def fetch_snodas(
             short_name=access["short_name"],
             version=access.get("version"),
             temporal=(f"{year}-01-01", f"{year}-12-31"),
-            bounding_box=tuple(access.get("bbox_nwse", BBOX_NWSE)),
+            bounding_box=tuple(bbox_nwse),
         )
         n_found = len(results)
         if n_found == 0:
@@ -194,7 +208,7 @@ def fetch_snodas(
             }
         )
 
-    _update_manifest(workdir, period, meta, year_records)
+    _update_manifest(workdir, period, meta, year_records, bbox_nwse)
 
     return {
         "source_key": _SOURCE_KEY,
@@ -203,11 +217,41 @@ def fetch_snodas(
         "license": meta.get("license", "public domain (NSIDC)"),
         "variables": [v["name"] for v in meta["variables"]],
         "period": period,
-        "bbox": BBOX_NWSE,
+        "bbox": bbox_nwse,
         "worker_index": worker_index,
         "n_workers": n_workers,
         "years": year_records,
         "download_timestamp": now_utc,
+    }
+
+
+def _completed_years_from_manifest(workdir: Path) -> set[int]:
+    """Return the set of years already recorded in manifest.json.
+
+    A year counts as complete when its manifest entry has ``n_granules > 0``;
+    years recorded with ``n_granules: 0`` (no CMR hits) are NOT considered
+    complete — re-runs will retry them, which is intentional because CMR
+    coverage can fill in retroactively.
+
+    Returns an empty set (with a warning) if the manifest is absent or
+    unparseable so the caller falls through to a clean fresh fetch.
+    """
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    if not manifest_path.exists():
+        return set()
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError:
+        logger.warning(
+            "snodas: manifest.json could not be parsed; treating all years as pending."
+        )
+        return set()
+    entry = manifest.get("sources", {}).get(_SOURCE_KEY, {})
+    return {
+        int(rec["year"])
+        for rec in entry.get("years", [])
+        if int(rec.get("n_granules", 0)) > 0
     }
 
 
@@ -216,6 +260,7 @@ def _update_manifest(
     period: str,
     meta: dict,
     year_records: list[dict],
+    bbox_nwse: list,
 ) -> None:
     """Merge SNODAS provenance into manifest.json (flock-protected).
 
@@ -255,7 +300,7 @@ def _update_manifest(
                 "doi": meta.get("doi"),
                 "license": meta.get("license", "public domain (NSIDC)"),
                 "period": period,
-                "bbox": BBOX_NWSE,
+                "bbox": list(bbox_nwse),
                 "variables": [v["name"] for v in meta["variables"]],
                 "years": merged_years,
             }

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1,0 +1,288 @@
+"""Fetch SNODAS daily snow water equivalent from NSIDC via earthaccess.
+
+This is the **fetch-only** scaffolding for SNODAS (NSIDC collection
+G02158). It downloads raw daily granules (tar/gz bundles of flat int16
+binary fields plus ENVI ``.Hdr`` headers) into
+``<datastore>/snodas/raw/<year>/`` and records them in ``manifest.json``.
+
+Consolidation of the raw bundles into per-year daily and monthly CF
+NetCDFs is **deferred** to the SNODAS aggregate follow-up issue. The
+SNODAS native format (flat binary + ENVI ``.Hdr``) needs operator
+characterisation in a notebook before a robust parser can be written,
+per CLAUDE.md "characterise the data first" guidance. Until that work
+lands, the fetch module records the raw paths and lets downstream
+aggregate code raise loudly when it tries to consume them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:  # Windows fallback (not used on HPC).
+    _HAVE_FLOCK = False
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets.fetch._period import parse_period, years_in_period
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "snodas"
+# Publisher-usable window. SNODAS daily archives begin 2003-09-30; the
+# year-level gate uses 2003 as the lower bound and accepts "present"
+# years up to the current calendar year + 1 (the plan records "present"
+# in the catalog rather than a fixed terminal year).
+_DATA_PERIOD_START = 2003
+# CONUS+contributing-watersheds bbox; matches the project convention.
+BBOX_NWSE = [53.0, -125.0, 24.7, -66.0]
+
+
+def _assign_worker_years(
+    all_years: list[int],
+    worker_index: int,
+    n_workers: int,
+) -> list[int]:
+    """Round-robin slice of ``all_years`` for ``worker_index`` of ``n_workers``.
+
+    Mirrors ``era5_land._assign_worker_years`` (without the manifest-merge
+    behaviour, which is not needed here — SNODAS does no per-month chunk
+    pre-staging). Each worker takes a deterministic slice of ``all_years``
+    keyed by ``worker_index``; slicing the full list (not a remaining
+    set) keeps each worker's assignment independent of sibling progress.
+    """
+    if n_workers < 1:
+        raise ValueError(f"n_workers must be >= 1, got {n_workers}")
+    if not 0 <= worker_index < n_workers:
+        raise ValueError(
+            f"worker_index must be in [0, {n_workers}); got {worker_index}"
+        )
+    return list(all_years[worker_index::n_workers])
+
+
+def fetch_snodas(
+    workdir: Path,
+    period: str,
+    *,
+    worker_index: int = 0,
+    n_workers: int = 1,
+) -> dict:
+    """Download SNODAS daily granules to the shared datastore.
+
+    This is the fetch-only path: search NSIDC via ``earthaccess`` for daily
+    granules covering each requested year and download the tar/gz bundles
+    into ``<datastore>/snodas/raw/<year>/``. The bundles are NOT decoded
+    into CF NetCDFs in this PR (see module docstring); the consolidation
+    step lives in the SNODAS aggregate follow-up issue.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory.
+    period : str
+        Temporal window ``"YYYY/YYYY"`` (inclusive). Validated against the
+        SNODAS publisher start (2003).
+    worker_index, n_workers : int
+        Round-robin year sharding for parallel workers (mirrors
+        ``fetch_era5_land``). Defaults to a single-worker run.
+
+    Returns
+    -------
+    dict
+        Provenance summary.
+
+    Raises
+    ------
+    ValueError
+        Period falls outside the publisher window or no granules match.
+    RuntimeError
+        ``earthaccess.download`` returned fewer files than the search
+        result count, or zero files at all.
+    """
+    import earthaccess
+
+    parse_period(period)
+    years = years_in_period(period)
+    for y in years:
+        if y < _DATA_PERIOD_START:
+            raise ValueError(
+                f"Year {y} is before the SNODAS publisher start "
+                f"({_DATA_PERIOD_START}). Adjust --period."
+            )
+
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    access = meta["access"]
+
+    raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
+    raw_root.mkdir(parents=True, exist_ok=True)
+
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    earthaccess.login(strategy="netrc")
+    assigned = _assign_worker_years(years, worker_index, n_workers)
+    if not assigned:
+        logger.info(
+            "snodas: worker %d/%d has no years to process for period %s",
+            worker_index,
+            n_workers,
+            period,
+        )
+        return {
+            "source_key": _SOURCE_KEY,
+            "access_url": access["url"],
+            "doi": meta.get("doi"),
+            "license": meta.get("license", "public domain (NSIDC)"),
+            "variables": [v["name"] for v in meta["variables"]],
+            "period": period,
+            "bbox": BBOX_NWSE,
+            "worker_index": worker_index,
+            "n_workers": n_workers,
+            "years": [],
+            "download_timestamp": now_utc,
+        }
+
+    year_records: list[dict] = []
+    for year in assigned:
+        year_dir = raw_root / f"{year}"
+        year_dir.mkdir(parents=True, exist_ok=True)
+        logger.info("snodas: searching CMR for year %d", year)
+        results = earthaccess.search_data(
+            short_name=access["short_name"],
+            version=access.get("version"),
+            temporal=(f"{year}-01-01", f"{year}-12-31"),
+            bounding_box=tuple(access.get("bbox_nwse", BBOX_NWSE)),
+        )
+        n_found = len(results)
+        if n_found == 0:
+            logger.warning("snodas: no granules found for year %d; skipping", year)
+            year_records.append(
+                {
+                    "year": year,
+                    "raw_dir": str(year_dir),
+                    "n_granules": 0,
+                    "downloaded_utc": now_utc,
+                    "note": "no_granules_in_CMR",
+                }
+            )
+            continue
+        downloaded = earthaccess.download(results, str(year_dir))
+        if not downloaded:
+            raise RuntimeError(
+                f"snodas: earthaccess.download returned no files for year {year}; "
+                f"check network connectivity and Earthdata credentials."
+            )
+        if len(downloaded) < n_found:
+            raise RuntimeError(
+                f"snodas: partial download for year {year}: "
+                f"{len(downloaded)}/{n_found} granules. Re-run to retry."
+            )
+        year_records.append(
+            {
+                "year": year,
+                "raw_dir": str(year_dir),
+                "n_granules": len(downloaded),
+                "downloaded_utc": now_utc,
+            }
+        )
+
+    _update_manifest(workdir, period, meta, year_records)
+
+    return {
+        "source_key": _SOURCE_KEY,
+        "access_url": access["url"],
+        "doi": meta.get("doi"),
+        "license": meta.get("license", "public domain (NSIDC)"),
+        "variables": [v["name"] for v in meta["variables"]],
+        "period": period,
+        "bbox": BBOX_NWSE,
+        "worker_index": worker_index,
+        "n_workers": n_workers,
+        "years": year_records,
+        "download_timestamp": now_utc,
+    }
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    meta: dict,
+    year_records: list[dict],
+) -> None:
+    """Merge SNODAS provenance into manifest.json (flock-protected).
+
+    Parallel workers may call this concurrently; the file lock makes the
+    read-modify-write atomic. Years from the new ``year_records`` overwrite
+    any earlier entries for the same year (latest write wins per year).
+    """
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _do_update() -> None:
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"manifest.json in {workdir} is corrupt and cannot be "
+                    f"parsed. Delete it and re-run the fetch step. "
+                    f"Original error: {exc}"
+                ) from exc
+        else:
+            manifest = {"sources": {}, "steps": []}
+
+        manifest.setdefault("sources", {})
+        entry = manifest["sources"].get(_SOURCE_KEY, {})
+        existing_by_year = {int(y["year"]): y for y in entry.get("years", [])}
+        for rec in year_records:
+            existing_by_year[int(rec["year"])] = rec
+        merged_years = [existing_by_year[y] for y in sorted(existing_by_year)]
+        access = meta["access"]
+        entry.update(
+            {
+                "source_key": _SOURCE_KEY,
+                "access_url": access["url"],
+                "doi": meta.get("doi"),
+                "license": meta.get("license", "public domain (NSIDC)"),
+                "period": period,
+                "bbox": BBOX_NWSE,
+                "variables": [v["name"] for v in meta["variables"]],
+                "years": merged_years,
+            }
+        )
+        manifest["sources"][_SOURCE_KEY] = entry
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=manifest_path.parent, suffix=".json.tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump(manifest, f, indent=2)
+            Path(tmp_path).replace(manifest_path)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+    if _HAVE_FLOCK:
+        with open(lock_path, "a") as _lock_f:
+            _fcntl.flock(_lock_f, _fcntl.LOCK_EX)
+            try:
+                _do_update()
+            finally:
+                _fcntl.flock(_lock_f, _fcntl.LOCK_UN)
+    else:
+        _do_update()
+    logger.info(
+        "Updated manifest.json with snodas provenance for years %s",
+        [r["year"] for r in year_records],
+    )

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,9 +57,22 @@ def test_era5_land_source_present():
     assert s["access"]["type"] == "copernicus_cds"
     assert s["access"]["dataset"] == "reanalysis-era5-land"
     var_names = [v["name"] for v in s["variables"]]
-    assert var_names == ["ro", "sro", "ssro"]
+    assert var_names == ["ro", "sro", "ssro", "sd"]
     assert s["time_step"] == "hourly (aggregated to daily and monthly)"
     assert s["status"] == "current"
+
+
+def test_era5_land_sd_is_instantaneous():
+    """`sd` (snow depth water equivalent) is instantaneous, not accumulated.
+
+    cell_methods must mark it as a point-in-time field so the consolidation
+    pipeline picks the .mean() reducer rather than the diff-of-accumulations
+    sum used for ro/sro/ssro.
+    """
+    s = source("era5_land")
+    sd = next(v for v in s["variables"] if v["name"] == "sd")
+    assert sd["cell_methods"] == "time: point"
+    assert sd["cf_units"] == "m"
 
 
 def test_gldas_source_present():
@@ -133,3 +146,69 @@ def test_aet_lists_mwbm_climgrid():
     # Existing sources still present
     assert "mod16a2_v061" in v["sources"]
     assert "ssebop" in v["sources"]
+
+
+# ---------------------------------------------------------------------------
+# SWE category — fetch-layer scaffolding (issue #99)
+# ---------------------------------------------------------------------------
+
+
+def test_snow_water_equivalent_variable_present():
+    v = variable("snow_water_equivalent")
+    assert v["prms_variable"] == "pkwater_equiv"
+    assert v["range_method"] == "multi_source_minmax"
+    assert v["normalize"] is False
+    assert v["sources"] == ["daymet", "snodas", "era5_land", "margulis_wus_sr"]
+
+
+def test_daymet_source_present():
+    s = source("daymet")
+    assert s["status"] == "current"
+    assert s["access"]["type"] == "zarr_verify"
+    stores = s["access"]["stores"]
+    assert set(stores.keys()) == {"na", "hi", "pr"}
+    # Stores keyed via the {daymet_root} template so projects can override.
+    for region_path in stores.values():
+        assert "{daymet_root}" in region_path
+    var_names = {v["name"] for v in s["variables"]}
+    assert "swe" in var_names
+    assert s["doi"] == "10.3334/ORNLDAAC/2129"
+
+
+def test_snodas_source_present():
+    s = source("snodas")
+    assert s["status"] == "current"
+    assert s["access"]["type"] == "nasa_nsidc"
+    assert s["access"]["short_name"] == "G02158"
+    var_names = {v["name"] for v in s["variables"]}
+    assert "swe" in var_names
+    assert s["period"] == "2003/present"
+
+
+def test_margulis_wus_sr_source_present():
+    s = source("margulis_wus_sr")
+    assert s["status"] == "current"
+    assert s["access"]["type"] == "nasa_nsidc"
+    assert s["access"]["short_name"] == "WUS_UCLA_SR"
+    assert s["doi"] == "10.5067/PP7T2GBI52I2"
+    assert s["period"] == "1985/2021"
+    var_names = {v["name"] for v in s["variables"]}
+    assert "SWE" in var_names
+
+
+def test_margulis_wus_sr_fabric_scope_oregon_only():
+    """Margulis WUS-SR carries the new optional fabric_scope field."""
+    s = source("margulis_wus_sr")
+    scope = s["fabric_scope"]
+    assert scope["fabrics"] == ["or"]
+    assert "notes" in scope
+
+
+def test_fabric_scope_field_only_on_scoped_sources():
+    """No other current source declares fabric_scope.
+
+    Defensive: catches accidental copy/paste of the field onto sources
+    that should be available to all fabrics.
+    """
+    scoped = {key for key, src in sources().items() if "fabric_scope" in src}
+    assert scoped == {"margulis_wus_sr"}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -159,20 +159,46 @@ def test_snow_water_equivalent_variable_present():
     assert v["range_method"] == "multi_source_minmax"
     assert v["normalize"] is False
     assert v["sources"] == ["daymet", "snodas", "era5_land", "margulis_wus_sr"]
+    # Required-fields sanity check (matches the existing target-variable
+    # schema across runoff/aet/recharge/soil_moisture/sca).
+    for field in (
+        "description",
+        "prms_reference",
+        "time_step",
+        "period",
+        "units",
+        "range_notes",
+        "output_format",
+    ):
+        assert field in v, f"snow_water_equivalent missing required field {field!r}"
+    # Units rework (C8): post-conversion units alongside original.
+    assert v["units"] == "inches"
+    assert v.get("original_units")
+    assert v["time_step"] == "daily"
 
 
 def test_daymet_source_present():
     s = source("daymet")
     assert s["status"] == "current"
     assert s["access"]["type"] == "zarr_verify"
+    assert s["access"]["url"].startswith("https://")
     stores = s["access"]["stores"]
     assert set(stores.keys()) == {"na", "hi", "pr"}
-    # Stores keyed via the {daymet_root} template so projects can override.
-    for region_path in stores.values():
+    # Stores keyed via the {daymet_root} template so projects can override,
+    # and the resolved per-region path must end with a `.zarr` directory.
+    for r, region_path in stores.items():
         assert "{daymet_root}" in region_path
+        assert region_path.endswith(f"daymet_{r}.zarr"), region_path
     var_names = {v["name"] for v in s["variables"]}
     assert "swe" in var_names
+    # The SWE variable carries a unit and cell_methods (drift-prevention).
+    swe = next(v for v in s["variables"] if v["name"] == "swe")
+    assert swe["cf_units"] == "kg m-2"
+    assert swe["cell_methods"] == "time: point"
     assert s["doi"] == "10.3334/ORNLDAAC/2129"
+    assert s["citations"]
+    assert s["units"]
+    assert s["spatial_resolution"]
 
 
 def test_snodas_source_present():
@@ -180,9 +206,18 @@ def test_snodas_source_present():
     assert s["status"] == "current"
     assert s["access"]["type"] == "nasa_nsidc"
     assert s["access"]["short_name"] == "G02158"
+    assert s["access"]["url"].startswith("https://")
+    # bbox is read from the catalog by fetch/snodas.py; required.
+    bbox = s["access"]["bbox_nwse"]
+    assert isinstance(bbox, list) and len(bbox) == 4
     var_names = {v["name"] for v in s["variables"]}
     assert "swe" in var_names
+    swe = next(v for v in s["variables"] if v["name"] == "swe")
+    assert swe["cf_units"] == "kg m-2"
+    assert swe["cell_methods"] == "time: point"
     assert s["period"] == "2003/present"
+    assert s["citations"]
+    assert s["units"]
 
 
 def test_margulis_wus_sr_source_present():
@@ -190,10 +225,19 @@ def test_margulis_wus_sr_source_present():
     assert s["status"] == "current"
     assert s["access"]["type"] == "nasa_nsidc"
     assert s["access"]["short_name"] == "WUS_UCLA_SR"
+    assert s["access"]["url"].startswith("https://")
     assert s["doi"] == "10.5067/PP7T2GBI52I2"
     assert s["period"] == "1985/2021"
     var_names = {v["name"] for v in s["variables"]}
     assert "SWE" in var_names
+    swe = next(v for v in s["variables"] if v["name"] == "SWE")
+    assert swe["cf_units"] == "m"
+    assert swe["cell_methods"] == "time: point"
+    assert s["citations"]
+    assert s["units"]
+    # N7 — spatial_extent is now a pure source-extent string, not a
+    # project-scoping mention. Fabric scoping lives in fabric_scope.
+    assert "Oregon-fabric only" not in s["spatial_extent"]
 
 
 def test_margulis_wus_sr_fabric_scope_oregon_only():
@@ -212,3 +256,43 @@ def test_fabric_scope_field_only_on_scoped_sources():
     """
     scoped = {key for key, src in sources().items() if "fabric_scope" in src}
     assert scoped == {"margulis_wus_sr"}
+
+
+def test_every_fabric_scope_block_validates():
+    """Every declared `fabric_scope` block passes the validator.
+
+    Catches typos like `fabrics: [oregon]` that would otherwise
+    silently disable scoping at the target-builder boundary.
+    """
+    from nhf_spatial_targets.catalog import validate_fabric_scope
+
+    for key, src in sources().items():
+        validate_fabric_scope(key, src.get("fabric_scope"))
+
+
+def test_validate_fabric_scope_rejects_unknown_token():
+    from nhf_spatial_targets.catalog import validate_fabric_scope
+
+    with pytest.raises(ValueError, match="unknown token"):
+        validate_fabric_scope("test_src", {"fabrics": ["oregon"]})
+
+
+def test_validate_fabric_scope_rejects_non_list_fabrics():
+    from nhf_spatial_targets.catalog import validate_fabric_scope
+
+    with pytest.raises(ValueError, match="non-empty list"):
+        validate_fabric_scope("test_src", {"fabrics": "or"})
+
+
+def test_validate_fabric_scope_rejects_empty_fabrics():
+    from nhf_spatial_targets.catalog import validate_fabric_scope
+
+    with pytest.raises(ValueError, match="non-empty list"):
+        validate_fabric_scope("test_src", {"fabrics": []})
+
+
+def test_validate_fabric_scope_none_is_ok():
+    """`fabric_scope: None` (i.e. field absent) is the global default and OK."""
+    from nhf_spatial_targets.catalog import validate_fabric_scope
+
+    validate_fabric_scope("test_src", None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,6 +505,117 @@ def test_fetch_mwbm_climgrid_calls_fetch(mock_fetch, tmp_path):
     mock_fetch.assert_called_once_with(workdir=workdir, period="1980/2015")
 
 
+# ---- SWE fetch commands (issue #99) ----------------------------------------
+
+
+@patch("nhf_spatial_targets.fetch.daymet.fetch_daymet")
+def test_fetch_daymet_calls_fetch(mock_fetch, tmp_path):
+    """CLI wires --project-dir, --period, --source-path, --region to fetch_daymet()."""
+    mock_fetch.return_value = {"regions": {}}
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+    zroot = tmp_path / "zarrs"
+    zroot.mkdir()
+    _run(
+        "fetch",
+        "daymet",
+        "--project-dir",
+        str(workdir),
+        "--period",
+        "2020/2020",
+        "--source-path",
+        str(zroot),
+        "--region",
+        "na",
+    )
+    mock_fetch.assert_called_once_with(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=zroot,
+        region="na",
+    )
+
+
+def test_fetch_daymet_nonexistent_project_dir(tmp_path):
+    """Exit code 2 when --project-dir does not exist."""
+    with pytest.raises(SystemExit, match="2"):
+        _run(
+            "fetch",
+            "daymet",
+            "--project-dir",
+            str(tmp_path / "missing"),
+            "--period",
+            "2020/2020",
+        )
+
+
+@patch("nhf_spatial_targets.fetch.snodas.fetch_snodas")
+def test_fetch_snodas_calls_fetch(mock_fetch, tmp_path):
+    """CLI wires --project-dir, --period, --worker-index, --n-workers to fetch_snodas()."""
+    mock_fetch.return_value = {"years": []}
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+    _run(
+        "fetch",
+        "snodas",
+        "--project-dir",
+        str(workdir),
+        "--period",
+        "2020/2020",
+        "--worker-index",
+        "0",
+        "--n-workers",
+        "1",
+    )
+    mock_fetch.assert_called_once_with(
+        workdir=workdir,
+        period="2020/2020",
+        worker_index=0,
+        n_workers=1,
+    )
+
+
+def test_fetch_snodas_nonexistent_project_dir(tmp_path):
+    with pytest.raises(SystemExit, match="2"):
+        _run(
+            "fetch",
+            "snodas",
+            "--project-dir",
+            str(tmp_path / "missing"),
+            "--period",
+            "2020/2020",
+        )
+
+
+@patch("nhf_spatial_targets.fetch.margulis_wus_sr.fetch_margulis_wus_sr")
+def test_fetch_wus_sr_calls_fetch(mock_fetch, tmp_path):
+    """CLI wires --project-dir and --period to fetch_margulis_wus_sr()."""
+    mock_fetch.return_value = {"years": []}
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+    _run(
+        "fetch",
+        "wus-sr",
+        "--project-dir",
+        str(workdir),
+        "--period",
+        "2000/2000",
+    )
+    mock_fetch.assert_called_once_with(workdir=workdir, period="2000/2000")
+
+
+def test_fetch_wus_sr_nonexistent_project_dir(tmp_path):
+    with pytest.raises(SystemExit, match="2"):
+        _run(
+            "fetch",
+            "wus-sr",
+            "--project-dir",
+            str(tmp_path / "missing"),
+            "--period",
+            "2000/2000",
+        )
+
+
 # ---- agg ssebop command ----------------------------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,14 +588,14 @@ def test_fetch_snodas_nonexistent_project_dir(tmp_path):
 
 
 @patch("nhf_spatial_targets.fetch.margulis_wus_sr.fetch_margulis_wus_sr")
-def test_fetch_wus_sr_calls_fetch(mock_fetch, tmp_path):
+def test_fetch_margulis_wus_sr_calls_fetch(mock_fetch, tmp_path):
     """CLI wires --project-dir and --period to fetch_margulis_wus_sr()."""
     mock_fetch.return_value = {"years": []}
     workdir = tmp_path / "workspace"
     workdir.mkdir()
     _run(
         "fetch",
-        "wus-sr",
+        "margulis-wus-sr",
         "--project-dir",
         str(workdir),
         "--period",
@@ -604,11 +604,11 @@ def test_fetch_wus_sr_calls_fetch(mock_fetch, tmp_path):
     mock_fetch.assert_called_once_with(workdir=workdir, period="2000/2000")
 
 
-def test_fetch_wus_sr_nonexistent_project_dir(tmp_path):
+def test_fetch_margulis_wus_sr_nonexistent_project_dir(tmp_path):
     with pytest.raises(SystemExit, match="2"):
         _run(
             "fetch",
-            "wus-sr",
+            "margulis-wus-sr",
             "--project-dir",
             str(tmp_path / "missing"),
             "--period",

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -588,7 +588,7 @@ def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch
     hourly_dir.mkdir()
 
     times = pd.date_range("2020-01-01", "2020-01-03 23:00", freq="1h")
-    for var in ("ro", "sro", "ssro"):
+    for var in ("ro", "sro", "ssro", "sd"):
         vals = np.tile(
             np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
             (len(times) // 24, 1, 1),
@@ -614,7 +614,7 @@ def test_consolidate_year_writes_daily_and_updates_monthly(tmp_path, monkeypatch
     assert daily_path.exists()
     daily = xr.open_dataset(daily_path)
     try:
-        assert {"ro", "sro", "ssro"}.issubset(set(daily.data_vars))
+        assert {"ro", "sro", "ssro", "sd"}.issubset(set(daily.data_vars))
         assert daily.sizes["time"] >= 2
     finally:
         daily.close()
@@ -633,7 +633,7 @@ def test_consolidate_year_valid_time_dim(tmp_path):
 
     # Write hourly NCs using 'valid_time' (CDS API ≥0.7 output convention)
     times = pd.date_range("2020-01-01", "2020-01-03 23:00", freq="1h")
-    for var in ("ro", "sro", "ssro"):
+    for var in ("ro", "sro", "ssro", "sd"):
         vals = np.tile(
             np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
             (len(times) // 24, 1, 1),
@@ -660,7 +660,7 @@ def test_consolidate_year_valid_time_dim(tmp_path):
     assert daily_path.exists()
     with xr.open_dataset(daily_path) as ds:
         assert "time" in ds.dims, "daily NC must have 'time' dimension"
-        assert {"ro", "sro", "ssro"}.issubset(set(ds.data_vars))
+        assert {"ro", "sro", "ssro", "sd"}.issubset(set(ds.data_vars))
 
     assert monthly_path.exists()
     with xr.open_dataset(monthly_path) as ds:
@@ -668,10 +668,10 @@ def test_consolidate_year_valid_time_dim(tmp_path):
 
 
 def _write_hourly_ncs(hourly_dir: Path, year: int) -> None:
-    """Write synthetic hourly NCs for all three ERA5-Land runoff variables."""
+    """Write synthetic hourly NCs for all four ERA5-Land variables (ro/sro/ssro/sd)."""
 
     times = pd.date_range(f"{year}-01-01", f"{year}-01-03 23:00", freq="1h")
-    for var in ("ro", "sro", "ssro"):
+    for var in ("ro", "sro", "ssro", "sd"):
         vals = np.tile(
             np.arange(24, dtype=float).reshape(24, 1, 1) * 0.001,
             (len(times) // 24, 1, 1),
@@ -1416,3 +1416,161 @@ def test_fetch_era5_land_returns_empty_when_no_years_assigned(tmp_path, monkeypa
     assert result["files"] == []
     assert result["worker_index"] == 1
     assert result["n_workers"] == 2
+
+
+# ---------------------------------------------------------------------------
+# `sd` (snow depth water equivalent) — instantaneous variable dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_hourly_instantaneous(
+    start: str, hours: int, level: float = 0.50
+) -> xr.DataArray:
+    """Synthetic hourly instantaneous snow depth water equivalent.
+
+    Constant level (in m water-eq) across the day; daily mean should equal
+    that level exactly. Mirrors the (time, lat, lon) shape of the accumulated
+    test fixture.
+    """
+    times = pd.date_range(start, periods=hours, freq="1h")
+    vals = np.full((hours, 1, 1), level)
+    return xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="sd",
+        attrs={"units": "m"},
+    )
+
+
+def test_variable_kind_table_covers_all_variables():
+    """Defensive: every entry in VARIABLES must be keyed in _VARIABLE_KIND."""
+    from nhf_spatial_targets.fetch.era5_land import VARIABLES, _VARIABLE_KIND
+
+    for v in VARIABLES:
+        assert v in _VARIABLE_KIND, f"{v} missing from _VARIABLE_KIND"
+    assert _VARIABLE_KIND["sd"] == "instantaneous"
+    assert _VARIABLE_KIND["ro"] == "accumulated"
+
+
+def test_hourly_to_daily_instantaneous_means_per_day():
+    """Daily mean of a flat-level instantaneous field equals that level."""
+    from nhf_spatial_targets.fetch.era5_land import hourly_to_daily_instantaneous
+
+    da = _make_hourly_instantaneous("2020-01-01 00:00", hours=48, level=0.50)
+    daily = hourly_to_daily_instantaneous(da)
+    assert daily.sizes["time"] == 2
+    np.testing.assert_allclose(daily.values, 0.50, rtol=1e-12)
+
+
+def test_hourly_to_daily_instantaneous_preserves_attrs():
+    from nhf_spatial_targets.fetch.era5_land import hourly_to_daily_instantaneous
+
+    da = _make_hourly_instantaneous("2020-01-01 00:00", hours=48, level=0.50)
+    da.attrs["units"] = "m"
+    daily = hourly_to_daily_instantaneous(da)
+    assert daily.attrs["units"] == "m"
+
+
+def test_daily_to_monthly_kind_accumulated_sums():
+    """`kind="accumulated"` (default) sums daily values into the month."""
+    times = pd.date_range("2020-01-01", periods=31, freq="1D")
+    vals = np.full((31, 1, 1), 0.001)
+    da = xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="ro",
+        attrs={"units": "m"},
+    )
+    monthly = daily_to_monthly(da)  # default kind="accumulated"
+    np.testing.assert_allclose(monthly.isel(time=0).values, 0.031, rtol=1e-9)
+
+
+def test_daily_to_monthly_kind_instantaneous_means():
+    """`kind="instantaneous"` returns the calendar-month mean."""
+    times = pd.date_range("2020-01-01", periods=31, freq="1D")
+    vals = np.full((31, 1, 1), 0.50)
+    da = xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+        name="sd",
+        attrs={"units": "m"},
+    )
+    monthly = daily_to_monthly(da, kind="instantaneous")
+    np.testing.assert_allclose(monthly.isel(time=0).values, 0.50, rtol=1e-12)
+
+
+def test_daily_to_monthly_rejects_unknown_kind():
+    times = pd.date_range("2020-01-01", periods=5, freq="1D")
+    vals = np.zeros((5, 1, 1))
+    da = xr.DataArray(
+        vals,
+        dims=("time", "latitude", "longitude"),
+        coords={"time": times, "latitude": [40.0], "longitude": [-100.0]},
+    )
+    with pytest.raises(ValueError, match="unknown kind"):
+        daily_to_monthly(da, kind="bogus")
+
+
+def test_consolidate_year_dispatches_by_variable_kind(tmp_path):
+    """consolidate_year picks the right reducer for ro (sum) vs sd (mean).
+
+    Build per-variable hourly NCs covering a full 2-day window: a flat
+    instantaneous level for ``sd`` and a midnight-resetting accumulation
+    for the three runoff vars. Confirm the resulting daily NC has
+    sd ≈ level and ro/sro/ssro ≈ within-day accumulated totals.
+    """
+    from nhf_spatial_targets.fetch.era5_land import consolidate_year
+
+    hourly = tmp_path / "hourly"
+    daily = tmp_path / "daily"
+    monthly = tmp_path / "monthly"
+    hourly.mkdir()
+
+    year = 2020
+
+    def _write(da: xr.DataArray, var: str) -> None:
+        path = hourly / f"era5_land_{var}_{year}.nc"
+        ds = xr.Dataset({var: da})
+        ds.to_netcdf(path)
+
+    # ro/sro/ssro accumulate 0.001 per hour resetting at midnight
+    for var in ("ro", "sro", "ssro"):
+        acc = _make_era5_midnight_reset(n_days=2, value_per_hour=0.001)
+        acc = acc.rename(var).reset_coords(drop=True)
+        acc.name = var
+        _write(acc, var)
+    # sd is instantaneous at 0.30 m water-eq for the same window
+    sd = _make_hourly_instantaneous("2020-01-01 00:00", hours=2 * 24 + 1, level=0.30)
+    _write(sd, "sd")
+
+    daily_path, monthly_path = consolidate_year(year, hourly, daily, monthly)
+
+    with xr.open_dataset(daily_path) as ds_daily:
+        # Daily ro should be the full-day accumulation (~24 * 0.001 = 0.024 m)
+        np.testing.assert_allclose(
+            ds_daily["ro"].isel(time=0).values.flatten()[0],
+            0.024,
+            rtol=1e-6,
+        )
+        # Daily sd should equal the constant 0.30 (mean, not sum)
+        np.testing.assert_allclose(
+            ds_daily["sd"].isel(time=0).values.flatten()[0],
+            0.30,
+            rtol=1e-9,
+        )
+    with xr.open_dataset(monthly_path) as ds_month:
+        # January 2020: ro is sum across 2 days ~= 0.048
+        np.testing.assert_allclose(
+            ds_month["ro"].isel(time=0).values.flatten()[0],
+            0.048,
+            rtol=1e-6,
+        )
+        # sd is the calendar-month mean = 0.30
+        np.testing.assert_allclose(
+            ds_month["sd"].isel(time=0).values.flatten()[0],
+            0.30,
+            rtol=1e-9,
+        )

--- a/tests/test_fetch_daymet.py
+++ b/tests/test_fetch_daymet.py
@@ -1,0 +1,322 @@
+"""Tests for Daymet V4 R1 zarr-verify registration.
+
+`fetch_daymet` does not download — it fingerprints the three regional
+zarrs (NA/HI/PR) staged on a shared filesystem and records per-region
+entries in manifest.json. These tests cover the period gate, the root
+resolution precedence (`--source-path` > `config.yml: daymet_root`),
+per-region registration and idempotency, the validation paths (missing
+swe variable, malformed zarr), and the operator-friendly fallback
+behaviour when only some regions are staged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import yaml
+
+from nhf_spatial_targets.fetch import daymet as _daymet_module
+from nhf_spatial_targets.fetch.daymet import fetch_daymet
+
+
+@pytest.fixture(autouse=True)
+def _short_stability_window(monkeypatch):
+    """Skip the stability window in tests."""
+    monkeypatch.setattr(_daymet_module, "_STABILITY_SECONDS", 0.0)
+
+
+def _make_project(tmp_path: Path, *, daymet_root: Path | None = None) -> Path:
+    """Materialize a minimal valid project directory.
+
+    If `daymet_root` is given, it is recorded in config.yml so we can
+    exercise the config-fallback path; otherwise tests must pass
+    `source_path=` explicitly.
+    """
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    cfg = {
+        "fabric": {
+            "path": str(tmp_path / "fabric.gpkg"),
+            "id_col": "nhm_id",
+        },
+        "datastore": str(datastore),
+    }
+    if daymet_root is not None:
+        cfg["daymet_root"] = str(daymet_root)
+    (tmp_path / "config.yml").write_text(yaml.dump(cfg))
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    return tmp_path
+
+
+def _write_dummy_zarr(
+    zroot: Path,
+    *,
+    variables: tuple[str, ...] = ("swe", "prcp", "tmax", "tmin", "srad", "vp"),
+    n_time: int = 5,
+) -> None:
+    """Materialize a tiny CF-ish Daymet-style zarr with consolidated metadata."""
+    times = pd.date_range("2020-01-01", periods=n_time, freq="D")
+    xs = np.arange(3, dtype=np.float64) * 1000.0
+    ys = np.arange(3, dtype=np.float64) * 1000.0
+    data_vars = {}
+    for v in variables:
+        data_vars[v] = (
+            ("time", "y", "x"),
+            np.zeros((n_time, 3, 3), dtype=np.float32),
+            {"units": "kg m-2"},
+        )
+    # CRS placeholder variable (Daymet ships a scalar holding the
+    # Lambert Conformal Conic spec).
+    data_vars["lambert_conformal_conic"] = (
+        (),
+        np.int32(0),
+        {"grid_mapping_name": "lambert_conformal_conic"},
+    )
+    ds = xr.Dataset(
+        data_vars=data_vars,
+        coords={"time": ("time", times), "x": ("x", xs), "y": ("y", ys)},
+    )
+    # consolidated=False to mirror the on-disk Daymet zarrs (zarr v2
+    # without a `.zmetadata` summary file).
+    ds.to_zarr(zroot, mode="w", consolidated=False, zarr_format=2)
+    ds.close()
+
+
+def _stage_regions(
+    root: Path, regions: tuple[str, ...] = ("na", "hi", "pr"), **kwargs
+) -> dict[str, Path]:
+    """Write a dummy zarr for each requested region; return the paths."""
+    root.mkdir(parents=True, exist_ok=True)
+    paths = {}
+    for r in regions:
+        zroot = root / f"daymet_{r}.zarr"
+        _write_dummy_zarr(zroot, **kwargs)
+        paths[r] = zroot
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Root resolution and period gate
+# ---------------------------------------------------------------------------
+
+
+def test_missing_zarr_root_raises_with_instructions(tmp_path):
+    workdir = _make_project(tmp_path)
+    with pytest.raises(FileNotFoundError, match="not configured"):
+        fetch_daymet(workdir=workdir, period="2020/2020")
+
+
+def test_source_path_overrides_config_yml(tmp_path):
+    """An explicit `source_path=` wins over `daymet_root` in config.yml."""
+    bogus = tmp_path / "bogus"
+    bogus.mkdir()
+    workdir = _make_project(tmp_path, daymet_root=bogus)
+    real_root = tmp_path / "real"
+    _stage_regions(real_root, regions=("na",))
+    result = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=real_root,
+        region="na",
+    )
+    assert "na" in result["regions"]
+    # Manifest path agrees with the real root, not the bogus one.
+    assert str(real_root) in result["regions"]["na"]["path"]
+
+
+def test_period_outside_data_range_rejected(tmp_path):
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na",))
+    with pytest.raises(ValueError, match="outside the Daymet V4 R1"):
+        fetch_daymet(
+            workdir=workdir,
+            period="1970/1970",
+            source_path=root,
+            region="na",
+        )
+
+
+def test_unknown_region_raises(tmp_path):
+    workdir = _make_project(tmp_path)
+    with pytest.raises(ValueError, match="not recognised"):
+        fetch_daymet(
+            workdir=workdir,
+            period="2020/2020",
+            source_path=tmp_path,
+            region="europe",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-region registration
+# ---------------------------------------------------------------------------
+
+
+def test_region_all_registers_three_regions(tmp_path):
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na", "hi", "pr"))
+    result = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="all",
+    )
+    assert set(result["regions"].keys()) == {"na", "hi", "pr"}
+    assert result["missing_regions"] == []
+    # Manifest persists per-region records.
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    regions = manifest["sources"]["daymet"]["regions"]
+    assert set(regions.keys()) == {"na", "hi", "pr"}
+    for r, rec in regions.items():
+        assert rec["region"] == r
+        assert rec["size_bytes"] > 0
+        assert len(rec["zmetadata_sha256"]) == 64
+
+
+def test_region_filter_single_region(tmp_path):
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na", "hi", "pr"))
+    result = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="na",
+    )
+    assert set(result["regions"].keys()) == {"na"}
+
+
+def test_partial_staging_skips_missing_regions(tmp_path):
+    """region='all' with only NA staged returns NA + missing_regions=[hi, pr]."""
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na",))
+    result = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="all",
+    )
+    assert set(result["regions"].keys()) == {"na"}
+    assert set(result["missing_regions"]) == {"hi", "pr"}
+
+
+def test_no_regions_present_raises(tmp_path):
+    workdir = _make_project(tmp_path)
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    with pytest.raises(FileNotFoundError, match="None of the requested"):
+        fetch_daymet(
+            workdir=workdir,
+            period="2020/2020",
+            source_path=empty_root,
+            region="all",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_when_manifest_matches(tmp_path):
+    """Second call with unchanged zarr is a no-op (download_timestamp None)."""
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na",))
+
+    first = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="na",
+    )
+    assert first["download_timestamp"] is not None
+
+    second = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="na",
+    )
+    # The cached record is reused — no new fingerprinting happened.
+    assert second["download_timestamp"] is None
+    assert (
+        second["regions"]["na"]["zmetadata_sha256"]
+        == first["regions"]["na"]["zmetadata_sha256"]
+    )
+
+
+def test_rerun_after_replacement_refingerprints(tmp_path):
+    """Replacing the zarr changes the sha256 → fingerprint is rewritten."""
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    paths = _stage_regions(root, regions=("na",))
+    first = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="na",
+    )
+    sha_before = first["regions"]["na"]["zmetadata_sha256"]
+
+    # Rewrite the zarr with different content (different time length).
+    import shutil
+
+    shutil.rmtree(paths["na"])
+    _write_dummy_zarr(paths["na"], n_time=10)
+
+    second = fetch_daymet(
+        workdir=workdir,
+        period="2020/2020",
+        source_path=root,
+        region="na",
+    )
+    assert second["download_timestamp"] is not None
+    assert second["regions"]["na"]["zmetadata_sha256"] != sha_before
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_zarr_missing_swe_variable(tmp_path):
+    """A zarr without the `swe` variable is rejected with a clear message."""
+    workdir = _make_project(tmp_path)
+    root = tmp_path / "zarrs"
+    root.mkdir()
+    # Build a zarr that only has prcp/tmin/tmax (no swe, srad, vp).
+    _write_dummy_zarr(
+        root / "daymet_na.zarr",
+        variables=("prcp", "tmin", "tmax"),
+    )
+    with pytest.raises(RuntimeError, match="missing required variables"):
+        fetch_daymet(
+            workdir=workdir,
+            period="2020/2020",
+            source_path=root,
+            region="na",
+        )
+
+
+def test_raises_on_corrupt_manifest(tmp_path):
+    """Bad JSON in manifest.json fails fast on the read."""
+    workdir = _make_project(tmp_path)
+    (workdir / "manifest.json").write_text("{not json")
+    root = tmp_path / "zarrs"
+    _stage_regions(root, regions=("na",))
+    with pytest.raises(ValueError, match="manifest.json .* is corrupt"):
+        fetch_daymet(
+            workdir=workdir,
+            period="2020/2020",
+            source_path=root,
+            region="na",
+        )

--- a/tests/test_fetch_margulis_wus_sr.py
+++ b/tests/test_fetch_margulis_wus_sr.py
@@ -1,0 +1,233 @@
+"""Tests for Margulis Western US Snow Reanalysis (NSIDC-0719) fetch.
+
+`fetch_margulis_wus_sr` does an earthaccess search and download per year,
+clipped to the project's fabric bbox. Consolidation into CF NetCDFs is
+deferred to the Margulis aggregate follow-up issue and is not exercised
+here. These tests cover the period gate, the fabric-bbox plumbing, the
+empty-search fallback, the zero-byte-drop / partial-download guards, the
+fabric_scope manifest recording, and Earthdata auth-failure propagation.
+
+All tests monkeypatch ``earthaccess.login``, ``search_data``, and
+``download`` — no network access is required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nhf_spatial_targets.fetch.margulis_wus_sr import fetch_margulis_wus_sr
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Materialize a minimal valid project directory with a fabric bbox."""
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {
+                    "path": str(tmp_path / "fabric.gpkg"),
+                    "id_col": "nhm_id",
+                },
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(
+        json.dumps(
+            {
+                "sha256": "f00",
+                "bbox": {
+                    "minx": -124.0,
+                    "miny": 42.0,
+                    "maxx": -116.0,
+                    "maxy": 46.5,
+                },
+                "bbox_buffered": {
+                    "minx": -124.2,
+                    "miny": 41.9,
+                    "maxx": -115.8,
+                    "maxy": 46.6,
+                },
+            }
+        )
+    )
+    return tmp_path
+
+
+def _stub_earthaccess(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    granules_per_year: int = 2,
+    files_returned: int | None = None,
+    zero_byte_count: int = 0,
+    login_error: Exception | None = None,
+) -> dict[str, list]:
+    """Patch earthaccess login/search/download; return a call log dict."""
+    import earthaccess
+
+    calls = {"search": [], "downloaded_dirs": [], "login": []}
+
+    def fake_login(strategy="netrc"):
+        calls["login"].append(strategy)
+        if login_error is not None:
+            raise login_error
+
+    def fake_search(**kwargs):
+        calls["search"].append(kwargs)
+        return [object()] * granules_per_year
+
+    def fake_download(results, dest):
+        calls["downloaded_dirs"].append(str(dest))
+        n = len(results) if files_returned is None else files_returned
+        dest_path = Path(dest)
+        dest_path.mkdir(parents=True, exist_ok=True)
+        paths = []
+        for i in range(n):
+            p = dest_path / f"margulis_stub_{i}.nc"
+            if i < zero_byte_count:
+                p.write_bytes(b"")
+            else:
+                p.write_bytes(b"\x00")
+            paths.append(str(p))
+        return paths
+
+    monkeypatch.setattr(earthaccess, "login", fake_login)
+    monkeypatch.setattr(earthaccess, "search_data", fake_search)
+    monkeypatch.setattr(earthaccess, "download", fake_download)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Period and inputs
+# ---------------------------------------------------------------------------
+
+
+def test_period_below_1985_rejected(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch)
+    with pytest.raises(ValueError, match="outside the Margulis WUS-SR"):
+        fetch_margulis_wus_sr(workdir=workdir, period="1980/1984")
+
+
+def test_period_above_2021_rejected(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch)
+    with pytest.raises(ValueError, match="outside the Margulis WUS-SR"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2022/2022")
+
+
+def test_period_clamps_to_publisher_window(tmp_path, monkeypatch):
+    """The boundary years 1985 and 2021 are inclusive."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    result = fetch_margulis_wus_sr(workdir=workdir, period="1985/1985")
+    assert [r["year"] for r in result["years"]] == [1985]
+
+
+def test_search_uses_fabric_bbox_buffered(tmp_path, monkeypatch):
+    """The CMR search bounding box is taken from fabric.json `bbox_buffered`."""
+    workdir = _make_project(tmp_path)
+    calls = _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    bbox = calls["search"][-1]["bounding_box"]
+    assert bbox == (-124.2, 41.9, -115.8, 46.6)
+
+
+# ---------------------------------------------------------------------------
+# Search / download paths
+# ---------------------------------------------------------------------------
+
+
+def test_empty_search_records_no_granules_note(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=0)
+    result = fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    assert result["years"][0]["n_granules"] == 0
+    assert result["years"][0]["note"] == "no_granules_in_CMR"
+
+
+def test_partial_download_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=3, files_returned=2)
+    with pytest.raises(RuntimeError, match="partial download"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+
+
+def test_zero_byte_files_dropped_then_partial_raises(tmp_path, monkeypatch):
+    """Zero-byte downloads are deleted; a shortfall after the drop raises."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(
+        monkeypatch,
+        granules_per_year=3,
+        files_returned=3,
+        zero_byte_count=2,
+    )
+    with pytest.raises(RuntimeError, match="partial download"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    # The zero-byte files are unlinked, leaving the year dir with just
+    # the surviving non-empty granule.
+    year_dir = tmp_path / "datastore" / "margulis_wus_sr" / "raw" / "2000"
+    survivors = [p for p in year_dir.iterdir() if p.stat().st_size > 0]
+    assert len(survivors) == 1
+
+
+def test_zero_download_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=2, files_returned=0)
+    with pytest.raises(RuntimeError, match="returned no files"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+
+
+def test_authentication_failure_propagates(tmp_path, monkeypatch):
+    """A login failure surfaces cleanly (not swallowed by retry logic)."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(
+        monkeypatch,
+        granules_per_year=1,
+        login_error=RuntimeError("Earthdata login refused"),
+    )
+    with pytest.raises(RuntimeError, match="Earthdata login refused"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+
+
+# ---------------------------------------------------------------------------
+# Manifest fields
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_records_fabric_scope(tmp_path, monkeypatch):
+    """The manifest entry carries the Oregon-only scope from the catalog."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    entry = manifest["sources"]["margulis_wus_sr"]
+    assert entry["fabric_scope"]["fabrics"] == ["or"]
+    assert entry["variables"] == ["SWE"]
+
+
+def test_manifest_accumulates_years_across_calls(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    fetch_margulis_wus_sr(workdir=workdir, period="2001/2001")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    years = [r["year"] for r in manifest["sources"]["margulis_wus_sr"]["years"]]
+    assert years == [2000, 2001]
+
+
+def test_missing_bbox_buffered_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    # Strip the buffered bbox from fabric.json to simulate a stale fabric.
+    fabric_path = workdir / "fabric.json"
+    fabric = json.loads(fabric_path.read_text())
+    fabric.pop("bbox_buffered", None)
+    fabric_path.write_text(json.dumps(fabric))
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    with pytest.raises(ValueError, match="bbox_buffered"):
+        fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")

--- a/tests/test_fetch_margulis_wus_sr.py
+++ b/tests/test_fetch_margulis_wus_sr.py
@@ -209,6 +209,35 @@ def test_manifest_records_fabric_scope(tmp_path, monkeypatch):
     entry = manifest["sources"]["margulis_wus_sr"]
     assert entry["fabric_scope"]["fabrics"] == ["or"]
     assert entry["variables"] == ["SWE"]
+    # Manifest field is `search_bbox` (the fabric-buffered search bbox),
+    # distinct from SNODAS's fixed `bbox`.
+    assert entry["search_bbox"] == [-124.2, 41.9, -115.8, 46.6]
+
+
+def test_completed_years_skipped_on_rerun(tmp_path, monkeypatch):
+    """Re-running the same period with a non-empty manifest skips done years."""
+    workdir = _make_project(tmp_path)
+    calls = _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    n_searches_first = len(calls["search"])
+    # Second run for the same period should issue NO new CMR searches.
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    assert len(calls["search"]) == n_searches_first
+
+
+def test_zero_granule_years_not_treated_as_complete(tmp_path, monkeypatch):
+    """Years with zero CMR hits are retried on the next run.
+
+    A year recorded with `n_granules: 0` means no CMR coverage was
+    available; coverage can fill in retroactively, so re-runs should
+    retry rather than treat the year as done.
+    """
+    workdir = _make_project(tmp_path)
+    calls = _stub_earthaccess(monkeypatch, granules_per_year=0)
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    n_searches_first = len(calls["search"])
+    fetch_margulis_wus_sr(workdir=workdir, period="2000/2000")
+    assert len(calls["search"]) == n_searches_first + 1
 
 
 def test_manifest_accumulates_years_across_calls(tmp_path, monkeypatch):

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -1,0 +1,199 @@
+"""Tests for SNODAS daily fetch via earthaccess.
+
+`fetch_snodas` does an earthaccess search and download per year. The
+consolidation step (raw tar/binary → CF NetCDF) is **deferred** to the
+SNODAS aggregate follow-up issue and is not exercised here. These tests
+cover the period gate, worker sharding, partial-download guard, the
+empty-search fallback, and the per-year manifest accumulation.
+
+All tests monkeypatch ``earthaccess.login``, ``search_data``, and
+``download`` — no network access is required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nhf_spatial_targets.fetch import snodas as _snodas_module
+from nhf_spatial_targets.fetch.snodas import fetch_snodas
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Materialize a minimal valid project directory."""
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {
+                    "path": str(tmp_path / "fabric.gpkg"),
+                    "id_col": "nhm_id",
+                },
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    return tmp_path
+
+
+def _stub_earthaccess(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    granules_per_year: int = 2,
+    files_returned: int | None = None,
+) -> dict[str, list]:
+    """Patch earthaccess login/search/download. Returns a call log dict."""
+    import earthaccess
+
+    calls = {"search": [], "downloaded_dirs": []}
+
+    def fake_login(strategy="netrc"):
+        calls.setdefault("login", []).append(strategy)
+        return None
+
+    def fake_search(**kwargs):
+        calls["search"].append(kwargs)
+        return [object()] * granules_per_year
+
+    def fake_download(results, dest):
+        calls["downloaded_dirs"].append(str(dest))
+        n = len(results) if files_returned is None else files_returned
+        # Write tiny placeholder files so the dest dir is non-empty.
+        dest_path = Path(dest)
+        dest_path.mkdir(parents=True, exist_ok=True)
+        paths = []
+        for i in range(n):
+            p = dest_path / f"snodas_stub_{i}.dat"
+            p.write_bytes(b"\x00")
+            paths.append(str(p))
+        return paths
+
+    monkeypatch.setattr(earthaccess, "login", fake_login)
+    monkeypatch.setattr(earthaccess, "search_data", fake_search)
+    monkeypatch.setattr(earthaccess, "download", fake_download)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Period and worker gates
+# ---------------------------------------------------------------------------
+
+
+def test_period_before_2003_rejected(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch)
+    with pytest.raises(ValueError, match="before the SNODAS publisher start"):
+        fetch_snodas(workdir=workdir, period="2000/2002")
+
+
+def test_worker_partitioning_3_years_3_workers(tmp_path, monkeypatch):
+    """Three workers across three years each take one distinct year."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    seen_years: list[int] = []
+    for wi in range(3):
+        result = fetch_snodas(
+            workdir=workdir,
+            period="2020/2022",
+            worker_index=wi,
+            n_workers=3,
+        )
+        for rec in result["years"]:
+            seen_years.append(rec["year"])
+    assert sorted(seen_years) == [2020, 2021, 2022]
+
+
+def test_worker_with_no_assigned_years_returns_empty(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    # 1 year, 2 workers → worker 1 gets nothing
+    result = fetch_snodas(
+        workdir=workdir,
+        period="2020/2020",
+        worker_index=1,
+        n_workers=2,
+    )
+    assert result["years"] == []
+    assert result["worker_index"] == 1
+
+
+def test_worker_index_out_of_range_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    with pytest.raises(ValueError, match="worker_index must be in"):
+        fetch_snodas(
+            workdir=workdir,
+            period="2020/2020",
+            worker_index=3,
+            n_workers=2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Search and download paths
+# ---------------------------------------------------------------------------
+
+
+def test_empty_search_records_no_granules_note(tmp_path, monkeypatch):
+    """Years with zero CMR hits are recorded with a note, not raised on."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=0)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    assert len(result["years"]) == 1
+    assert result["years"][0]["n_granules"] == 0
+    assert result["years"][0]["note"] == "no_granules_in_CMR"
+
+
+def test_partial_download_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=3, files_returned=2)
+    with pytest.raises(RuntimeError, match="partial download"):
+        fetch_snodas(workdir=workdir, period="2020/2020")
+
+
+def test_zero_download_raises(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=2, files_returned=0)
+    with pytest.raises(RuntimeError, match="returned no files"):
+        fetch_snodas(workdir=workdir, period="2020/2020")
+
+
+# ---------------------------------------------------------------------------
+# Manifest accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_accumulates_years_across_calls(tmp_path, monkeypatch):
+    """Two successive single-year fetches yield both years in manifest."""
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    fetch_snodas(workdir=workdir, period="2021/2021")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    years = [r["year"] for r in manifest["sources"]["snodas"]["years"]]
+    assert years == [2020, 2021]
+
+
+def test_manifest_records_bbox_and_metadata(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    entry = manifest["sources"]["snodas"]
+    assert entry["bbox"] == _snodas_module.BBOX_NWSE
+    assert entry["variables"] == ["swe"]
+    assert entry["period"] == "2020/2020"
+
+
+def test_raw_directory_created_under_datastore(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    raw_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
+    assert raw_dir.exists()
+    assert any(raw_dir.iterdir())  # at least one stub granule landed here

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -18,12 +18,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from nhf_spatial_targets.fetch import snodas as _snodas_module
 from nhf_spatial_targets.fetch.snodas import fetch_snodas
 
 
 def _make_project(tmp_path: Path) -> Path:
     """Materialize a minimal valid project directory."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
     datastore = tmp_path / "datastore"
     datastore.mkdir()
     (tmp_path / "config.yml").write_text(
@@ -87,16 +87,22 @@ def _stub_earthaccess(
 def test_period_before_2003_rejected(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
     _stub_earthaccess(monkeypatch)
-    with pytest.raises(ValueError, match="before the SNODAS publisher start"):
+    with pytest.raises(ValueError, match="outside the SNODAS publisher window"):
         fetch_snodas(workdir=workdir, period="2000/2002")
 
 
 def test_worker_partitioning_3_years_3_workers(tmp_path, monkeypatch):
-    """Three workers across three years each take one distinct year."""
-    workdir = _make_project(tmp_path)
+    """Three workers across three years each take one distinct year.
+
+    Each worker gets its own project directory so the partitioning logic
+    is exercised against an empty manifest — i.e. exactly the state every
+    worker sees at startup when they're launched in parallel against the
+    shared real manifest.
+    """
     _stub_earthaccess(monkeypatch, granules_per_year=1)
     seen_years: list[int] = []
     for wi in range(3):
+        workdir = _make_project(tmp_path / f"worker_{wi}")
         result = fetch_snodas(
             workdir=workdir,
             period="2020/2022",
@@ -185,7 +191,10 @@ def test_manifest_records_bbox_and_metadata(tmp_path, monkeypatch):
     fetch_snodas(workdir=workdir, period="2020/2020")
     manifest = json.loads((workdir / "manifest.json").read_text())
     entry = manifest["sources"]["snodas"]
-    assert entry["bbox"] == _snodas_module.BBOX_NWSE
+    # Bbox is read from the catalog (sources.yml[snodas].access.bbox_nwse).
+    from nhf_spatial_targets import catalog as _catalog
+
+    assert entry["bbox"] == list(_catalog.source("snodas")["access"]["bbox_nwse"])
     assert entry["variables"] == ["swe"]
     assert entry["period"] == "2020/2020"
 


### PR DESCRIPTION
## Summary

- Adds a sixth calibration target category, **snow water equivalent (SWE)**, at the fetch layer only.
- Catalog: new `snow_water_equivalent` target in `variables.yml`; new sources `daymet` / `snodas` / `margulis_wus_sr` and new variable `sd` (snow depth water equivalent) on the existing `era5_land` source. `margulis_wus_sr` introduces an optional `fabric_scope` field, Oregon-only.
- ERA5-Land `consolidate_year` / `daily_to_monthly` gain an instantaneous-vs-accumulated dispatch (`_VARIABLE_KIND`): `sd` is reduced with `.mean()`, `ro/sro/ssro` stay on the diff-of-accumulations sum.
- New fetch modules: `fetch/daymet.py` (verify-only, mirrors `mwbm_climgrid`), `fetch/snodas.py` and `fetch/margulis_wus_sr.py` (earthaccess + flock-protected manifest). SNODAS and Margulis are fetch-only — raw-format consolidation is deferred to the per-source follow-up issues per the plan.
- CLI: `nhf-targets fetch {daymet,snodas,wus-sr}` plus extended docstring on `fetch era5-land`; `fetch all` skip-list widened so `FileNotFoundError` from `daymet` / `margulis-wus-sr` yields a yellow "skipped" rather than a fatal error.
- 34 new tests; full suite 698 passing (16 integration deselected).

Closes #99.

## Out of scope (deferred follow-up issues)

1. SWE: Daymet aggregate + target wiring (3-region adapter).
2. SWE: SNODAS aggregate + target wiring (incl. binary/.Hdr parser; characterise in a notebook first).
3. SWE: ERA5-Land `sd` aggregate + target wiring (extend `aggregate/era5_land.py`).
4. SWE: Margulis WUS-SR aggregate + target wiring with `fabric_scope` enforcement.
5. SWE target builder (`targets/swe.py`) consuming the four sources.

## Plan

Approved plan checked in at [docs/superpowers/plans/2026-05-12-swe-fetch-scaffolding.md](docs/superpowers/plans/2026-05-12-swe-fetch-scaffolding.md).

## Test plan

- [x] `pixi run -e dev fmt` — clean
- [x] `pixi run -e dev lint` — clean
- [x] `pixi run -e dev test` — 698 passing, 16 deselected
- [ ] CI green on PR
- [ ] Manual smoke: stage a real Daymet NA zarr and run `nhf-targets fetch daymet --source-path .../zarr --region na --period 2020/2020`, verify the manifest carries the per-region fingerprint
- [ ] Manual smoke: `nhf-targets fetch era5-land --period 2020/2020` and confirm the daily/monthly NCs now carry `ro`, `sro`, `ssro`, `sd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)