### PR TITLE
fix(driver): merge update_manifest at entry level (#119)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-driver-update-manifest-merge.md
+++ b/docs/superpowers/plans/2026-05-14-driver-update-manifest-merge.md
@@ -1,0 +1,173 @@
+# Fix `_driver.update_manifest` to merge at entry level (closes #119)
+
+## Context
+
+The shared
+[src/nhf_spatial_targets/aggregate/_driver.py](src/nhf_spatial_targets/aggregate/_driver.py)
+helper `update_manifest` builds a fresh entry dict and assigns it to
+`manifest["sources"][source_key]` at line 80, replacing the whole
+sub-entry. Every fetch module in this repo (era5_land, snodas,
+margulis, modis, mwbm_climgrid, ncep_ncar, gldas, nldas, pangaea,
+reitz2017, daymet) already does **entry-level read-merge-write**:
+
+```python
+entry = manifest["sources"].get(_SOURCE_KEY, {})
+entry.update({...})
+manifest["sources"][_SOURCE_KEY] = entry
+```
+
+The aggregator helper is the one place that diverges from this
+convention. Daymet's fetch records nested provenance
+(`sources.daymet.regions.<r>`); if the daymet aggregator called the
+shared `update_manifest`, those keys would be wiped. PR #118
+worked around this with a **local `_merge_manifest_entry` copy** in
+`aggregate/daymet.py` and filed #119 for the central fix.
+
+SNODAS has the same latent bug: `fetch/snodas.py` writes a
+per-year `years` list that the SNODAS aggregator's
+`update_manifest` call silently overwrites every run. The fix here
+benefits both daymet (lets us delete the local copy) and SNODAS
+(stops the silent overwrite).
+
+Closes #119. References PR #117 (SNODAS), PR #118 (daymet),
+umbrella #101.
+
+## Approach
+
+### 1. Three-line fix in `_driver.update_manifest`
+
+[src/nhf_spatial_targets/aggregate/_driver.py:80](src/nhf_spatial_targets/aggregate/_driver.py#L80):
+
+```python
+# before
+manifest["sources"][source_key] = entry
+
+# after
+existing = manifest["sources"].get(source_key, {})
+existing.update(entry)
+manifest["sources"][source_key] = existing
+```
+
+**Backward compatibility.** For sources whose fetch doesn't write
+nested state, the existing entry contains only keys that the new
+entry also writes (`source_key`, `access_type`, `period`,
+`fabric_sha256`, `output_files`, `weight_files`, `timestamp`, plus
+optional `doi`/`collection_id`/`short_name`/`version`). `dict.update`
+overwrites those keys to the same effective values, so the call is a
+no-op behavior change for ~10 of the 12 aggregators. For daymet and
+SNODAS, fetch-side keys (`regions`, `years`, `doi`, `license`,
+`access_url`, `spatial_extent`, `variables`) survive.
+
+Update the function's docstring to mention the merge semantics
+explicitly — current docstring says "Merge an aggregation provenance
+entry" but isn't specific about entry-level vs source-level merge.
+
+### 2. Delete daymet's local copy
+
+[src/nhf_spatial_targets/aggregate/daymet.py](src/nhf_spatial_targets/aggregate/daymet.py):
+
+- Delete `_merge_manifest_entry` (lines 52-117).
+- Swap the call site at line 426 from `_merge_manifest_entry(...)` to
+  `update_manifest(project=project, source_key=_SOURCE_KEY,
+  access=access_with_doi, period=..., output_files=...,
+  weight_files=...)`.
+- Add `update_manifest` to the `_driver` import block (lines 28-37).
+- Prune now-unused module imports: `os`, `tempfile`, and
+  `from datetime import datetime, timezone`. Keep `json` (still
+  used by `_resolve_zarr_path` at lines 163-164).
+
+### 3. Regression test for the shared helper
+
+Add a focused unit test in
+[tests/test_aggregate_driver.py](tests/test_aggregate_driver.py)
+alongside the existing
+`test_update_manifest_preserves_existing_sources` (line 61) — same
+pattern, different invariant:
+
+```python
+def test_update_manifest_preserves_pre_existing_entry_keys(...):
+    """`update_manifest` must merge into the existing entry for
+    `source_key`, not overwrite it. Guards against the bug from
+    issue #119 where fetch-side keys (e.g. daymet's `regions` dict,
+    snodas's `years` list) were silently wiped on every aggregator
+    run."""
+    # Pre-populate sources.foo with a fetch-style nested key.
+    # Call update_manifest(source_key="foo", ...).
+    # Assert: the pre-existing nested key survives; new aggregator
+    # keys are present.
+```
+
+### 4. Existing daymet test stays as the integration guard
+
+[tests/test_aggregate_daymet.py:359-399](tests/test_aggregate_daymet.py#L359-L399)
+(`test_manifest_merge_preserves_fetch_regions`) was written in PR #118
+to assert that fetch-side `regions` keys survive the manifest write.
+The test goes through `aggregate_daymet` (public API), not the
+private helper. After the swap, it exercises the shared
+`update_manifest` path — same assertion, free integration coverage.
+**No edit needed.**
+
+## Files modified
+
+- [src/nhf_spatial_targets/aggregate/_driver.py](src/nhf_spatial_targets/aggregate/_driver.py)
+  — 3-line merge swap at L80; docstring tweak.
+- [src/nhf_spatial_targets/aggregate/daymet.py](src/nhf_spatial_targets/aggregate/daymet.py)
+  — delete `_merge_manifest_entry`; swap call site; prune unused
+  imports; add `update_manifest` to existing `_driver` import.
+- [tests/test_aggregate_driver.py](tests/test_aggregate_driver.py)
+  — one new test (`test_update_manifest_preserves_pre_existing_entry_keys`).
+
+## Files **not** modified
+
+- `tests/test_aggregate_daymet.py` — existing manifest-merge test
+  continues to pass through the new code path.
+- All other aggregator modules — they use `update_manifest` already
+  via `_driver.aggregate_source` and pick up the new merge for free.
+- `aggregate/ssebop.py` — calls `update_manifest` directly
+  ([line 297](src/nhf_spatial_targets/aggregate/ssebop.py#L297));
+  picks up the merge behavior. No fetch-side keys at risk because
+  ssebop is read-on-the-fly from STAC (no fetch module).
+- Catalog, slurm scripts, notebooks, CLI, CLAUDE.md.
+
+## Reused helpers
+
+- `update_manifest` from
+  [src/nhf_spatial_targets/aggregate/_driver.py](src/nhf_spatial_targets/aggregate/_driver.py)
+  is the helper being fixed and re-used.
+- Existing test fixtures in `tests/test_aggregate_driver.py` (e.g.
+  `tmp_workdir` setup at line 17+) already cover the manifest-on-disk
+  pattern.
+
+## Verification
+
+```bash
+pixi run -e dev fmt && pixi run -e dev lint   # locally
+git push                                       # let CI run pytest
+```
+
+CI must run, and these three tests must pass:
+
+- `tests/test_aggregate_driver.py::test_update_manifest_preserves_pre_existing_entry_keys` (new)
+- `tests/test_aggregate_driver.py::test_update_manifest_preserves_existing_sources` (existing cross-source guard)
+- `tests/test_aggregate_daymet.py::test_manifest_merge_preserves_fetch_regions` (now exercises the shared helper through `aggregate_daymet`)
+
+Manual cross-check after merge: on a project with a real
+fetch-populated manifest, re-run `pixi run nhf-targets agg daymet
+--project-dir <…> --period <…>`. Confirm `manifest.json`
+`sources.daymet` still carries the fetch-side `regions` dict
+alongside the new `output_files`/`weight_files`/`timestamp`. Same
+check for SNODAS — `sources.snodas.years` should survive
+post-aggregation (regression that the new path also fixes).
+
+Per `feedback_skip_local_pytest_on_hpc` memory: don't run
+`pixi run -e dev test` locally on this HPC; CI is the gate.
+
+## Git workflow
+
+- Branch from `main`: `fix/119-driver-update-manifest-merge`.
+- PR title: `fix(driver): merge update_manifest at entry level (#119)`.
+- PR body: closes #119; cite PR #117 (SNODAS, fixed-for-free) and
+  PR #118 (daymet, deletes local copy).
+- Copy this plan to
+  `docs/superpowers/plans/2026-05-14-driver-update-manifest-merge.md`
+  and include it in the PR (precedent: PR #117, PR #118).

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -37,11 +37,18 @@ def update_manifest(
     """Merge an aggregation provenance entry into ``manifest.json`` atomically.
 
     The manifest is keyed as ``sources[source_key]``; existing entries for
-    other sources are preserved. ``period`` is stored as-is for provenance;
-    ``fabric_sha256`` is read from ``fabric.json``. ``output_files`` lists
-    aggregated output NC paths relative to ``project.workdir`` (one per year
-    for per-year pipelines, a single-element list for sources like ssebop
-    that emit one consolidated file).
+    other sources are preserved. **Within** ``sources[source_key]``, the
+    aggregator-owned fields below are merged into any pre-existing entry
+    rather than overwriting it — fetch modules write per-source provenance
+    (e.g. daymet's ``regions`` dict, snodas's ``years`` list) and the
+    aggregator must not erase those keys when it adds ``output_files`` /
+    ``weight_files`` / ``timestamp`` (issue #119).
+
+    ``period`` is stored as-is for provenance; ``fabric_sha256`` is read
+    from ``fabric.json``. ``output_files`` lists aggregated output NC
+    paths relative to ``project.workdir`` (one per year for per-year
+    pipelines, a single-element list for sources like ssebop that emit
+    one consolidated file).
     """
     manifest_path = project.manifest_path
     if manifest_path.exists():
@@ -77,7 +84,13 @@ def update_manifest(
         if extra_key in access:
             entry[extra_key] = access[extra_key]
 
-    manifest["sources"][source_key] = entry
+    # Entry-level read-merge-write: preserve fetch-side keys (issue #119).
+    # For sources whose fetch doesn't write nested state, the existing
+    # entry only contains keys the new entry also writes, so this is a
+    # no-op behavior change.
+    existing = manifest["sources"].get(source_key, {})
+    existing.update(entry)
+    manifest["sources"][source_key] = existing
 
     tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
     try:

--- a/src/nhf_spatial_targets/aggregate/daymet.py
+++ b/src/nhf_spatial_targets/aggregate/daymet.py
@@ -18,9 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -36,6 +33,7 @@ from nhf_spatial_targets.aggregate._driver import (
     aggregate_variables_for_batch,
     compute_or_load_weights,
     load_and_batch_fabric,
+    update_manifest,
 )
 from nhf_spatial_targets.fetch._period import parse_period
 from nhf_spatial_targets.workspace import Project
@@ -47,73 +45,6 @@ _SOURCE_KEY = "daymet"
 _SOURCE_VAR = "swe"
 _GRID_MAPPING_VAR = "lambert_conformal_conic"
 _SUPPORTED_REGIONS = frozenset({"na"})
-
-
-def _merge_manifest_entry(
-    project: Project,
-    access: dict,
-    period: str,
-    output_files: list[str],
-    weight_files: list[str],
-) -> None:
-    """Write the aggregator's provenance into ``manifest.json`` while
-    preserving fetch-side keys on ``sources.daymet``.
-
-    Daymet's fetch module records per-region zarr provenance under
-    ``sources.daymet.regions``. The shared ``_driver.update_manifest``
-    helper builds a fresh entry dict and replaces ``sources[<key>]``
-    wholesale, which would erase the fetch entry. Every fetch module
-    in this repo already does read-merge-write at the entry level
-    (``entry.update({...})``) — this helper applies the same
-    convention to the aggregator side until the shared driver helper
-    is fixed.
-    """
-    manifest_path = project.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {project.workdir} is corrupt: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-    manifest.setdefault("sources", {})
-
-    fabric_json = project.workdir / "fabric.json"
-    fabric_sha = ""
-    if fabric_json.exists():
-        fabric_meta = json.loads(fabric_json.read_text())
-        fabric_sha = fabric_meta.get("sha256", "")
-
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    agg_fields: dict = {
-        "source_key": _SOURCE_KEY,
-        "access_type": access.get("type", ""),
-        "period": period,
-        "fabric_sha256": fabric_sha,
-        "output_files": list(output_files),
-        "weight_files": list(weight_files),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
-    for extra_key in ("collection_id", "short_name", "version", "doi"):
-        if extra_key in access:
-            agg_fields[extra_key] = access[extra_key]
-    entry.update(agg_fields)
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except Exception:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
-    logger.info(
-        "daymet: merged aggregator provenance into %s (regions preserved)",
-        manifest_path,
-    )
 
 
 def _region_source_key(region: str) -> str:
@@ -423,8 +354,9 @@ def aggregate_daymet(
     access_with_doi = {**access}
     if meta.get("doi"):
         access_with_doi["doi"] = meta["doi"]
-    _merge_manifest_entry(
+    update_manifest(
         project=project,
+        source_key=_SOURCE_KEY,
         access=access_with_doi,
         period=f"{start_year}-01-01/{end_year}-12-31",
         output_files=rel_outputs,

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -75,6 +75,63 @@ def test_update_manifest_preserves_existing_sources(project):
     assert set(manifest["sources"].keys()) == {"foo", "bar"}
 
 
+def test_update_manifest_preserves_pre_existing_entry_keys(project):
+    """Entry-level read-merge-write: keys written by the fetch module
+    survive the aggregator's ``update_manifest`` call (issue #119).
+
+    Without this, fetch-side nested provenance like daymet's ``regions``
+    dict or snodas's ``years`` list is silently wiped on every
+    aggregator run. The aggregator must merge into the existing entry,
+    not overwrite it.
+    """
+    manifest_path = project.workdir / "manifest.json"
+    # Simulate a fetch module having written nested + flat provenance
+    # under ``sources.foo`` before the aggregator runs.
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "sources": {
+                    "foo": {
+                        "source_key": "foo",
+                        "doi": "10.1234/foo",
+                        "license": "public domain",
+                        "regions": {
+                            "na": {"path": "/data/foo_na.zarr", "sha256": "deadbeef"}
+                        },
+                        "years": [{"year": 2003, "n_files": 365}],
+                    }
+                },
+                "steps": [],
+            }
+        )
+    )
+    update_manifest(
+        project=project,
+        source_key="foo",
+        access={"type": "local"},
+        period="2003-01-01/2003-12-31",
+        output_files=["data/aggregated/foo/foo_2003_agg.nc"],
+        weight_files=["weights/foo_batch0.csv"],
+    )
+    manifest = json.loads(manifest_path.read_text())
+    entry = manifest["sources"]["foo"]
+    # Fetch-side keys preserved:
+    assert entry["doi"] == "10.1234/foo"
+    assert entry["license"] == "public domain"
+    assert entry["regions"] == {
+        "na": {"path": "/data/foo_na.zarr", "sha256": "deadbeef"}
+    }
+    assert entry["years"] == [{"year": 2003, "n_files": 365}]
+    # Aggregator-side keys added on top:
+    assert entry["output_files"] == ["data/aggregated/foo/foo_2003_agg.nc"]
+    assert entry["weight_files"] == ["weights/foo_batch0.csv"]
+    assert entry["period"] == "2003-01-01/2003-12-31"
+    assert entry["access_type"] == "local"
+    assert "timestamp" in entry
+    # source_key unchanged:
+    assert entry["source_key"] == "foo"
+
+
 def test_source_adapter_defaults():
     from nhf_spatial_targets.aggregate._adapter import SourceAdapter
 


### PR DESCRIPTION
## Summary

Closes #119. The shared \`_driver.update_manifest\` helper built a fresh entry dict and overwrote \`manifest[\"sources\"][source_key]\` wholesale. Every fetch module already does entry-level read-merge-write, so fetch-side keys (e.g. daymet's \`regions\` dict, snodas's \`years\` list) were silently wiped on every aggregator run.

Three focused changes:

1. **\`_driver.update_manifest\` now merges into the existing entry** (3-line swap at the assignment + docstring update). Backward-compatible: for sources whose fetch doesn't write nested state, the existing entry only contains keys the new entry also writes, so it's a no-op behavior change.

2. **Delete the daymet workaround.** PR #118 added a local \`_merge_manifest_entry\` copy in \`aggregate/daymet.py\` as a stopgap; this PR swaps the call site back to the shared helper and prunes the now-unused \`os\` / \`tempfile\` / \`datetime\` imports. Net deletion of ~65 lines.

3. **Regression test.** New \`test_update_manifest_preserves_pre_existing_entry_keys\` in \`tests/test_aggregate_driver.py\` pre-populates \`sources.foo\` with both nested (\`regions\`) and flat (\`years\`, \`doi\`, \`license\`) fetch-side keys and asserts they all survive the aggregator's \`update_manifest\` call.

The existing daymet integration test \`test_manifest_merge_preserves_fetch_regions\` (from PR #118) continues to pass through the new code path — it asserted the invariant via the public \`aggregate_daymet\` API, not the private helper, so it transparently becomes the integration guard for the shared helper.

## Latent bug also fixed

PR #117's SNODAS aggregator was silently overwriting the fetch-side \`sources.snodas.years\` list on every run. The merge fix repairs that for free; no SNODAS code touched.

## Test plan

- [x] \`pixi run -e dev fmt && pixi run -e dev lint\` — clean.
- [ ] CI runs pytest. Three tests must pass:
  - \`test_aggregate_driver.py::test_update_manifest_preserves_pre_existing_entry_keys\` (new)
  - \`test_aggregate_driver.py::test_update_manifest_preserves_existing_sources\` (existing cross-source guard)
  - \`test_aggregate_daymet.py::test_manifest_merge_preserves_fetch_regions\` (now exercises the shared helper)
- [ ] Post-merge manual smoke: re-run \`pixi run nhf-targets agg daymet --project-dir <…> --period <…>\` on a fetch-populated project; confirm \`sources.daymet.regions\` still present after the agg run. Same for SNODAS (\`sources.snodas.years\` survives).

Refs PR #117 (SNODAS), PR #118 (daymet workaround), umbrella #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)