### PR TITLE
fix(snodas): direct HTTPS download from NSIDC archive (#107)

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -748,11 +748,12 @@ sources:
       url: https://nsidc.org/data/g02158
       archive_url: https://noaadata.apps.nsidc.org/NOAA/G02158/masked/
       # CMR collection record (granule-less metadata stub) — kept for
-      # provenance; do NOT use earthaccess.search_data on this short_name,
-      # it returns 0 hits.
-      cmr_short_name: G02158
-      cmr_version: "1"
-      cmr_concept_id: C1386246263-NSIDCV0
+      # provenance and to flag the trap for the next reader; do NOT use
+      # earthaccess.search_data on this short_name, it returns 0 hits.
+      cmr:
+        short_name: G02158
+        version: "1"
+        concept_id: C1386246263-NSIDCV0
       notes: >
         SNODAS is distributed by NSIDC via an Earthdata-Login-gated
         HTTPS archive at https://noaadata.apps.nsidc.org/NOAA/G02158/.
@@ -798,7 +799,11 @@ sources:
       - "Fang, Y., Liu, Y., and Margulis, S.A., 2022, doi:10.5067/PP7T2GBI52I2"
     doi: "10.5067/PP7T2GBI52I2"
     access:
-      type: nasa_nsidc
+      # `nsidc` = CMR-mediated earthaccess.search_data path (same as
+      # MOD10C1). Distinct from `nsidc_https` (SNODAS), where the CMR
+      # record is granule-less and the fetch goes direct to the HTTPS
+      # archive instead.
+      type: nsidc
       short_name: WUS_UCLA_SR
       version: "1"
       url: https://nsidc.org/data/nsidc-0719

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -744,20 +744,31 @@ sources:
       - "National Operational Hydrologic Remote Sensing Center, 2004, doi:10.7265/N5TB14TC"
     doi: "10.7265/N5TB14TC"
     access:
-      type: nasa_nsidc
-      short_name: G02158
-      version: "1"
+      type: nsidc_https
       url: https://nsidc.org/data/g02158
-      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      archive_url: https://noaadata.apps.nsidc.org/NOAA/G02158/masked/
+      # CMR collection record (granule-less metadata stub) — kept for
+      # provenance; do NOT use earthaccess.search_data on this short_name,
+      # it returns 0 hits.
+      cmr_short_name: G02158
+      cmr_version: "1"
+      cmr_concept_id: C1386246263-NSIDCV0
       notes: >
-        Access via earthaccess (NASA Earthdata login required). Daily
-        granules are tar/gz bundles containing flat int16 binary files
-        plus ENVI-style `.Hdr` headers; the SWE field is in mm with a
-        fill value of -9999 (scale_factor 1). Apply scale + fill mask
-        before any quantitative aggregation. The masked product is used
-        (CONUS only); the unmasked variant covering parts of southern
-        Canada is NOT used. Short_name/version should be confirmed via
-        an earthaccess CMR query at implementation time.
+        SNODAS is distributed by NSIDC via an Earthdata-Login-gated
+        HTTPS archive at https://noaadata.apps.nsidc.org/NOAA/G02158/.
+        The `masked/` subtree (CONUS-trimmed) covers 2003-present, daily
+        .tar bundles named SNODAS_YYYYMMDD.tar. Each tar contains flat
+        int16 binary fields plus ENVI-style `.Hdr` headers; the SWE
+        field is in mm with a fill value of -9999 (scale_factor 1).
+        Apply scale + fill mask before any quantitative aggregation.
+        IMPORTANT: although a CMR collection record exists
+        (concept-id C1386246263-NSIDCV0), CMR holds NO granule-level
+        metadata for this product (verified via direct CMR query in
+        issue #107). The fetch module constructs URLs from dates and
+        downloads through the earthaccess HTTPS auth session rather
+        than via earthaccess.search_data. The unmasked variant
+        (2009-present, ~60 N to 24.95 N including parts of Canada/
+        Mexico) is NOT used.
     variables:
       - name: swe
         long_name: snow water equivalent

--- a/docs/sources/snodas.md
+++ b/docs/sources/snodas.md
@@ -107,12 +107,33 @@ so parallel workers do not lose each other's year records.
   in umbrella issue #101: characterise the int16+`.Hdr` layout in a
   notebook, then write the decoder, then write the aggregate adapter.
 
+## Known limitations
+
+- **EDL token expiry on multi-hour runs.** The auth'd session is built
+  once per worker via `earthaccess.login(strategy='netrc').get_session()`.
+  Earthdata bearer tokens typically live 1-2 hours, refreshable up to a
+  few days. For single-worker fetches of the full 2003-present archive
+  (which can run 24+ hours), the token may expire mid-run. When that
+  happens the next `session.get()` returns 401 and the day is recorded
+  as `n_errors += 1`. Workarounds: (1) bump `--n-workers` so no worker's
+  share exceeds ~1 hour, or (2) re-submit the job — failed days have
+  no `out_path` on disk and are picked up cleanly on the next run.
+
 ## Troubleshooting
 
 - `RuntimeError: earthaccess login failed for SNODAS` — Earthdata
   credentials are missing or wrong. Re-run
   `nhf-targets materialize-credentials --project-dir <project>` after
   editing `.credentials.yml`.
+
+- All `n_errors` for a year, no `downloaded` or `already_present`, late
+  in a long run — most likely an expired EDL token (see above). Re-run
+  the job; the worker rebuilds its session and picks up where the
+  errors started.
+
+- `short read for <url> — wrote N of M declared bytes` log lines — NSIDC
+  closed the connection mid-stream. The `.tar.tmp` is unlinked and the
+  day is recorded as `error`. Re-run; transient.
 
 - `ValueError: outside the SNODAS publisher window` — the requested
   `--period` includes years before the catalog's start year. SNODAS

--- a/docs/sources/snodas.md
+++ b/docs/sources/snodas.md
@@ -2,28 +2,49 @@
 
 The NOAA NOHRSC Snow Data Assimilation System (SNODAS) daily 1 km
 CONUS snow products are distributed by NSIDC as collection
-[G02158](https://nsidc.org/data/g02158)
-(doi:10.7265/N5TB14TC). Daily tar/gz bundles contain flat int16
-binary fields plus ENVI-style `.Hdr` headers. SWE is the variable of
-interest for the snow water equivalent calibration target.
+[G02158](https://nsidc.org/data/g02158) (doi:10.7265/N5TB14TC). Daily
+`.tar` bundles contain flat int16 binary fields plus ENVI-style `.Hdr`
+headers; SWE is the variable of interest for the snow water equivalent
+calibration target.
 
-This PR ships the **fetch-only** path: download raw bundles via
-`earthaccess` (NASA Earthdata login) into
-`<datastore>/snodas/raw/<year>/` and record a per-year manifest
-entry. Decoding the int16 binary into a CF NetCDF, and clipping or
-re-projecting it for HRU aggregation, is **deferred** to the SNODAS
-aggregate follow-up issue — the native format needs operator
-characterisation in a notebook (per CLAUDE.md "characterise the data
-first") before a robust parser is committed.
+## Access path — direct HTTPS, not CMR
+
+> **Heads-up:** despite the existence of a CMR collection record
+> (`short_name=G02158, version=1, concept-id=C1386246263-NSIDCV0`),
+> CMR holds **zero granule-level metadata** for this product. Verified
+> in issue #107:
+>
+> ```python
+> earthaccess.search_data(short_name='G02158')             # hits=0
+> earthaccess.search_data(concept_id='C1386246263-NSIDCV0')  # hits=0
+> ```
+>
+> The CMR record is a metadata-only stub pointing at NSIDC's external
+> archive. NOAA NOHRSC products at NSIDC (SNODAS, NIC, etc.) are
+> routinely distributed this way.
+
+The real archive lives at:
+
+```
+https://noaadata.apps.nsidc.org/NOAA/G02158/masked/YYYY/MM_Mon/SNODAS_YYYYMMDD.tar
+```
+
+- Authenticated via Earthdata Login (`.netrc`-based; same credentials
+  as the rest of the pipeline).
+- `masked/` subtree (CONUS-trimmed): **2003 onward**, daily bundles.
+- `unmasked/` subtree (~60 N to 24.95 N including parts of Canada/
+  Mexico): 2009 onward. NOT used by this pipeline.
+
+The fetch module constructs daily URLs from each date and streams the
+`.tar` via the earthaccess HTTPS auth session
+(`earthaccess.login().get_session()`), one file per calendar day.
 
 ## Prerequisites
 
 - NASA Earthdata account with credentials materialized into `~/.netrc`
-  (run `nhf-targets materialize-credentials --project-dir <project>`
-  after editing `.credentials.yml`).
-- Project's `fabric.json` present with a `bbox_buffered` covering the
-  CONUS footprint of interest. (The catalog also carries a CONUS-wide
-  fallback `bbox_nwse` at `sources.yml[snodas].access.bbox_nwse`.)
+  (`nhf-targets materialize-credentials --project-dir <project>`).
+- A few hundred GB of free space in `<datastore>/snodas/raw/` for the
+  full 2003-present period (~8k .tars × 10-30 MB each).
 
 ## Procedure
 
@@ -34,43 +55,71 @@ nhf-targets fetch snodas \
     [--worker-index 0 --n-workers 1]
 ```
 
+Or via the SLURM array job:
+
+```bash
+sbatch fetch_snodas.slurm   # 4-worker array by default
+```
+
 The command:
 
-1. Logs in to NASA EDL via `earthaccess`.
-2. Reads `sources.yml[snodas].period` for the publisher window and
-   rejects out-of-window years before any network work.
+1. Logs in to NASA EDL via `earthaccess.login(strategy='netrc')` and
+   obtains an auth'd `requests.Session` via `auth.get_session()`.
+2. Reads the publisher window from `sources.yml[snodas].period` and
+   rejects out-of-window years before any HTTP work.
 3. Pre-filters years against the existing manifest — years recorded
-   with `n_granules > 0` are skipped on re-runs (years with
-   `n_granules: 0` are retried because CMR coverage can fill in
-   retroactively).
+   with `n_granules > 0` are skipped on re-runs.
 4. Round-robin assigns the remaining years to `--worker-index` of
    `--n-workers` so parallel SLURM array jobs cover the period
    without overlap or gaps.
-5. For each assigned year, searches CMR (`short_name: G02158`,
-   `version: "1"`) inside the catalog bbox, downloads matching
-   granules into `<datastore>/snodas/raw/<year>/`, and records the
-   per-year tally in `manifest.json` → `sources.snodas.years`.
-6. The manifest update is flock-protected so parallel workers do not
-   lose each other's year records.
+5. For each assigned year, iterates over every calendar day, builds
+   the URL `<archive_url>/<year>/MM_Mon/SNODAS_YYYYMMDD.tar`, and
+   streams the bundle into
+   `<datastore>/snodas/raw/<year>/SNODAS_YYYYMMDD.tar`.
+
+Per-day status accounting (recorded in the manifest year entry):
+
+| Status            | Meaning                                                    |
+| ----------------- | ---------------------------------------------------------- |
+| `downloaded`      | Streamed successfully this call.                            |
+| `already_present` | File already on disk with non-zero size; skipped.           |
+| `missing_404`     | Server returned 404; normal at year boundaries and gaps.   |
+| `error`           | 5xx, connection reset, partial write, etc.; logged.         |
+
+`n_granules` in the manifest entry is the cumulative `downloaded +
+already_present` for the year. The manifest update is flock-protected
+so parallel workers do not lose each other's year records.
+
+## Resumability
+
+- Pre-existing non-empty `.tar` files on disk are skipped — `n_already_present`
+  in the manifest grows on subsequent runs without re-downloading.
+- Years with `n_granules == 0` (e.g. all 404s, or all errors) are
+  retried on the next run because NSIDC coverage can fill in
+  retroactively.
+- The atomic write (`.tar.tmp` → rename) means an interrupted download
+  leaves no partial `.tar` for the next run to mistake for "already
+  present".
 
 ## Known follow-ups
 
-- **CMR short_name/version verification.** `G02158` / `"1"` is the
-  best-guess pair; confirm against an `earthaccess.search_data` smoke
-  test before the first production run.
-- **Binary decoding.** Filed as the SNODAS aggregate follow-up issue:
-  characterise the flat int16 + `.Hdr` layout in a notebook, then
-  write the decoder, then write the aggregate adapter.
+- **Binary decoding to CF NetCDF** is the SNODAS aggregate follow-up
+  in umbrella issue #101: characterise the int16+`.Hdr` layout in a
+  notebook, then write the decoder, then write the aggregate adapter.
 
 ## Troubleshooting
 
-- `RuntimeError: snodas: earthaccess.download returned no files` —
-  Earthdata credentials are missing or wrong, or the CMR endpoint is
-  unreachable. Re-run `nhf-targets materialize-credentials`.
-
-- `RuntimeError: snodas: partial download` — a granule failed mid-run.
-  Re-run the same command to retry only the missing files.
+- `RuntimeError: earthaccess login failed for SNODAS` — Earthdata
+  credentials are missing or wrong. Re-run
+  `nhf-targets materialize-credentials --project-dir <project>` after
+  editing `.credentials.yml`.
 
 - `ValueError: outside the SNODAS publisher window` — the requested
   `--period` includes years before the catalog's start year. SNODAS
-  daily archives begin 2003-09-30.
+  daily archives begin 2003-09-30; year 2003 will see ~270 404s for
+  pre-September dates (recorded as `n_missing_404`, not errors).
+
+- All `n_errors` for a year, no `downloaded`/`already_present` — the
+  NSIDC archive is likely down. Confirm with
+  `curl -I https://noaadata.apps.nsidc.org/NOAA/G02158/masked/` then
+  retry (the manifest fast-path will replay only the failed year).

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1,17 +1,21 @@
-"""Fetch SNODAS daily snow water equivalent from NSIDC via earthaccess.
+"""Fetch SNODAS daily snow water equivalent from NSIDC's HTTPS archive.
 
 This is the **fetch-only** scaffolding for SNODAS (NSIDC collection
-G02158). It downloads raw daily granules (tar/gz bundles of flat int16
-binary fields plus ENVI ``.Hdr`` headers) into
-``<datastore>/snodas/raw/<year>/`` and records them in ``manifest.json``.
+G02158). NSIDC's CMR record for G02158 is a metadata-only stub with
+**zero granule-level records** (verified in issue #107):
+``earthaccess.search_data(short_name='G02158')`` returns 0 hits, no
+matter the bbox or temporal filter. The data actually lives behind
+NSIDC's Earthdata-Login-gated HTTPS archive at:
 
-Consolidation of the raw bundles into per-year daily and monthly CF
-NetCDFs is **deferred** to the SNODAS aggregate follow-up issue. The
-SNODAS native format (flat binary + ENVI ``.Hdr``) needs operator
-characterisation in a notebook before a robust parser can be written,
-per CLAUDE.md "characterise the data first" guidance. Until that work
-lands, the fetch module records the raw paths and lets downstream
-aggregate code raise loudly when it tries to consume them.
+    https://noaadata.apps.nsidc.org/NOAA/G02158/masked/YYYY/MM_Mon/
+        SNODAS_YYYYMMDD.tar
+
+The fetch module constructs daily URLs from each date and streams the
+``.tar`` bundle via the earthaccess HTTPS auth session
+(``earthaccess.login(strategy='netrc').get_session()``). Each bundle
+contains flat int16 binary fields plus ENVI-style ``.Hdr`` headers;
+decoding to a CF NetCDF is **deferred** to the SNODAS aggregate
+follow-up issue.
 """
 
 from __future__ import annotations
@@ -22,6 +26,8 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+import pandas as pd
 
 try:
     import fcntl as _fcntl
@@ -41,6 +47,11 @@ from nhf_spatial_targets.workspace import load as _load_project
 logger = logging.getLogger(__name__)
 
 _SOURCE_KEY = "snodas"
+# Per-request HTTP timeout (connect + first-byte). SNODAS .tar bundles
+# are O(10-30 MB); 60s is generous for a healthy network.
+_HTTP_TIMEOUT_SECONDS = 60
+# Chunk size for streaming downloads.
+_DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 
 
 def _assign_worker_years(
@@ -52,9 +63,8 @@ def _assign_worker_years(
 
     Mirrors ``era5_land._assign_worker_years`` (without the manifest-merge
     behaviour, which is not needed here — SNODAS does no per-month chunk
-    pre-staging). Each worker takes a deterministic slice of ``all_years``
-    keyed by ``worker_index``; slicing the full list (not a remaining
-    set) keeps each worker's assignment independent of sibling progress.
+    pre-staging). Slicing the full list (not a remaining set) keeps each
+    worker's assignment independent of sibling progress.
     """
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
@@ -65,6 +75,95 @@ def _assign_worker_years(
     return list(all_years[worker_index::n_workers])
 
 
+def _daily_urls(archive_url: str, year: int) -> list[tuple[pd.Timestamp, str]]:
+    """Yield (date, URL) pairs for every calendar day in ``year``.
+
+    Archive layout is ``<archive_url>/<year>/MM_Mon/SNODAS_YYYYMMDD.tar``,
+    e.g. ``.../2020/01_Jan/SNODAS_20200101.tar``. Not every date carries
+    a file — partial-year boundaries (2003 starts late September) and
+    occasional gaps are normal; 404s are handled upstream.
+    """
+    base = archive_url.rstrip("/")
+    days = pd.date_range(f"{year}-01-01", f"{year}-12-31", freq="1D")
+    out: list[tuple[pd.Timestamp, str]] = []
+    for d in days:
+        month_dir = f"{d.month:02d}_{d.strftime('%b')}"
+        fname = f"SNODAS_{d.strftime('%Y%m%d')}.tar"
+        out.append((d, f"{base}/{year}/{month_dir}/{fname}"))
+    return out
+
+
+def _download_tar(
+    session, url: str, out_path: Path, *, timeout: int = _HTTP_TIMEOUT_SECONDS
+) -> str:
+    """Stream a single .tar from *url* to *out_path*. Returns a status code.
+
+    Status codes (manifest-friendly):
+      - ``"downloaded"`` — file streamed and written this call.
+      - ``"already_present"`` — file exists on disk with non-zero size; skipped.
+      - ``"missing_404"`` — server returned 404; not an error (partial years
+        and gaps are normal in SNODAS).
+      - ``"error"`` — any other failure; logged, not raised.
+
+    Atomic: streams to a ``.tar.tmp`` sibling, then renames on success.
+    The ``.tar.tmp`` is unlinked on any failure path so resume sees a
+    clean directory.
+    """
+    if out_path.exists() and out_path.stat().st_size > 0:
+        return "already_present"
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    try:
+        resp = session.get(url, timeout=timeout, stream=True, allow_redirects=True)
+    except Exception as exc:
+        logger.warning("snodas: GET failed for %s: %s", url, exc)
+        tmp.unlink(missing_ok=True)
+        return "error"
+    try:
+        if resp.status_code == 404:
+            return "missing_404"
+        if resp.status_code != 200:
+            logger.warning(
+                "snodas: unexpected status %d for %s; skipping",
+                resp.status_code,
+                url,
+            )
+            return "error"
+        with tmp.open("wb") as f:
+            for chunk in resp.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+                if chunk:
+                    f.write(chunk)
+        tmp.replace(out_path)
+        return "downloaded"
+    except Exception as exc:
+        logger.warning("snodas: write failed for %s → %s: %s", url, out_path, exc)
+        tmp.unlink(missing_ok=True)
+        return "error"
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+
+def _earthaccess_session():
+    """Return an authenticated HTTPS session for noaadata.apps.nsidc.org.
+
+    Wrapped for monkeypatch in tests. Production calls
+    ``earthaccess.login(strategy='netrc').get_session()``.
+    """
+    import earthaccess
+
+    auth = earthaccess.login(strategy="netrc")
+    if not auth.authenticated:
+        raise RuntimeError(
+            "earthaccess login failed for SNODAS; check ~/.netrc has a "
+            "machine urs.earthdata.nasa.gov entry. Run "
+            "`nhf-targets materialize-credentials --project-dir <project>` "
+            "to refresh from .credentials.yml."
+        )
+    return auth.get_session()
+
+
 def fetch_snodas(
     workdir: Path,
     period: str,
@@ -72,13 +171,14 @@ def fetch_snodas(
     worker_index: int = 0,
     n_workers: int = 1,
 ) -> dict:
-    """Download SNODAS daily granules to the shared datastore.
+    """Download SNODAS daily .tar bundles to the shared datastore.
 
-    This is the fetch-only path: search NSIDC via ``earthaccess`` for daily
-    granules covering each requested year and download the tar/gz bundles
-    into ``<datastore>/snodas/raw/<year>/``. The bundles are NOT decoded
-    into CF NetCDFs in this PR (see module docstring); the consolidation
-    step lives in the SNODAS aggregate follow-up issue.
+    Fetch-only path: for each assigned year, walk the daily URLs at
+    ``<archive_url>/<year>/MM_Mon/SNODAS_YYYYMMDD.tar`` and stream each
+    bundle via the earthaccess HTTPS auth session. Per-day 404s are
+    recorded but do not fail the year (partial-year boundaries and
+    occasional gaps are normal). Decoding the int16 binary into CF
+    NetCDFs is deferred to the SNODAS aggregate follow-up.
 
     Parameters
     ----------
@@ -86,66 +186,56 @@ def fetch_snodas(
         Project directory.
     period : str
         Temporal window ``"YYYY/YYYY"`` (inclusive). Validated against the
-        SNODAS publisher start (2003).
+        catalog's ``period``.
     worker_index, n_workers : int
-        Round-robin year sharding for parallel workers (mirrors
-        ``fetch_era5_land``). Defaults to a single-worker run.
+        Round-robin year sharding for parallel workers. Default
+        single-worker (serial).
 
     Returns
     -------
     dict
-        Provenance summary.
+        Provenance summary including a per-year ``years`` list with
+        ``n_downloaded_this_run``, ``n_already_present``,
+        ``n_missing_404``, ``n_errors``, and the cumulative
+        ``n_granules`` (downloaded + already on disk).
 
     Raises
     ------
     ValueError
-        Period falls outside the publisher window or no granules match.
+        Period falls outside the catalog window or
+        ``access.archive_url`` is missing from the catalog.
     RuntimeError
-        ``earthaccess.download`` returned fewer files than the search
-        result count, or zero files at all.
+        Earthdata login failed.
     """
-    import earthaccess
-
     parse_period(period)
     ws = _load_project(workdir)
     meta = _catalog.source(_SOURCE_KEY)
     access = meta["access"]
+    archive_url = access.get("archive_url")
+    if not archive_url:
+        raise ValueError(
+            f"catalog `sources.yml[{_SOURCE_KEY}].access.archive_url` is "
+            f"missing. Set it to the NSIDC HTTPS archive root, e.g. "
+            f"https://noaadata.apps.nsidc.org/NOAA/G02158/masked/"
+        )
     data_lo, data_hi = period_bounds(meta["period"])
     years = years_in_period(period)
     for y in years:
         if y < data_lo or y > data_hi:
             raise ValueError(
                 f"Year {y} is outside the SNODAS publisher window "
-                f"({data_lo}-{data_hi}, from catalog `sources.yml[{_SOURCE_KEY}]"
-                f".period`). Adjust --period."
+                f"({data_lo}-{data_hi}, from catalog "
+                f"`sources.yml[{_SOURCE_KEY}].period`). Adjust --period."
             )
-    # Use the project's buffered fabric bbox as the CMR search bounding
-    # box (matches the pattern in merra2.py / nldas.py / margulis_wus_sr.py).
-    # The catalog's `bbox_nwse` is CDS-convention metadata (kept for the
-    # ERA5-Land fetch); CMR / earthaccess want `(W, S, E, N)`, which is
-    # exactly the (minx, miny, maxx, maxy) order fabric.json records.
-    bbox_buffered = ws.fabric.get("bbox_buffered") or {}
-    if not bbox_buffered:
-        raise ValueError(
-            "SNODAS fetch needs a buffered fabric bbox; fabric.json has "
-            "no 'bbox_buffered' key. Re-run `nhf-targets validate` to "
-            "regenerate fabric.json."
-        )
-    search_bbox = (
-        float(bbox_buffered["minx"]),
-        float(bbox_buffered["miny"]),
-        float(bbox_buffered["maxx"]),
-        float(bbox_buffered["maxy"]),
-    )
 
     raw_root = ws.raw_dir(_SOURCE_KEY) / "raw"
     raw_root.mkdir(parents=True, exist_ok=True)
-
     now_utc = datetime.now(timezone.utc).isoformat()
 
-    earthaccess.login(strategy="netrc")
+    session = _earthaccess_session()
+
     # Pre-filter against the manifest: years already fully downloaded
-    # in a prior run are skipped before any CMR search/download work.
+    # are skipped before any HTTP work.
     completed = _completed_years_from_manifest(workdir)
     pending = [y for y in years if y not in completed]
     if completed:
@@ -162,74 +252,85 @@ def fetch_snodas(
             n_workers,
             period,
         )
-        return {
-            "source_key": _SOURCE_KEY,
-            "access_url": access["url"],
-            "doi": meta.get("doi"),
-            "license": meta.get("license", "public domain (NSIDC)"),
-            "variables": [v["name"] for v in meta["variables"]],
-            "period": period,
-            "search_bbox": list(search_bbox),
-            "worker_index": worker_index,
-            "n_workers": n_workers,
-            "years": [],
-            "download_timestamp": now_utc,
-        }
+        return _build_summary(
+            meta, period, archive_url, worker_index, n_workers, [], now_utc
+        )
 
     year_records: list[dict] = []
     for year in assigned:
         year_dir = raw_root / f"{year}"
         year_dir.mkdir(parents=True, exist_ok=True)
-        logger.info("snodas: searching CMR for year %d", year)
-        results = earthaccess.search_data(
-            short_name=access["short_name"],
-            version=access.get("version"),
-            temporal=(f"{year}-01-01", f"{year}-12-31"),
-            bounding_box=search_bbox,
-        )
-        n_found = len(results)
-        if n_found == 0:
-            logger.warning("snodas: no granules found for year %d; skipping", year)
-            year_records.append(
-                {
-                    "year": year,
-                    "raw_dir": str(year_dir),
-                    "n_granules": 0,
-                    "downloaded_utc": now_utc,
-                    "note": "no_granules_in_CMR",
-                }
-            )
-            continue
-        downloaded = earthaccess.download(results, str(year_dir))
-        if not downloaded:
-            raise RuntimeError(
-                f"snodas: earthaccess.download returned no files for year {year}; "
-                f"check network connectivity and Earthdata credentials."
-            )
-        if len(downloaded) < n_found:
-            raise RuntimeError(
-                f"snodas: partial download for year {year}: "
-                f"{len(downloaded)}/{n_found} granules. Re-run to retry."
-            )
-        year_records.append(
-            {
-                "year": year,
-                "raw_dir": str(year_dir),
-                "n_granules": len(downloaded),
-                "downloaded_utc": now_utc,
-            }
+        rec = _fetch_year(session, archive_url, year, year_dir)
+        rec["downloaded_utc"] = now_utc
+        year_records.append(rec)
+        logger.info(
+            "snodas: year %d — downloaded=%d, already_present=%d, "
+            "missing_404=%d, errors=%d",
+            year,
+            rec["n_downloaded_this_run"],
+            rec["n_already_present"],
+            rec["n_missing_404"],
+            rec["n_errors"],
         )
 
-    _update_manifest(workdir, period, meta, year_records, search_bbox)
+    _update_manifest(workdir, period, meta, year_records, archive_url)
+    return _build_summary(
+        meta, period, archive_url, worker_index, n_workers, year_records, now_utc
+    )
 
+
+def _fetch_year(session, archive_url: str, year: int, year_dir: Path) -> dict:
+    """Download every available daily .tar for ``year`` into ``year_dir``.
+
+    Returns a per-year record dict. Per-day 404s are common at year
+    boundaries and not treated as errors.
+    """
+    n_downloaded = 0
+    n_already = 0
+    n_404 = 0
+    n_err = 0
+    for date, url in _daily_urls(archive_url, year):
+        fname = f"SNODAS_{date.strftime('%Y%m%d')}.tar"
+        out_path = year_dir / fname
+        status = _download_tar(session, url, out_path)
+        if status == "downloaded":
+            n_downloaded += 1
+        elif status == "already_present":
+            n_already += 1
+        elif status == "missing_404":
+            n_404 += 1
+        else:
+            n_err += 1
+    n_granules = n_downloaded + n_already
+    return {
+        "year": year,
+        "raw_dir": str(year_dir),
+        "n_granules": n_granules,
+        "n_downloaded_this_run": n_downloaded,
+        "n_already_present": n_already,
+        "n_missing_404": n_404,
+        "n_errors": n_err,
+    }
+
+
+def _build_summary(
+    meta: dict,
+    period: str,
+    archive_url: str,
+    worker_index: int,
+    n_workers: int,
+    year_records: list[dict],
+    now_utc: str,
+) -> dict:
+    access = meta["access"]
     return {
         "source_key": _SOURCE_KEY,
         "access_url": access["url"],
+        "archive_url": archive_url,
         "doi": meta.get("doi"),
         "license": meta.get("license", "public domain (NSIDC)"),
         "variables": [v["name"] for v in meta["variables"]],
         "period": period,
-        "search_bbox": list(search_bbox),
         "worker_index": worker_index,
         "n_workers": n_workers,
         "years": year_records,
@@ -238,15 +339,13 @@ def fetch_snodas(
 
 
 def _completed_years_from_manifest(workdir: Path) -> set[int]:
-    """Return the set of years already recorded in manifest.json.
+    """Return the set of years already recorded with ``n_granules > 0``.
 
-    A year counts as complete when its manifest entry has ``n_granules > 0``;
-    years recorded with ``n_granules: 0`` (no CMR hits) are NOT considered
-    complete — re-runs will retry them, which is intentional because CMR
-    coverage can fill in retroactively.
-
-    Returns an empty set (with a warning) if the manifest is absent or
-    unparseable so the caller falls through to a clean fresh fetch.
+    Years recorded with ``n_granules: 0`` are NOT considered complete —
+    re-runs retry them (NSIDC coverage can fill in retroactively, and
+    a year of all 404s usually means a transient archive issue).
+    Missing/corrupt manifest yields an empty set so the caller falls
+    through to a fresh fetch.
     """
     ws = _load_project(workdir)
     manifest_path = ws.manifest_path
@@ -272,7 +371,7 @@ def _update_manifest(
     period: str,
     meta: dict,
     year_records: list[dict],
-    search_bbox: tuple[float, float, float, float],
+    archive_url: str,
 ) -> None:
     """Merge SNODAS provenance into manifest.json (flock-protected).
 
@@ -309,10 +408,10 @@ def _update_manifest(
             {
                 "source_key": _SOURCE_KEY,
                 "access_url": access["url"],
+                "archive_url": archive_url,
                 "doi": meta.get("doi"),
                 "license": meta.get("license", "public domain (NSIDC)"),
                 "period": period,
-                "search_bbox": list(search_bbox),
                 "variables": [v["name"] for v in meta["variables"]],
                 "years": merged_years,
             }

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -60,6 +60,26 @@ _DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
 # minimum is a fallback for cases where the server omits Content-Length.
 _MIN_VALID_TAR_BYTES = 1 * 1024 * 1024  # 1 MiB
 
+# Locale-independent month abbreviations for URL construction. The NSIDC
+# archive uses fixed English short names (e.g. ``01_Jan``); using
+# ``date.strftime('%b')`` would emit ``01_Jän`` on a German LC_TIME and
+# every URL would 404. Index 0 unused so month integer maps directly.
+_MONTH_NAMES: tuple[str, ...] = (
+    "",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
 
 def _assign_worker_years(
     all_years: list[int],
@@ -90,11 +110,14 @@ def _daily_urls(archive_url: str, year: int) -> list[tuple[pd.Timestamp, str]]:
     a file — partial-year boundaries (2003 starts late September) and
     occasional gaps are normal; 404s are handled upstream.
     """
+    # Intentionally probe-by-GET rather than HEAD-then-GET: 404s are
+    # cheap (single round trip, no body), and HTML directory parsing
+    # would add complexity and locale assumptions about the index page.
     base = archive_url.rstrip("/")
     days = pd.date_range(f"{year}-01-01", f"{year}-12-31", freq="1D")
     out: list[tuple[pd.Timestamp, str]] = []
     for d in days:
-        month_dir = f"{d.month:02d}_{d.strftime('%b')}"
+        month_dir = f"{d.month:02d}_{_MONTH_NAMES[d.month]}"
         fname = f"SNODAS_{d.strftime('%Y%m%d')}.tar"
         out.append((d, f"{base}/{year}/{month_dir}/{fname}"))
     return out
@@ -219,10 +242,21 @@ def _download_tar(
 def _earthaccess_session():
     """Return an authenticated HTTPS session for noaadata.apps.nsidc.org.
 
-    Wrapped for monkeypatch in tests. Production calls
-    ``earthaccess.login(strategy='netrc').get_session()``.
+    Wraps ``earthaccess.login(strategy='netrc').get_session()`` and
+    mounts a ``urllib3.Retry`` adapter so transient flakes (502/503/504
+    and connection resets) don't immediately turn into permanent
+    ``"error"`` records on the per-day status counter. With ~8k daily
+    files per full run, even a 99.9% per-request success rate produces
+    a handful of stragglers; the retry budget of 3 attempts with
+    exponential backoff turns most of those into successful downloads
+    rather than operator-driven re-runs.
+
+    Wrapped (rather than inlined into ``fetch_snodas``) for
+    monkeypatching in tests.
     """
     import earthaccess
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
 
     auth = earthaccess.login(strategy="netrc")
     if not auth.authenticated:
@@ -232,7 +266,22 @@ def _earthaccess_session():
             "`nhf-targets materialize-credentials --project-dir <project>` "
             "to refresh from .credentials.yml."
         )
-    return auth.get_session()
+    session = auth.get_session()
+    retry = Retry(
+        total=3,
+        connect=3,
+        read=3,
+        status=3,
+        backoff_factor=1.0,
+        status_forcelist=(500, 502, 503, 504),
+        # Idempotent GETs only — safe to retry.
+        allowed_methods=frozenset({"GET", "HEAD"}),
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
 
 
 def fetch_snodas(
@@ -354,12 +403,17 @@ def _fetch_year(session, archive_url: str, year: int, year_dir: Path) -> dict:
     """Download every available daily .tar for ``year`` into ``year_dir``.
 
     Returns a per-year record dict. Per-day 404s are common at year
-    boundaries and not treated as errors.
+    boundaries and not treated as errors. When ``n_errors > 0`` the
+    manifest record also carries ``first_error_url`` / ``last_error_url``
+    and a ``.failed_urls.txt`` sidecar lists every failed URL — both
+    purely for operator diagnostics, no functional behaviour depends on
+    them.
     """
     n_downloaded = 0
     n_already = 0
     n_404 = 0
     n_err = 0
+    failed_urls: list[str] = []
     for date, url in _daily_urls(archive_url, year):
         fname = f"SNODAS_{date.strftime('%Y%m%d')}.tar"
         out_path = year_dir / fname
@@ -372,8 +426,9 @@ def _fetch_year(session, archive_url: str, year: int, year_dir: Path) -> dict:
             n_404 += 1
         else:
             n_err += 1
+            failed_urls.append(url)
     n_granules = n_downloaded + n_already
-    return {
+    rec: dict = {
         "year": year,
         "raw_dir": str(year_dir),
         "n_granules": n_granules,
@@ -382,6 +437,16 @@ def _fetch_year(session, archive_url: str, year: int, year_dir: Path) -> dict:
         "n_missing_404": n_404,
         "n_errors": n_err,
     }
+    if failed_urls:
+        rec["first_error_url"] = failed_urls[0]
+        rec["last_error_url"] = failed_urls[-1]
+        # Sidecar makes the full list available for `curl -I`-style
+        # triage without bloating the manifest. Overwritten each run so
+        # the file reflects only the most recent run's failures (which
+        # is what operators expect when investigating).
+        sidecar = year_dir / ".failed_urls.txt"
+        sidecar.write_text("\n".join(failed_urls) + "\n")
+    return rec
 
 
 def _build_summary(

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -52,6 +52,13 @@ _SOURCE_KEY = "snodas"
 _HTTP_TIMEOUT_SECONDS = 60
 # Chunk size for streaming downloads.
 _DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
+# Defense in depth against truncated bodies (issue #107 review): a real
+# SNODAS .tar is 10-30 MB, never below ~5 MB even for the early sparse
+# years. Anything smaller is either a 404 HTML body that slipped past
+# the status check or a mid-stream connection drop. The Content-Length
+# integrity check in `_download_tar` is the primary defense; this
+# minimum is a fallback for cases where the server omits Content-Length.
+_MIN_VALID_TAR_BYTES = 1 * 1024 * 1024  # 1 MiB
 
 
 def _assign_worker_years(
@@ -99,18 +106,39 @@ def _download_tar(
     """Stream a single .tar from *url* to *out_path*. Returns a status code.
 
     Status codes (manifest-friendly):
-      - ``"downloaded"`` — file streamed and written this call.
-      - ``"already_present"`` — file exists on disk with non-zero size; skipped.
+      - ``"downloaded"`` — file streamed AND verified against Content-Length
+        (or, if the server omits Content-Length, written through to a
+        non-zero non-truncated-looking length) and written this call.
+      - ``"already_present"`` — file exists on disk with size above
+        :data:`_MIN_VALID_TAR_BYTES`; skipped.
       - ``"missing_404"`` — server returned 404; not an error (partial years
         and gaps are normal in SNODAS).
       - ``"error"`` — any other failure; logged, not raised.
 
     Atomic: streams to a ``.tar.tmp`` sibling, then renames on success.
-    The ``.tar.tmp`` is unlinked on any failure path so resume sees a
-    clean directory.
+    The ``.tar.tmp`` is unlinked on any failure path (including a
+    Content-Length mismatch) so resume sees a clean directory.
+
+    Assumes the caller has partitioned writers so only one worker
+    targets any given year directory (mirrors ``fetch_era5_land``'s
+    contract). The atomic rename is per-file race-free even within a
+    worker.
     """
-    if out_path.exists() and out_path.stat().st_size > 0:
-        return "already_present"
+    # Treat existing files smaller than _MIN_VALID_TAR_BYTES as suspect
+    # — SNODAS .tars are 10-30 MB; a few-hundred-byte stub is the
+    # signature of a pre-fix #107 truncated write that the now-stricter
+    # path would have rejected. Re-download on the next run.
+    if out_path.exists():
+        sz = out_path.stat().st_size
+        if sz >= _MIN_VALID_TAR_BYTES:
+            return "already_present"
+        logger.warning(
+            "snodas: existing %s is suspiciously small (%d bytes < %d); redownloading.",
+            out_path.name,
+            sz,
+            _MIN_VALID_TAR_BYTES,
+        )
+        out_path.unlink(missing_ok=True)
     tmp = out_path.with_suffix(out_path.suffix + ".tmp")
     try:
         resp = session.get(url, timeout=timeout, stream=True, allow_redirects=True)
@@ -128,10 +156,53 @@ def _download_tar(
                 url,
             )
             return "error"
+
+        # Capture the advertised body size BEFORE streaming so we can
+        # verify integrity on close. NSIDC's archive sets Content-Length
+        # on tarball responses; if it ever stops doing so (gzip transfer
+        # encoding, etc.) we fall back to a minimum-size check.
+        declared_len = resp.headers.get("Content-Length")
+        try:
+            declared_bytes: int | None = int(declared_len) if declared_len else None
+        except ValueError:
+            declared_bytes = None
+
+        bytes_written = 0
         with tmp.open("wb") as f:
             for chunk in resp.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
                 if chunk:
                     f.write(chunk)
+                    bytes_written += len(chunk)
+
+        # Integrity gate: requests' iter_content does NOT raise on a
+        # short read — a mid-stream connection close that delivers
+        # fewer bytes than promised leaves a truncated file looking
+        # "complete". Prefer Content-Length when the server provided
+        # one (NSIDC's archive does); fall back to a minimum-size
+        # check otherwise. Either way, a failed check unlinks the tmp
+        # and returns "error" so the next run retries the day cleanly.
+        if declared_bytes is not None:
+            if bytes_written != declared_bytes:
+                logger.warning(
+                    "snodas: short read for %s — wrote %d of %d declared bytes",
+                    url,
+                    bytes_written,
+                    declared_bytes,
+                )
+                tmp.unlink(missing_ok=True)
+                return "error"
+        elif bytes_written < _MIN_VALID_TAR_BYTES:
+            logger.warning(
+                "snodas: truncated response for %s — wrote %d bytes "
+                "(< %d minimum and no Content-Length header to confirm); "
+                "discarding",
+                url,
+                bytes_written,
+                _MIN_VALID_TAR_BYTES,
+            )
+            tmp.unlink(missing_ok=True)
+            return "error"
+
         tmp.replace(out_path)
         return "downloaded"
     except Exception as exc:

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -332,7 +332,9 @@ def _check_credentials(workdir: Path) -> None:
     # catalog. Keep in sync with the fetch modules — any new EDL-using
     # type needs to be added here so `nhf-targets validate` still
     # catches missing creds before the operator hits a runtime auth
-    # failure inside earthaccess.
+    # failure inside earthaccess. `nasa_nsidc` is retained as a defensive
+    # fallback for historical entries even though current entries use
+    # the cleaner `nsidc` / `nsidc_https` tags.
     _EDL_TYPES = (
         "nasa_gesdisc",
         "nasa_earthdata",

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -328,9 +328,21 @@ def _check_credentials(workdir: Path) -> None:
         (src.get("access") or {}).get("type") == "copernicus_cds"
         for src in srcs.values()
     )
+    # Every NASA-Earthdata-authenticated `access.type` value used in the
+    # catalog. Keep in sync with the fetch modules — any new EDL-using
+    # type needs to be added here so `nhf-targets validate` still
+    # catches missing creds before the operator hits a runtime auth
+    # failure inside earthaccess.
+    _EDL_TYPES = (
+        "nasa_gesdisc",
+        "nasa_earthdata",
+        "nasa_nsidc",
+        "nsidc",
+        "nsidc_https",
+        "lpdaac",
+    )
     needs_earthdata = any(
-        (src.get("access") or {}).get("type") in ("nasa_gesdisc", "nasa_earthdata")
-        for src in srcs.values()
+        (src.get("access") or {}).get("type") in _EDL_TYPES for src in srcs.values()
     )
     if needs_cds:
         required.append("cds")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -204,12 +204,16 @@ def test_daymet_source_present():
 def test_snodas_source_present():
     s = source("snodas")
     assert s["status"] == "current"
-    assert s["access"]["type"] == "nasa_nsidc"
-    assert s["access"]["short_name"] == "G02158"
+    # SNODAS is fetched directly from NSIDC's HTTPS archive (issue #107).
+    # The CMR collection record is a granule-less stub, so earthaccess.
+    # search_data is not used; the catalog records both the human-facing
+    # landing URL and the machine-facing archive_url for the fetcher.
+    assert s["access"]["type"] == "nsidc_https"
     assert s["access"]["url"].startswith("https://")
-    # bbox is read from the catalog by fetch/snodas.py; required.
-    bbox = s["access"]["bbox_nwse"]
-    assert isinstance(bbox, list) and len(bbox) == 4
+    assert s["access"]["archive_url"].startswith(
+        "https://noaadata.apps.nsidc.org/NOAA/G02158/"
+    )
+    assert s["access"]["cmr_short_name"] == "G02158"
     var_names = {v["name"] for v in s["variables"]}
     assert "swe" in var_names
     swe = next(v for v in s["variables"] if v["name"] == "swe")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -213,7 +213,11 @@ def test_snodas_source_present():
     assert s["access"]["archive_url"].startswith(
         "https://noaadata.apps.nsidc.org/NOAA/G02158/"
     )
-    assert s["access"]["cmr_short_name"] == "G02158"
+    # CMR record exists as a metadata-only stub (zero granules) and is
+    # preserved for provenance; the fetch module deliberately does NOT
+    # call earthaccess.search_data on it (see #107).
+    assert s["access"]["cmr"]["short_name"] == "G02158"
+    assert s["access"]["cmr"]["concept_id"] == "C1386246263-NSIDCV0"
     var_names = {v["name"] for v in s["variables"]}
     assert "swe" in var_names
     swe = next(v for v in s["variables"] if v["name"] == "swe")
@@ -227,7 +231,9 @@ def test_snodas_source_present():
 def test_margulis_wus_sr_source_present():
     s = source("margulis_wus_sr")
     assert s["status"] == "current"
-    assert s["access"]["type"] == "nasa_nsidc"
+    # `nsidc` = CMR-mediated path; distinct from SNODAS's `nsidc_https`
+    # which uses the granule-less CMR record only as metadata.
+    assert s["access"]["type"] == "nsidc"
     assert s["access"]["short_name"] == "WUS_UCLA_SR"
     assert s["access"]["url"].startswith("https://")
     assert s["doi"] == "10.5067/PP7T2GBI52I2"

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -1,19 +1,20 @@
-"""Tests for SNODAS daily fetch via earthaccess.
+"""Tests for SNODAS daily fetch via NSIDC's HTTPS archive (issue #107).
 
-`fetch_snodas` does an earthaccess search and download per year. The
-consolidation step (raw tar/binary → CF NetCDF) is **deferred** to the
-SNODAS aggregate follow-up issue and is not exercised here. These tests
-cover the period gate, worker sharding, partial-download guard, the
-empty-search fallback, and the per-year manifest accumulation.
-
-All tests monkeypatch ``earthaccess.login``, ``search_data``, and
-``download`` — no network access is required.
+The original implementation used ``earthaccess.search_data`` against a
+CMR collection that turned out to be a metadata-only stub with zero
+granule records; the rewrite constructs URLs directly from dates and
+streams each ``.tar`` via ``earthaccess.login().get_session()``. These
+tests cover the period gate, worker sharding, per-day status accounting
+(downloaded / already-present / 404 / error), manifest accumulation,
+and the EDL auth-failure surface. No network is touched — the HTTPS
+session is stubbed via ``_earthaccess_session`` monkeypatch.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Callable
 
 import pytest
 import yaml
@@ -21,8 +22,18 @@ import yaml
 from nhf_spatial_targets.fetch.snodas import fetch_snodas
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 def _make_project(tmp_path: Path) -> Path:
-    """Materialize a minimal valid project directory."""
+    """Materialize a minimal valid project directory.
+
+    SNODAS no longer needs a fabric bbox at fetch time (download is a
+    full-CONUS daily .tar regardless of project fabric), but the project
+    loader still requires fabric.json to exist with a basic shape.
+    """
     tmp_path.mkdir(parents=True, exist_ok=True)
     datastore = tmp_path / "datastore"
     datastore.mkdir()
@@ -37,90 +48,111 @@ def _make_project(tmp_path: Path) -> Path:
             }
         )
     )
-    # A buffered fabric bbox is required by the CMR-search path of
-    # fetch_snodas (matches merra2 / nldas / margulis). Pick a small
-    # CONUS-overlapping rectangle.
-    (tmp_path / "fabric.json").write_text(
-        json.dumps(
-            {
-                "sha256": "f00",
-                "bbox": {
-                    "minx": -110.0,
-                    "miny": 40.0,
-                    "maxx": -105.0,
-                    "maxy": 45.0,
-                },
-                "bbox_buffered": {
-                    "minx": -110.2,
-                    "miny": 39.9,
-                    "maxx": -104.8,
-                    "maxy": 45.1,
-                },
-            }
-        )
-    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
     return tmp_path
 
 
-def _stub_earthaccess(
+class _FakeResponse:
+    """Tiny stand-in for ``requests.Response`` covering the bits we use."""
+
+    def __init__(
+        self, status_code: int, body: bytes = b"", chunks: list[bytes] | None = None
+    ):
+        self.status_code = status_code
+        self._body = body
+        self._chunks = chunks if chunks is not None else [body]
+
+    def iter_content(self, chunk_size: int = 8192):
+        for c in self._chunks:
+            yield c
+
+    def close(self):
+        pass
+
+
+def _stub_session(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    granules_per_year: int = 2,
-    files_returned: int | None = None,
+    responder: Callable[[str], _FakeResponse] | None = None,
+    body: bytes = b"FAKE_SNODAS_TAR",
 ) -> dict[str, list]:
-    """Patch earthaccess login/search/download. Returns a call log dict."""
-    import earthaccess
+    """Patch ``_earthaccess_session`` with a session whose ``.get`` is stubbed.
 
-    calls = {"search": [], "downloaded_dirs": []}
+    ``responder`` overrides the per-URL response (e.g. to return 404
+    for boundary dates). Otherwise every URL returns a 200 with
+    ``body``. Returns a call-log dict for assertions.
+    """
+    calls: dict[str, list] = {"urls": [], "session_built": 0}
 
-    def fake_login(strategy="netrc"):
-        calls.setdefault("login", []).append(strategy)
-        return None
+    if responder is None:
 
-    def fake_search(**kwargs):
-        calls["search"].append(kwargs)
-        return [object()] * granules_per_year
+        def responder(url: str) -> _FakeResponse:  # type: ignore[misc]
+            return _FakeResponse(200, body=body)
 
-    def fake_download(results, dest):
-        calls["downloaded_dirs"].append(str(dest))
-        n = len(results) if files_returned is None else files_returned
-        # Write tiny placeholder files so the dest dir is non-empty.
-        dest_path = Path(dest)
-        dest_path.mkdir(parents=True, exist_ok=True)
-        paths = []
-        for i in range(n):
-            p = dest_path / f"snodas_stub_{i}.dat"
-            p.write_bytes(b"\x00")
-            paths.append(str(p))
-        return paths
+    class _Session:
+        def get(self, url, timeout=None, stream=None, allow_redirects=None):
+            calls["urls"].append(url)
+            return responder(url)
 
-    monkeypatch.setattr(earthaccess, "login", fake_login)
-    monkeypatch.setattr(earthaccess, "search_data", fake_search)
-    monkeypatch.setattr(earthaccess, "download", fake_download)
+    def _fake_session():
+        calls["session_built"] += 1
+        return _Session()
+
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.snodas._earthaccess_session", _fake_session
+    )
     return calls
 
 
 # ---------------------------------------------------------------------------
-# Period and worker gates
+# Period / catalog gate
 # ---------------------------------------------------------------------------
 
 
-def test_period_before_2003_rejected(tmp_path, monkeypatch):
+def test_period_before_publisher_window_rejected(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch)
+    _stub_session(monkeypatch)
     with pytest.raises(ValueError, match="outside the SNODAS publisher window"):
         fetch_snodas(workdir=workdir, period="2000/2002")
 
 
+def test_missing_archive_url_raises(tmp_path, monkeypatch):
+    """If catalog access.archive_url is missing, fail fast with instructions.
+
+    Exercises the catalog-validity guard by monkeypatching the catalog
+    `archive_url` to empty.
+    """
+    workdir = _make_project(tmp_path)
+    _stub_session(monkeypatch)
+
+    from nhf_spatial_targets import catalog as _catalog
+
+    real_source = _catalog.source
+
+    def fake_source(name: str):
+        s = real_source(name).copy()
+        if name == "snodas":
+            s["access"] = {**s["access"], "archive_url": ""}
+        return s
+
+    monkeypatch.setattr("nhf_spatial_targets.fetch.snodas._catalog.source", fake_source)
+    with pytest.raises(ValueError, match="archive_url"):
+        fetch_snodas(workdir=workdir, period="2020/2020")
+
+
+# ---------------------------------------------------------------------------
+# Worker partitioning
+# ---------------------------------------------------------------------------
+
+
 def test_worker_partitioning_3_years_3_workers(tmp_path, monkeypatch):
-    """Three workers across three years each take one distinct year.
+    """Three workers across three years each cover one distinct year.
 
     Each worker gets its own project directory so the partitioning logic
-    is exercised against an empty manifest — i.e. exactly the state every
-    worker sees at startup when they're launched in parallel against the
-    shared real manifest.
+    is exercised against an empty manifest — exactly what parallel
+    workers see at startup against the shared real manifest.
     """
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    _stub_session(monkeypatch)
     seen_years: list[int] = []
     for wi in range(3):
         workdir = _make_project(tmp_path / f"worker_{wi}")
@@ -137,7 +169,7 @@ def test_worker_partitioning_3_years_3_workers(tmp_path, monkeypatch):
 
 def test_worker_with_no_assigned_years_returns_empty(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    _stub_session(monkeypatch)
     # 1 year, 2 workers → worker 1 gets nothing
     result = fetch_snodas(
         workdir=workdir,
@@ -151,7 +183,7 @@ def test_worker_with_no_assigned_years_returns_empty(tmp_path, monkeypatch):
 
 def test_worker_index_out_of_range_raises(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    _stub_session(monkeypatch)
     with pytest.raises(ValueError, match="worker_index must be in"):
         fetch_snodas(
             workdir=workdir,
@@ -162,43 +194,141 @@ def test_worker_index_out_of_range_raises(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Search and download paths
+# URL construction and download accounting
 # ---------------------------------------------------------------------------
 
 
-def test_empty_search_records_no_granules_note(tmp_path, monkeypatch):
-    """Years with zero CMR hits are recorded with a note, not raised on."""
+def test_full_year_download_writes_tars_to_year_dir(tmp_path, monkeypatch):
+    """Happy path: 200 OK for every day → 365 .tars on disk + recorded counts."""
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=0)
+    _stub_session(monkeypatch, body=b"\x00\x01\x02")
     result = fetch_snodas(workdir=workdir, period="2020/2020")
-    assert len(result["years"]) == 1
-    assert result["years"][0]["n_granules"] == 0
-    assert result["years"][0]["note"] == "no_granules_in_CMR"
+    rec = result["years"][0]
+    assert rec["year"] == 2020
+    # 2020 is a leap year — 366 days.
+    assert rec["n_downloaded_this_run"] == 366
+    assert rec["n_already_present"] == 0
+    assert rec["n_missing_404"] == 0
+    assert rec["n_errors"] == 0
+    assert rec["n_granules"] == 366
+    year_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
+    tars = sorted(year_dir.glob("SNODAS_*.tar"))
+    assert len(tars) == 366
+    # First and last day filenames are exact.
+    assert tars[0].name == "SNODAS_20200101.tar"
+    assert tars[-1].name == "SNODAS_20201231.tar"
 
 
-def test_partial_download_raises(tmp_path, monkeypatch):
+def test_url_layout_matches_nsidc_archive(tmp_path, monkeypatch):
+    """URLs follow ``<archive>/<year>/MM_Mon/SNODAS_YYYYMMDD.tar``."""
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=3, files_returned=2)
-    with pytest.raises(RuntimeError, match="partial download"):
-        fetch_snodas(workdir=workdir, period="2020/2020")
+    calls = _stub_session(monkeypatch)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    urls = calls["urls"]
+    # Sample a January 1 URL.
+    jan1 = next(u for u in urls if u.endswith("SNODAS_20200101.tar"))
+    assert "/2020/01_Jan/" in jan1
+    assert jan1.startswith("https://noaadata.apps.nsidc.org/NOAA/G02158/masked/")
+    # December 31 URL.
+    dec31 = next(u for u in urls if u.endswith("SNODAS_20201231.tar"))
+    assert "/2020/12_Dec/" in dec31
 
 
-def test_zero_download_raises(tmp_path, monkeypatch):
+def test_404_days_recorded_not_raised(tmp_path, monkeypatch):
+    """Per-day 404s are normal (partial-year boundaries); record, don't fail."""
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=2, files_returned=0)
-    with pytest.raises(RuntimeError, match="returned no files"):
-        fetch_snodas(workdir=workdir, period="2020/2020")
+
+    def responder(url: str) -> _FakeResponse:
+        # First 30 days of the year are missing (mimics 2003 partial year).
+        for d in range(1, 31):
+            if f"SNODAS_20200{d:02d}".replace("SNODAS_2020001", "X") and url.endswith(
+                f"SNODAS_202001{d:02d}.tar"
+            ):
+                return _FakeResponse(404)
+        return _FakeResponse(200, body=b"\x00")
+
+    _stub_session(monkeypatch, responder=responder)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_missing_404"] == 30
+    assert rec["n_downloaded_this_run"] == 366 - 30
+    assert rec["n_errors"] == 0
+
+
+def test_already_present_files_are_skipped(tmp_path, monkeypatch):
+    """Pre-existing non-empty .tar files are accounted as ``already_present``."""
+    workdir = _make_project(tmp_path)
+    year_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
+    year_dir.mkdir(parents=True)
+    # Pre-stage 5 .tars on disk.
+    for day in range(1, 6):
+        (year_dir / f"SNODAS_202001{day:02d}.tar").write_bytes(b"PRE_STAGED")
+    _stub_session(monkeypatch)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_already_present"] == 5
+    assert rec["n_downloaded_this_run"] == 366 - 5
+    assert rec["n_granules"] == 366
+    # Pre-staged files were NOT overwritten.
+    assert (year_dir / "SNODAS_20200101.tar").read_bytes() == b"PRE_STAGED"
+
+
+def test_other_status_recorded_as_error(tmp_path, monkeypatch):
+    """5xx / unexpected status surfaces as an `error`, not a crash."""
+    workdir = _make_project(tmp_path)
+    _stub_session(monkeypatch, responder=lambda url: _FakeResponse(503))
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_errors"] == 366
+    assert rec["n_downloaded_this_run"] == 0
+
+
+def test_partial_year_2003_boundary(tmp_path, monkeypatch):
+    """SNODAS starts late September 2003; pre-Sep-30 URLs return 404.
+
+    Regression guard: the year-boundary handling must not raise — partial
+    coverage is part of normal SNODAS behaviour, and the manifest entry
+    is expected to record `n_missing_404 > 0` for 2003 specifically.
+    """
+    workdir = _make_project(tmp_path)
+
+    def responder(url: str) -> _FakeResponse:
+        # Anything before 2003-09-30 → 404
+        # Filename embeds the date as SNODAS_YYYYMMDD.tar
+        date = url.rsplit("SNODAS_", 1)[-1].split(".tar")[0]
+        if int(date) < 20030930:
+            return _FakeResponse(404)
+        return _FakeResponse(200, body=b"\x00")
+
+    _stub_session(monkeypatch, responder=responder)
+    result = fetch_snodas(workdir=workdir, period="2003/2003")
+    rec = result["years"][0]
+    assert rec["n_missing_404"] > 0
+    assert rec["n_downloaded_this_run"] > 0
+    assert rec["n_errors"] == 0
 
 
 # ---------------------------------------------------------------------------
-# Manifest accumulation
+# Manifest accumulation + idempotency
 # ---------------------------------------------------------------------------
+
+
+def test_manifest_records_archive_url_and_metadata(tmp_path, monkeypatch):
+    workdir = _make_project(tmp_path)
+    _stub_session(monkeypatch)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    entry = manifest["sources"]["snodas"]
+    assert entry["variables"] == ["swe"]
+    assert entry["period"] == "2020/2020"
+    assert entry["archive_url"].startswith(
+        "https://noaadata.apps.nsidc.org/NOAA/G02158/"
+    )
 
 
 def test_manifest_accumulates_years_across_calls(tmp_path, monkeypatch):
-    """Two successive single-year fetches yield both years in manifest."""
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    _stub_session(monkeypatch)
     fetch_snodas(workdir=workdir, period="2020/2020")
     fetch_snodas(workdir=workdir, period="2021/2021")
     manifest = json.loads((workdir / "manifest.json").read_text())
@@ -206,52 +336,40 @@ def test_manifest_accumulates_years_across_calls(tmp_path, monkeypatch):
     assert years == [2020, 2021]
 
 
-def test_manifest_records_bbox_and_metadata(tmp_path, monkeypatch):
+def test_completed_years_skipped_on_rerun(tmp_path, monkeypatch):
+    """Re-running the same period skips years already recorded as complete."""
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    calls = _stub_session(monkeypatch)
     fetch_snodas(workdir=workdir, period="2020/2020")
-    manifest = json.loads((workdir / "manifest.json").read_text())
-    entry = manifest["sources"]["snodas"]
-    # search_bbox is the buffered fabric bbox, ordered (W, S, E, N) for CMR.
-    assert entry["search_bbox"] == [-110.2, 39.9, -104.8, 45.1]
-    assert entry["variables"] == ["swe"]
-    assert entry["period"] == "2020/2020"
-
-
-def test_search_uses_fabric_buffered_bbox_in_wsen_order(tmp_path, monkeypatch):
-    """CMR rejects bboxes whose 2nd coord (South) is outside [-90, 90].
-
-    This is a regression guard for #105: the catalog's `bbox_nwse` is
-    CDS convention `[N, W, S, E]`. Passing it directly to
-    `earthaccess.search_data` puts -125.0 (West) in the South slot and
-    CMR refuses. We use the fabric's `bbox_buffered` `(minx, miny,
-    maxx, maxy)` which is already in CMR's `(W, S, E, N)` order.
-    """
-    workdir = _make_project(tmp_path)
-    calls = _stub_earthaccess(monkeypatch, granules_per_year=1)
+    urls_first = len(calls["urls"])
     fetch_snodas(workdir=workdir, period="2020/2020")
-    bbox = calls["search"][-1]["bounding_box"]
-    assert bbox == (-110.2, 39.9, -104.8, 45.1)
-    # Second slot (South) MUST be a latitude in [-90, 90].
-    assert -90.0 <= bbox[1] <= 90.0
-
-
-def test_missing_bbox_buffered_raises(tmp_path, monkeypatch):
-    """Stale fabric.json without `bbox_buffered` fails fast with instructions."""
-    workdir = _make_project(tmp_path)
-    fabric_path = workdir / "fabric.json"
-    fabric = json.loads(fabric_path.read_text())
-    fabric.pop("bbox_buffered", None)
-    fabric_path.write_text(json.dumps(fabric))
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
-    with pytest.raises(ValueError, match="bbox_buffered"):
-        fetch_snodas(workdir=workdir, period="2020/2020")
+    # Second call issued zero new HTTP requests.
+    assert len(calls["urls"]) == urls_first
 
 
 def test_raw_directory_created_under_datastore(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
-    _stub_earthaccess(monkeypatch, granules_per_year=1)
+    _stub_session(monkeypatch)
     fetch_snodas(workdir=workdir, period="2020/2020")
     raw_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
     assert raw_dir.exists()
-    assert any(raw_dir.iterdir())  # at least one stub granule landed here
+    assert any(raw_dir.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# Auth failure surface
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_login_raises(tmp_path, monkeypatch):
+    """A failed earthaccess login surfaces cleanly, not as a NoneType crash."""
+    workdir = _make_project(tmp_path)
+
+    def fake_session():
+        raise RuntimeError("Earthdata login failed")
+
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.snodas._earthaccess_session", fake_session
+    )
+    with pytest.raises(RuntimeError, match="Earthdata login failed"):
+        fetch_snodas(workdir=workdir, period="2020/2020")

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -369,6 +369,109 @@ def test_no_content_length_large_body_accepted(tmp_path, monkeypatch):
     assert rec["n_errors"] == 0
 
 
+# ---------------------------------------------------------------------------
+# Locale-safe URL construction (N1)
+# ---------------------------------------------------------------------------
+
+
+def test_month_names_are_locale_independent():
+    """URL month names come from a hardcoded table, not strftime('%b').
+
+    Regression guard: on a non-English LC_TIME (e.g. de_DE.UTF-8),
+    `strftime('%b')` would emit 'Jän' / 'Mär' and every URL would 404.
+    The hardcoded table makes the fetch portable across locales.
+    """
+    from nhf_spatial_targets.fetch.snodas import _MONTH_NAMES, _daily_urls
+
+    assert _MONTH_NAMES[1] == "Jan"
+    assert _MONTH_NAMES[12] == "Dec"
+
+    urls = _daily_urls("https://example.test/archive", 2020)
+    jan1 = next(u for _, u in urls if u.endswith("SNODAS_20200101.tar"))
+    jul15 = next(u for _, u in urls if u.endswith("SNODAS_20200715.tar"))
+    dec31 = next(u for _, u in urls if u.endswith("SNODAS_20201231.tar"))
+    assert "/2020/01_Jan/" in jan1
+    assert "/2020/07_Jul/" in jul15
+    assert "/2020/12_Dec/" in dec31
+
+
+# ---------------------------------------------------------------------------
+# Retry adapter (C2)
+# ---------------------------------------------------------------------------
+
+
+def test_session_carries_retry_adapter_on_https(monkeypatch):
+    """`_earthaccess_session` mounts a urllib3.Retry adapter on https://.
+
+    Stubs earthaccess.login so we exercise the real adapter wiring
+    without hitting the network. Doesn't try to exercise actual retry
+    behaviour (that's urllib3's responsibility) — just confirms the
+    adapter is attached with the expected config.
+    """
+    import earthaccess
+    import requests
+    from urllib3.util.retry import Retry
+
+    from nhf_spatial_targets.fetch.snodas import _earthaccess_session
+
+    class _StubAuth:
+        authenticated = True
+
+        def get_session(self):
+            return requests.Session()
+
+    monkeypatch.setattr(earthaccess, "login", lambda strategy=None: _StubAuth())
+
+    session = _earthaccess_session()
+    adapter = session.get_adapter("https://example.com")
+    assert isinstance(adapter.max_retries, Retry)
+    assert adapter.max_retries.total == 3
+    assert 500 in adapter.max_retries.status_forcelist
+    assert 503 in adapter.max_retries.status_forcelist
+
+
+# ---------------------------------------------------------------------------
+# Per-day error visibility (C6)
+# ---------------------------------------------------------------------------
+
+
+def test_errors_recorded_with_first_last_url_and_sidecar(tmp_path, monkeypatch):
+    """When `n_errors > 0`, manifest carries first/last_error_url AND a sidecar.
+
+    Sidecar `.failed_urls.txt` lives in the year dir and lists every
+    failing URL line-separated. Lets operators triage with `curl -I`
+    against the boundary URLs.
+    """
+    workdir = _make_project(tmp_path)
+    # Every day returns 503 → 366 errors for 2020.
+    _stub_session(monkeypatch, responder=lambda url: _FakeResponse(503))
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    rec = manifest["sources"]["snodas"]["years"][0]
+    assert rec["n_errors"] == 366
+    assert rec["first_error_url"].endswith("SNODAS_20200101.tar")
+    assert rec["last_error_url"].endswith("SNODAS_20201231.tar")
+
+    sidecar = tmp_path / "datastore" / "snodas" / "raw" / "2020" / ".failed_urls.txt"
+    lines = sidecar.read_text().strip().splitlines()
+    assert len(lines) == 366
+    assert lines[0].endswith("SNODAS_20200101.tar")
+    assert lines[-1].endswith("SNODAS_20201231.tar")
+
+
+def test_no_sidecar_when_no_errors(tmp_path, monkeypatch):
+    """A clean year (no errors) does not write the diagnostic sidecar."""
+    workdir = _make_project(tmp_path)
+    _stub_session(monkeypatch)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    sidecar = tmp_path / "datastore" / "snodas" / "raw" / "2020" / ".failed_urls.txt"
+    assert not sidecar.exists()
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    rec = manifest["sources"]["snodas"]["years"][0]
+    assert "first_error_url" not in rec
+    assert "last_error_url" not in rec
+
+
 def test_other_status_recorded_as_error(tmp_path, monkeypatch):
     """5xx / unexpected status surfaces as an `error`, not a crash."""
     workdir = _make_project(tmp_path)

--- a/tests/test_fetch_snodas.py
+++ b/tests/test_fetch_snodas.py
@@ -53,14 +53,35 @@ def _make_project(tmp_path: Path) -> Path:
 
 
 class _FakeResponse:
-    """Tiny stand-in for ``requests.Response`` covering the bits we use."""
+    """Tiny stand-in for ``requests.Response`` covering the bits we use.
+
+    `Content-Length` is auto-derived from the body length unless an
+    explicit value is passed via ``content_length``. Pass
+    ``content_length=None`` to simulate a server that omits the header.
+    Pass an integer that *disagrees* with the body length to exercise
+    the short-read integrity path.
+    """
+
+    _UNSET = object()
 
     def __init__(
-        self, status_code: int, body: bytes = b"", chunks: list[bytes] | None = None
+        self,
+        status_code: int,
+        body: bytes = b"",
+        chunks: list[bytes] | None = None,
+        content_length: object = _UNSET,
     ):
         self.status_code = status_code
         self._body = body
         self._chunks = chunks if chunks is not None else [body]
+        self.headers: dict[str, str] = {}
+        if content_length is _FakeResponse._UNSET:
+            # Default: server sets Content-Length matching the body
+            # (NSIDC's archive does this on tarball responses).
+            self.headers["Content-Length"] = str(len(body))
+        elif content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+        # else: caller asked for no Content-Length header at all.
 
     def iter_content(self, chunk_size: int = 8192):
         for c in self._chunks:
@@ -239,11 +260,9 @@ def test_404_days_recorded_not_raised(tmp_path, monkeypatch):
     workdir = _make_project(tmp_path)
 
     def responder(url: str) -> _FakeResponse:
-        # First 30 days of the year are missing (mimics 2003 partial year).
+        # First 30 days of the year are missing (mimics a partial-year boundary).
         for d in range(1, 31):
-            if f"SNODAS_20200{d:02d}".replace("SNODAS_2020001", "X") and url.endswith(
-                f"SNODAS_202001{d:02d}.tar"
-            ):
+            if url.endswith(f"SNODAS_202001{d:02d}.tar"):
                 return _FakeResponse(404)
         return _FakeResponse(200, body=b"\x00")
 
@@ -256,13 +275,20 @@ def test_404_days_recorded_not_raised(tmp_path, monkeypatch):
 
 
 def test_already_present_files_are_skipped(tmp_path, monkeypatch):
-    """Pre-existing non-empty .tar files are accounted as ``already_present``."""
+    """Pre-existing realistically-sized .tar files are accounted as already_present.
+
+    The fetch now requires existing files to be at least
+    :data:`_MIN_VALID_TAR_BYTES` (1 MiB) to count as already-present,
+    so a few-byte stub from a pre-fix corrupted run gets re-downloaded
+    rather than silently treated as valid.
+    """
     workdir = _make_project(tmp_path)
     year_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
     year_dir.mkdir(parents=True)
-    # Pre-stage 5 .tars on disk.
+    # Pre-stage 5 realistically-sized .tars (>= 1 MiB) on disk.
+    payload = b"PRE_STAGED" * (200 * 1024)  # ~2 MiB
     for day in range(1, 6):
-        (year_dir / f"SNODAS_202001{day:02d}.tar").write_bytes(b"PRE_STAGED")
+        (year_dir / f"SNODAS_202001{day:02d}.tar").write_bytes(payload)
     _stub_session(monkeypatch)
     result = fetch_snodas(workdir=workdir, period="2020/2020")
     rec = result["years"][0]
@@ -270,7 +296,77 @@ def test_already_present_files_are_skipped(tmp_path, monkeypatch):
     assert rec["n_downloaded_this_run"] == 366 - 5
     assert rec["n_granules"] == 366
     # Pre-staged files were NOT overwritten.
-    assert (year_dir / "SNODAS_20200101.tar").read_bytes() == b"PRE_STAGED"
+    assert (year_dir / "SNODAS_20200101.tar").read_bytes() == payload
+
+
+def test_suspiciously_small_existing_file_is_redownloaded(tmp_path, monkeypatch):
+    """A few-byte stub from a pre-fix corrupted run is redownloaded.
+
+    Defends against the truncated-body bug class flagged in PR #108
+    review: a previous, weaker `>0` predicate would lock such stubs
+    in forever. The new predicate requires `>= _MIN_VALID_TAR_BYTES`.
+    """
+    workdir = _make_project(tmp_path)
+    year_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
+    year_dir.mkdir(parents=True)
+    stub_path = year_dir / "SNODAS_20200101.tar"
+    stub_path.write_bytes(b"oops")  # 4 bytes, way below 1 MiB
+    _stub_session(monkeypatch)
+    fetch_snodas(workdir=workdir, period="2020/2020")
+    # Stub was replaced by the (fake) full payload.
+    assert stub_path.read_bytes() != b"oops"
+
+
+def test_short_read_with_content_length_mismatch_recorded_as_error(
+    tmp_path, monkeypatch
+):
+    """A server that drops mid-stream below Content-Length yields `n_errors`.
+
+    Regression guard for the PR #108 review must-fix: `iter_content`
+    does not raise on a short read, so without an explicit
+    Content-Length check, a truncated body would be installed as
+    `downloaded` and the next run would skip it forever. The check
+    must catch the mismatch and unlink the .tar.tmp.
+    """
+    workdir = _make_project(tmp_path)
+    # Server claims 1000 bytes but delivers 10.
+    short_resp = _FakeResponse(200, body=b"\x00" * 10, content_length=1000)
+    _stub_session(monkeypatch, responder=lambda url: short_resp)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_errors"] == 366  # every day failed integrity
+    assert rec["n_downloaded_this_run"] == 0
+    # No partial .tar.tmp files left behind.
+    year_dir = tmp_path / "datastore" / "snodas" / "raw" / "2020"
+    leftovers = list(year_dir.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_no_content_length_small_body_recorded_as_error(tmp_path, monkeypatch):
+    """Server omits Content-Length AND the body is below the size floor.
+
+    Falls back to the `_MIN_VALID_TAR_BYTES` sanity check (1 MiB) and
+    discards the response.
+    """
+    workdir = _make_project(tmp_path)
+    no_cl_resp = _FakeResponse(200, body=b"\x00" * 10, content_length=None)
+    _stub_session(monkeypatch, responder=lambda url: no_cl_resp)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_errors"] == 366
+    assert rec["n_downloaded_this_run"] == 0
+
+
+def test_no_content_length_large_body_accepted(tmp_path, monkeypatch):
+    """Without Content-Length, a body >= 1 MiB is accepted (defense fallback)."""
+    workdir = _make_project(tmp_path)
+    big = b"\x00" * (2 * 1024 * 1024)
+    no_cl_resp = _FakeResponse(200, body=big, content_length=None)
+    _stub_session(monkeypatch, responder=lambda url: no_cl_resp)
+    result = fetch_snodas(workdir=workdir, period="2020/2020")
+    rec = result["years"][0]
+    assert rec["n_downloaded_this_run"] == 366
+    assert rec["n_errors"] == 0
 
 
 def test_other_status_recorded_as_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

After #106 fixed the bbox ordering, \`sbatch fetch_snodas.slurm\` ran cleanly but returned **zero granules for every year**. Root cause (verified in #107): CMR has the SNODAS collection metadata (\`G02158, v1, concept-id C1386246263-NSIDCV0\`) but **no granule-level records**. Both \`earthaccess.search_data\` and a direct CMR HTTP query return 0 hits regardless of bbox/temporal. The CMR record is a metadata-only stub pointing at NSIDC's external archive.

The real archive is at \`https://noaadata.apps.nsidc.org/NOAA/G02158/masked/YYYY/MM_Mon/SNODAS_YYYYMMDD.tar\`, behind Earthdata Login (200 OK with our existing \`.netrc\`). The masked subtree covers 2003-present, one daily \`.tar\` per date.

## Changes

- **Catalog** — \`access.type\` switched from \`nasa_nsidc\` to \`nsidc_https\`; new \`archive_url\` field; CMR identifiers preserved under \`cmr_*\` keys for provenance. The \`notes:\` block now explicitly documents the CMR-stub situation so the next person doesn't repeat the debug session.
- **\`fetch/snodas.py\`** — rewrites the year loop to enumerate calendar days and stream each \`.tar\` via the authenticated session from \`earthaccess.login(strategy='netrc').get_session()\`. Per-day status accounting tracks \`n_downloaded_this_run\`, \`n_already_present\`, \`n_missing_404\`, \`n_errors\`; \`n_granules\` in the manifest is \`downloaded + already_present\`. Atomic per-file write so interrupted downloads leave a clean directory. **Public signature, worker partitioning, flock-protected manifest update, and the per-year skip fast-path are all unchanged in shape** — only the inner download mechanics moved from CMR/earthaccess to direct HTTPS.
- **Tests** — rewritten to stub the HTTPS session instead of \`earthaccess.search_data/download\`. Covers full-year happy path, URL layout assertion (\`/YYYY/MM_Mon/SNODAS_YYYYMMDD.tar\`), 404 accounting, pre-staged file skip, 5xx error accounting, partial-year 2003 boundary, manifest accumulation, idempotency, and EDL auth-failure surface.
- **Docs** — \`docs/sources/snodas.md\` rewritten with the new access pattern, per-day status table, resumability semantics, and the CMR-stub heads-up.

Closes #107.

## Out of scope

- Binary decoding of the \`.tar\` bundles into CF NetCDFs — that's the SNODAS aggregate follow-up in umbrella #101. Characterise the int16+\`.Hdr\` layout in a notebook first.
- A \`nhf-targets manifest rebuild\` helper to recreate lost provenance — separate small follow-up if needed.

## Test plan

- [x] \`pixi run -e dev fmt && pixi run -e dev lint\` clean
- [x] \`pytest tests/test_fetch_snodas.py tests/test_catalog.py\` — 43 passed (was 33, added regression coverage for URL layout / 404 / partial-year / etc.)
- [x] Full unit suite: 715 passed, 16 deselected (pre-existing ssebop integration flake + 15 other integration-marked tests)
- [ ] CI green
- [ ] Smoke \`sbatch --array=0 fetch_snodas.slurm\` (1 worker, 1 year of period) against \`gfv2-spatial-targets\` and confirm 2020 actually downloads ~366 \`.tar\` files to \`<datastore>/snodas/raw/2020/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)