### PR TITLE
fix(margulis): drop redundant sortby + rechunk for dask graph efficiency

### DIFF
--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -320,9 +320,17 @@ def consolidate_calendar_year_margulis_wus_sr(
             cy_tiles.append(ds_tile_cy)
 
     # Mosaic all (per-tile, per-WY-half) datasets into one WUS-wide
-    # (time, lat, lon) dataset.
+    # (time, lat, lon) dataset. ``combine_by_coords`` already returns
+    # coords sorted ascending — no `sortby` needed (and explicit sorts
+    # over a 732-tile dask graph trigger O(n) chunk-rebalancing
+    # blockwise ops, with `dask` emitting PerformanceWarnings about
+    # 14x chunk-count growth). Flip latitude to descending via a cheap
+    # `isel` view; the time axis already lands in chronological order
+    # because we appended WY *X* (Jan–Sep) before WY *X+1* (Oct–Dec)
+    # and combine_by_coords preserves that.
     merged = _mosaic_tiles(cy_tiles)
-    merged = merged.sortby("time").sortby("lat", ascending=False).sortby("lon")
+    if float(merged.lat.values[0]) < float(merged.lat.values[-1]):
+        merged = merged.isel(lat=slice(None, None, -1))
 
     # Sanity-check the assembled time axis: every day of the calendar
     # year must be present, no duplicates.
@@ -362,8 +370,19 @@ def consolidate_calendar_year_margulis_wus_sr(
     # with per-timestep chunking so downstream consumers can stream
     # single-day reads. The shared `_write_netcdf` handles atomic
     # temp-file + rename.
+    #
+    # Rechunk dask blocks to match the NetCDF encoding chunks BEFORE
+    # write. With ~732 lazily-opened tile granules feeding into
+    # ``combine_by_coords``, the resulting dask array carries thousands
+    # of small (per-tile, per-WY-time-slice) blocks. Writing that to
+    # NetCDF encoding ``(1, nlat, nlon)`` without an intermediate
+    # rechunk drives dask to do a blockwise rebalance over the whole
+    # graph (the 14x-chunk-growth PerformanceWarning). Rechunking to
+    # ``(time=1, lat=-1, lon=-1)`` produces one dask block per
+    # timestep, aligned 1:1 with the output NetCDF chunks.
     nlat = int(merged.sizes["lat"])
     nlon = int(merged.sizes["lon"])
+    merged = merged.chunk({"time": 1, "lat": -1, "lon": -1})
     encoding = {
         "SWE": {
             "zlib": True,


### PR DESCRIPTION
Follow-up to #112. The production fetch on `/caldera/.../gfv2-spatial-targets` (SLURM 17562373, since cancelled) emitted repeated dask PerformanceWarnings during the CY 1985 consolidate and stalled at 0% progress for 6+ minutes (`logs/margulis_wus_sr_17562373.err`).

## Root cause

The consolidator builds a dask graph from ~732 lazily-opened tile granules (366 tiles × 2 water years) and then runs three chained `sortby` ops on the merged dataset:

```python
merged = merged.sortby("time").sortby("lat", ascending=False).sortby("lon")
```

With that many small chunks, each `sortby` forces a blockwise rebalance of the entire graph — chunk count balloons by a factor of 14 per the warning, the dask scheduler thrashes before any data hits disk, and `to_netcdf` never makes progress.

## Fix

1. **Drop all three `sortby` calls.** `combine_by_coords` returns coords sorted ascending already, and we append WY *X* (Jan–Sep) before WY *X+1* (Oct–Dec), so the assembled time axis is chronological at concat time. Latitude is flipped to descending via a cheap `isel(lat=slice(None, None, -1))` view, not a full sort.
2. **Rechunk dask blocks to `(time=1, lat=-1, lon=-1)` immediately before write.** This matches the NetCDF encoding chunksizes `(1, nlat, nlon)` 1:1, so dask emits exactly one block per timestep and writes them straight into the NetCDF chunks without rebalancing the graph.

## Test plan

- [x] `pixi run -e dev fmt && pixi run -e dev lint && pixi run -e dev pytest tests/test_fetch_margulis_wus_sr.py` — all 22 margulis tests pass; no test changes needed (the CF-1.6 compliance test still asserts lat-descending, which the `isel` flip preserves).
- [ ] After merge, re-launch `pixi run fetch-margulis-wus-sr` via SLURM and confirm the PerformanceWarning is gone + CY 1985 consolidates in reasonable time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)