### PR TITLE
feat(hpc): SLURM batch jobs + pixi tasks for SWE fetches (#102)

### DIFF
--- a/fetch_all.slurm
+++ b/fetch_all.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=nhf-fetch
 #SBATCH --account=impd
 #SBATCH --partition=cpu
-#SBATCH --array=0-10
+#SBATCH --array=0-13
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
@@ -11,7 +11,7 @@
 #SBATCH --error=logs/fetch_%a_%A.err
 
 # NHF Spatial Targets — parallel fetch array
-# Submits one SLURM job per source dataset (11 total).
+# Submits one SLURM job per source dataset (14 total).
 # Each job downloads independently; they can run concurrently.
 #
 # Usage (REPO_DIR and PROJECT_DIR are overridable via environment):
@@ -35,6 +35,19 @@
 #
 # Use this after a pipeline change has invalidated the existing
 # consolidated NCs (e.g. PR #88's MOD16A2 fill-mask fix).
+#
+# Daymet (index 11) is verify-only — it does not download. The fetch
+# expects the three regional zarrs (NA/HI/PR) pre-staged on a shared
+# filesystem. Configure ONE of:
+#   - `daymet_root: /path/to/zarr/parent` in <project>/config.yml, OR
+#   - DAYMET_ROOT env var, which this script forwards as --source-path.
+# Missing zarrs raise FileNotFoundError per region. See
+# docs/sources/daymet.md.
+#
+# Margulis WUS-SR (index 13) is fabric-scoped to Oregon. Non-Oregon
+# projects can still fetch it (raw downloads stay reusable across
+# projects sharing a datastore) but expect zero granules per year and
+# a one-line warning. See docs/sources/margulis_wus_sr.md.
 
 set -euo pipefail
 
@@ -59,6 +72,9 @@ FETCH_TASKS=(
     "fetch-mod16a2"        # 8  — 2000–present at 500m, 8-day (LP DAAC/earthaccess)
     "fetch-mod10c1"        # 9  — 2000–present at 0.05°, daily (NSIDC/earthaccess)
     "fetch-mwbm-climgrid"  # 10 — 1900–2020 at 2.5 arcmin, monthly (ScienceBase, MANUAL DOWNLOAD; see docs/sources/mwbm_climgrid.md) — ends 2020
+    "fetch-daymet"         # 11 — 1980–2024 at 1 km, daily (ORNL DAAC zarr, MANUAL STAGING; see docs/sources/daymet.md)
+    "fetch-snodas"         # 12 — 2003–present at 1 km, daily (NSIDC G02158 via earthaccess)
+    "fetch-margulis-wus-sr" # 13 — 1985–2021 at 90 m, daily (NSIDC-0719 via earthaccess) — Oregon-fabric only
 )
 
 # Map array index → fetch period (YYYY/YYYY)
@@ -77,6 +93,9 @@ FETCH_PERIODS=(
     "2000/2025"   # 8  mod16a2     (MODIS starts 2000)
     "2000/2025"   # 9  mod10c1     (MODIS starts 2000)
     "1979/2020"   # 10 mwbm-climgrid (publisher ends 2020; 1895-1899 spinup excluded)
+    "1980/2024"   # 11 daymet      (publisher ends 2024; V4 R1)
+    "2003/2025"   # 12 snodas      (daily archive starts 2003-09-30)
+    "1985/2021"   # 13 margulis-wus-sr (water years 1985-2021)
 )
 
 TASK="${FETCH_TASKS[$SLURM_ARRAY_TASK_ID]}"
@@ -103,6 +122,16 @@ case "${FORCE:-}" in
         esac
         ;;
 esac
+
+# fetch-daymet is verify-only and needs to locate the staged regional
+# zarrs. Two ways: `daymet_root:` in <project>/config.yml (preferred)
+# or pass the directory via DAYMET_ROOT env → --source-path here.
+# If neither is set, the fetch raises FileNotFoundError with operator
+# instructions.
+if [ "$TASK" = "fetch-daymet" ] && [ -n "${DAYMET_ROOT:-}" ]; then
+    EXTRA_ARGS+=("--source-path" "$DAYMET_ROOT")
+    echo "=== DAYMET_ROOT=$DAYMET_ROOT: appending --source-path to $TASK ==="
+fi
 
 pixi run "$TASK" -- --project-dir "$PROJECT_DIR" --period "$PERIOD" \
     ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}

--- a/fetch_era5_land.slurm
+++ b/fetch_era5_land.slurm
@@ -36,6 +36,20 @@
 #
 # To fetch a subset of years only:
 #   PERIOD=2000/2010 sbatch fetch_era5_land.slurm
+#
+# GOTCHA — `sd` (snow depth water equivalent) backfill on old projects:
+#   ERA5-Land grew a 4th variable `sd` in PR #100 (SWE category fetch
+#   scaffolding). Years whose daily/monthly NCs predate that PR will
+#   be SKIPPED on re-run because `_completed_years_from_manifest`
+#   keys on path existence, not declared-variable membership.  To
+#   backfill `sd` on those years, delete the affected daily/monthly
+#   NCs first so the consolidator rebuilds with the full variable list:
+#
+#     rm <datastore>/era5_land/daily/era5_land_daily_{2020..2024}.nc
+#     rm <datastore>/era5_land/monthly/era5_land_monthly_{2020..2024}.nc
+#
+#   Then re-submit this job; the hourly chunks are already on disk so
+#   the rebuild is fast (no CDS traffic).
 
 set -euo pipefail
 

--- a/fetch_margulis_wus_sr.slurm
+++ b/fetch_margulis_wus_sr.slurm
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-margulis-wus-sr
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH --time=24:00:00      # NSIDC-0719 is per-water-year per-tile; ~37 years total
+#SBATCH --output=logs/margulis_wus_sr_%j.out
+#SBATCH --error=logs/margulis_wus_sr_%j.err
+
+# NHF Spatial Targets — Margulis Western US Snow Reanalysis (NSIDC-0719) fetch
+#
+# Single-task job (no --array): fetch_margulis_wus_sr does not support
+# worker sharding today and the granule volume is modest enough that
+# serial year-by-year iteration finishes well within the 24h wall clock.
+# Years already recorded with n_granules > 0 are skipped at startup
+# (manifest fast path), so resuming after a partial run requires no
+# flag changes.
+#
+# This source is fabric-scoped to Oregon (catalog/sources.yml ->
+# margulis_wus_sr.fabric_scope.fabrics: ["or"]). Running on a non-Oregon
+# project emits a warning and proceeds — raw data lands in the shared
+# datastore and remains usable by any Oregon-fabric project pointed at
+# the same datastore — but expect zero granules per year.
+#
+# Consolidation of the per-water-year per-tile granules into per-year
+# NetCDFs is DEFERRED to the Margulis aggregate follow-up (umbrella
+# #101). This script only stages raw downloads. See
+# docs/sources/margulis_wus_sr.md.
+#
+# Usage:
+#   mkdir -p logs
+#   export PROJECT_DIR=/path/to/oregon-project
+#   sbatch fetch_margulis_wus_sr.slurm
+#
+# To fetch a subset of years only:
+#   PERIOD=2000/2010 sbatch fetch_margulis_wus_sr.slurm
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets}"
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
+PERIOD="${PERIOD:-1985/2021}"
+
+echo "=== Margulis WUS-SR fetch ==="
+echo "=== Period:  ${PERIOD} ==="
+echo "=== Project: ${PROJECT_DIR} ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+cd "${REPO_DIR}" || { echo "ERROR: REPO_DIR=${REPO_DIR} not found" >&2; exit 1; }
+
+pixi run fetch-margulis-wus-sr -- \
+    --project-dir "${PROJECT_DIR}" \
+    --period      "${PERIOD}"
+
+echo "=== Done: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/fetch_snodas.slurm
+++ b/fetch_snodas.slurm
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-snodas
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --array=0-3          # 4 workers — adjust with --n-workers below
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH --time=48:00:00      # SNODAS daily archive is ~1.7k granules/year × ~22 years
+#SBATCH --output=logs/snodas_%a_%A.out
+#SBATCH --error=logs/snodas_%a_%A.err
+
+# NHF Spatial Targets — parallel SNODAS fetch (NSIDC G02158)
+#
+# Each array task downloads a non-overlapping slice of years to
+# <datastore>/snodas/raw/<year>/. Years are round-robin assigned by
+# worker_index so load spreads evenly. Each worker reads manifest.json
+# at startup and skips years already recorded with n_granules > 0
+# (years recorded with n_granules: 0 are retried, in case CMR coverage
+# fills in retroactively).
+#
+# Decoding the raw int16 binary + ENVI .Hdr bundles into CF NetCDFs is
+# DEFERRED to the SNODAS aggregate follow-up issue (umbrella #101);
+# this script only stages the raw bytes. See docs/sources/snodas.md.
+#
+# Usage:
+#   mkdir -p logs
+#   export PROJECT_DIR=/path/to/your/project
+#   sbatch fetch_snodas.slurm
+#
+# To change the number of workers (must edit BOTH --array and N_WORKERS):
+#   Edit  --array=0-2  and  N_WORKERS=3  below for 3 workers, etc.
+#
+# To resume after a partial run — just re-submit; no other flags needed.
+# Completed years are detected from manifest.json + on-disk file presence.
+#
+# To fetch a subset of years only:
+#   PERIOD=2003/2010 sbatch fetch_snodas.slurm
+
+set -euo pipefail
+
+# Must match the --array upper bound + 1 (i.e. --array=0-3 → N_WORKERS=4).
+N_WORKERS=4
+
+REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets}"
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
+PERIOD="${PERIOD:-2003/2024}"
+
+echo "=== SNODAS fetch: worker ${SLURM_ARRAY_TASK_ID}/${N_WORKERS} ==="
+echo "=== Period:  ${PERIOD} ==="
+echo "=== Project: ${PROJECT_DIR} ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+cd "${REPO_DIR}" || { echo "ERROR: REPO_DIR=${REPO_DIR} not found" >&2; exit 1; }
+
+pixi run fetch-snodas -- \
+    --project-dir "${PROJECT_DIR}" \
+    --period       "${PERIOD}" \
+    --worker-index "${SLURM_ARRAY_TASK_ID}" \
+    --n-workers    "${N_WORKERS}"
+
+echo "=== Done: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,6 +87,9 @@ fetch-reitz2017 = { cmd = "nhf-targets fetch reitz2017", description = "Download
 fetch-mod16a2 = { cmd = "nhf-targets fetch mod16a2", description = "Download MOD16A2 v061 AET data via earthaccess" }
 fetch-mod10c1 = { cmd = "nhf-targets fetch mod10c1", description = "Download MOD10C1 v061 snow cover data via earthaccess" }
 fetch-mwbm-climgrid = { cmd = "nhf-targets fetch mwbm-climgrid", description = "Download USGS MWBM (ClimGrid-forced) monthly outputs from ScienceBase" }
+fetch-daymet = { cmd = "nhf-targets fetch daymet", description = "Register operator-staged Daymet V4 R1 regional zarr stores (verify-only)" }
+fetch-snodas = { cmd = "nhf-targets fetch snodas", description = "Download SNODAS daily SWE granules from NSIDC (G02158) via earthaccess" }
+fetch-margulis-wus-sr = { cmd = "nhf-targets fetch margulis-wus-sr", description = "Download Margulis Western US Snow Reanalysis (NSIDC-0719) via earthaccess" }
 fetch-all = { cmd = "nhf-targets fetch all", description = "Download all source datasets sequentially" }
 
 # Aggregation


### PR DESCRIPTION
## Summary

Closes the HPC gap left after #100: the new daymet / snodas / margulis_wus_sr fetches had no pixi task aliases or SLURM scripts, so they couldn't be driven through the same array-job pattern as the rest of the pipeline. This PR adds the missing scaffolding.

- **pixi.toml** — three new task aliases: `fetch-daymet`, `fetch-snodas`, `fetch-margulis-wus-sr`.
- **fetch_snodas.slurm** (new) — parallel 4-worker array job; mirrors `fetch_era5_land.slurm`. Round-robin year assignment, manifest-based skip on resume, flock-protected writes.
- **fetch_margulis_wus_sr.slurm** (new) — single-task job. NSIDC-0719 volume is modest and the fetch module doesn't support worker sharding today.
- **fetch_all.slurm** — array extended from 0-10 to 0-13. Daymet (index 11) gets a `DAYMET_ROOT` env-var shim that forwards as `--source-path` so operators don't have to put `daymet_root:` in `config.yml` just for the bulk job. Inline comments document Daymet manual-staging and Margulis Oregon-fabric scope.
- **fetch_era5_land.slurm** — doc note on the `sd` backfill gotcha: re-runs on pre-#100 projects skip already-complete years because `_completed_years_from_manifest` keys on path existence, not declared variables. Workaround: delete the affected daily/monthly NCs first.

Closes #102.

## Out of scope

- Aggregate / target builder SLURM scripts for SWE (tracked by umbrella #101).
- A "force backfill" flag for ERA5-Land that re-runs already-complete years with the expanded variable list — see the doc note in [fetch_era5_land.slurm](fetch_era5_land.slurm).

## Test plan

- [x] `pixi run fetch-daymet -- --help` succeeds
- [x] `pixi run fetch-snodas -- --help` succeeds
- [x] `pixi run fetch-margulis-wus-sr -- --help` succeeds
- [x] `bash -n` clean on all four SLURM scripts
- [x] `pixi run -e dev fmt && pixi run -e dev lint` clean
- [x] Focused tests green (catalog + cli + fetch_{daymet,snodas,margulis_wus_sr,era5_land}): 150 passed
- [ ] CI green on this PR
- [ ] Smoke `sbatch --array=0 fetch_snodas.slurm` against a real project (1 worker, 1 year) — defer to operator on first live run
- [ ] Smoke `sbatch fetch_margulis_wus_sr.slurm` against the Oregon project — defer to operator
- [ ] Smoke `sbatch --array=11 fetch_all.slurm` with `DAYMET_ROOT` set — defer to operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)