### PR TITLE
refactor(targets): SourceShim dataclass replaces parallel per-source dicts (#128)

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -17,6 +17,8 @@ keeps ``mm_per_month_to_cfs``); this module is unit-agnostic.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -26,6 +28,63 @@ import xarray as xr
 from nhf_spatial_targets.workspace import Project
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SourceShim:
+    """Per-source contract for a multi-source target builder.
+
+    Co-locates the three facts each target needs about a contributing
+    source: the catalog key it loads from, the variable name in the
+    aggregated NC, the human-readable label for the output NC's global
+    ``source`` attr, and the per-source unit-shim function that brings the
+    native variable into the target's common intermediate units (e.g.
+    mm/month for runoff and AET).
+
+    Target modules declare a tuple of :class:`SourceShim` instances as
+    their ``SHIMS`` constant and call :func:`shims_by_key` to look one up
+    by catalog key inside their build loop. Adding a future source is a
+    single edit — there is no parallel-dict drift surface.
+
+    Attributes
+    ----------
+    source_key
+        Catalog key (e.g. ``"ssebop"``). Must match ``catalog.source(...)``
+        and the directory name under ``<project>/data/aggregated/``.
+    aggregated_var
+        Variable name to extract from the aggregated NC (e.g. ``"et"``).
+    description
+        Human-readable label for the output NC's global ``source`` attr.
+    to_common_units
+        Callable that converts the source's native variable to the
+        target's common intermediate units. For multi_source_minmax
+        targets the common intermediate is usually mm/month; the per-
+        target unit chain then applies a final linear conversion (e.g.
+        mm/month → cfs for runoff, mm/month → inches/day for AET).
+    """
+
+    source_key: str
+    aggregated_var: str
+    description: str
+    to_common_units: Callable[[xr.DataArray], xr.DataArray]
+
+
+def shims_by_key(shims: "tuple[SourceShim, ...]") -> "dict[str, SourceShim]":
+    """Index a ``SHIMS`` tuple by ``source_key`` for lookup at build time.
+
+    Raises ``ValueError`` if two shims share the same ``source_key`` —
+    that would silently shadow one entry, which is exactly the kind of
+    drift this refactor prevents.
+    """
+    out: dict[str, SourceShim] = {}
+    for shim in shims:
+        if shim.source_key in out:
+            raise ValueError(
+                f"Duplicate SourceShim.source_key={shim.source_key!r} in "
+                f"target SHIMS registry. Each source may appear at most once."
+            )
+        out[shim.source_key] = shim
+    return out
 
 
 def read_aggregated_source(

--- a/src/nhf_spatial_targets/targets/aet.py
+++ b/src/nhf_spatial_targets/targets/aet.py
@@ -32,7 +32,6 @@ code edit.
 from __future__ import annotations
 
 import logging
-from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -40,10 +39,12 @@ import xarray as xr
 
 from nhf_spatial_targets.normalize.methods import nn_fill_bounds
 from nhf_spatial_targets.targets._common import (
+    SourceShim,
     compute_hru_centroids,
     multi_source_nanminmax,
     read_aggregated_source,
     reindex_to_month_start,
+    shims_by_key,
     write_target_nc,
 )
 from nhf_spatial_targets.workspace import Project
@@ -53,22 +54,6 @@ logger = logging.getLogger(__name__)
 
 # 1 inch = 25.4 mm.
 _MM_PER_INCH = 25.4
-
-# Per-source variable name in the aggregated NC.
-_SOURCE_VAR: dict[str, str] = {
-    "mod16a2_v061": "ET_500m",
-    "ssebop": "et",
-    "mwbm_climgrid": "aet",
-}
-
-# Per-source human-readable description for the output NC's global ``source`` attr.
-_SOURCE_DESCRIPTION: dict[str, str] = {
-    "mod16a2_v061": (
-        "MOD16A2 v061 ET_500m (8-day kg m-2; overlap-weighted to mm/month)"
-    ),
-    "ssebop": "SSEBop et (mm/month, native)",
-    "mwbm_climgrid": "MWBM ClimGrid aet (mm/month, native)",
-}
 
 
 # ---------------------------------------------------------------------------
@@ -169,11 +154,30 @@ def mod16a2_to_mm_per_month(
     return monthly
 
 
-_TO_MM: dict[str, Callable[[xr.DataArray], xr.DataArray]] = {
-    "mod16a2_v061": mod16a2_to_mm_per_month,
-    "ssebop": ssebop_to_mm_per_month,
-    "mwbm_climgrid": mwbm_to_mm_per_month,
-}
+# Per-source registry: (source_key, aggregated_var, description, to_mm shim).
+# `shims_by_key(SHIMS)` is used at build time for O(1) lookup.
+SHIMS: tuple[SourceShim, ...] = (
+    SourceShim(
+        source_key="mod16a2_v061",
+        aggregated_var="ET_500m",
+        description=(
+            "MOD16A2 v061 ET_500m (8-day kg m-2; overlap-weighted to mm/month)"
+        ),
+        to_common_units=mod16a2_to_mm_per_month,
+    ),
+    SourceShim(
+        source_key="ssebop",
+        aggregated_var="et",
+        description="SSEBop et (mm/month, native)",
+        to_common_units=ssebop_to_mm_per_month,
+    ),
+    SourceShim(
+        source_key="mwbm_climgrid",
+        aggregated_var="aet",
+        description="MWBM ClimGrid aet (mm/month, native)",
+        to_common_units=mwbm_to_mm_per_month,
+    ),
+)
 
 
 def mm_per_month_to_inches_per_day(da: xr.DataArray) -> xr.DataArray:
@@ -238,19 +242,23 @@ def build(project: Project) -> None:
 
     # 3. Read, convert, reindex each source.
     fabric_hru_ids = hru_meta.index.values
+    shims = shims_by_key(SHIMS)
     sources_in_day: dict[str, xr.DataArray] = {}
     for src in sources:
-        if src not in _SOURCE_VAR:
+        if src not in shims:
             raise ValueError(
-                f"aet.sources includes unknown source '{src}'. "
-                f"Known: {sorted(_SOURCE_VAR.keys())}"
+                f"aet.sources includes unknown source '{src}'. Known: {sorted(shims)}"
             )
-        var = _SOURCE_VAR[src]
+        shim = shims[src]
         # For MOD16A2 the time dim is 8-day; slicing by the requested
         # monthly period is still correct because xr.sel(time=slice(...))
         # is a half-open inclusive-of-both-endpoints date range.
         da_native = read_aggregated_source(
-            project, src, var, period, chunks={"time": chunk_months, id_col: -1}
+            project,
+            shim.source_key,
+            shim.aggregated_var,
+            period,
+            chunks={"time": chunk_months, id_col: -1},
         )
         # HRU coord check (same canonical-sort invariant as runoff target).
         src_hru_ids = da_native[id_col].values
@@ -274,7 +282,7 @@ def build(project: Project) -> None:
                 f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
                 f"Re-aggregate '{src}' against the current fabric."
             )
-        da_mm = _TO_MM[src](da_native)
+        da_mm = shim.to_common_units(da_native)
         da_in_day = mm_per_month_to_inches_per_day(da_mm)
         sources_in_day[src] = reindex_to_month_start(da_in_day, master_idx)
 
@@ -362,7 +370,7 @@ def build(project: Project) -> None:
     ds[id_col].attrs["cf_role"] = "timeseries_id"
 
     extra_attrs = {
-        "source": "; ".join(_SOURCE_DESCRIPTION[s] for s in sources),
+        "source": "; ".join(shims[s].description for s in sources),
         "references": "Hay et al. 2022, doi:10.3133/tm6B10",
         "fabric": project.config["fabric"]["path"],
         "fabric_sha256": project.fabric.get("sha256", ""),

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -22,7 +22,6 @@ finite HRU's value at the same time step (cKDTree donor walk in
 from __future__ import annotations
 
 import logging
-from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -30,10 +29,12 @@ import xarray as xr
 
 from nhf_spatial_targets.normalize.methods import nn_fill_bounds
 from nhf_spatial_targets.targets._common import (
+    SourceShim,
     compute_hru_area_and_centroids,
     multi_source_nanminmax,
     read_aggregated_source,
     reindex_to_month_start,
+    shims_by_key,
     write_target_nc,
 )
 from nhf_spatial_targets.workspace import Project
@@ -43,20 +44,6 @@ logger = logging.getLogger(__name__)
 
 # 1 m³/day = (1/86400) m³/s = (35.3147/86400) ft³/s
 _M3_PER_DAY_TO_CFS = 35.3146667 / 86400.0
-
-# Per-source variable name in the aggregated NC.
-_SOURCE_VAR: dict[str, str] = {
-    "era5_land": "ro",
-    "gldas_noah_v21_monthly": "runoff_total",
-    "mwbm_climgrid": "runoff",
-}
-
-# Per-source human-readable description for the output NC's global ``source`` attr.
-_SOURCE_DESCRIPTION: dict[str, str] = {
-    "era5_land": "ERA5-Land ro",
-    "gldas_noah_v21_monthly": "GLDAS-2.1 NOAH runoff_total (Qs_acc + Qsb_acc, summed at consolidation)",
-    "mwbm_climgrid": "MWBM ClimGrid runoff",
-}
 
 
 # ---------------------------------------------------------------------------
@@ -99,11 +86,30 @@ def mwbm_to_mm_per_month(da: xr.DataArray) -> xr.DataArray:
     return out
 
 
-_TO_MM: dict[str, Callable[[xr.DataArray], xr.DataArray]] = {
-    "era5_land": era5_to_mm_per_month,
-    "gldas_noah_v21_monthly": gldas_to_mm_per_month,
-    "mwbm_climgrid": mwbm_to_mm_per_month,
-}
+# Per-source registry: (source_key, aggregated_var, description, to_mm shim).
+# `shims_by_key(SHIMS)` is used at build time for O(1) lookup.
+SHIMS: tuple[SourceShim, ...] = (
+    SourceShim(
+        source_key="era5_land",
+        aggregated_var="ro",
+        description="ERA5-Land ro",
+        to_common_units=era5_to_mm_per_month,
+    ),
+    SourceShim(
+        source_key="gldas_noah_v21_monthly",
+        aggregated_var="runoff_total",
+        description=(
+            "GLDAS-2.1 NOAH runoff_total (Qs_acc + Qsb_acc, summed at consolidation)"
+        ),
+        to_common_units=gldas_to_mm_per_month,
+    ),
+    SourceShim(
+        source_key="mwbm_climgrid",
+        aggregated_var="runoff",
+        description="MWBM ClimGrid runoff",
+        to_common_units=mwbm_to_mm_per_month,
+    ),
+)
 
 
 def mm_per_month_to_cfs(da: xr.DataArray, hru_area_m2: xr.DataArray) -> xr.DataArray:
@@ -177,16 +183,21 @@ def build(project: Project) -> None:
     # Fabric HRU IDs as a numpy array for coord-agreement checks.
     fabric_hru_ids = hru_meta.index.values
 
+    shims = shims_by_key(SHIMS)
     sources_cfs: dict[str, xr.DataArray] = {}
     for src in sources:
-        if src not in _SOURCE_VAR:
+        if src not in shims:
             raise ValueError(
                 f"runoff.sources includes unknown source '{src}'. "
-                f"Known: {sorted(_SOURCE_VAR.keys())}"
+                f"Known: {sorted(shims)}"
             )
-        var = _SOURCE_VAR[src]
+        shim = shims[src]
         da_native = read_aggregated_source(
-            project, src, var, period, chunks={"time": chunk_months, id_col: -1}
+            project,
+            shim.source_key,
+            shim.aggregated_var,
+            period,
+            chunks={"time": chunk_months, id_col: -1},
         )
         # Validate that the source's HRU IDs match the fabric before any
         # arithmetic that would silently broadcast/intersect mismatched coords.
@@ -217,7 +228,7 @@ def build(project: Project) -> None:
                 f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
                 f"Re-aggregate '{src}' against the current fabric."
             )
-        da_mm = _TO_MM[src](da_native)
+        da_mm = shim.to_common_units(da_native)
         da_cfs = mm_per_month_to_cfs(da_mm, hru_area_da)
         sources_cfs[src] = reindex_to_month_start(da_cfs, master_idx)
 
@@ -309,7 +320,7 @@ def build(project: Project) -> None:
     ds[id_col].attrs["cf_role"] = "timeseries_id"
 
     extra_attrs = {
-        "source": "; ".join(_SOURCE_DESCRIPTION[s] for s in sources),
+        "source": "; ".join(shims[s].description for s in sources),
         "references": "Hay et al. 2022, doi:10.3133/tm6B10",
         "fabric": project.config["fabric"]["path"],
         "fabric_sha256": project.fabric.get("sha256", ""),

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -600,3 +600,97 @@ def test_compute_hru_area_and_centroids_raises_on_duplicate_id_col(tmp_path: Pat
     project = load(workdir)
     with pytest.raises(ValueError, match="duplicate"):
         compute_hru_area_and_centroids(project)
+
+
+# ---------------------------------------------------------------------------
+# SourceShim / shims_by_key
+# ---------------------------------------------------------------------------
+
+
+def _identity_shim(da: xr.DataArray) -> xr.DataArray:
+    return da
+
+
+def test_source_shim_is_frozen_dataclass():
+    """SourceShim instances are immutable so SHIMS tuples can be module-level."""
+    from dataclasses import FrozenInstanceError
+
+    from nhf_spatial_targets.targets._common import SourceShim
+
+    shim = SourceShim(
+        source_key="foo",
+        aggregated_var="x",
+        description="foo",
+        to_common_units=_identity_shim,
+    )
+    with pytest.raises(FrozenInstanceError):
+        shim.source_key = "bar"  # type: ignore[misc]
+
+
+def test_shims_by_key_returns_keyed_lookup():
+    """shims_by_key indexes a SHIMS tuple by source_key."""
+    from nhf_spatial_targets.targets._common import SourceShim, shims_by_key
+
+    a = SourceShim("a", "va", "A", _identity_shim)
+    b = SourceShim("b", "vb", "B", _identity_shim)
+    out = shims_by_key((a, b))
+    assert out == {"a": a, "b": b}
+
+
+def test_shims_by_key_raises_on_duplicate_source_key():
+    """Two shims with the same key would silently shadow; must raise."""
+    from nhf_spatial_targets.targets._common import SourceShim, shims_by_key
+
+    a = SourceShim("dup", "va", "A", _identity_shim)
+    b = SourceShim("dup", "vb", "B", _identity_shim)
+    with pytest.raises(ValueError, match="Duplicate SourceShim.source_key='dup'"):
+        shims_by_key((a, b))
+
+
+def test_shims_by_key_empty_tuple_returns_empty_dict():
+    """Empty SHIMS tuple is a degenerate but valid input."""
+    from nhf_spatial_targets.targets._common import shims_by_key
+
+    assert shims_by_key(()) == {}
+
+
+def test_run_target_module_exposes_well_formed_shims():
+    """targets/run.py SHIMS registry has the expected source keys and aggregated vars."""
+    from nhf_spatial_targets.targets.run import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert set(by_key) == {"era5_land", "gldas_noah_v21_monthly", "mwbm_climgrid"}
+    assert by_key["era5_land"].aggregated_var == "ro"
+    assert by_key["gldas_noah_v21_monthly"].aggregated_var == "runoff_total"
+    assert by_key["mwbm_climgrid"].aggregated_var == "runoff"
+    # Each shim's to_common_units must be callable on a synthetic DataArray.
+    da = xr.DataArray(
+        np.array([[1.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": pd.DatetimeIndex(["2000-01-01"]), "nhm_id": [1]},
+        attrs={"units": "anything"},
+    )
+    for shim in SHIMS:
+        out = shim.to_common_units(da)
+        assert out.attrs.get("units") == "mm"
+
+
+def test_aet_target_module_exposes_well_formed_shims():
+    """targets/aet.py SHIMS registry has the expected source keys and aggregated vars."""
+    from nhf_spatial_targets.targets.aet import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert set(by_key) == {"mod16a2_v061", "ssebop", "mwbm_climgrid"}
+    assert by_key["mod16a2_v061"].aggregated_var == "ET_500m"
+    assert by_key["ssebop"].aggregated_var == "et"
+    assert by_key["mwbm_climgrid"].aggregated_var == "aet"
+    # SSEBop and MWBM are pass-throughs; verify they accept a synthetic DataArray.
+    da = xr.DataArray(
+        np.array([[1.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": pd.DatetimeIndex(["2000-01-01"]), "nhm_id": [1]},
+        attrs={"units": "anything"},
+    )
+    for key in ("ssebop", "mwbm_climgrid"):
+        out = by_key[key].to_common_units(da)
+        assert out.attrs.get("units") == "mm"


### PR DESCRIPTION
## Summary

- Adds \`SourceShim\` frozen dataclass + \`shims_by_key\` helper to [src/nhf_spatial_targets/targets/_common.py](src/nhf_spatial_targets/targets/_common.py).
- Replaces three parallel per-source dicts (\`_SOURCE_VAR\`, \`_SOURCE_DESCRIPTION\`, \`_TO_MM\`) in [targets/run.py](src/nhf_spatial_targets/targets/run.py) and [targets/aet.py](src/nhf_spatial_targets/targets/aet.py) with a single \`SHIMS: tuple[SourceShim, ...]\` registry per target module.
- Build loop becomes \`shim = shims[src]; ...; da_mm = shim.to_common_units(da_native)\` — no parallel dicts to drift between.
- \`shims_by_key\` raises on duplicate \`source_key\`; tested.

## Why now

PR #127 review nit-2. Landing before rch + som means those builders adopt the single-registry pattern from day one rather than adding 7 more parallel-dict entries that would need refactoring later.

## Test plan

- [x] \`pixi run -e dev fmt\` — clean
- [x] \`pixi run -e dev lint\` — clean
- [x] \`pytest tests/test_targets_common.py tests/test_targets_aet.py tests/test_targets_run.py tests/test_cli.py\` — 109 passed (6 new tests for \`SourceShim\` immutability, \`shims_by_key\` basic + duplicate-key + empty paths, and live-registry assertions on run/aet's SHIMS; all existing tests untouched)
- [ ] CI green

## Out of scope

- The catalog-units sanity check (#130) is the natural next field on \`SourceShim\`. Deliberately left out so this PR stays a pure refactor.
- rch + som builders adopt this pattern in their own bundled PR.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)