### PR TITLE
fix(snodas): use fabric bbox in CMR-correct order (#105)

### DIFF
--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -119,12 +119,24 @@ def fetch_snodas(
                 f"({data_lo}-{data_hi}, from catalog `sources.yml[{_SOURCE_KEY}]"
                 f".period`). Adjust --period."
             )
-    bbox_nwse = access.get("bbox_nwse")
-    if not bbox_nwse:
+    # Use the project's buffered fabric bbox as the CMR search bounding
+    # box (matches the pattern in merra2.py / nldas.py / margulis_wus_sr.py).
+    # The catalog's `bbox_nwse` is CDS-convention metadata (kept for the
+    # ERA5-Land fetch); CMR / earthaccess want `(W, S, E, N)`, which is
+    # exactly the (minx, miny, maxx, maxy) order fabric.json records.
+    bbox_buffered = ws.fabric.get("bbox_buffered") or {}
+    if not bbox_buffered:
         raise ValueError(
-            f"catalog `sources.yml[{_SOURCE_KEY}].access.bbox_nwse` is missing. "
-            f"Add a [N, W, S, E] bbox before running the SNODAS fetch."
+            "SNODAS fetch needs a buffered fabric bbox; fabric.json has "
+            "no 'bbox_buffered' key. Re-run `nhf-targets validate` to "
+            "regenerate fabric.json."
         )
+    search_bbox = (
+        float(bbox_buffered["minx"]),
+        float(bbox_buffered["miny"]),
+        float(bbox_buffered["maxx"]),
+        float(bbox_buffered["maxy"]),
+    )
 
     raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
     raw_root.mkdir(parents=True, exist_ok=True)
@@ -157,7 +169,7 @@ def fetch_snodas(
             "license": meta.get("license", "public domain (NSIDC)"),
             "variables": [v["name"] for v in meta["variables"]],
             "period": period,
-            "bbox": bbox_nwse,
+            "search_bbox": list(search_bbox),
             "worker_index": worker_index,
             "n_workers": n_workers,
             "years": [],
@@ -173,7 +185,7 @@ def fetch_snodas(
             short_name=access["short_name"],
             version=access.get("version"),
             temporal=(f"{year}-01-01", f"{year}-12-31"),
-            bounding_box=tuple(bbox_nwse),
+            bounding_box=search_bbox,
         )
         n_found = len(results)
         if n_found == 0:
@@ -208,7 +220,7 @@ def fetch_snodas(
             }
         )
 
-    _update_manifest(workdir, period, meta, year_records, bbox_nwse)
+    _update_manifest(workdir, period, meta, year_records, search_bbox)
 
     return {
         "source_key": _SOURCE_KEY,
@@ -217,7 +229,7 @@ def fetch_snodas(
         "license": meta.get("license", "public domain (NSIDC)"),
         "variables": [v["name"] for v in meta["variables"]],
         "period": period,
-        "bbox": bbox_nwse,
+        "search_bbox": list(search_bbox),
         "worker_index": worker_index,
         "n_workers": n_workers,
         "years": year_records,
@@ -260,7 +272,7 @@ def _update_manifest(
     period: str,
     meta: dict,
     year_records: list[dict],
-    bbox_nwse: list,
+    search_bbox: tuple[float, float, float, float],
 ) -> None:
     """Merge SNODAS provenance into manifest.json (flock-protected).
 
@@ -300,7 +312,7 @@ def _update_manifest(
                 "doi": meta.get("doi"),
                 "license": meta.get("license", "public domain (NSIDC)"),
                 "period": period,
-                "bbox": list(bbox_nwse),
+                "search_bbox": list(search_bbox),
                 "variables": [v["name"] for v in meta["variables"]],
                 "years": merged_years,
             }

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -37,7 +37,28 @@ def _make_project(tmp_path: Path) -> Path:
             }
         )
     )
-    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    # A buffered fabric bbox is required by the CMR-search path of
+    # fetch_snodas (matches merra2 / nldas / margulis). Pick a small
+    # CONUS-overlapping rectangle.
+    (tmp_path / "fabric.json").write_text(
+        json.dumps(
+            {
+                "sha256": "f00",
+                "bbox": {
+                    "minx": -110.0,
+                    "miny": 40.0,
+                    "maxx": -105.0,
+                    "maxy": 45.0,
+                },
+                "bbox_buffered": {
+                    "minx": -110.2,
+                    "miny": 39.9,
+                    "maxx": -104.8,
+                    "maxy": 45.1,
+                },
+            }
+        )
+    )
     return tmp_path
 
 
@@ -191,12 +212,40 @@ def test_manifest_records_bbox_and_metadata(tmp_path, monkeypatch):
     fetch_snodas(workdir=workdir, period="2020/2020")
     manifest = json.loads((workdir / "manifest.json").read_text())
     entry = manifest["sources"]["snodas"]
-    # Bbox is read from the catalog (sources.yml[snodas].access.bbox_nwse).
-    from nhf_spatial_targets import catalog as _catalog
-
-    assert entry["bbox"] == list(_catalog.source("snodas")["access"]["bbox_nwse"])
+    # search_bbox is the buffered fabric bbox, ordered (W, S, E, N) for CMR.
+    assert entry["search_bbox"] == [-110.2, 39.9, -104.8, 45.1]
     assert entry["variables"] == ["swe"]
     assert entry["period"] == "2020/2020"
+
+
+def test_search_uses_fabric_buffered_bbox_in_wsen_order(tmp_path, monkeypatch):
+    """CMR rejects bboxes whose 2nd coord (South) is outside [-90, 90].
+
+    This is a regression guard for #105: the catalog's `bbox_nwse` is
+    CDS convention `[N, W, S, E]`. Passing it directly to
+    `earthaccess.search_data` puts -125.0 (West) in the South slot and
+    CMR refuses. We use the fabric's `bbox_buffered` `(minx, miny,
+    maxx, maxy)` which is already in CMR's `(W, S, E, N)` order.
+    """
+    workdir = _make_project(tmp_path)
+    calls = _stub_earthaccess(monkeypatch, granules_per_year=1)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    bbox = calls["search"][-1]["bounding_box"]
+    assert bbox == (-110.2, 39.9, -104.8, 45.1)
+    # Second slot (South) MUST be a latitude in [-90, 90].
+    assert -90.0 <= bbox[1] <= 90.0
+
+
+def test_missing_bbox_buffered_raises(tmp_path, monkeypatch):
+    """Stale fabric.json without `bbox_buffered` fails fast with instructions."""
+    workdir = _make_project(tmp_path)
+    fabric_path = workdir / "fabric.json"
+    fabric = json.loads(fabric_path.read_text())
+    fabric.pop("bbox_buffered", None)
+    fabric_path.write_text(json.dumps(fabric))
+    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    with pytest.raises(ValueError, match="bbox_buffered"):
+        fetch_snodas(workdir=workdir, period="2020/2020")
 
 
 def test_raw_directory_created_under_datastore(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`fetch_snodas` was passing the catalog's \`bbox_nwse: [N, W, S, E]\` straight to \`earthaccess.search_data\`, which expects \`(W, S, E, N)\`. CMR rejected the request because slot 2 (South) was \`-125.0\` (the West value):

\`\`\`
Error: {"errors":["South must be within [-90.0] and [90.0] but was [-125.0]."]}
\`\`\`

Observed in the wild: \`logs/snodas_0_17437511.err\` from \`sbatch fetch_snodas.slurm\` failing on the first CMR query for year 2003.

## Fix

Match the precedent in [\`fetch/merra2.py:114\`](src/nhf_spatial_targets/fetch/merra2.py#L114), [\`fetch/nldas.py:156\`](src/nhf_spatial_targets/fetch/nldas.py#L156), [\`fetch/margulis_wus_sr.py\`](src/nhf_spatial_targets/fetch/margulis_wus_sr.py): read \`ws.fabric["bbox_buffered"]\` as \`(minx, miny, maxx, maxy)\`, which is already CMR's \`(W, S, E, N)\` order. The catalog's \`bbox_nwse\` becomes informational metadata (kept for ERA5-Land's CDS API, which genuinely wants NWSE) rather than a CMR-search input.

Manifest field renamed \`bbox\` → \`search_bbox\` to match Margulis and make the source-of-truth obvious (fabric-derived, not a fixed CONUS constant). The catalog-bbox guard is replaced with a "fabric.json missing bbox_buffered → re-run validate" guard mirroring Margulis.

Closes #105.

## Out of scope

- Re-running the SNODAS fetch on \`gfv2-spatial-targets\` to actually pull granules — that's an operator action once this lands, not a code change.
- A general regression guard "every earthaccess search bounding_box has -90 <= bbox[1] <= 90". Easy follow-up but probably overkill since only one fetch ever made this mistake and the new test catches it for SNODAS specifically.

## Test plan

- [x] \`pixi run -e dev fmt && pixi run -e dev lint\` clean
- [x] \`pytest tests/test_fetch_snodas.py\` — 12 passed (was 10, added 2 regression guards)
- [x] Unit suite: 707 passed, 16 deselected
- [ ] CI green
- [ ] Re-submit \`sbatch fetch_snodas.slurm\` on \`gfv2-spatial-targets\` and confirm year 2003 actually downloads at least one granule (was failing instantly before the fix)

## New tests

- \`test_search_uses_fabric_buffered_bbox_in_wsen_order\` — regression guard: asserts the bbox passed to \`earthaccess.search_data\` is in WSEN order with \`-90 <= S <= 90\`. Fails fast if anyone reintroduces the bug.
- \`test_missing_bbox_buffered_raises\` — stale-fabric guard mirrors Margulis.
- \`test_manifest_records_bbox_and_metadata\` updated for the \`search_bbox\` field rename.
- \`_make_project\` fixture now populates \`bbox\` + \`bbox_buffered\` in \`fabric.json\` (CONUS-overlapping rectangle around the Rockies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)