### PR TITLE
feat(targets): implement recharge and soil_moisture targets (#133)

### DIFF
--- a/config/pipeline.yml
+++ b/config/pipeline.yml
@@ -96,6 +96,10 @@ targets:
       - monthly
       - annual
     period: "1982-01-01/2010-12-31"
+    # Independent normalization window; leave null (or omit) to use `period`.
+    # Values in `period` outside this window may produce normalized values
+    # < 0 or > 1 by design (visibly out-of-range, not silently re-scaled).
+    normalize_period: null
     prms_variable: soil_rechr
     range_method: normalized_minmax
     normalize: true

--- a/config/pipeline.yml
+++ b/config/pipeline.yml
@@ -82,6 +82,8 @@ targets:
     normalize: true
     normalize_period: "2000-01-01/2009-12-31"   # verify vs Appendix 1
     output_file: recharge_targets.nc
+    nn_fill: true
+    nn_max_candidates: 10
 
   soil_moisture:
     enabled: true
@@ -98,7 +100,11 @@ targets:
     range_method: normalized_minmax
     normalize: true
     normalize_by: calendar_month   # monthly normalization per calendar month
+    # Two NCs are written derived from this base name:
+    #   <base>_monthly.nc and <base>_annual.nc (plus *_nn_filled.nc).
     output_file: soil_moisture_targets.nc
+    nn_fill: true
+    nn_max_candidates: 10
 
   snow_covered_area:
     enabled: true

--- a/src/nhf_spatial_targets/defaults.py
+++ b/src/nhf_spatial_targets/defaults.py
@@ -82,6 +82,11 @@ DEFAULTS: dict = {
             "sources": ["merra2", "ncep_ncar", "nldas_mosaic", "nldas_noah"],
             "time_step": ["monthly", "annual"],
             "period": None,
+            # If null, defaults to `period` (whole-period normalization).
+            # Set independently to extend the output time axis past the
+            # calibration-period climatology — values outside the window
+            # may then produce normalized values < 0 or > 1, by design.
+            "normalize_period": None,
             "prms_variable": "soil_rechr",
             "range_method": "normalized_minmax",
             "normalize": True,

--- a/src/nhf_spatial_targets/normalize/methods.py
+++ b/src/nhf_spatial_targets/normalize/methods.py
@@ -81,6 +81,92 @@ def normalize_0_1_by_calendar_month(da: xr.DataArray) -> xr.DataArray:
     return norm
 
 
+def normalize_0_1_over_window(
+    da: xr.DataArray, window: xr.DataArray, dim: str = "time"
+) -> xr.DataArray:
+    """Normalize ``da`` to [0, 1] using ``window``'s min/max along ``dim``.
+
+    Like :func:`normalize_0_1` but the min/max are computed over a subset
+    of ``da`` (the calibration / normalization period). Values in ``da``
+    that fall outside ``window``'s climatology may produce values < 0 or
+    > 1 — by design: TM 6-B10 §3 and §4 say the bound reflects the
+    calibration-period climatology, and a future year outside that
+    climatology should be visibly out-of-range, not silently re-normalized
+    against extended data.
+
+    Cells where the window's range is zero (constant series or all-NaN
+    over the window) yield NaN; see :func:`normalize_0_1` for the
+    reasoning.
+
+    Parameters
+    ----------
+    da
+        DataArray to normalize. Must have ``dim`` as one of its dimensions.
+    window
+        Subset of ``da`` along ``dim`` (typically a time-slice) used to
+        compute the min/max. The remaining (non-``dim``) dims must match
+        ``da``.
+    dim
+        Dimension to compute min/max over. Defaults to ``"time"``.
+    """
+    if dim not in da.dims:
+        raise ValueError(
+            f"normalize_0_1_over_window: dim {dim!r} not in DataArray dims "
+            f"{tuple(da.dims)!r}"
+        )
+    mn = window.min(dim=dim, skipna=True)
+    mx = window.max(dim=dim, skipna=True)
+    rng = mx - mn
+    safe_rng = rng.where(rng > 0)
+    norm = (da - mn) / safe_rng
+    norm.attrs = dict(da.attrs)
+    norm.attrs["units"] = "1"
+    return norm
+
+
+def normalize_0_1_by_calendar_month_over_window(
+    da: xr.DataArray, window: xr.DataArray
+) -> xr.DataArray:
+    """Per-calendar-month [0, 1] normalize using ``window``'s monthly min/max.
+
+    Like :func:`normalize_0_1_by_calendar_month` but the per-calendar-month
+    min/max are computed over a subset (the normalization period). All
+    Januaries within ``window`` pool to give the January min/max, which
+    is then applied to every January in ``da`` — including Januaries
+    outside ``window``, which may produce values < 0 or > 1 by the same
+    "visibly out-of-range" design as :func:`normalize_0_1_over_window`.
+
+    Per TM 6-B10 §4 Appendix 1, this is the monthly soil moisture
+    target's normalization when ``period`` and ``normalize_period``
+    differ; when they are equal, the behavior collapses to
+    :func:`normalize_0_1_by_calendar_month` applied to the full period.
+    """
+    if "time" not in da.dims:
+        raise ValueError(
+            f"normalize_0_1_by_calendar_month_over_window: expected 'time' "
+            f"dim, got {tuple(da.dims)!r}"
+        )
+    if "time" not in window.dims:
+        raise ValueError(
+            f"normalize_0_1_by_calendar_month_over_window: window must also "
+            f"have 'time' dim; got {tuple(window.dims)!r}"
+        )
+    # Per-calendar-month min/max over the window. Result is dim ``month``.
+    window_grouped = window.groupby("time.month")
+    mn_by_month = window_grouped.min("time", skipna=True)
+    mx_by_month = window_grouped.max("time", skipna=True)
+    # For each timestep in da, look up its calendar month's window min/max.
+    months_da = da["time"].dt.month
+    mn = mn_by_month.sel(month=months_da)
+    mx = mx_by_month.sel(month=months_da)
+    rng = mx - mn
+    safe_rng = rng.where(rng > 0)
+    norm = (da - mn) / safe_rng
+    norm.attrs = dict(da.attrs)
+    norm.attrs["units"] = "1"
+    return norm
+
+
 def multi_source_minmax(datasets: list) -> tuple:
     """Compute lower/upper bounds as min/max across a list of DataArrays."""
     raise NotImplementedError

--- a/src/nhf_spatial_targets/normalize/methods.py
+++ b/src/nhf_spatial_targets/normalize/methods.py
@@ -10,14 +10,75 @@ import xarray as xr
 logger = logging.getLogger(__name__)
 
 
-def normalize_0_1(da, dim: str = "time") -> object:
-    """Normalize an xarray DataArray to [0, 1] over the given dimension."""
-    raise NotImplementedError
+def normalize_0_1(da: xr.DataArray, dim: str = "time") -> xr.DataArray:
+    """Min/max normalize a DataArray to [0, 1] along ``dim``.
+
+    Each non-``dim`` cell is independently normalized using its own min/max
+    over ``dim``::
+
+        norm = (x - x.min(dim)) / (x.max(dim) - x.min(dim))
+
+    NaNs along ``dim`` are ignored when computing min/max (``skipna=True``).
+    Cells where the range is zero (constant series or all-NaN) yield NaN —
+    a zero-range normalization is undefined and a sentinel like 0.5 would
+    fabricate spurious "middle of the range" coverage that the
+    multi-source min/max combiner would then propagate as a real bound.
+
+    The original variable's ``units`` attr is replaced with ``"1"``
+    (dimensionless); other attrs are preserved.
+
+    Used by normalized_minmax targets (recharge, soil_moisture) to bring
+    sources with different native units onto a common 0-1 scale before
+    multi-source min/max combination, per TM 6-B10 §3 and §4.
+    """
+    if dim not in da.dims:
+        raise ValueError(
+            f"normalize_0_1: dim {dim!r} not in DataArray dims {tuple(da.dims)!r}"
+        )
+    mn = da.min(dim=dim, skipna=True)
+    mx = da.max(dim=dim, skipna=True)
+    rng = mx - mn
+    # Zero-range mask: cells where every value is the same (or all-NaN).
+    # xr arithmetic with a True mask propagates NaN through the division.
+    safe_rng = rng.where(rng > 0)
+    norm = (da - mn) / safe_rng
+    norm.attrs = dict(da.attrs)
+    norm.attrs["units"] = "1"
+    return norm
 
 
-def normalize_by_calendar_month(da) -> object:
-    """Normalize per calendar month: each month normalized independently."""
-    raise NotImplementedError
+def normalize_0_1_by_calendar_month(da: xr.DataArray) -> xr.DataArray:
+    """Min/max normalize a DataArray to [0, 1] **per calendar month**.
+
+    Each calendar month is normalized independently — all Januaries across
+    the input period are pooled and normalized to [0, 1]; all Februaries
+    are pooled separately and normalized to [0, 1]; etc. This is the
+    monthly soil-moisture target's normalization per TM 6-B10 §4 Appendix 1:
+    cross-month seasonality is removed so the bound reflects relative wet/dry
+    *within* each month rather than absolute differences between January and
+    July.
+
+    Implementation: groupby ``time.month`` and apply :func:`normalize_0_1`
+    along ``time`` within each group. The output preserves the input's
+    ``(time, ...)`` shape and order; only ``units`` is replaced with
+    ``"1"``.
+
+    Requires a monotonic ``time`` coordinate (no shuffling required, but
+    the groupby relies on the time dim being addressable).
+    """
+    if "time" not in da.dims:
+        raise ValueError(
+            f"normalize_0_1_by_calendar_month: expected 'time' dim, got "
+            f"{tuple(da.dims)!r}"
+        )
+    grouped = da.groupby("time.month")
+    norm = grouped.map(lambda g: normalize_0_1(g, dim="time"))
+    # `groupby.map` drops the synthetic 'month' coord automatically when the
+    # callable returns same-dim output; the result is back on the original
+    # time index. Re-stamp units to be unambiguous.
+    norm.attrs = dict(da.attrs)
+    norm.attrs["units"] = "1"
+    return norm
 
 
 def multi_source_minmax(datasets: list) -> tuple:

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -486,3 +486,313 @@ def write_target_nc(
         tmp.unlink(missing_ok=True)
         raise
     logger.info("Wrote %s (%.1f MB)", output_path, output_path.stat().st_size / 1e6)
+
+
+# ---------------------------------------------------------------------------
+# Shared target-builder helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_period(period_str: str) -> tuple[str, str]:
+    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into ``(start, end)``.
+
+    Used by every target builder to split the project config's
+    ``<target>.period`` (and ``<target>.normalize_period`` where present)
+    into the two endpoints needed to slice ``read_aggregated_source``'s
+    output.
+    """
+    if "/" not in period_str:
+        raise ValueError(
+            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
+        )
+    start, end = period_str.split("/", 1)
+    return start.strip(), end.strip()
+
+
+def check_hru_coords(
+    da: xr.DataArray,
+    fabric_hru_ids: np.ndarray,
+    id_col: str,
+    source_key: str,
+) -> None:
+    """Raise if the source DataArray's HRU dim disagrees with the fabric.
+
+    Both sides are expected to be sorted ascending by ``id_col`` upstream
+    (``compute_hru_*`` helpers and ``read_aggregated_source`` enforce
+    this). Three outcomes:
+
+    - Coords match exactly: returns ``None``.
+    - Coords have the SAME SET but a different order: raises with a
+      "canonical-sort invariant regression" message — the upstream
+      sort-on-emission contract (#93) has been broken somewhere.
+    - Coords have different SETS: raises a "re-aggregate this source
+      against the current fabric" message.
+
+    Called by target builders right after ``read_aggregated_source``
+    so any HRU misalignment is caught before silent broadcast/intersect
+    arithmetic poisons downstream values.
+    """
+    src_hru_ids = da[id_col].values
+    if np.array_equal(src_hru_ids, fabric_hru_ids):
+        return
+    same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
+        np.sort(src_hru_ids), np.sort(fabric_hru_ids)
+    )
+    if same_set:
+        raise ValueError(
+            f"HRU coords for source '{source_key}' have the same set as the "
+            f"fabric ({len(fabric_hru_ids)} HRUs) but a different order. "
+            f"Both sides are expected to be sorted ascending by id_col="
+            f"'{id_col}' — this indicates a regression in the canonical-"
+            f"sort invariant in targets/_common.py."
+        )
+    raise ValueError(
+        f"HRU coords differ between fabric and source '{source_key}' as "
+        f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
+        f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
+        f"source has {len(src_hru_ids)} "
+        f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
+        f"Re-aggregate '{source_key}' against the current fabric."
+    )
+
+
+def build_n_sources_attrs(
+    n_sources_count: int,
+    ancillary_coords: str = "centroid_lat centroid_lon",
+) -> dict:
+    """Build the per-variable attrs dict for an ``n_sources`` diagnostic var.
+
+    Parameters
+    ----------
+    n_sources_count
+        Number of source contributors (an integer ≥ 0 and ≤ 5). Determines
+        the length of the ``flag_values`` list and the matching
+        ``flag_meanings`` labels (``none one two three four five``,
+        truncated to ``n_sources_count + 1`` entries).
+    ancillary_coords
+        Space-separated list of ancillary coordinate variable names to
+        record under CF's ``coordinates`` attr. Defaults to the centroid
+        pair used by every target builder.
+    """
+    flag_labels = ["none", "one", "two", "three", "four", "five"]
+    if n_sources_count + 1 > len(flag_labels):
+        raise ValueError(
+            f"build_n_sources_attrs: n_sources_count={n_sources_count} exceeds "
+            f"the {len(flag_labels) - 1}-source label vocabulary."
+        )
+    return {
+        "units": "1",
+        "long_name": "number of finite source contributions",
+        "flag_values": list(range(0, n_sources_count + 1)),
+        "flag_meanings": " ".join(flag_labels[: n_sources_count + 1]),
+        "coordinates": ancillary_coords,
+    }
+
+
+def write_bounds_target(
+    *,
+    project: Project,
+    lower: xr.DataArray,
+    upper: xr.DataArray,
+    n_sources: xr.DataArray,
+    n_sources_count: int,
+    time_index: pd.DatetimeIndex,
+    time_offset_unit: object,
+    bounds_units: str,
+    bounds_long_name_kind: str,
+    cell_methods: str,
+    output_path: Path,
+    title: str,
+    nn_title: str,
+    extra_global_attrs: dict,
+    hru_meta: "pd.DataFrame",
+    nn_fill: bool,
+    nn_max_candidates: int,
+    id_col: str,
+) -> None:
+    """Assemble + write a bounds-target Dataset, with optional NN-fill companion.
+
+    Consolidates the assemble-and-write pipeline shared by every target
+    builder (runoff, AET, recharge, soil moisture): centroid coords,
+    ``time_bnds``, per-variable attrs (units / long_name / cell_methods /
+    coordinates), global attrs, atomic write via ``write_target_nc``, a
+    coverage-summary log line, and the optional ``nn_fill_bounds``
+    companion file.
+
+    Parameters
+    ----------
+    project
+        Loaded :class:`~nhf_spatial_targets.workspace.Project`.
+    lower, upper, n_sources
+        The three combined-source DataArrays from
+        :func:`multi_source_nanminmax`.
+    n_sources_count
+        Total number of source contributors (an int); drives the
+        ``n_sources`` diagnostic's ``flag_values`` length.
+    time_index
+        Master ``DatetimeIndex`` that ``lower`` / ``upper`` are aligned to.
+    time_offset_unit
+        Offset added to each ``time_index`` entry to form ``time_bnds``'s
+        upper edge (e.g. ``pd.offsets.MonthBegin(1)`` for monthly,
+        ``pd.offsets.YearBegin(1)`` for annual).
+    bounds_units
+        Units string for the lower/upper variable attrs (e.g. ``"cfs"``,
+        ``"inches/day"``, ``"1"``).
+    bounds_long_name_kind
+        Substituted into the ``long_name`` template: ``"lower bound of
+        {kind} (NaN-aware min across sources)"``. Examples: ``"monthly
+        runoff"``, ``"annual recharge"``.
+    cell_methods
+        CF ``cell_methods`` attr value for both bounds (e.g.
+        ``"time: sum"``, ``"time: mean"``).
+    output_path
+        Final NetCDF path for the unfilled target.
+    title
+        ``title`` global attr for the unfilled target.
+    nn_title
+        ``title`` global attr for the NN-filled companion (only used when
+        ``nn_fill`` is True).
+    extra_global_attrs
+        Per-target metadata (``source``, ``period``, ``fabric_sha256``,
+        etc.) — passed through to ``write_target_nc``.
+    hru_meta
+        DataFrame returned by ``compute_hru_centroids`` (or the combined
+        helper). Must contain ``centroid_lat``, ``centroid_lon``,
+        ``centroid_x``, ``centroid_y`` columns.
+    nn_fill
+        If True, additionally write ``<output>_nn_filled.nc`` via
+        :func:`nn_fill_bounds`.
+    nn_max_candidates
+        Forwarded to :func:`nn_fill_bounds`.
+    id_col
+        HRU id column name (e.g. ``"nhm_id"``); the dataset is sorted
+        ascending on this dim at emission per the #93 canonical-row-order
+        invariant.
+    """
+    # Avoid a circular-import by deferring this helper-internal import.
+    from nhf_spatial_targets.normalize.methods import nn_fill_bounds
+
+    lower.name = "lower_bound"
+    upper.name = "upper_bound"
+    n_sources.name = "n_sources"
+
+    time_bnds = xr.DataArray(
+        list(zip(time_index.values, (time_index + time_offset_unit).values)),
+        dims=("time", "nv"),
+        coords={"time": time_index.values},
+        name="time_bnds",
+    )
+    centroid_lat = xr.DataArray(
+        hru_meta["centroid_lat"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_north",
+            "standard_name": "latitude",
+            "long_name": "HRU centroid latitude",
+        },
+    )
+    centroid_lon = xr.DataArray(
+        hru_meta["centroid_lon"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_east",
+            "standard_name": "longitude",
+            "long_name": "HRU centroid longitude",
+        },
+    )
+
+    lower.attrs.update(
+        {
+            "units": bounds_units,
+            "long_name": (
+                f"lower bound of {bounds_long_name_kind} (NaN-aware min across sources)"
+            ),
+            "cell_methods": cell_methods,
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    upper.attrs.update(
+        {
+            "units": bounds_units,
+            "long_name": (
+                f"upper bound of {bounds_long_name_kind} (NaN-aware max across sources)"
+            ),
+            "cell_methods": cell_methods,
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    n_sources.attrs.update(build_n_sources_attrs(n_sources_count))
+
+    ds = xr.Dataset(
+        {
+            "lower_bound": lower,
+            "upper_bound": upper,
+            "n_sources": n_sources,
+        },
+        coords={
+            "time": time_index,
+            id_col: lower[id_col],
+            "time_bnds": time_bnds,
+            "centroid_lat": centroid_lat,
+            "centroid_lon": centroid_lon,
+        },
+    )
+    ds["time"].attrs["bounds"] = "time_bnds"
+    ds["time"].attrs["axis"] = "T"
+    ds["time"].attrs["standard_name"] = "time"
+    ds[id_col].attrs["long_name"] = "HRU identifier"
+    ds[id_col].attrs["cf_role"] = "timeseries_id"
+
+    ds_loaded = ds.compute()
+
+    write_target_nc(
+        ds_loaded,
+        output_path,
+        title=title,
+        extra_global_attrs=extra_global_attrs,
+        sort_dim=id_col,
+    )
+
+    n = ds_loaded["n_sources"].values
+    total = n.size
+    none = int((n == 0).sum())
+    logger.info(
+        "%s coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
+        bounds_long_name_kind,
+        total - none,
+        total,
+        100.0 * none / total if total else 0.0,
+    )
+
+    if not nn_fill:
+        return
+
+    centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
+    filled_ds, nn_diag = nn_fill_bounds(
+        ds_loaded, centroids_xy, max_candidates=nn_max_candidates
+    )
+    nn_diag.attrs.update(
+        {
+            "units": "1",
+            "long_name": "nearest-neighbor fill flag",
+            "flag_values": [0, 1],
+            "flag_meanings": "not_filled filled",
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    filled_ds["nn_filled"] = nn_diag
+    filled_attrs = dict(extra_global_attrs)
+    filled_attrs["nn_fill_max_candidates"] = nn_max_candidates
+    filled_attrs["nn_fill_distance_crs"] = project.area_crs
+    nn_path = output_path.with_name(
+        output_path.stem + "_nn_filled" + output_path.suffix
+    )
+    write_target_nc(
+        filled_ds,
+        nn_path,
+        title=nn_title,
+        extra_global_attrs=filled_attrs,
+        sort_dim=id_col,
+    )

--- a/src/nhf_spatial_targets/targets/aet.py
+++ b/src/nhf_spatial_targets/targets/aet.py
@@ -37,15 +37,16 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from nhf_spatial_targets.normalize.methods import nn_fill_bounds
 from nhf_spatial_targets.targets._common import (
     SourceShim,
+    check_hru_coords,
     compute_hru_centroids,
     multi_source_nanminmax,
+    parse_period,
     read_aggregated_source,
     reindex_to_month_start,
     shims_by_key,
-    write_target_nc,
+    write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
 
@@ -194,16 +195,6 @@ def mm_per_month_to_inches_per_day(da: xr.DataArray) -> xr.DataArray:
 # ---------------------------------------------------------------------------
 
 
-def _parse_period(period_str: str) -> tuple[str, str]:
-    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
-    if "/" not in period_str:
-        raise ValueError(
-            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
-        )
-    start, end = period_str.split("/", 1)
-    return start.strip(), end.strip()
-
-
 def build(project: Project) -> None:
     """Build the AET calibration target.
 
@@ -214,7 +205,7 @@ def build(project: Project) -> None:
     ``aet_targets_nn_filled.nc``.
     """
     aet_cfg = project.target("aet")
-    period = _parse_period(aet_cfg["period"])
+    period = parse_period(aet_cfg["period"])
     sources = list(aet_cfg["sources"])
     chunk_months = int(aet_cfg["chunk_months"])
 
@@ -260,115 +251,15 @@ def build(project: Project) -> None:
             period,
             chunks={"time": chunk_months, id_col: -1},
         )
-        # HRU coord check (same canonical-sort invariant as runoff target).
-        src_hru_ids = da_native[id_col].values
-        if not np.array_equal(src_hru_ids, fabric_hru_ids):
-            same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
-                np.sort(src_hru_ids), np.sort(fabric_hru_ids)
-            )
-            if same_set:
-                raise ValueError(
-                    f"HRU coords for source '{src}' have the same set as the "
-                    f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
-                    f"order. Both sides are expected to be sorted ascending by "
-                    f"id_col='{id_col}' — this indicates a regression in the "
-                    f"canonical-sort invariant in targets/_common.py."
-                )
-            raise ValueError(
-                f"HRU coords differ between fabric and source '{src}' as "
-                f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
-                f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
-                f"source has {len(src_hru_ids)} "
-                f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
-                f"Re-aggregate '{src}' against the current fabric."
-            )
+        check_hru_coords(da_native, fabric_hru_ids, id_col, src)
         da_mm = shim.to_common_units(da_native)
         da_in_day = mm_per_month_to_inches_per_day(da_mm)
         sources_in_day[src] = reindex_to_month_start(da_in_day, master_idx)
 
-    # 4. NaN-aware combination.
+    # 4. NaN-aware combination across sources.
     lower, upper, n_sources = multi_source_nanminmax(sources_in_day)
-    lower.name = "lower_bound"
-    upper.name = "upper_bound"
-    n_sources.name = "n_sources"
 
-    # 5. Assemble Dataset with CF metadata + ancillary coords.
-    time_bnds = xr.DataArray(
-        list(zip(master_idx.values, (master_idx + pd.offsets.MonthBegin(1)).values)),
-        dims=("time", "nv"),
-        coords={"time": master_idx.values},
-        name="time_bnds",
-    )
-    centroid_lat = xr.DataArray(
-        hru_meta["centroid_lat"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_north",
-            "standard_name": "latitude",
-            "long_name": "HRU centroid latitude",
-        },
-    )
-    centroid_lon = xr.DataArray(
-        hru_meta["centroid_lon"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_east",
-            "standard_name": "longitude",
-            "long_name": "HRU centroid longitude",
-        },
-    )
-
-    lower.attrs.update(
-        {
-            "units": "inches/day",
-            "long_name": ("lower bound of monthly AET (NaN-aware min across sources)"),
-            "cell_methods": "time: mean",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    upper.attrs.update(
-        {
-            "units": "inches/day",
-            "long_name": ("upper bound of monthly AET (NaN-aware max across sources)"),
-            "cell_methods": "time: mean",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    n_sources.attrs.update(
-        {
-            "units": "1",
-            "long_name": "number of finite source contributions",
-            "flag_values": list(range(0, len(sources) + 1)),
-            "flag_meanings": " ".join(
-                ["none", "one", "two", "three", "four", "five"][: len(sources) + 1]
-            ),
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-
-    ds = xr.Dataset(
-        {
-            "lower_bound": lower,
-            "upper_bound": upper,
-            "n_sources": n_sources,
-        },
-        coords={
-            "time": master_idx,
-            id_col: lower[id_col],
-            "time_bnds": time_bnds,
-            "centroid_lat": centroid_lat,
-            "centroid_lon": centroid_lon,
-        },
-    )
-    ds["time"].attrs["bounds"] = "time_bnds"
-    ds["time"].attrs["axis"] = "T"
-    ds["time"].attrs["standard_name"] = "time"
-    ds["time"].attrs["long_name"] = "time at month start"
-    ds[id_col].attrs["long_name"] = "HRU identifier"
-    ds[id_col].attrs["cf_role"] = "timeseries_id"
-
+    # 5. Assemble + write (with optional NN-fill companion).
     extra_attrs = {
         "source": "; ".join(shims[s].description for s in sources),
         "references": "Hay et al. 2022, doi:10.3133/tm6B10",
@@ -377,57 +268,24 @@ def build(project: Project) -> None:
         "period": aet_cfg["period"],
         "area_crs": project.area_crs,
     }
-
-    ds_loaded = ds.compute()
-
     output_path = project.targets_dir() / aet_cfg["output_file"]
-    write_target_nc(
-        ds_loaded,
-        output_path,
+    write_bounds_target(
+        project=project,
+        lower=lower,
+        upper=upper,
+        n_sources=n_sources,
+        n_sources_count=len(sources),
+        time_index=master_idx,
+        time_offset_unit=pd.offsets.MonthBegin(1),
+        bounds_units="inches/day",
+        bounds_long_name_kind="monthly AET",
+        cell_methods="time: mean",
+        output_path=output_path,
         title="NHM AET calibration target (lower/upper bounds in inches/day)",
+        nn_title="NHM AET calibration target (NN-filled, inches/day)",
         extra_global_attrs=extra_attrs,
-        sort_dim=id_col,
+        hru_meta=hru_meta,
+        nn_fill=aet_cfg["nn_fill"],
+        nn_max_candidates=int(aet_cfg["nn_max_candidates"]),
+        id_col=id_col,
     )
-
-    n = ds_loaded["n_sources"].values
-    total = n.size
-    none = int((n == 0).sum())
-    logger.info(
-        "Coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
-        total - none,
-        total,
-        100.0 * none / total if total else 0.0,
-    )
-
-    # 6. NN-fill (optional).
-    if aet_cfg["nn_fill"]:
-        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
-        filled_ds, nn_diag = nn_fill_bounds(
-            ds_loaded,
-            centroids_xy,
-            max_candidates=int(aet_cfg["nn_max_candidates"]),
-        )
-        nn_diag.attrs.update(
-            {
-                "units": "1",
-                "long_name": "nearest-neighbor fill flag",
-                "flag_values": [0, 1],
-                "flag_meanings": "not_filled filled",
-                "coordinates": "centroid_lat centroid_lon",
-            }
-        )
-        filled_ds["nn_filled"] = nn_diag
-        filled_attrs = dict(extra_attrs)
-        filled_attrs["nn_fill_max_candidates"] = int(aet_cfg["nn_max_candidates"])
-        filled_attrs["nn_fill_distance_crs"] = project.area_crs
-
-        nn_path = output_path.with_name(
-            output_path.stem + "_nn_filled" + output_path.suffix
-        )
-        write_target_nc(
-            filled_ds,
-            nn_path,
-            title="NHM AET calibration target (NN-filled, inches/day)",
-            extra_global_attrs=filled_attrs,
-            sort_dim=id_col,
-        )

--- a/src/nhf_spatial_targets/targets/rch.py
+++ b/src/nhf_spatial_targets/targets/rch.py
@@ -1,23 +1,420 @@
-"""Build recharge calibration targets.
+"""Build recharge calibration targets from Reitz 2017 + WaterGAP 2.2d + ERA5-Land.
 
-Sources (per catalog/variables.yml):
-  - reitz2017: total_recharge (in/yr)
-  - watergap22d: groundwater_recharge (kg m-2 s-1, → mm/yr)
-  - era5_land: ssro summed monthly→annual (m water-eq, → mm/yr)
+Three annual-cadence sources contribute to per-HRU per-year bounds in
+dimensionless [0, 1] (per ``catalog/variables.yml`` → ``recharge.units``):
 
-Method: each source aggregated to HRU, normalized 0-1 per HRU over
-2000-2009, then per-HRU per-year lower/upper = min/max across the three
-normalized sources.
+  - Reitz 2017 ``total_recharge``  (m/year, native annual; mid-year timestamp)
+  - WaterGAP 2.2d ``qrdif``         (kg m-2 s-1, native monthly mean rate)
+  - ERA5-Land ``ssro``              (m water-eq, native monthly accumulation;
+                                    end-of-month timestamp)
+
+Per-source pipeline (Option D from PR #132 review consider-2 — the shim
+absorbs unit conversion AND any monthly→annual aggregation; rch's
+``to_common_units`` is mm/year at year-start):
+
+  - reitz2017: × 1000 → mm/year, time canonicalized to year-start
+  - watergap22d: × (days_in_month × 86400) per month → mm/month, sum to mm/year
+  - era5_land ssro: × 1000 per month → mm/month, sum to mm/year
+
+Each source is then independently normalized to [0, 1] using its own
+min/max over the configured ``normalize_period`` (TM 6-B10 §3 default:
+2000-01-01 / 2009-12-31). The multi-source NaN-aware min/max combines
+the three normalized series per HRU per year; the bound is NaN only when
+every source is NaN at that (HRU, year), which is exactly when
+``n_sources == 0``.
+
+If ``recharge.nn_fill`` is True (default), a second file
+``<output>_nn_filled.nc`` is written with bound NaNs filled by the
+nearest finite HRU's value at the same time step.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
 
-if TYPE_CHECKING:
-    from nhf_spatial_targets.workspace import Project
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.normalize.methods import nn_fill_bounds
+from nhf_spatial_targets.targets._common import (
+    SourceShim,
+    compute_hru_centroids,
+    multi_source_nanminmax,
+    read_aggregated_source,
+    shims_by_key,
+    write_target_nc,
+)
+from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
 
 
-def build(project: "Project") -> None:
-    """Build recharge target dataset."""
-    raise NotImplementedError
+_SECONDS_PER_DAY = 86400.0
+
+
+# ---------------------------------------------------------------------------
+# Per-source shims (mm/year at year-start is the common intermediate)
+# ---------------------------------------------------------------------------
+
+
+def reitz_to_mm_per_year(da: xr.DataArray) -> xr.DataArray:
+    """Reitz 2017 ``total_recharge`` (m/year, mid-year timestamp) → mm/year.
+
+    Time coord is canonicalized to year-start via a year-resampled mean
+    (the mean is a no-op for native annual data with one timestamp per
+    year; the resample shifts the mid-year label to year-start).
+    """
+    mm = da * 1000.0
+    annual = mm.resample(time="YS").mean()
+    annual.attrs = dict(da.attrs)
+    annual.attrs["units"] = "mm"
+    return annual
+
+
+def watergap22d_to_mm_per_year(da: xr.DataArray) -> xr.DataArray:
+    """WaterGAP 2.2d ``qrdif`` (kg m-2 s-1, monthly mean rate) → mm/year.
+
+    Per month: × (days_in_month × 86400) → mm/month (kg/m² ≡ mm). Then
+    sum 12 months per year → mm/year at year-start.
+    """
+    seconds_in_month = da["time"].dt.days_in_month * _SECONDS_PER_DAY
+    monthly_mm = da * seconds_in_month
+    annual = monthly_mm.resample(time="YS").sum(skipna=True)
+    annual.attrs = dict(da.attrs)
+    annual.attrs["units"] = "mm"
+    return annual
+
+
+def era5_ssro_to_mm_per_year(da: xr.DataArray) -> xr.DataArray:
+    """ERA5-Land ``ssro`` (m water-eq, monthly accumulation) → mm/year.
+
+    × 1000 per month → mm/month, then sum 12 months per year → mm/year
+    at year-start. End-of-month timestamps from ERA5 land in the correct
+    calendar year (Dec 31 ∈ year Y, not Y+1), so the resample groups
+    them correctly.
+    """
+    monthly_mm = da * 1000.0
+    annual = monthly_mm.resample(time="YS").sum(skipna=True)
+    annual.attrs = dict(da.attrs)
+    annual.attrs["units"] = "mm"
+    return annual
+
+
+SHIMS: tuple[SourceShim, ...] = (
+    SourceShim(
+        source_key="reitz2017",
+        aggregated_var="total_recharge",
+        description="Reitz 2017 total_recharge (m/year → mm/year)",
+        to_common_units=reitz_to_mm_per_year,
+    ),
+    SourceShim(
+        source_key="watergap22d",
+        aggregated_var="qrdif",
+        description=("WaterGAP 2.2d qrdif (kg/m²/s monthly rate, summed to mm/year)"),
+        to_common_units=watergap22d_to_mm_per_year,
+    ),
+    SourceShim(
+        source_key="era5_land",
+        aggregated_var="ssro",
+        description="ERA5-Land ssro (m/month, summed to mm/year)",
+        to_common_units=era5_ssro_to_mm_per_year,
+    ),
+)
+
+
+def _normalize_0_1_over_window(
+    da: xr.DataArray, window: xr.DataArray, dim: str = "time"
+) -> xr.DataArray:
+    """Normalize ``da`` to [0, 1] using ``window``'s min/max along ``dim``.
+
+    Like :func:`normalize_0_1` but the min/max are computed over a subset
+    of ``da`` (the normalization period). Values in ``da`` outside the
+    window may produce values < 0 or > 1 — by design: TM 6-B10 §3 says
+    the bound reflects the calibration-period climatology, and a future
+    year outside that climatology should be visibly out-of-range, not
+    silently re-normalized.
+    """
+    mn = window.min(dim=dim, skipna=True)
+    mx = window.max(dim=dim, skipna=True)
+    rng = mx - mn
+    safe_rng = rng.where(rng > 0)
+    norm = (da - mn) / safe_rng
+    norm.attrs = dict(da.attrs)
+    norm.attrs["units"] = "1"
+    return norm
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _parse_period(period_str: str) -> tuple[str, str]:
+    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
+    if "/" not in period_str:
+        raise ValueError(
+            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
+        )
+    start, end = period_str.split("/", 1)
+    return start.strip(), end.strip()
+
+
+def build(project: Project) -> None:
+    """Build the recharge calibration target.
+
+    Reads each enabled source's per-year aggregated NCs, harmonizes onto
+    a master year-start index over ``recharge.period``, normalizes each
+    independently to [0, 1] using its min/max over
+    ``recharge.normalize_period``, combines via NaN-aware min/max, and
+    writes a CF-1.6 NetCDF. If ``recharge.nn_fill`` is True, also writes
+    ``recharge_targets_nn_filled.nc``.
+    """
+    rch_cfg = project.target("recharge")
+    period = _parse_period(rch_cfg["period"])
+    normalize_period = _parse_period(rch_cfg["normalize_period"])
+    sources = list(rch_cfg["sources"])
+
+    logger.info(
+        "Building recharge target: %d sources (%s), period %s..%s, "
+        "normalize_period %s..%s, fabric=%s",
+        len(sources),
+        ",".join(sources),
+        period[0],
+        period[1],
+        normalize_period[0],
+        normalize_period[1],
+        project.config["fabric"]["path"],
+    )
+
+    # 1. Per-HRU centroids for NN-fill (no area conversion needed).
+    hru_meta = compute_hru_centroids(project)
+    id_col = project.id_col
+
+    # 2. Master year-start index over the requested period.
+    master_idx = pd.date_range(period[0], period[1], freq="YS")
+    if len(master_idx) == 0:
+        raise ValueError(
+            f"recharge.period {rch_cfg['period']} produces no years at "
+            "freq='YS'. Check the date range."
+        )
+
+    # 3. Read, harmonize, normalize each source.
+    shims = shims_by_key(SHIMS)
+    fabric_hru_ids = hru_meta.index.values
+    sources_normalized: dict[str, xr.DataArray] = {}
+    for src in sources:
+        if src not in shims:
+            raise ValueError(
+                f"recharge.sources includes unknown source '{src}'. "
+                f"Known: {sorted(shims)}"
+            )
+        shim = shims[src]
+        # Period for read: union of output period and normalize_period so we
+        # have enough data to (a) emit on the output period and (b) compute
+        # min/max over the normalize_period.
+        read_start = min(period[0], normalize_period[0])
+        read_end = max(period[1], normalize_period[1])
+        da_native = read_aggregated_source(
+            project,
+            shim.source_key,
+            shim.aggregated_var,
+            (read_start, read_end),
+            chunks={"time": 12, id_col: -1},
+        )
+        # HRU coord check (canonical-sort invariant, same as runoff/aet).
+        src_hru_ids = da_native[id_col].values
+        if not np.array_equal(src_hru_ids, fabric_hru_ids):
+            same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
+                np.sort(src_hru_ids), np.sort(fabric_hru_ids)
+            )
+            if same_set:
+                raise ValueError(
+                    f"HRU coords for source '{src}' have the same set as the "
+                    f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
+                    f"order. Both sides are expected to be sorted ascending by "
+                    f"id_col='{id_col}' — this indicates a regression in the "
+                    f"canonical-sort invariant in targets/_common.py."
+                )
+            raise ValueError(
+                f"HRU coords differ between fabric and source '{src}' as "
+                f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
+                f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
+                f"source has {len(src_hru_ids)} "
+                f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
+                f"Re-aggregate '{src}' against the current fabric."
+            )
+        da_annual_mm = shim.to_common_units(da_native)
+        # Normalize using normalize_period's min/max; project onto master_idx.
+        window = da_annual_mm.sel(time=slice(normalize_period[0], normalize_period[1]))
+        if window.sizes.get("time", 0) == 0:
+            raise ValueError(
+                f"recharge.normalize_period {rch_cfg['normalize_period']} "
+                f"yields no annual timesteps for source '{src}'. "
+                f"Source covers {da_annual_mm.time.values[0]} .. "
+                f"{da_annual_mm.time.values[-1]}."
+            )
+        da_normalized = _normalize_0_1_over_window(da_annual_mm, window)
+        # Reindex to master year-start index (NaN-pads years the source
+        # doesn't cover; the multi-source min/max handles partial coverage).
+        sources_normalized[src] = da_normalized.reindex(time=master_idx)
+
+    # 4. NaN-aware combination across normalized sources.
+    lower, upper, n_sources = multi_source_nanminmax(sources_normalized)
+    lower.name = "lower_bound"
+    upper.name = "upper_bound"
+    n_sources.name = "n_sources"
+
+    # 5. Assemble Dataset with CF metadata + ancillary coords.
+    time_bnds = xr.DataArray(
+        list(
+            zip(
+                master_idx.values,
+                (master_idx + pd.offsets.YearBegin(1)).values,
+            )
+        ),
+        dims=("time", "nv"),
+        coords={"time": master_idx.values},
+        name="time_bnds",
+    )
+    centroid_lat = xr.DataArray(
+        hru_meta["centroid_lat"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_north",
+            "standard_name": "latitude",
+            "long_name": "HRU centroid latitude",
+        },
+    )
+    centroid_lon = xr.DataArray(
+        hru_meta["centroid_lon"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_east",
+            "standard_name": "longitude",
+            "long_name": "HRU centroid longitude",
+        },
+    )
+
+    lower.attrs.update(
+        {
+            "units": "1",
+            "long_name": (
+                "lower bound of annual recharge "
+                "(NaN-aware min across normalized sources)"
+            ),
+            "cell_methods": "time: sum",
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    upper.attrs.update(
+        {
+            "units": "1",
+            "long_name": (
+                "upper bound of annual recharge "
+                "(NaN-aware max across normalized sources)"
+            ),
+            "cell_methods": "time: sum",
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    n_sources.attrs.update(
+        {
+            "units": "1",
+            "long_name": "number of finite source contributions",
+            "flag_values": list(range(0, len(sources) + 1)),
+            "flag_meanings": " ".join(
+                ["none", "one", "two", "three", "four", "five"][: len(sources) + 1]
+            ),
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+
+    ds = xr.Dataset(
+        {
+            "lower_bound": lower,
+            "upper_bound": upper,
+            "n_sources": n_sources,
+        },
+        coords={
+            "time": master_idx,
+            id_col: lower[id_col],
+            "time_bnds": time_bnds,
+            "centroid_lat": centroid_lat,
+            "centroid_lon": centroid_lon,
+        },
+    )
+    ds["time"].attrs["bounds"] = "time_bnds"
+    ds["time"].attrs["axis"] = "T"
+    ds["time"].attrs["standard_name"] = "time"
+    ds["time"].attrs["long_name"] = "time at year start"
+    ds[id_col].attrs["long_name"] = "HRU identifier"
+    ds[id_col].attrs["cf_role"] = "timeseries_id"
+
+    extra_attrs = {
+        "source": "; ".join(shims[s].description for s in sources),
+        "references": "Hay et al. 2022, doi:10.3133/tm6B10",
+        "fabric": project.config["fabric"]["path"],
+        "fabric_sha256": project.fabric.get("sha256", ""),
+        "period": rch_cfg["period"],
+        "normalize_period": rch_cfg["normalize_period"],
+        "area_crs": project.area_crs,
+    }
+
+    ds_loaded = ds.compute()
+
+    output_path = project.targets_dir() / rch_cfg["output_file"]
+    write_target_nc(
+        ds_loaded,
+        output_path,
+        title=(
+            "NHM recharge calibration target (lower/upper bounds, dimensionless 0-1)"
+        ),
+        extra_global_attrs=extra_attrs,
+        sort_dim=id_col,
+    )
+
+    n = ds_loaded["n_sources"].values
+    total = n.size
+    none = int((n == 0).sum())
+    logger.info(
+        "Coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
+        total - none,
+        total,
+        100.0 * none / total if total else 0.0,
+    )
+
+    # 6. NN-fill (optional).
+    if rch_cfg["nn_fill"]:
+        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
+        filled_ds, nn_diag = nn_fill_bounds(
+            ds_loaded,
+            centroids_xy,
+            max_candidates=int(rch_cfg["nn_max_candidates"]),
+        )
+        nn_diag.attrs.update(
+            {
+                "units": "1",
+                "long_name": "nearest-neighbor fill flag",
+                "flag_values": [0, 1],
+                "flag_meanings": "not_filled filled",
+                "coordinates": "centroid_lat centroid_lon",
+            }
+        )
+        filled_ds["nn_filled"] = nn_diag
+        filled_attrs = dict(extra_attrs)
+        filled_attrs["nn_fill_max_candidates"] = int(rch_cfg["nn_max_candidates"])
+        filled_attrs["nn_fill_distance_crs"] = project.area_crs
+
+        nn_path = output_path.with_name(
+            output_path.stem + "_nn_filled" + output_path.suffix
+        )
+        write_target_nc(
+            filled_ds,
+            nn_path,
+            title=("NHM recharge calibration target (NN-filled, dimensionless 0-1)"),
+            extra_global_attrs=filled_attrs,
+            sort_dim=id_col,
+        )

--- a/src/nhf_spatial_targets/targets/rch.py
+++ b/src/nhf_spatial_targets/targets/rch.py
@@ -32,18 +32,19 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 
-from nhf_spatial_targets.normalize.methods import nn_fill_bounds
+from nhf_spatial_targets.normalize.methods import normalize_0_1_over_window
 from nhf_spatial_targets.targets._common import (
     SourceShim,
+    check_hru_coords,
     compute_hru_centroids,
     multi_source_nanminmax,
+    parse_period,
     read_aggregated_source,
     shims_by_key,
-    write_target_nc,
+    write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
 
@@ -123,41 +124,9 @@ SHIMS: tuple[SourceShim, ...] = (
 )
 
 
-def _normalize_0_1_over_window(
-    da: xr.DataArray, window: xr.DataArray, dim: str = "time"
-) -> xr.DataArray:
-    """Normalize ``da`` to [0, 1] using ``window``'s min/max along ``dim``.
-
-    Like :func:`normalize_0_1` but the min/max are computed over a subset
-    of ``da`` (the normalization period). Values in ``da`` outside the
-    window may produce values < 0 or > 1 — by design: TM 6-B10 §3 says
-    the bound reflects the calibration-period climatology, and a future
-    year outside that climatology should be visibly out-of-range, not
-    silently re-normalized.
-    """
-    mn = window.min(dim=dim, skipna=True)
-    mx = window.max(dim=dim, skipna=True)
-    rng = mx - mn
-    safe_rng = rng.where(rng > 0)
-    norm = (da - mn) / safe_rng
-    norm.attrs = dict(da.attrs)
-    norm.attrs["units"] = "1"
-    return norm
-
-
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
-
-
-def _parse_period(period_str: str) -> tuple[str, str]:
-    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
-    if "/" not in period_str:
-        raise ValueError(
-            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
-        )
-    start, end = period_str.split("/", 1)
-    return start.strip(), end.strip()
 
 
 def build(project: Project) -> None:
@@ -171,8 +140,8 @@ def build(project: Project) -> None:
     ``recharge_targets_nn_filled.nc``.
     """
     rch_cfg = project.target("recharge")
-    period = _parse_period(rch_cfg["period"])
-    normalize_period = _parse_period(rch_cfg["normalize_period"])
+    period = parse_period(rch_cfg["period"])
+    normalize_period = parse_period(rch_cfg["normalize_period"])
     sources = list(rch_cfg["sources"])
 
     logger.info(
@@ -223,27 +192,7 @@ def build(project: Project) -> None:
             chunks={"time": 12, id_col: -1},
         )
         # HRU coord check (canonical-sort invariant, same as runoff/aet).
-        src_hru_ids = da_native[id_col].values
-        if not np.array_equal(src_hru_ids, fabric_hru_ids):
-            same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
-                np.sort(src_hru_ids), np.sort(fabric_hru_ids)
-            )
-            if same_set:
-                raise ValueError(
-                    f"HRU coords for source '{src}' have the same set as the "
-                    f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
-                    f"order. Both sides are expected to be sorted ascending by "
-                    f"id_col='{id_col}' — this indicates a regression in the "
-                    f"canonical-sort invariant in targets/_common.py."
-                )
-            raise ValueError(
-                f"HRU coords differ between fabric and source '{src}' as "
-                f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
-                f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
-                f"source has {len(src_hru_ids)} "
-                f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
-                f"Re-aggregate '{src}' against the current fabric."
-            )
+        check_hru_coords(da_native, fabric_hru_ids, id_col, src)
         da_annual_mm = shim.to_common_units(da_native)
         # Normalize using normalize_period's min/max; project onto master_idx.
         window = da_annual_mm.sel(time=slice(normalize_period[0], normalize_period[1]))
@@ -254,105 +203,15 @@ def build(project: Project) -> None:
                 f"Source covers {da_annual_mm.time.values[0]} .. "
                 f"{da_annual_mm.time.values[-1]}."
             )
-        da_normalized = _normalize_0_1_over_window(da_annual_mm, window)
+        da_normalized = normalize_0_1_over_window(da_annual_mm, window)
         # Reindex to master year-start index (NaN-pads years the source
         # doesn't cover; the multi-source min/max handles partial coverage).
         sources_normalized[src] = da_normalized.reindex(time=master_idx)
 
     # 4. NaN-aware combination across normalized sources.
     lower, upper, n_sources = multi_source_nanminmax(sources_normalized)
-    lower.name = "lower_bound"
-    upper.name = "upper_bound"
-    n_sources.name = "n_sources"
 
-    # 5. Assemble Dataset with CF metadata + ancillary coords.
-    time_bnds = xr.DataArray(
-        list(
-            zip(
-                master_idx.values,
-                (master_idx + pd.offsets.YearBegin(1)).values,
-            )
-        ),
-        dims=("time", "nv"),
-        coords={"time": master_idx.values},
-        name="time_bnds",
-    )
-    centroid_lat = xr.DataArray(
-        hru_meta["centroid_lat"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_north",
-            "standard_name": "latitude",
-            "long_name": "HRU centroid latitude",
-        },
-    )
-    centroid_lon = xr.DataArray(
-        hru_meta["centroid_lon"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_east",
-            "standard_name": "longitude",
-            "long_name": "HRU centroid longitude",
-        },
-    )
-
-    lower.attrs.update(
-        {
-            "units": "1",
-            "long_name": (
-                "lower bound of annual recharge "
-                "(NaN-aware min across normalized sources)"
-            ),
-            "cell_methods": "time: sum",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    upper.attrs.update(
-        {
-            "units": "1",
-            "long_name": (
-                "upper bound of annual recharge "
-                "(NaN-aware max across normalized sources)"
-            ),
-            "cell_methods": "time: sum",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    n_sources.attrs.update(
-        {
-            "units": "1",
-            "long_name": "number of finite source contributions",
-            "flag_values": list(range(0, len(sources) + 1)),
-            "flag_meanings": " ".join(
-                ["none", "one", "two", "three", "four", "five"][: len(sources) + 1]
-            ),
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-
-    ds = xr.Dataset(
-        {
-            "lower_bound": lower,
-            "upper_bound": upper,
-            "n_sources": n_sources,
-        },
-        coords={
-            "time": master_idx,
-            id_col: lower[id_col],
-            "time_bnds": time_bnds,
-            "centroid_lat": centroid_lat,
-            "centroid_lon": centroid_lon,
-        },
-    )
-    ds["time"].attrs["bounds"] = "time_bnds"
-    ds["time"].attrs["axis"] = "T"
-    ds["time"].attrs["standard_name"] = "time"
-    ds["time"].attrs["long_name"] = "time at year start"
-    ds[id_col].attrs["long_name"] = "HRU identifier"
-    ds[id_col].attrs["cf_role"] = "timeseries_id"
-
+    # 5. Assemble + write (with optional NN-fill companion).
     extra_attrs = {
         "source": "; ".join(shims[s].description for s in sources),
         "references": "Hay et al. 2022, doi:10.3133/tm6B10",
@@ -362,59 +221,26 @@ def build(project: Project) -> None:
         "normalize_period": rch_cfg["normalize_period"],
         "area_crs": project.area_crs,
     }
-
-    ds_loaded = ds.compute()
-
     output_path = project.targets_dir() / rch_cfg["output_file"]
-    write_target_nc(
-        ds_loaded,
-        output_path,
+    write_bounds_target(
+        project=project,
+        lower=lower,
+        upper=upper,
+        n_sources=n_sources,
+        n_sources_count=len(sources),
+        time_index=master_idx,
+        time_offset_unit=pd.offsets.YearBegin(1),
+        bounds_units="1",
+        bounds_long_name_kind="annual recharge",
+        cell_methods="time: sum",
+        output_path=output_path,
         title=(
             "NHM recharge calibration target (lower/upper bounds, dimensionless 0-1)"
         ),
+        nn_title="NHM recharge calibration target (NN-filled, dimensionless 0-1)",
         extra_global_attrs=extra_attrs,
-        sort_dim=id_col,
+        hru_meta=hru_meta,
+        nn_fill=rch_cfg["nn_fill"],
+        nn_max_candidates=int(rch_cfg["nn_max_candidates"]),
+        id_col=id_col,
     )
-
-    n = ds_loaded["n_sources"].values
-    total = n.size
-    none = int((n == 0).sum())
-    logger.info(
-        "Coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
-        total - none,
-        total,
-        100.0 * none / total if total else 0.0,
-    )
-
-    # 6. NN-fill (optional).
-    if rch_cfg["nn_fill"]:
-        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
-        filled_ds, nn_diag = nn_fill_bounds(
-            ds_loaded,
-            centroids_xy,
-            max_candidates=int(rch_cfg["nn_max_candidates"]),
-        )
-        nn_diag.attrs.update(
-            {
-                "units": "1",
-                "long_name": "nearest-neighbor fill flag",
-                "flag_values": [0, 1],
-                "flag_meanings": "not_filled filled",
-                "coordinates": "centroid_lat centroid_lon",
-            }
-        )
-        filled_ds["nn_filled"] = nn_diag
-        filled_attrs = dict(extra_attrs)
-        filled_attrs["nn_fill_max_candidates"] = int(rch_cfg["nn_max_candidates"])
-        filled_attrs["nn_fill_distance_crs"] = project.area_crs
-
-        nn_path = output_path.with_name(
-            output_path.stem + "_nn_filled" + output_path.suffix
-        )
-        write_target_nc(
-            filled_ds,
-            nn_path,
-            title=("NHM recharge calibration target (NN-filled, dimensionless 0-1)"),
-            extra_global_attrs=filled_attrs,
-            sort_dim=id_col,
-        )

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -23,19 +23,19 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 
-from nhf_spatial_targets.normalize.methods import nn_fill_bounds
 from nhf_spatial_targets.targets._common import (
     SourceShim,
+    check_hru_coords,
     compute_hru_area_and_centroids,
     multi_source_nanminmax,
+    parse_period,
     read_aggregated_source,
     reindex_to_month_start,
     shims_by_key,
-    write_target_nc,
+    write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
 
@@ -128,16 +128,6 @@ def mm_per_month_to_cfs(da: xr.DataArray, hru_area_m2: xr.DataArray) -> xr.DataA
 # ---------------------------------------------------------------------------
 
 
-def _parse_period(period_str: str) -> tuple[str, str]:
-    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
-    if "/" not in period_str:
-        raise ValueError(
-            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
-        )
-    start, end = period_str.split("/", 1)
-    return start.strip(), end.strip()
-
-
 def build(project: Project) -> None:
     """Build the runoff calibration target.
 
@@ -148,7 +138,7 @@ def build(project: Project) -> None:
     additionally writes ``runoff_targets_nn_filled.nc``.
     """
     runoff_cfg = project.target("runoff")
-    period = _parse_period(runoff_cfg["period"])
+    period = parse_period(runoff_cfg["period"])
     sources = list(runoff_cfg["sources"])
     chunk_months = int(runoff_cfg["chunk_months"])
 
@@ -199,126 +189,15 @@ def build(project: Project) -> None:
             period,
             chunks={"time": chunk_months, id_col: -1},
         )
-        # Validate that the source's HRU IDs match the fabric before any
-        # arithmetic that would silently broadcast/intersect mismatched coords.
-        # Both sides are canonically sorted ascending by id_col upstream
-        # (compute_hru_area_and_centroids and read_aggregated_source); a
-        # remaining mismatch is therefore a true set difference, not an
-        # ordering artifact. Distinguish the two cases in the error so a
-        # regression in the canonical-sort invariant is diagnosable from the
-        # log alone.
-        src_hru_ids = da_native[id_col].values
-        if not np.array_equal(src_hru_ids, fabric_hru_ids):
-            same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
-                np.sort(src_hru_ids), np.sort(fabric_hru_ids)
-            )
-            if same_set:
-                raise ValueError(
-                    f"HRU coords for source '{src}' have the same set as the "
-                    f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
-                    f"order. Both sides are expected to be sorted ascending by "
-                    f"id_col='{id_col}' — this indicates a regression in the "
-                    f"canonical-sort invariant in targets/_common.py."
-                )
-            raise ValueError(
-                f"HRU coords differ between fabric and source '{src}' as "
-                f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
-                f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
-                f"source has {len(src_hru_ids)} "
-                f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
-                f"Re-aggregate '{src}' against the current fabric."
-            )
+        check_hru_coords(da_native, fabric_hru_ids, id_col, src)
         da_mm = shim.to_common_units(da_native)
         da_cfs = mm_per_month_to_cfs(da_mm, hru_area_da)
         sources_cfs[src] = reindex_to_month_start(da_cfs, master_idx)
 
-    # 4. NaN-aware combination.
+    # 4. NaN-aware combination across sources.
     lower, upper, n_sources = multi_source_nanminmax(sources_cfs)
-    lower.name = "lower_bound"
-    upper.name = "upper_bound"
-    n_sources.name = "n_sources"
 
-    # 5. Assemble Dataset with CF metadata + ancillary coords.
-    time_bnds = xr.DataArray(
-        list(zip(master_idx.values, (master_idx + pd.offsets.MonthBegin(1)).values)),
-        dims=("time", "nv"),
-        coords={"time": master_idx.values},
-        name="time_bnds",
-    )
-    centroid_lat = xr.DataArray(
-        hru_meta["centroid_lat"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_north",
-            "standard_name": "latitude",
-            "long_name": "HRU centroid latitude",
-        },
-    )
-    centroid_lon = xr.DataArray(
-        hru_meta["centroid_lon"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_east",
-            "standard_name": "longitude",
-            "long_name": "HRU centroid longitude",
-        },
-    )
-
-    lower.attrs.update(
-        {
-            "units": "cfs",
-            "long_name": (
-                "lower bound of monthly runoff (NaN-aware min across sources)"
-            ),
-            "cell_methods": "time: sum",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    upper.attrs.update(
-        {
-            "units": "cfs",
-            "long_name": (
-                "upper bound of monthly runoff (NaN-aware max across sources)"
-            ),
-            "cell_methods": "time: sum",
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    n_sources.attrs.update(
-        {
-            "units": "1",
-            "long_name": "number of finite source contributions",
-            "flag_values": list(range(0, len(sources) + 1)),
-            "flag_meanings": " ".join(
-                ["none", "one", "two", "three", "four", "five"][: len(sources) + 1]
-            ),
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-
-    ds = xr.Dataset(
-        {
-            "lower_bound": lower,
-            "upper_bound": upper,
-            "n_sources": n_sources,
-        },
-        coords={
-            "time": master_idx,
-            id_col: lower[id_col],
-            "time_bnds": time_bnds,
-            "centroid_lat": centroid_lat,
-            "centroid_lon": centroid_lon,
-        },
-    )
-    ds["time"].attrs["bounds"] = "time_bnds"
-    ds["time"].attrs["axis"] = "T"
-    ds["time"].attrs["standard_name"] = "time"
-    ds["time"].attrs["long_name"] = "time at month start"
-    ds[id_col].attrs["long_name"] = "HRU identifier"
-    ds[id_col].attrs["cf_role"] = "timeseries_id"
-
+    # 5. Assemble + write (with optional NN-fill companion).
     extra_attrs = {
         "source": "; ".join(shims[s].description for s in sources),
         "references": "Hay et al. 2022, doi:10.3133/tm6B10",
@@ -327,60 +206,24 @@ def build(project: Project) -> None:
         "period": runoff_cfg["period"],
         "area_crs": project.area_crs,
     }
-
-    # Materialize once: the bound vars + diagnostic are needed for the log
-    # line, the unfilled-file write, and (optionally) the NN-fill walk.
-    ds_loaded = ds.compute()
-
     output_path = project.targets_dir() / runoff_cfg["output_file"]
-    write_target_nc(
-        ds_loaded,
-        output_path,
+    write_bounds_target(
+        project=project,
+        lower=lower,
+        upper=upper,
+        n_sources=n_sources,
+        n_sources_count=len(sources),
+        time_index=master_idx,
+        time_offset_unit=pd.offsets.MonthBegin(1),
+        bounds_units="cfs",
+        bounds_long_name_kind="monthly runoff",
+        cell_methods="time: sum",
+        output_path=output_path,
         title="NHM runoff calibration target (lower/upper bounds in cfs)",
+        nn_title="NHM runoff calibration target (NN-filled, cfs)",
         extra_global_attrs=extra_attrs,
-        sort_dim=id_col,
+        hru_meta=hru_meta,
+        nn_fill=runoff_cfg["nn_fill"],
+        nn_max_candidates=int(runoff_cfg["nn_max_candidates"]),
+        id_col=id_col,
     )
-
-    # Coverage summary log line (read from the in-memory materialized array).
-    n = ds_loaded["n_sources"].values
-    total = n.size
-    none = int((n == 0).sum())
-    logger.info(
-        "Coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
-        total - none,
-        total,
-        100.0 * none / total if total else 0.0,
-    )
-
-    # 6. NN-fill (optional).
-    if runoff_cfg["nn_fill"]:
-        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
-        filled_ds, nn_diag = nn_fill_bounds(
-            ds_loaded,
-            centroids_xy,
-            max_candidates=int(runoff_cfg["nn_max_candidates"]),
-        )
-        nn_diag.attrs.update(
-            {
-                "units": "1",
-                "long_name": "nearest-neighbor fill flag",
-                "flag_values": [0, 1],
-                "flag_meanings": "not_filled filled",
-                "coordinates": "centroid_lat centroid_lon",
-            }
-        )
-        filled_ds["nn_filled"] = nn_diag
-        filled_attrs = dict(extra_attrs)
-        filled_attrs["nn_fill_max_candidates"] = int(runoff_cfg["nn_max_candidates"])
-        filled_attrs["nn_fill_distance_crs"] = project.area_crs
-
-        nn_path = output_path.with_name(
-            output_path.stem + "_nn_filled" + output_path.suffix
-        )
-        write_target_nc(
-            filled_ds,
-            nn_path,
-            title="NHM runoff calibration target (NN-filled, cfs)",
-            extra_global_attrs=filled_attrs,
-            sort_dim=id_col,
-        )

--- a/src/nhf_spatial_targets/targets/som.py
+++ b/src/nhf_spatial_targets/targets/som.py
@@ -33,23 +33,23 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 
 from nhf_spatial_targets.normalize.methods import (
-    nn_fill_bounds,
-    normalize_0_1,
-    normalize_0_1_by_calendar_month,
+    normalize_0_1_by_calendar_month_over_window,
+    normalize_0_1_over_window,
 )
 from nhf_spatial_targets.targets._common import (
     SourceShim,
+    check_hru_coords,
     compute_hru_centroids,
     multi_source_nanminmax,
+    parse_period,
     read_aggregated_source,
     reindex_to_month_start,
     shims_by_key,
-    write_target_nc,
+    write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
 
@@ -102,16 +102,6 @@ SHIMS: tuple[SourceShim, ...] = (
 # ---------------------------------------------------------------------------
 
 
-def _parse_period(period_str: str) -> tuple[str, str]:
-    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
-    if "/" not in period_str:
-        raise ValueError(
-            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
-        )
-    start, end = period_str.split("/", 1)
-    return start.strip(), end.strip()
-
-
 def _derive_variant_path(base_path, variant: str):
     """Insert '_<variant>' before the suffix of ``base_path``.
 
@@ -119,201 +109,6 @@ def _derive_variant_path(base_path, variant: str):
     ``soil_moisture_targets_monthly.nc``.
     """
     return base_path.with_name(base_path.stem + f"_{variant}" + base_path.suffix)
-
-
-def _hru_coord_check(da_native, fabric_hru_ids, id_col: str, src: str) -> None:
-    """Same canonical-sort invariant as runoff/aet/rch."""
-    src_hru_ids = da_native[id_col].values
-    if np.array_equal(src_hru_ids, fabric_hru_ids):
-        return
-    same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
-        np.sort(src_hru_ids), np.sort(fabric_hru_ids)
-    )
-    if same_set:
-        raise ValueError(
-            f"HRU coords for source '{src}' have the same set as the "
-            f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
-            f"order. Both sides are expected to be sorted ascending by "
-            f"id_col='{id_col}' — this indicates a regression in the "
-            f"canonical-sort invariant in targets/_common.py."
-        )
-    raise ValueError(
-        f"HRU coords differ between fabric and source '{src}' as "
-        f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
-        f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
-        f"source has {len(src_hru_ids)} "
-        f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
-        f"Re-aggregate '{src}' against the current fabric."
-    )
-
-
-def _build_diag_attrs(n_sources: int, ancillary_coords: str) -> dict:
-    return {
-        "units": "1",
-        "long_name": "number of finite source contributions",
-        "flag_values": list(range(0, n_sources + 1)),
-        "flag_meanings": " ".join(
-            ["none", "one", "two", "three", "four", "five"][: n_sources + 1]
-        ),
-        "coordinates": ancillary_coords,
-    }
-
-
-def _assemble_and_write(
-    *,
-    project: Project,
-    lower: xr.DataArray,
-    upper: xr.DataArray,
-    n_sources: xr.DataArray,
-    n_sources_count: int,
-    time_index: pd.DatetimeIndex,
-    time_offset_unit: pd.offsets.BaseOffset,
-    long_name_suffix: str,
-    cell_methods: str,
-    output_path,
-    title: str,
-    extra_global_attrs: dict,
-    hru_meta,
-    nn_fill: bool,
-    nn_max_candidates: int,
-    nn_title: str,
-    id_col: str,
-) -> None:
-    """Wrap up a (lower, upper, n_sources) trio into a NC file + optional NN-fill.
-
-    Common code for both the monthly and annual SOM variants — the only
-    things that differ are the time index, the variable long_names, the
-    cell_methods string, the output paths, and the dataset titles.
-    """
-    lower.name = "lower_bound"
-    upper.name = "upper_bound"
-    n_sources.name = "n_sources"
-
-    time_bnds = xr.DataArray(
-        list(zip(time_index.values, (time_index + time_offset_unit).values)),
-        dims=("time", "nv"),
-        coords={"time": time_index.values},
-        name="time_bnds",
-    )
-    centroid_lat = xr.DataArray(
-        hru_meta["centroid_lat"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_north",
-            "standard_name": "latitude",
-            "long_name": "HRU centroid latitude",
-        },
-    )
-    centroid_lon = xr.DataArray(
-        hru_meta["centroid_lon"].values,
-        dims=(id_col,),
-        coords={id_col: hru_meta.index.values},
-        attrs={
-            "units": "degrees_east",
-            "standard_name": "longitude",
-            "long_name": "HRU centroid longitude",
-        },
-    )
-
-    lower.attrs.update(
-        {
-            "units": "1",
-            "long_name": (
-                f"lower bound of {long_name_suffix} "
-                f"(NaN-aware min across normalized sources)"
-            ),
-            "cell_methods": cell_methods,
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    upper.attrs.update(
-        {
-            "units": "1",
-            "long_name": (
-                f"upper bound of {long_name_suffix} "
-                f"(NaN-aware max across normalized sources)"
-            ),
-            "cell_methods": cell_methods,
-            "coordinates": "centroid_lat centroid_lon",
-        }
-    )
-    n_sources.attrs.update(
-        _build_diag_attrs(
-            n_sources=n_sources_count,
-            ancillary_coords="centroid_lat centroid_lon",
-        )
-    )
-
-    ds = xr.Dataset(
-        {
-            "lower_bound": lower,
-            "upper_bound": upper,
-            "n_sources": n_sources,
-        },
-        coords={
-            "time": time_index,
-            id_col: lower[id_col],
-            "time_bnds": time_bnds,
-            "centroid_lat": centroid_lat,
-            "centroid_lon": centroid_lon,
-        },
-    )
-    ds["time"].attrs["bounds"] = "time_bnds"
-    ds["time"].attrs["axis"] = "T"
-    ds["time"].attrs["standard_name"] = "time"
-    ds[id_col].attrs["long_name"] = "HRU identifier"
-    ds[id_col].attrs["cf_role"] = "timeseries_id"
-
-    ds_loaded = ds.compute()
-
-    write_target_nc(
-        ds_loaded,
-        output_path,
-        title=title,
-        extra_global_attrs=extra_global_attrs,
-        sort_dim=id_col,
-    )
-
-    n = ds_loaded["n_sources"].values
-    total = n.size
-    none = int((n == 0).sum())
-    logger.info(
-        "%s coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
-        long_name_suffix,
-        total - none,
-        total,
-        100.0 * none / total if total else 0.0,
-    )
-
-    if nn_fill:
-        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
-        filled_ds, nn_diag = nn_fill_bounds(
-            ds_loaded, centroids_xy, max_candidates=nn_max_candidates
-        )
-        nn_diag.attrs.update(
-            {
-                "units": "1",
-                "long_name": "nearest-neighbor fill flag",
-                "flag_values": [0, 1],
-                "flag_meanings": "not_filled filled",
-                "coordinates": "centroid_lat centroid_lon",
-            }
-        )
-        filled_ds["nn_filled"] = nn_diag
-        filled_attrs = dict(extra_global_attrs)
-        filled_attrs["nn_fill_max_candidates"] = nn_max_candidates
-        filled_attrs["nn_fill_distance_crs"] = project.area_crs
-        nn_path = output_path.with_name(
-            output_path.stem + "_nn_filled" + output_path.suffix
-        )
-        write_target_nc(
-            filled_ds,
-            nn_path,
-            title=nn_title,
-            extra_global_attrs=filled_attrs,
-            sort_dim=id_col,
-        )
 
 
 def build(project: Project) -> None:
@@ -332,15 +127,24 @@ def build(project: Project) -> None:
     ``soil_moisture.nn_fill`` is True.
     """
     som_cfg = project.target("soil_moisture")
-    period = _parse_period(som_cfg["period"])
+    period = parse_period(som_cfg["period"])
+    # normalize_period defaults to the output period (whole-period
+    # normalization). Set independently to extend the output past the
+    # calibration-period climatology; values outside the window may then
+    # produce normalized values < 0 or > 1, by design.
+    raw_norm_period = som_cfg.get("normalize_period") or som_cfg["period"]
+    normalize_period = parse_period(raw_norm_period)
     sources = list(som_cfg["sources"])
 
     logger.info(
-        "Building SOM target: %d sources (%s), period %s..%s, fabric=%s",
+        "Building SOM target: %d sources (%s), period %s..%s, "
+        "normalize_period %s..%s, fabric=%s",
         len(sources),
         ",".join(sources),
         period[0],
         period[1],
+        normalize_period[0],
+        normalize_period[1],
         project.config["fabric"]["path"],
     )
 
@@ -372,14 +176,25 @@ def build(project: Project) -> None:
             period,
             chunks={"time": 12, id_col: -1},
         )
-        _hru_coord_check(da_native, fabric_hru_ids, id_col, src)
+        check_hru_coords(da_native, fabric_hru_ids, id_col, src)
         da_monthly_native = shim.to_common_units(da_native)
         sources_monthly[src] = reindex_to_month_start(da_monthly_native, master_monthly)
 
-    # --- Monthly variant: per-calendar-month normalize, then combine.
-    sources_monthly_norm = {
-        src: normalize_0_1_by_calendar_month(da) for src, da in sources_monthly.items()
-    }
+    # --- Monthly variant: per-calendar-month normalize over the window,
+    # then combine. Window equals the full output period when
+    # normalize_period == period (default).
+    sources_monthly_norm: dict[str, xr.DataArray] = {}
+    for src, da in sources_monthly.items():
+        window = da.sel(time=slice(normalize_period[0], normalize_period[1]))
+        if window.sizes.get("time", 0) == 0:
+            raise ValueError(
+                f"soil_moisture.normalize_period {raw_norm_period} yields no "
+                f"monthly timesteps for source '{src}' (period intersection "
+                f"with source's monthly index is empty)."
+            )
+        sources_monthly_norm[src] = normalize_0_1_by_calendar_month_over_window(
+            da, window
+        )
     lo_m, up_m, ns_m = multi_source_nanminmax(sources_monthly_norm)
 
     base_output = project.targets_dir() / som_cfg["output_file"]
@@ -389,10 +204,11 @@ def build(project: Project) -> None:
         "fabric": project.config["fabric"]["path"],
         "fabric_sha256": project.fabric.get("sha256", ""),
         "period": som_cfg["period"],
+        "normalize_period": raw_norm_period,
         "normalize_method": "per_calendar_month",
         "area_crs": project.area_crs,
     }
-    _assemble_and_write(
+    write_bounds_target(
         project=project,
         lower=lo_m,
         upper=up_m,
@@ -400,29 +216,37 @@ def build(project: Project) -> None:
         n_sources_count=len(sources),
         time_index=master_monthly,
         time_offset_unit=pd.offsets.MonthBegin(1),
-        long_name_suffix="monthly soil moisture",
+        bounds_units="1",
+        bounds_long_name_kind="monthly soil moisture",
         cell_methods="time: mean",
         output_path=_derive_variant_path(base_output, "monthly"),
         title="NHM soil moisture monthly calibration target (dimensionless 0-1)",
-        extra_global_attrs=extra_attrs_monthly,
-        hru_meta=hru_meta,
-        nn_fill=som_cfg["nn_fill"],
-        nn_max_candidates=int(som_cfg["nn_max_candidates"]),
         nn_title=(
             "NHM soil moisture monthly calibration target (NN-filled, "
             "dimensionless 0-1)"
         ),
+        extra_global_attrs=extra_attrs_monthly,
+        hru_meta=hru_meta,
+        nn_fill=som_cfg["nn_fill"],
+        nn_max_candidates=int(som_cfg["nn_max_candidates"]),
         id_col=id_col,
     )
 
-    # --- Annual variant: monthly → annual mean per source, then normalize.
+    # --- Annual variant: monthly → annual mean per source, then normalize
+    # over the annual slice of the normalize window.
     sources_annual = {
         src: da.resample(time="YS").mean(skipna=True)
         for src, da in sources_monthly.items()
     }
-    sources_annual_norm = {
-        src: normalize_0_1(da, dim="time") for src, da in sources_annual.items()
-    }
+    sources_annual_norm: dict[str, xr.DataArray] = {}
+    for src, da in sources_annual.items():
+        window = da.sel(time=slice(normalize_period[0], normalize_period[1]))
+        if window.sizes.get("time", 0) == 0:
+            raise ValueError(
+                f"soil_moisture.normalize_period {raw_norm_period} yields no "
+                f"annual timesteps for source '{src}' after annual aggregation."
+            )
+        sources_annual_norm[src] = normalize_0_1_over_window(da, window)
     lo_a, up_a, ns_a = multi_source_nanminmax(sources_annual_norm)
     master_annual = pd.date_range(period[0], period[1], freq="YS")
     extra_attrs_annual = {
@@ -431,11 +255,12 @@ def build(project: Project) -> None:
         "fabric": project.config["fabric"]["path"],
         "fabric_sha256": project.fabric.get("sha256", ""),
         "period": som_cfg["period"],
+        "normalize_period": raw_norm_period,
         "normalize_method": "whole_period",
         "annual_aggregation": "mean",
         "area_crs": project.area_crs,
     }
-    _assemble_and_write(
+    write_bounds_target(
         project=project,
         lower=lo_a,
         upper=up_a,
@@ -443,16 +268,17 @@ def build(project: Project) -> None:
         n_sources_count=len(sources),
         time_index=master_annual,
         time_offset_unit=pd.offsets.YearBegin(1),
-        long_name_suffix="annual soil moisture",
+        bounds_units="1",
+        bounds_long_name_kind="annual soil moisture",
         cell_methods="time: mean",
         output_path=_derive_variant_path(base_output, "annual"),
         title="NHM soil moisture annual calibration target (dimensionless 0-1)",
+        nn_title=(
+            "NHM soil moisture annual calibration target (NN-filled, dimensionless 0-1)"
+        ),
         extra_global_attrs=extra_attrs_annual,
         hru_meta=hru_meta,
         nn_fill=som_cfg["nn_fill"],
         nn_max_candidates=int(som_cfg["nn_max_candidates"]),
-        nn_title=(
-            "NHM soil moisture annual calibration target (NN-filled, dimensionless 0-1)"
-        ),
         id_col=id_col,
     )

--- a/src/nhf_spatial_targets/targets/som.py
+++ b/src/nhf_spatial_targets/targets/som.py
@@ -1,18 +1,458 @@
-"""Build soil moisture calibration targets from MERRA, NCEP, NLDAS."""
+"""Build soil moisture calibration targets from MERRA-2 + NCEP/NCAR + NLDAS-2.
 
-# Sources:  merra_land (or merra2), ncep_ncar, nldas_mosaic, nldas_noah
-# Method:   normalized_minmax (per calendar month for monthly)
-# Variable: soil_rechr
-# Timestep: monthly and annual
+Four monthly-cadence sources contribute to per-HRU per-time bounds in
+dimensionless [0, 1]. Emits TWO target NCs:
+
+  - Monthly: per-calendar-month normalization (all Januaries pooled,
+    all Februaries pooled, etc.); time axis at month-start.
+  - Annual: monthly → annual mean (state variable) per source, then
+    single-period normalization over the full target period; time axis
+    at year-start.
+
+Per TM 6-B10 §4 Appendix 1: the per-calendar-month normalization for
+the monthly variant removes seasonality so the bound reflects relative
+wet/dry within each month rather than absolute differences between
+January and July.
+
+Sources (all native monthly; native units differ but the per-source
+0-1 normalization cancels the offsets, so the SHIMS pass through values
+unchanged — only time canonicalization happens via
+``reindex_to_month_start``):
+
+  - MERRA-2 ``GWETTOP`` (dimensionless 0-1 plant-available wetness;
+    mid-month timestamp)
+  - NCEP/NCAR ``soilw_0_10cm`` (m³/m³ VWC; end-of-month timestamp)
+  - NLDAS-2 MOSAIC ``SoilM_0_10cm`` (kg/m² in 0-10 cm; month-start)
+  - NLDAS-2 NOAH ``SoilM_0_10cm`` (kg/m² in 0-10 cm; month-start)
+
+If ``soil_moisture.nn_fill`` is True (default), NN-filled companion
+files are written for both the monthly and annual outputs.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
 
-if TYPE_CHECKING:
-    from nhf_spatial_targets.workspace import Project
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.normalize.methods import (
+    nn_fill_bounds,
+    normalize_0_1,
+    normalize_0_1_by_calendar_month,
+)
+from nhf_spatial_targets.targets._common import (
+    SourceShim,
+    compute_hru_centroids,
+    multi_source_nanminmax,
+    read_aggregated_source,
+    reindex_to_month_start,
+    shims_by_key,
+    write_target_nc,
+)
+from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
 
 
-def build(project: "Project") -> None:
-    """Build soil moisture target dataset."""
-    raise NotImplementedError
+def som_passthrough(da: xr.DataArray) -> xr.DataArray:
+    """SOM sources arrive at native monthly cadence; no unit conversion needed.
+
+    Per recipes §4: the four sources carry incompatible native units
+    (dimensionless plant-available wetness vs m³/m³ VWC vs kg/m² mass)
+    but the per-source 0-1 normalization downstream cancels the constant
+    offset. Cross-source unit harmonization is therefore cosmetic and
+    omitted here. Time canonicalization to month-start is handled by
+    ``reindex_to_month_start`` in the build loop, after this shim.
+    """
+    return da
+
+
+SHIMS: tuple[SourceShim, ...] = (
+    SourceShim(
+        source_key="merra2",
+        aggregated_var="GWETTOP",
+        description=("MERRA-2 GWETTOP (dimensionless plant-available wetness, 0-5 cm)"),
+        to_common_units=som_passthrough,
+    ),
+    SourceShim(
+        source_key="ncep_ncar",
+        aggregated_var="soilw_0_10cm",
+        description="NCEP/NCAR soilw_0_10cm (m³/m³ VWC, 0-10 cm)",
+        to_common_units=som_passthrough,
+    ),
+    SourceShim(
+        source_key="nldas_mosaic",
+        aggregated_var="SoilM_0_10cm",
+        description="NLDAS-2 MOSAIC SoilM_0_10cm (kg/m², 0-10 cm)",
+        to_common_units=som_passthrough,
+    ),
+    SourceShim(
+        source_key="nldas_noah",
+        aggregated_var="SoilM_0_10cm",
+        description="NLDAS-2 NOAH SoilM_0_10cm (kg/m², 0-10 cm)",
+        to_common_units=som_passthrough,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _parse_period(period_str: str) -> tuple[str, str]:
+    """Parse 'YYYY-MM-DD/YYYY-MM-DD' (or 'YYYY/YYYY') into (start, end)."""
+    if "/" not in period_str:
+        raise ValueError(
+            f"Invalid period {period_str!r}. Expected 'YYYY-MM-DD/YYYY-MM-DD'."
+        )
+    start, end = period_str.split("/", 1)
+    return start.strip(), end.strip()
+
+
+def _derive_variant_path(base_path, variant: str):
+    """Insert '_<variant>' before the suffix of ``base_path``.
+
+    Example: ``soil_moisture_targets.nc`` + ``monthly`` →
+    ``soil_moisture_targets_monthly.nc``.
+    """
+    return base_path.with_name(base_path.stem + f"_{variant}" + base_path.suffix)
+
+
+def _hru_coord_check(da_native, fabric_hru_ids, id_col: str, src: str) -> None:
+    """Same canonical-sort invariant as runoff/aet/rch."""
+    src_hru_ids = da_native[id_col].values
+    if np.array_equal(src_hru_ids, fabric_hru_ids):
+        return
+    same_set = len(src_hru_ids) == len(fabric_hru_ids) and np.array_equal(
+        np.sort(src_hru_ids), np.sort(fabric_hru_ids)
+    )
+    if same_set:
+        raise ValueError(
+            f"HRU coords for source '{src}' have the same set as the "
+            f"fabric ({len(fabric_hru_ids)} HRUs) but a different "
+            f"order. Both sides are expected to be sorted ascending by "
+            f"id_col='{id_col}' — this indicates a regression in the "
+            f"canonical-sort invariant in targets/_common.py."
+        )
+    raise ValueError(
+        f"HRU coords differ between fabric and source '{src}' as "
+        f"sets. Fabric has {len(fabric_hru_ids)} HRUs "
+        f"(first={fabric_hru_ids[0]}, last={fabric_hru_ids[-1]}); "
+        f"source has {len(src_hru_ids)} "
+        f"(first={src_hru_ids[0]}, last={src_hru_ids[-1]}). "
+        f"Re-aggregate '{src}' against the current fabric."
+    )
+
+
+def _build_diag_attrs(n_sources: int, ancillary_coords: str) -> dict:
+    return {
+        "units": "1",
+        "long_name": "number of finite source contributions",
+        "flag_values": list(range(0, n_sources + 1)),
+        "flag_meanings": " ".join(
+            ["none", "one", "two", "three", "four", "five"][: n_sources + 1]
+        ),
+        "coordinates": ancillary_coords,
+    }
+
+
+def _assemble_and_write(
+    *,
+    project: Project,
+    lower: xr.DataArray,
+    upper: xr.DataArray,
+    n_sources: xr.DataArray,
+    n_sources_count: int,
+    time_index: pd.DatetimeIndex,
+    time_offset_unit: pd.offsets.BaseOffset,
+    long_name_suffix: str,
+    cell_methods: str,
+    output_path,
+    title: str,
+    extra_global_attrs: dict,
+    hru_meta,
+    nn_fill: bool,
+    nn_max_candidates: int,
+    nn_title: str,
+    id_col: str,
+) -> None:
+    """Wrap up a (lower, upper, n_sources) trio into a NC file + optional NN-fill.
+
+    Common code for both the monthly and annual SOM variants — the only
+    things that differ are the time index, the variable long_names, the
+    cell_methods string, the output paths, and the dataset titles.
+    """
+    lower.name = "lower_bound"
+    upper.name = "upper_bound"
+    n_sources.name = "n_sources"
+
+    time_bnds = xr.DataArray(
+        list(zip(time_index.values, (time_index + time_offset_unit).values)),
+        dims=("time", "nv"),
+        coords={"time": time_index.values},
+        name="time_bnds",
+    )
+    centroid_lat = xr.DataArray(
+        hru_meta["centroid_lat"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_north",
+            "standard_name": "latitude",
+            "long_name": "HRU centroid latitude",
+        },
+    )
+    centroid_lon = xr.DataArray(
+        hru_meta["centroid_lon"].values,
+        dims=(id_col,),
+        coords={id_col: hru_meta.index.values},
+        attrs={
+            "units": "degrees_east",
+            "standard_name": "longitude",
+            "long_name": "HRU centroid longitude",
+        },
+    )
+
+    lower.attrs.update(
+        {
+            "units": "1",
+            "long_name": (
+                f"lower bound of {long_name_suffix} "
+                f"(NaN-aware min across normalized sources)"
+            ),
+            "cell_methods": cell_methods,
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    upper.attrs.update(
+        {
+            "units": "1",
+            "long_name": (
+                f"upper bound of {long_name_suffix} "
+                f"(NaN-aware max across normalized sources)"
+            ),
+            "cell_methods": cell_methods,
+            "coordinates": "centroid_lat centroid_lon",
+        }
+    )
+    n_sources.attrs.update(
+        _build_diag_attrs(
+            n_sources=n_sources_count,
+            ancillary_coords="centroid_lat centroid_lon",
+        )
+    )
+
+    ds = xr.Dataset(
+        {
+            "lower_bound": lower,
+            "upper_bound": upper,
+            "n_sources": n_sources,
+        },
+        coords={
+            "time": time_index,
+            id_col: lower[id_col],
+            "time_bnds": time_bnds,
+            "centroid_lat": centroid_lat,
+            "centroid_lon": centroid_lon,
+        },
+    )
+    ds["time"].attrs["bounds"] = "time_bnds"
+    ds["time"].attrs["axis"] = "T"
+    ds["time"].attrs["standard_name"] = "time"
+    ds[id_col].attrs["long_name"] = "HRU identifier"
+    ds[id_col].attrs["cf_role"] = "timeseries_id"
+
+    ds_loaded = ds.compute()
+
+    write_target_nc(
+        ds_loaded,
+        output_path,
+        title=title,
+        extra_global_attrs=extra_global_attrs,
+        sort_dim=id_col,
+    )
+
+    n = ds_loaded["n_sources"].values
+    total = n.size
+    none = int((n == 0).sum())
+    logger.info(
+        "%s coverage: %d/%d cells have >=1 finite source (%.2f%% all-NaN)",
+        long_name_suffix,
+        total - none,
+        total,
+        100.0 * none / total if total else 0.0,
+    )
+
+    if nn_fill:
+        centroids_xy = hru_meta[["centroid_x", "centroid_y"]].values
+        filled_ds, nn_diag = nn_fill_bounds(
+            ds_loaded, centroids_xy, max_candidates=nn_max_candidates
+        )
+        nn_diag.attrs.update(
+            {
+                "units": "1",
+                "long_name": "nearest-neighbor fill flag",
+                "flag_values": [0, 1],
+                "flag_meanings": "not_filled filled",
+                "coordinates": "centroid_lat centroid_lon",
+            }
+        )
+        filled_ds["nn_filled"] = nn_diag
+        filled_attrs = dict(extra_global_attrs)
+        filled_attrs["nn_fill_max_candidates"] = nn_max_candidates
+        filled_attrs["nn_fill_distance_crs"] = project.area_crs
+        nn_path = output_path.with_name(
+            output_path.stem + "_nn_filled" + output_path.suffix
+        )
+        write_target_nc(
+            filled_ds,
+            nn_path,
+            title=nn_title,
+            extra_global_attrs=filled_attrs,
+            sort_dim=id_col,
+        )
+
+
+def build(project: Project) -> None:
+    """Build the soil moisture calibration target (monthly + annual variants).
+
+    Reads each enabled source's per-year aggregated NCs, harmonizes onto
+    a monthly master index over ``soil_moisture.period``, then emits
+    two CF-1.6 NetCDFs:
+
+      - ``<output>_monthly.nc`` — per-calendar-month 0-1 normalization,
+        multi-source min/max bound, monthly cadence.
+      - ``<output>_annual.nc`` — monthly → annual mean per source,
+        whole-period 0-1 normalization, year-start cadence.
+
+    NN-filled companions are written for both when
+    ``soil_moisture.nn_fill`` is True.
+    """
+    som_cfg = project.target("soil_moisture")
+    period = _parse_period(som_cfg["period"])
+    sources = list(som_cfg["sources"])
+
+    logger.info(
+        "Building SOM target: %d sources (%s), period %s..%s, fabric=%s",
+        len(sources),
+        ",".join(sources),
+        period[0],
+        period[1],
+        project.config["fabric"]["path"],
+    )
+
+    hru_meta = compute_hru_centroids(project)
+    id_col = project.id_col
+
+    master_monthly = pd.date_range(period[0], period[1], freq="MS")
+    if len(master_monthly) == 0:
+        raise ValueError(
+            f"soil_moisture.period {som_cfg['period']} produces no months at "
+            "freq='MS'. Check the date range."
+        )
+
+    # Read + canonicalize each source to monthly cadence at month-start.
+    shims = shims_by_key(SHIMS)
+    fabric_hru_ids = hru_meta.index.values
+    sources_monthly: dict[str, xr.DataArray] = {}
+    for src in sources:
+        if src not in shims:
+            raise ValueError(
+                f"soil_moisture.sources includes unknown source '{src}'. "
+                f"Known: {sorted(shims)}"
+            )
+        shim = shims[src]
+        da_native = read_aggregated_source(
+            project,
+            shim.source_key,
+            shim.aggregated_var,
+            period,
+            chunks={"time": 12, id_col: -1},
+        )
+        _hru_coord_check(da_native, fabric_hru_ids, id_col, src)
+        da_monthly_native = shim.to_common_units(da_native)
+        sources_monthly[src] = reindex_to_month_start(da_monthly_native, master_monthly)
+
+    # --- Monthly variant: per-calendar-month normalize, then combine.
+    sources_monthly_norm = {
+        src: normalize_0_1_by_calendar_month(da) for src, da in sources_monthly.items()
+    }
+    lo_m, up_m, ns_m = multi_source_nanminmax(sources_monthly_norm)
+
+    base_output = project.targets_dir() / som_cfg["output_file"]
+    extra_attrs_monthly = {
+        "source": "; ".join(shims[s].description for s in sources),
+        "references": "Hay et al. 2022, doi:10.3133/tm6B10",
+        "fabric": project.config["fabric"]["path"],
+        "fabric_sha256": project.fabric.get("sha256", ""),
+        "period": som_cfg["period"],
+        "normalize_method": "per_calendar_month",
+        "area_crs": project.area_crs,
+    }
+    _assemble_and_write(
+        project=project,
+        lower=lo_m,
+        upper=up_m,
+        n_sources=ns_m,
+        n_sources_count=len(sources),
+        time_index=master_monthly,
+        time_offset_unit=pd.offsets.MonthBegin(1),
+        long_name_suffix="monthly soil moisture",
+        cell_methods="time: mean",
+        output_path=_derive_variant_path(base_output, "monthly"),
+        title="NHM soil moisture monthly calibration target (dimensionless 0-1)",
+        extra_global_attrs=extra_attrs_monthly,
+        hru_meta=hru_meta,
+        nn_fill=som_cfg["nn_fill"],
+        nn_max_candidates=int(som_cfg["nn_max_candidates"]),
+        nn_title=(
+            "NHM soil moisture monthly calibration target (NN-filled, "
+            "dimensionless 0-1)"
+        ),
+        id_col=id_col,
+    )
+
+    # --- Annual variant: monthly → annual mean per source, then normalize.
+    sources_annual = {
+        src: da.resample(time="YS").mean(skipna=True)
+        for src, da in sources_monthly.items()
+    }
+    sources_annual_norm = {
+        src: normalize_0_1(da, dim="time") for src, da in sources_annual.items()
+    }
+    lo_a, up_a, ns_a = multi_source_nanminmax(sources_annual_norm)
+    master_annual = pd.date_range(period[0], period[1], freq="YS")
+    extra_attrs_annual = {
+        "source": "; ".join(shims[s].description for s in sources),
+        "references": "Hay et al. 2022, doi:10.3133/tm6B10",
+        "fabric": project.config["fabric"]["path"],
+        "fabric_sha256": project.fabric.get("sha256", ""),
+        "period": som_cfg["period"],
+        "normalize_method": "whole_period",
+        "annual_aggregation": "mean",
+        "area_crs": project.area_crs,
+    }
+    _assemble_and_write(
+        project=project,
+        lower=lo_a,
+        upper=up_a,
+        n_sources=ns_a,
+        n_sources_count=len(sources),
+        time_index=master_annual,
+        time_offset_unit=pd.offsets.YearBegin(1),
+        long_name_suffix="annual soil moisture",
+        cell_methods="time: mean",
+        output_path=_derive_variant_path(base_output, "annual"),
+        title="NHM soil moisture annual calibration target (dimensionless 0-1)",
+        extra_global_attrs=extra_attrs_annual,
+        hru_meta=hru_meta,
+        nn_fill=som_cfg["nn_fill"],
+        nn_max_candidates=int(som_cfg["nn_max_candidates"]),
+        nn_title=(
+            "NHM soil moisture annual calibration target (NN-filled, dimensionless 0-1)"
+        ),
+        id_col=id_col,
+    )

--- a/tests/test_normalize_methods.py
+++ b/tests/test_normalize_methods.py
@@ -1,0 +1,203 @@
+"""Tests for the per-HRU normalization primitives in normalize.methods."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+
+def _da(times, values, dims=("time", "nhm_id"), hrus=(1, 2, 3)) -> xr.DataArray:
+    return xr.DataArray(
+        np.asarray(values, dtype=np.float32),
+        dims=dims,
+        coords={"time": pd.DatetimeIndex(times), "nhm_id": list(hrus)},
+        attrs={"units": "mm"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# normalize_0_1
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_0_1_simple_range():
+    """Linear input on [0, 10] over 3 times normalizes to [0.0, 0.5, 1.0]."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    da = _da(
+        ["2000-01-01", "2000-02-01", "2000-03-01"],
+        [[0.0, 0.0, 0.0], [5.0, 5.0, 5.0], [10.0, 10.0, 10.0]],
+    )
+    out = normalize_0_1(da, dim="time")
+    np.testing.assert_allclose(
+        out.values, [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [1.0, 1.0, 1.0]], rtol=1e-6
+    )
+    assert out.attrs["units"] == "1"
+
+
+def test_normalize_0_1_per_hru_min_max():
+    """Each HRU is normalized independently using its own min/max."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    # HRU 1 swings 0..100, HRU 2 swings 10..30, HRU 3 swings 5..5 (constant).
+    da = _da(
+        ["2000-01-01", "2000-02-01", "2000-03-01"],
+        [[0.0, 10.0, 5.0], [50.0, 20.0, 5.0], [100.0, 30.0, 5.0]],
+    )
+    out = normalize_0_1(da, dim="time")
+    # HRU 1: (0,50,100) -> (0,0.5,1)
+    np.testing.assert_allclose(out.values[:, 0], [0.0, 0.5, 1.0], rtol=1e-6)
+    # HRU 2: (10,20,30) -> (0,0.5,1)
+    np.testing.assert_allclose(out.values[:, 1], [0.0, 0.5, 1.0], rtol=1e-6)
+    # HRU 3: constant series -> all NaN (zero range)
+    assert np.isnan(out.values[:, 2]).all()
+
+
+def test_normalize_0_1_handles_nan_skipna_for_minmax():
+    """NaNs along the dim are ignored when computing min/max."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    da = _da(
+        ["2000-01-01", "2000-02-01", "2000-03-01", "2000-04-01"],
+        [
+            [10.0, 0.0, 0.0],
+            [np.nan, 5.0, 0.0],
+            [20.0, np.nan, 0.0],
+            [30.0, 10.0, 0.0],
+        ],
+    )
+    out = normalize_0_1(da, dim="time")
+    # HRU 1: min=10, max=30 (NaN ignored) -> 10->0, NaN->NaN, 20->0.5, 30->1
+    np.testing.assert_allclose(out.values[0, 0], 0.0, rtol=1e-6)
+    assert np.isnan(out.values[1, 0])
+    np.testing.assert_allclose(out.values[2, 0], 0.5, rtol=1e-6)
+    np.testing.assert_allclose(out.values[3, 0], 1.0, rtol=1e-6)
+    # HRU 3: constant 0 -> all NaN (zero range)
+    assert np.isnan(out.values[:, 2]).all()
+
+
+def test_normalize_0_1_all_nan_yields_all_nan():
+    """All-NaN cell stays NaN (range is NaN, propagates)."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    da = _da(
+        ["2000-01-01", "2000-02-01"],
+        [[np.nan, 1.0], [np.nan, 2.0]],
+        hrus=(1, 2),
+    )
+    out = normalize_0_1(da, dim="time")
+    assert np.isnan(out.values[:, 0]).all()
+    # HRU 2 normalizes as usual
+    np.testing.assert_allclose(out.values[:, 1], [0.0, 1.0], rtol=1e-6)
+
+
+def test_normalize_0_1_raises_on_unknown_dim():
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    da = _da(["2000-01-01"], [[1.0, 2.0, 3.0]])
+    with pytest.raises(ValueError, match="not in DataArray dims"):
+        normalize_0_1(da, dim="not_a_dim")
+
+
+def test_normalize_0_1_preserves_non_units_attrs():
+    """Custom attrs (e.g. long_name) survive; only `units` is replaced."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1
+
+    da = _da(["2000-01-01", "2000-02-01"], [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    da.attrs["long_name"] = "monthly recharge"
+    da.attrs["source"] = "synthetic"
+    out = normalize_0_1(da, dim="time")
+    assert out.attrs["long_name"] == "monthly recharge"
+    assert out.attrs["source"] == "synthetic"
+    assert out.attrs["units"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# normalize_0_1_by_calendar_month
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_0_1_by_calendar_month_independence_across_months():
+    """Each calendar month is normalized with its own min/max.
+
+    Two Januaries (year A: 0, year B: 10) normalize to [0, 1]. Two Julys
+    with the same swing (200 to 300) also normalize to [0, 1] — the Jan
+    min of 0 must NOT pull Jul's normalization toward zero.
+    """
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_by_calendar_month
+
+    times = pd.to_datetime(["2000-01-01", "2000-07-01", "2001-01-01", "2001-07-01"])
+    # Values per (year, month) pair for HRU 1:
+    #   2000-01: 0     2000-07: 200
+    #   2001-01: 10    2001-07: 300
+    da = xr.DataArray(
+        np.array([[0.0], [200.0], [10.0], [300.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "mm"},
+    )
+    out = normalize_0_1_by_calendar_month(da)
+    # 2000-01 norm-jan: (0-0)/(10-0) = 0
+    np.testing.assert_allclose(out.sel(time="2000-01-01").values, [0.0], rtol=1e-6)
+    # 2001-01 norm-jan: (10-0)/(10-0) = 1
+    np.testing.assert_allclose(out.sel(time="2001-01-01").values, [1.0], rtol=1e-6)
+    # 2000-07 norm-jul: (200-200)/(300-200) = 0
+    np.testing.assert_allclose(out.sel(time="2000-07-01").values, [0.0], rtol=1e-6)
+    # 2001-07 norm-jul: (300-200)/(300-200) = 1
+    np.testing.assert_allclose(out.sel(time="2001-07-01").values, [1.0], rtol=1e-6)
+    assert out.attrs["units"] == "1"
+
+
+def test_normalize_0_1_by_calendar_month_preserves_input_order():
+    """Output is on the original (monotonic) time index, not regrouped."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_by_calendar_month
+
+    times = pd.date_range("2000-01-01", "2001-12-01", freq="MS")
+    values = np.arange(len(times) * 1, dtype=np.float32).reshape(-1, 1)
+    da = xr.DataArray(
+        values,
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "mm"},
+    )
+    out = normalize_0_1_by_calendar_month(da)
+    assert list(out.time.values) == list(times.values)
+    assert out.shape == da.shape
+
+
+def test_normalize_0_1_by_calendar_month_constant_month_yields_nan():
+    """A calendar month with constant value across years -> NaN (zero range)."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_by_calendar_month
+
+    times = pd.to_datetime(
+        ["2000-01-01", "2001-01-01", "2002-01-01", "2000-07-01", "2001-07-01"]
+    )
+    # All Januaries equal 5.0; Julys swing 100..200
+    values = np.array([[5.0], [5.0], [5.0], [100.0], [200.0]], dtype=np.float32)
+    da = xr.DataArray(
+        values,
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "mm"},
+    )
+    out = normalize_0_1_by_calendar_month(da)
+    # Three constant Januaries -> NaN
+    jans = out.sel(time=out.time.dt.month == 1).values
+    assert np.isnan(jans).all()
+    # Two-element July normalization -> 0, 1
+    juls = out.sel(time=out.time.dt.month == 7).values
+    np.testing.assert_allclose(juls.flatten(), [0.0, 1.0], rtol=1e-6)
+
+
+def test_normalize_0_1_by_calendar_month_raises_on_missing_time_dim():
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_by_calendar_month
+
+    da = xr.DataArray(
+        np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        dims=("nhm_id",),
+        coords={"nhm_id": [1, 2, 3]},
+    )
+    with pytest.raises(ValueError, match="expected 'time' dim"):
+        normalize_0_1_by_calendar_month(da)

--- a/tests/test_normalize_methods.py
+++ b/tests/test_normalize_methods.py
@@ -201,3 +201,182 @@ def test_normalize_0_1_by_calendar_month_raises_on_missing_time_dim():
     )
     with pytest.raises(ValueError, match="expected 'time' dim"):
         normalize_0_1_by_calendar_month(da)
+
+
+# ---------------------------------------------------------------------------
+# normalize_0_1_over_window
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_0_1_over_window_uses_window_minmax():
+    """Window's min/max drive the normalization; values outside may exceed [0, 1]."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_over_window
+
+    # da spans 5 years; window is years 2000-2002 (min=10, max=30).
+    # Year 2003 = 50 should normalize to (50-10)/(30-10) = 2.0 (visibly out of range).
+    times = pd.date_range("2000-01-01", "2004-01-01", freq="YS")
+    da = xr.DataArray(
+        np.array([[10.0], [20.0], [30.0], [50.0], [80.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "mm"},
+    )
+    window = da.sel(time=slice("2000-01-01", "2002-12-31"))
+    out = normalize_0_1_over_window(da, window)
+    np.testing.assert_allclose(
+        out.values, [[0.0], [0.5], [1.0], [2.0], [3.5]], rtol=1e-6
+    )
+    assert out.attrs["units"] == "1"
+
+
+def test_normalize_0_1_over_window_equals_normalize_0_1_when_window_is_da():
+    """When window == da, the window variant matches the no-window primitive."""
+    from nhf_spatial_targets.normalize.methods import (
+        normalize_0_1,
+        normalize_0_1_over_window,
+    )
+
+    times = pd.date_range("2000-01-01", "2004-01-01", freq="YS")
+    da = xr.DataArray(
+        np.array([[0.0, 5.0], [10.0, 15.0], [20.0, 25.0], [30.0, 35.0], [40.0, 45.0]]),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1, 2]},
+        attrs={"units": "mm"},
+    )
+    np.testing.assert_allclose(
+        normalize_0_1_over_window(da, da).values,
+        normalize_0_1(da, dim="time").values,
+        rtol=1e-6,
+    )
+
+
+def test_normalize_0_1_over_window_zero_range_yields_nan():
+    """Constant series over window → NaN (zero range)."""
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_over_window
+
+    times = pd.date_range("2000-01-01", "2003-01-01", freq="YS")
+    da = xr.DataArray(
+        np.array([[5.0], [5.0], [5.0], [10.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+    )
+    window = da.sel(time=slice("2000-01-01", "2002-12-31"))
+    out = normalize_0_1_over_window(da, window)
+    assert np.isnan(out.values).all()
+
+
+def test_normalize_0_1_over_window_raises_on_unknown_dim():
+    from nhf_spatial_targets.normalize.methods import normalize_0_1_over_window
+
+    da = xr.DataArray(
+        np.array([1.0, 2.0]),
+        dims=("nhm_id",),
+        coords={"nhm_id": [1, 2]},
+    )
+    with pytest.raises(ValueError, match="not in DataArray dims"):
+        normalize_0_1_over_window(da, da, dim="time")
+
+
+# ---------------------------------------------------------------------------
+# normalize_0_1_by_calendar_month_over_window
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_0_1_by_calendar_month_over_window_uses_window_per_month():
+    """Each calendar month is normalized using only that month's window min/max."""
+    from nhf_spatial_targets.normalize.methods import (
+        normalize_0_1_by_calendar_month_over_window,
+    )
+
+    # 4 years × 2 calendar months. Window = years 2000-2001 only.
+    #   Jan window: 0, 10 → min=0, max=10
+    #   Jul window: 100, 200 → min=100, max=200
+    # da's 2002-2003 values are normalized using the window's min/max.
+    times = pd.to_datetime(
+        [
+            "2000-01-01",
+            "2000-07-01",
+            "2001-01-01",
+            "2001-07-01",
+            "2002-01-01",
+            "2002-07-01",
+            "2003-01-01",
+            "2003-07-01",
+        ]
+    )
+    values = np.array(
+        [[0.0], [100.0], [10.0], [200.0], [20.0], [300.0], [5.0], [150.0]],
+        dtype=np.float32,
+    )
+    da = xr.DataArray(
+        values,
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "mm"},
+    )
+    window = da.sel(time=slice("2000-01-01", "2001-12-31"))
+    out = normalize_0_1_by_calendar_month_over_window(da, window)
+    # Jan: window min=0, max=10
+    #   2000-01: (0-0)/(10-0) = 0
+    #   2001-01: (10-0)/(10-0) = 1
+    #   2002-01: (20-0)/(10-0) = 2.0 (above window max — by design)
+    #   2003-01: (5-0)/(10-0) = 0.5
+    # Jul: window min=100, max=200
+    #   2000-07: (100-100)/(200-100) = 0
+    #   2001-07: (200-100)/(200-100) = 1
+    #   2002-07: (300-100)/(200-100) = 2.0
+    #   2003-07: (150-100)/(200-100) = 0.5
+    np.testing.assert_allclose(
+        out.values,
+        [[0.0], [0.0], [1.0], [1.0], [2.0], [2.0], [0.5], [0.5]],
+        rtol=1e-6,
+    )
+    assert out.attrs["units"] == "1"
+
+
+def test_normalize_0_1_by_calendar_month_over_window_equals_no_window():
+    """When window == da, the variant matches the no-window primitive."""
+    from nhf_spatial_targets.normalize.methods import (
+        normalize_0_1_by_calendar_month,
+        normalize_0_1_by_calendar_month_over_window,
+    )
+
+    times = pd.to_datetime(["2000-01-01", "2000-07-01", "2001-01-01", "2001-07-01"])
+    da = xr.DataArray(
+        np.array([[0.0], [100.0], [10.0], [200.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+    )
+    out_with = normalize_0_1_by_calendar_month_over_window(da, da)
+    out_no = normalize_0_1_by_calendar_month(da)
+    np.testing.assert_allclose(out_with.values, out_no.values, rtol=1e-6)
+
+
+def test_normalize_0_1_by_calendar_month_over_window_raises_on_missing_time():
+    from nhf_spatial_targets.normalize.methods import (
+        normalize_0_1_by_calendar_month_over_window,
+    )
+
+    da = xr.DataArray(
+        np.array([1.0, 2.0]),
+        dims=("nhm_id",),
+        coords={"nhm_id": [1, 2]},
+    )
+    with pytest.raises(ValueError, match="expected 'time' dim"):
+        normalize_0_1_by_calendar_month_over_window(da, da)
+
+
+def test_normalize_0_1_by_calendar_month_over_window_raises_when_window_lacks_time():
+    from nhf_spatial_targets.normalize.methods import (
+        normalize_0_1_by_calendar_month_over_window,
+    )
+
+    times = pd.to_datetime(["2000-01-01", "2000-07-01"])
+    da = xr.DataArray(
+        np.array([[1.0], [2.0]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+    )
+    bad_window = xr.DataArray(np.array([1.0]), dims=("nhm_id",), coords={"nhm_id": [1]})
+    with pytest.raises(ValueError, match="window must also have 'time' dim"):
+        normalize_0_1_by_calendar_month_over_window(da, bad_window)

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -694,3 +694,133 @@ def test_aet_target_module_exposes_well_formed_shims():
     for key in ("ssebop", "mwbm_climgrid"):
         out = by_key[key].to_common_units(da)
         assert out.attrs.get("units") == "mm"
+
+
+# ---------------------------------------------------------------------------
+# parse_period
+# ---------------------------------------------------------------------------
+
+
+def test_parse_period_splits_endpoints():
+    from nhf_spatial_targets.targets._common import parse_period
+
+    assert parse_period("2000-01-01/2009-12-31") == ("2000-01-01", "2009-12-31")
+    assert parse_period("2000/2009") == ("2000", "2009")
+
+
+def test_parse_period_strips_whitespace():
+    from nhf_spatial_targets.targets._common import parse_period
+
+    assert parse_period("  2000-01-01 / 2009-12-31  ") == (
+        "2000-01-01",
+        "2009-12-31",
+    )
+
+
+def test_parse_period_raises_on_missing_slash():
+    from nhf_spatial_targets.targets._common import parse_period
+
+    with pytest.raises(ValueError, match="Expected 'YYYY-MM-DD"):
+        parse_period("2000-01-01")
+
+
+# ---------------------------------------------------------------------------
+# check_hru_coords  (consider-2 follow-up; nit-5 test coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_check_hru_coords_returns_none_when_coords_match():
+    """Exact-match returns None (no raise)."""
+    from nhf_spatial_targets.targets._common import check_hru_coords
+
+    fabric_ids = np.array([1, 2, 3], dtype=np.int32)
+    da = xr.DataArray(
+        np.zeros(3, dtype=np.float32),
+        dims=("nhm_id",),
+        coords={"nhm_id": fabric_ids},
+    )
+    # Returning None is the contract; no exception means success.
+    assert check_hru_coords(da, fabric_ids, "nhm_id", "test_source") is None
+
+
+def test_check_hru_coords_raises_on_same_set_different_order():
+    """Permuted-but-same-set raises a 'canonical-sort regression' message."""
+    from nhf_spatial_targets.targets._common import check_hru_coords
+
+    fabric_ids = np.array([1, 2, 3], dtype=np.int32)
+    da = xr.DataArray(
+        np.zeros(3, dtype=np.float32),
+        dims=("nhm_id",),
+        coords={"nhm_id": np.array([3, 1, 2], dtype=np.int32)},  # permuted
+    )
+    with pytest.raises(ValueError, match="canonical-sort invariant"):
+        check_hru_coords(da, fabric_ids, "nhm_id", "test_source")
+
+
+def test_check_hru_coords_raises_on_different_sets():
+    """Different sets raise a 'Re-aggregate' message."""
+    from nhf_spatial_targets.targets._common import check_hru_coords
+
+    fabric_ids = np.array([1, 2, 3], dtype=np.int32)
+    da = xr.DataArray(
+        np.zeros(3, dtype=np.float32),
+        dims=("nhm_id",),
+        coords={"nhm_id": np.array([1, 2, 99], dtype=np.int32)},
+    )
+    with pytest.raises(ValueError, match="Re-aggregate 'test_source'"):
+        check_hru_coords(da, fabric_ids, "nhm_id", "test_source")
+
+
+def test_check_hru_coords_raises_on_different_length():
+    """Different-length coords go through the 'different sets' branch."""
+    from nhf_spatial_targets.targets._common import check_hru_coords
+
+    fabric_ids = np.array([1, 2, 3], dtype=np.int32)
+    da = xr.DataArray(
+        np.zeros(2, dtype=np.float32),
+        dims=("nhm_id",),
+        coords={"nhm_id": np.array([1, 2], dtype=np.int32)},
+    )
+    with pytest.raises(ValueError, match="differ between fabric and source"):
+        check_hru_coords(da, fabric_ids, "nhm_id", "test_source")
+
+
+# ---------------------------------------------------------------------------
+# build_n_sources_attrs  (consider-2 follow-up; nit-1 docstring/count check)
+# ---------------------------------------------------------------------------
+
+
+def test_build_n_sources_attrs_three_sources():
+    """3-source target → flag_values=[0,1,2,3] and meanings 'none one two three'."""
+    from nhf_spatial_targets.targets._common import build_n_sources_attrs
+
+    attrs = build_n_sources_attrs(3)
+    assert attrs["units"] == "1"
+    assert attrs["long_name"] == "number of finite source contributions"
+    assert attrs["flag_values"] == [0, 1, 2, 3]
+    assert attrs["flag_meanings"] == "none one two three"
+    assert attrs["coordinates"] == "centroid_lat centroid_lon"
+
+
+def test_build_n_sources_attrs_one_source():
+    """Single-source target → flag_values=[0,1], meanings 'none one'."""
+    from nhf_spatial_targets.targets._common import build_n_sources_attrs
+
+    attrs = build_n_sources_attrs(1)
+    assert attrs["flag_values"] == [0, 1]
+    assert attrs["flag_meanings"] == "none one"
+
+
+def test_build_n_sources_attrs_custom_coords():
+    from nhf_spatial_targets.targets._common import build_n_sources_attrs
+
+    attrs = build_n_sources_attrs(2, ancillary_coords="lat lon")
+    assert attrs["coordinates"] == "lat lon"
+
+
+def test_build_n_sources_attrs_raises_when_count_exceeds_label_vocab():
+    """6+ sources outpace the 'none..five' vocabulary and must raise."""
+    from nhf_spatial_targets.targets._common import build_n_sources_attrs
+
+    with pytest.raises(ValueError, match="5-source label vocabulary"):
+        build_n_sources_attrs(6)

--- a/tests/test_targets_rch.py
+++ b/tests/test_targets_rch.py
@@ -1,0 +1,441 @@
+"""Tests for the recharge target builder end-to-end."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import yaml
+
+
+def _write_synthetic_fabric(path: Path, id_col: str = "nhm_id"):
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    gdf = gpd.GeoDataFrame(
+        {id_col: [1, 2, 3]},
+        geometry=[
+            box(-105.0, 40.0, -104.9, 40.1),
+            box(-104.9, 40.0, -104.8, 40.1),
+            box(-104.8, 40.0, -104.7, 40.1),
+        ],
+        crs="EPSG:4326",
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gdf.to_file(path, driver="GPKG")
+
+
+def _write_reitz_year_nc(
+    path: Path, year: int, value: float, id_col: str = "nhm_id"
+) -> None:
+    """Reitz native: 1 timestep per year at mid-year, m/year."""
+    times = pd.DatetimeIndex([f"{year}-07-01"])
+    hrus = [1, 2, 3]
+    arr = np.full((1, len(hrus)), value, dtype=np.float32)
+    ds = xr.Dataset(
+        {"total_recharge": (("time", id_col), arr)},
+        coords={"time": times, id_col: hrus},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _write_watergap_year_nc(
+    path: Path, year: int, value: float, id_col: str = "nhm_id"
+) -> None:
+    """WaterGAP native: 12 monthly mean rates at month-start, kg m-2 s-1."""
+    times = pd.date_range(f"{year}-01-01", f"{year}-12-01", freq="MS")
+    hrus = [1, 2, 3]
+    arr = np.full((len(times), len(hrus)), value, dtype=np.float32)
+    ds = xr.Dataset(
+        {"qrdif": (("time", id_col), arr)},
+        coords={"time": times, id_col: hrus},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _write_era5_year_nc(
+    path: Path, year: int, value: float, id_col: str = "nhm_id"
+) -> None:
+    """ERA5-Land native: 12 monthly accumulations at month-end, m water-eq."""
+    times = pd.date_range(f"{year}-01-31", f"{year}-12-31", freq="ME")
+    hrus = [1, 2, 3]
+    arr = np.full((len(times), len(hrus)), value, dtype=np.float32)
+    ds = xr.Dataset(
+        {"ssro": (("time", id_col), arr)},
+        coords={"time": times, id_col: hrus},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _make_rch_project(
+    tmp_path: Path,
+    *,
+    period: str = "2000-01-01/2009-12-31",
+    normalize_period: str | None = None,
+    sources: list[str] | None = None,
+    nn_fill: bool = True,
+    write_reitz: bool = True,
+    write_watergap: bool = True,
+    write_era5: bool = True,
+    reitz_value: float = 0.05,  # m/yr -> 50 mm/yr
+    watergap_value: float = 1e-6,  # kg/m²/s -> ~31.5 mm/yr (linear in days_in_month)
+    era5_value: float = 0.001,  # m/month -> 1 mm/month -> 12 mm/yr
+) -> Path:
+    """Build a project skeleton with synthetic fabric + per-year aggregated NCs."""
+    if sources is None:
+        sources = ["reitz2017", "watergap22d", "era5_land"]
+    if normalize_period is None:
+        normalize_period = period
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    fabric_path = tmp_path / "fabric.gpkg"
+    _write_synthetic_fabric(fabric_path)
+    (workdir / "fabric.json").write_text(json.dumps({"id_col": "nhm_id"}))
+
+    cfg = {
+        "datastore": str(tmp_path / "store"),
+        "fabric": {"path": str(fabric_path), "id_col": "nhm_id"},
+        "targets": {
+            "recharge": {
+                "period": period,
+                "normalize_period": normalize_period,
+                "sources": sources,
+                "nn_fill": nn_fill,
+            },
+            "runoff": {"enabled": False},
+            "aet": {"enabled": False},
+            "soil_moisture": {"enabled": False},
+            "snow_covered_area": {"enabled": False},
+            "snow_water_equivalent": {"enabled": False},
+        },
+    }
+    (workdir / "config.yml").write_text(yaml.safe_dump(cfg))
+
+    agg_dir = workdir / "data" / "aggregated"
+    years = list(
+        range(
+            pd.Timestamp(period.split("/")[0]).year,
+            pd.Timestamp(period.split("/")[1]).year + 1,
+        )
+    )
+    # Make the source values vary year-over-year so the normalize bound is
+    # non-degenerate. Use a deterministic ramp (multiplier in [0.5, 1.5]).
+    for i, year in enumerate(years):
+        scale = 0.5 + (i / max(len(years) - 1, 1))  # 0.5 ramp to 1.5
+        if write_reitz and "reitz2017" in sources:
+            _write_reitz_year_nc(
+                agg_dir / "reitz2017" / f"reitz2017_{year}_agg.nc",
+                year,
+                reitz_value * scale,
+            )
+        if write_watergap and "watergap22d" in sources:
+            _write_watergap_year_nc(
+                agg_dir / "watergap22d" / f"watergap22d_{year}_agg.nc",
+                year,
+                watergap_value * scale,
+            )
+        if write_era5 and "era5_land" in sources:
+            _write_era5_year_nc(
+                agg_dir / "era5_land" / f"era5_land_{year}_agg.nc",
+                year,
+                era5_value * scale,
+            )
+    return workdir
+
+
+# ---------------------------------------------------------------------------
+# Per-source unit shims
+# ---------------------------------------------------------------------------
+
+
+def test_reitz_to_mm_per_year_x1000_and_year_start():
+    """reitz 0.05 m/yr → 50 mm/yr; time canonicalized to year-start."""
+    from nhf_spatial_targets.targets.rch import reitz_to_mm_per_year
+
+    da = xr.DataArray(
+        np.array([[0.05, 0.10, 0.20]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": pd.DatetimeIndex(["2000-07-01"]), "nhm_id": [1, 2, 3]},
+        attrs={"units": "m yr-1"},
+    )
+    out = reitz_to_mm_per_year(da)
+    np.testing.assert_allclose(out.values, [[50.0, 100.0, 200.0]], rtol=1e-6)
+    assert pd.Timestamp(out.time.values[0]) == pd.Timestamp("2000-01-01")
+    assert out.attrs["units"] == "mm"
+
+
+def test_watergap22d_to_mm_per_year_constant_rate():
+    """1e-6 kg/m²/s × seconds_in_year (non-leap) = ~31.5 mm/yr."""
+    from nhf_spatial_targets.targets.rch import watergap22d_to_mm_per_year
+
+    times = pd.date_range("2001-01-01", "2001-12-01", freq="MS")
+    da = xr.DataArray(
+        np.full((12, 1), 1e-6, dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "kg m-2 s-1"},
+    )
+    out = watergap22d_to_mm_per_year(da)
+    expected = 1e-6 * 365 * 86400.0  # non-leap year: 365 days
+    np.testing.assert_allclose(out.values, [[expected]], rtol=1e-5)
+    assert pd.Timestamp(out.time.values[0]) == pd.Timestamp("2001-01-01")
+    assert out.attrs["units"] == "mm"
+
+
+def test_watergap22d_to_mm_per_year_leap_year():
+    """Leap year (2000) → 366 days × 86400 s × rate."""
+    from nhf_spatial_targets.targets.rch import watergap22d_to_mm_per_year
+
+    times = pd.date_range("2000-01-01", "2000-12-01", freq="MS")
+    da = xr.DataArray(
+        np.full((12, 1), 1e-6, dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+    )
+    out = watergap22d_to_mm_per_year(da)
+    expected = 1e-6 * 366 * 86400.0
+    np.testing.assert_allclose(out.values, [[expected]], rtol=1e-5)
+
+
+def test_era5_ssro_to_mm_per_year_constant_accumulation():
+    """0.001 m/month × 1000 × 12 months = 12 mm/yr."""
+    from nhf_spatial_targets.targets.rch import era5_ssro_to_mm_per_year
+
+    times = pd.date_range("2005-01-31", "2005-12-31", freq="ME")
+    da = xr.DataArray(
+        np.full((12, 1), 0.001, dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": times, "nhm_id": [1]},
+        attrs={"units": "m"},
+    )
+    out = era5_ssro_to_mm_per_year(da)
+    np.testing.assert_allclose(out.values, [[12.0]], rtol=1e-6)
+    assert pd.Timestamp(out.time.values[0]) == pd.Timestamp("2005-01-01")
+    assert out.attrs["units"] == "mm"
+
+
+def test_shims_registered_and_well_formed():
+    """SHIMS exposes the three expected source keys with correct aggregated_vars."""
+    from nhf_spatial_targets.targets.rch import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert set(by_key) == {"reitz2017", "watergap22d", "era5_land"}
+    assert by_key["reitz2017"].aggregated_var == "total_recharge"
+    assert by_key["watergap22d"].aggregated_var == "qrdif"
+    assert by_key["era5_land"].aggregated_var == "ssro"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end build
+# ---------------------------------------------------------------------------
+
+
+def test_build_writes_unfilled_and_filled_files(tmp_path: Path):
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31")
+    project = load(workdir)
+    build(project)
+    assert (project.targets_dir() / "recharge_targets.nc").exists()
+    assert (project.targets_dir() / "recharge_targets_nn_filled.nc").exists()
+
+
+def test_build_output_schema(tmp_path: Path):
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as ds:
+        assert "lower_bound" in ds and "upper_bound" in ds
+        assert "n_sources" in ds
+        assert ds["lower_bound"].attrs["units"] == "1"
+        assert ds["upper_bound"].attrs["units"] == "1"
+        assert ds.attrs["Conventions"] == "CF-1.6"
+        assert ds["time"].attrs["bounds"] == "time_bnds"
+        assert "time_bnds" in ds.variables
+        # 10 annual timesteps for 2000-2009
+        assert ds.sizes["time"] == 10
+
+
+def test_build_bounds_in_0_1_range(tmp_path: Path):
+    """Normalized output: 0 <= lower <= upper <= 1 everywhere (or NaN)."""
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as ds:
+        finite_lo = ds["lower_bound"].values[np.isfinite(ds["lower_bound"].values)]
+        finite_up = ds["upper_bound"].values[np.isfinite(ds["upper_bound"].values)]
+        assert (finite_lo >= 0).all()
+        assert (finite_lo <= 1).all()
+        assert (finite_up >= 0).all()
+        assert (finite_up <= 1).all()
+        finite_pair = np.isfinite(ds["lower_bound"].values) & np.isfinite(
+            ds["upper_bound"].values
+        )
+        assert (
+            ds["upper_bound"].values[finite_pair]
+            >= ds["lower_bound"].values[finite_pair]
+        ).all()
+
+
+def test_build_n_sources_full_period(tmp_path: Path):
+    """All three sources present at every year-step → n_sources=3 everywhere."""
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as ds:
+        assert (ds["n_sources"].values == 3).all()
+
+
+def test_build_normalize_uses_window(tmp_path: Path):
+    """A flat-rate source on a year-varying scale normalizes to span [0, 1].
+
+    The synthetic data ramps from 0.5x to 1.5x across years, so the min is
+    at year 0 and max at year N-1. After normalization, year 0 should be 0
+    and year N-1 should be 1 (per HRU, per source).
+    """
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as ds:
+        # All three sources scale together → the min/max bound at each year
+        # is the SAME across the three normalized sources (so lower == upper)
+        # AND walks 0 -> 1 across the 10-year span.
+        lower = ds["lower_bound"].values
+        upper = ds["upper_bound"].values
+        # First year: 0.0 (smallest scale value); last year: 1.0
+        np.testing.assert_allclose(lower[0], 0.0, atol=1e-6)
+        np.testing.assert_allclose(upper[0], 0.0, atol=1e-6)
+        np.testing.assert_allclose(lower[-1], 1.0, atol=1e-6)
+        np.testing.assert_allclose(upper[-1], 1.0, atol=1e-6)
+
+
+def test_build_source_attr_reflects_active_sources(tmp_path: Path):
+    """Dropping a source from config removes it from the output's source attr."""
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(
+        tmp_path,
+        period="2000-01-01/2009-12-31",
+        sources=["reitz2017", "era5_land"],
+        write_watergap=False,
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as ds:
+        src_attr = ds.attrs["source"]
+        assert "Reitz 2017" in src_attr
+        assert "ERA5-Land" in src_attr
+        assert "WaterGAP" not in src_attr
+
+
+def test_build_unknown_source_raises(tmp_path: Path):
+    """recharge.sources with an unknown key raises before any IO."""
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(
+        tmp_path,
+        period="2000-01-01/2009-12-31",
+        sources=["reitz2017", "not_a_real_source"],
+        write_watergap=False,
+        write_era5=False,
+        nn_fill=False,
+    )
+    project = load(workdir)
+    with pytest.raises(ValueError, match="unknown source 'not_a_real_source'"):
+        build(project)
+
+
+def test_build_hru_mismatch_raises(tmp_path: Path):
+    """Source aggregated to a different HRU set than the fabric → raise."""
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(tmp_path, period="2000-01-01/2009-12-31", nn_fill=False)
+    # Overwrite the reitz2017 2005 NC with a bad HRU set.
+    bad = workdir / "data" / "aggregated" / "reitz2017" / "reitz2017_2005_agg.nc"
+    times = pd.DatetimeIndex(["2005-07-01"])
+    hrus = [1, 2, 99]  # 99 instead of 3
+    ds = xr.Dataset(
+        {
+            "total_recharge": (
+                ("time", "nhm_id"),
+                np.full((1, 3), 0.05, dtype=np.float32),
+            )
+        },
+        coords={"time": times, "nhm_id": hrus},
+    )
+    bad.unlink()
+    ds.to_netcdf(bad)
+
+    project = load(workdir)
+    with pytest.raises(ValueError, match="HRU coords differ.*as sets"):
+        build(project)
+
+
+def test_build_nn_fill_actually_fills_nan_cells(tmp_path: Path):
+    """End-to-end NN-fill: a single-source build with NaN at HRU 2 → filled file
+    has HRU 2 finite and nn_filled=1 there.
+    """
+    from nhf_spatial_targets.targets.rch import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_rch_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        sources=["reitz2017"],
+        write_watergap=False,
+        write_era5=False,
+        nn_fill=True,
+    )
+    # Rewrite all three reitz NCs so HRU 2 is NaN throughout.
+    for year in (2000, 2001, 2002):
+        bad = workdir / "data" / "aggregated" / "reitz2017" / f"reitz2017_{year}_agg.nc"
+        bad.unlink()
+        times = pd.DatetimeIndex([f"{year}-07-01"])
+        vals = np.array(
+            [[0.05 * (1 + (year - 2000) * 0.5), np.nan, 0.20]], dtype=np.float32
+        )
+        ds = xr.Dataset(
+            {"total_recharge": (("time", "nhm_id"), vals)},
+            coords={"time": times, "nhm_id": [1, 2, 3]},
+        )
+        ds.to_netcdf(bad)
+
+    project = load(workdir)
+    build(project)
+
+    with xr.open_dataset(project.targets_dir() / "recharge_targets.nc") as out:
+        assert np.isnan(out["lower_bound"].values[:, 1]).all()
+        assert (out["n_sources"].values[:, 1] == 0).all()
+
+    nn_path = project.targets_dir() / "recharge_targets_nn_filled.nc"
+    assert nn_path.exists()
+    with xr.open_dataset(nn_path) as filled:
+        assert "nn_filled" in filled.data_vars
+        assert np.isfinite(filled["lower_bound"].values[:, 1]).all()
+        assert (filled["nn_filled"].values[:, 1] == 1).all()
+        assert (filled["nn_filled"].values[:, 0] == 0).all()

--- a/tests/test_targets_som.py
+++ b/tests/test_targets_som.py
@@ -67,6 +67,7 @@ def _make_som_project(
     period: str = "2000-01-01/2002-12-31",
     sources: list[str] | None = None,
     nn_fill: bool = True,
+    normalize_period: str | None = None,
 ) -> Path:
     """Build a project skeleton with synthetic fabric + per-year aggregated NCs.
 
@@ -88,6 +89,7 @@ def _make_som_project(
         "targets": {
             "soil_moisture": {
                 "period": period,
+                "normalize_period": normalize_period,
                 "sources": sources,
                 "nn_fill": nn_fill,
             },
@@ -388,3 +390,136 @@ def test_build_hru_mismatch_raises(tmp_path: Path):
     project = load(workdir)
     with pytest.raises(ValueError, match="HRU coords differ.*as sets"):
         build(project)
+
+
+# ---------------------------------------------------------------------------
+# normalize_period config knob
+# ---------------------------------------------------------------------------
+
+
+def test_build_normalize_period_defaults_to_period(tmp_path: Path):
+    """When normalize_period is None, behavior matches the no-window primitive."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        normalize_period=None,
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_annual.nc"
+    ) as ds:
+        # Default behavior unchanged from PR base: ramp 2000→2002 normalizes to 0,0.5,1.
+        np.testing.assert_allclose(
+            ds["lower_bound"].values[:, 0], [0.0, 0.5, 1.0], atol=1e-6
+        )
+        assert ds.attrs["normalize_period"] == "2000-01-01/2002-12-31"
+
+
+def test_build_normalize_period_narrower_than_period_extrapolates_above_1(
+    tmp_path: Path,
+):
+    """normalize_period < period: years past the window normalize above 1.
+
+    Use a 5-year period with normalize_period covering only the first 3 years.
+    The ramp (1.0, 1.125, 1.25, 1.375, 1.5x) means the first 3 years' annual
+    means normalize to [0, 0.5, 1.0]; the 4th year (1.375x) is above the
+    window max so normalizes to 1.5 (visibly out-of-range, by design).
+    """
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2004-12-31",
+        normalize_period="2000-01-01/2002-12-31",
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_annual.nc"
+    ) as ds:
+        lo = ds["lower_bound"].values[:, 0]
+        # Window years 2000, 2001, 2002 → 0, 0.5, 1.0
+        np.testing.assert_allclose(lo[:3], [0.0, 0.5, 1.0], atol=1e-6)
+        # Years 2003 and 2004 extrapolate above 1 (by design)
+        assert lo[3] > 1.0
+        assert lo[4] > lo[3]
+        assert ds.attrs["normalize_period"] == "2000-01-01/2002-12-31"
+
+
+def test_build_normalize_period_monthly_variant_records_attr(tmp_path: Path):
+    """Monthly variant records the normalize_period in its global attrs."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        normalize_period="2000-01-01/2001-12-31",
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    ) as ds:
+        assert ds.attrs["normalize_period"] == "2000-01-01/2001-12-31"
+
+
+# ---------------------------------------------------------------------------
+# NN-fill effect
+# ---------------------------------------------------------------------------
+
+
+def test_build_nn_fill_actually_fills_nan_cells(tmp_path: Path):
+    """End-to-end NN-fill for the SOM monthly variant: a NaN HRU is filled in
+    the *_nn_filled.nc companion and the nn_filled flag is set."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        sources=["merra2"],  # single source so any NaN propagates to bound NaN
+        nn_fill=True,
+    )
+    # Rewrite each merra2 NC so HRU 2 is NaN throughout.
+    for year in (2000, 2001, 2002):
+        path = workdir / "data" / "aggregated" / "merra2" / f"merra2_{year}_agg.nc"
+        path.unlink()
+        times = pd.DatetimeIndex([f"{year}-{m:02d}-15" for m in range(1, 13)])
+        # Per-month base value × year-over-year ramp so the normalization
+        # produces non-degenerate bounds for HRUs 1 and 3.
+        scale = 1.0 + 0.5 * ((year - 2000) / 2)
+        arr = np.full((12, 3), 0.5 * scale, dtype=np.float32)
+        arr[:, 1] = np.nan
+        ds = xr.Dataset(
+            {"GWETTOP": (("time", "nhm_id"), arr)},
+            coords={"time": times, "nhm_id": [1, 2, 3]},
+        )
+        ds.to_netcdf(path)
+
+    project = load(workdir)
+    build(project)
+
+    monthly = project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    monthly_nn = project.targets_dir() / "soil_moisture_targets_monthly_nn_filled.nc"
+
+    # Honest-NaN file: HRU 2 NaN throughout, n_sources=0 there.
+    with xr.open_dataset(monthly) as raw:
+        assert np.isnan(raw["lower_bound"].values[:, 1]).all()
+        assert (raw["n_sources"].values[:, 1] == 0).all()
+
+    # NN-filled file: HRU 2 now finite, nn_filled=1 there.
+    assert monthly_nn.exists()
+    with xr.open_dataset(monthly_nn) as filled:
+        assert "nn_filled" in filled.data_vars
+        assert np.isfinite(filled["lower_bound"].values[:, 1]).all()
+        assert (filled["nn_filled"].values[:, 1] == 1).all()
+        assert (filled["nn_filled"].values[:, 0] == 0).all()

--- a/tests/test_targets_som.py
+++ b/tests/test_targets_som.py
@@ -1,0 +1,390 @@
+"""Tests for the soil moisture target builder end-to-end (monthly + annual)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import yaml
+
+
+def _write_synthetic_fabric(path: Path, id_col: str = "nhm_id"):
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    gdf = gpd.GeoDataFrame(
+        {id_col: [1, 2, 3]},
+        geometry=[
+            box(-105.0, 40.0, -104.9, 40.1),
+            box(-104.9, 40.0, -104.8, 40.1),
+            box(-104.8, 40.0, -104.7, 40.1),
+        ],
+        crs="EPSG:4326",
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gdf.to_file(path, driver="GPKG")
+
+
+def _write_monthly_nc(
+    path: Path,
+    year: int,
+    var: str,
+    timestamp_style: str,
+    values: np.ndarray,
+    id_col: str = "nhm_id",
+) -> None:
+    """Write a per-year aggregated NC at monthly cadence.
+
+    ``timestamp_style`` is one of:
+      - ``"month_start"`` — 12 timestamps at YYYY-MM-01 (nldas_mosaic, nldas_noah)
+      - ``"month_end"`` — 12 timestamps at YYYY-MM-(last) (ncep_ncar)
+      - ``"mid_month"`` — 12 timestamps at YYYY-MM-15 (merra2)
+    """
+    if timestamp_style == "month_start":
+        times = pd.date_range(f"{year}-01-01", f"{year}-12-01", freq="MS")
+    elif timestamp_style == "month_end":
+        times = pd.date_range(f"{year}-01-31", f"{year}-12-31", freq="ME")
+    elif timestamp_style == "mid_month":
+        times = pd.DatetimeIndex([f"{year}-{m:02d}-15" for m in range(1, 13)])
+    else:
+        raise ValueError(f"Unknown timestamp_style: {timestamp_style!r}")
+    assert values.shape[0] == 12
+    ds = xr.Dataset(
+        {var: (("time", id_col), values)},
+        coords={"time": times, id_col: [1, 2, 3]},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _make_som_project(
+    tmp_path: Path,
+    *,
+    period: str = "2000-01-01/2002-12-31",
+    sources: list[str] | None = None,
+    nn_fill: bool = True,
+) -> Path:
+    """Build a project skeleton with synthetic fabric + per-year aggregated NCs.
+
+    Each source gets a year-by-year linear ramp at every month so the
+    per-calendar-month normalization is exercised (multiple years per month).
+    """
+    if sources is None:
+        sources = ["merra2", "ncep_ncar", "nldas_mosaic", "nldas_noah"]
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    fabric_path = tmp_path / "fabric.gpkg"
+    _write_synthetic_fabric(fabric_path)
+    (workdir / "fabric.json").write_text(json.dumps({"id_col": "nhm_id"}))
+
+    cfg = {
+        "datastore": str(tmp_path / "store"),
+        "fabric": {"path": str(fabric_path), "id_col": "nhm_id"},
+        "targets": {
+            "soil_moisture": {
+                "period": period,
+                "sources": sources,
+                "nn_fill": nn_fill,
+            },
+            "runoff": {"enabled": False},
+            "aet": {"enabled": False},
+            "recharge": {"enabled": False},
+            "snow_covered_area": {"enabled": False},
+            "snow_water_equivalent": {"enabled": False},
+        },
+    }
+    (workdir / "config.yml").write_text(yaml.safe_dump(cfg))
+
+    agg_dir = workdir / "data" / "aggregated"
+    years = list(
+        range(
+            pd.Timestamp(period.split("/")[0]).year,
+            pd.Timestamp(period.split("/")[1]).year + 1,
+        )
+    )
+
+    spec = {
+        "merra2": ("GWETTOP", "mid_month", 0.5),
+        "ncep_ncar": ("soilw_0_10cm", "month_end", 0.3),
+        "nldas_mosaic": ("SoilM_0_10cm", "month_start", 30.0),
+        "nldas_noah": ("SoilM_0_10cm", "month_start", 25.0),
+    }
+    for src in sources:
+        if src not in spec:
+            # Unknown source — caller is exercising the "unknown source" error
+            # path; skip writing NCs we have no synthetic data spec for.
+            continue
+        var, style, base = spec[src]
+        for i, year in enumerate(years):
+            # Year-over-year ramp 1.0 → 1.5 to give per-calendar-month
+            # normalization a non-degenerate min/max range. Per HRU, all 3
+            # HRUs share the same value (synthetic uniform field).
+            scale = 1.0 + 0.5 * (i / max(len(years) - 1, 1))
+            arr = np.full((12, 3), base * scale, dtype=np.float32)
+            _write_monthly_nc(
+                agg_dir / src / f"{src}_{year}_agg.nc",
+                year,
+                var,
+                style,
+                arr,
+            )
+    return workdir
+
+
+# ---------------------------------------------------------------------------
+# Per-source shim + registry
+# ---------------------------------------------------------------------------
+
+
+def test_som_passthrough_returns_input_unchanged():
+    from nhf_spatial_targets.targets.som import som_passthrough
+
+    da = xr.DataArray(
+        np.array([[0.5, 0.6, 0.7]], dtype=np.float32),
+        dims=("time", "nhm_id"),
+        coords={"time": pd.DatetimeIndex(["2000-01-15"]), "nhm_id": [1, 2, 3]},
+        attrs={"units": "1"},
+    )
+    out = som_passthrough(da)
+    np.testing.assert_array_equal(out.values, da.values)
+    # Identity contract: same object reference is fine; alternatively assert
+    # values + attrs equality.
+    assert out.attrs == da.attrs
+
+
+def test_shims_registered_and_well_formed():
+    """SHIMS exposes all four expected source keys with the right aggregated_vars."""
+    from nhf_spatial_targets.targets.som import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert set(by_key) == {"merra2", "ncep_ncar", "nldas_mosaic", "nldas_noah"}
+    assert by_key["merra2"].aggregated_var == "GWETTOP"
+    assert by_key["ncep_ncar"].aggregated_var == "soilw_0_10cm"
+    assert by_key["nldas_mosaic"].aggregated_var == "SoilM_0_10cm"
+    assert by_key["nldas_noah"].aggregated_var == "SoilM_0_10cm"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end build (monthly + annual variants)
+# ---------------------------------------------------------------------------
+
+
+def test_build_writes_both_monthly_and_annual_files(tmp_path: Path):
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31")
+    project = load(workdir)
+    build(project)
+    out = project.targets_dir()
+    assert (out / "soil_moisture_targets_monthly.nc").exists()
+    assert (out / "soil_moisture_targets_monthly_nn_filled.nc").exists()
+    assert (out / "soil_moisture_targets_annual.nc").exists()
+    assert (out / "soil_moisture_targets_annual_nn_filled.nc").exists()
+
+
+def test_build_monthly_output_schema(tmp_path: Path):
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    ) as ds:
+        assert "lower_bound" in ds and "upper_bound" in ds
+        assert "n_sources" in ds
+        assert ds["lower_bound"].attrs["units"] == "1"
+        assert ds.attrs["Conventions"] == "CF-1.6"
+        assert ds.attrs["normalize_method"] == "per_calendar_month"
+        # 36 monthly timesteps for 2000-2002
+        assert ds.sizes["time"] == 36
+
+
+def test_build_annual_output_schema(tmp_path: Path):
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_annual.nc"
+    ) as ds:
+        assert "lower_bound" in ds and "upper_bound" in ds
+        assert "n_sources" in ds
+        assert ds["lower_bound"].attrs["units"] == "1"
+        assert ds.attrs["Conventions"] == "CF-1.6"
+        assert ds.attrs["normalize_method"] == "whole_period"
+        assert ds.attrs["annual_aggregation"] == "mean"
+        # 3 annual timesteps for 2000-2002
+        assert ds.sizes["time"] == 3
+
+
+def test_build_monthly_bounds_in_0_1_range(tmp_path: Path):
+    """Per-calendar-month normalization: 0 <= lower <= upper <= 1 everywhere."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    ) as ds:
+        finite_lo = ds["lower_bound"].values[np.isfinite(ds["lower_bound"].values)]
+        finite_up = ds["upper_bound"].values[np.isfinite(ds["upper_bound"].values)]
+        assert (finite_lo >= 0).all()
+        assert (finite_lo <= 1).all()
+        assert (finite_up >= 0).all()
+        assert (finite_up <= 1).all()
+
+
+def test_build_annual_bounds_in_0_1_range(tmp_path: Path):
+    """Whole-period normalization: 0 <= lower <= upper <= 1 everywhere."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_annual.nc"
+    ) as ds:
+        finite_lo = ds["lower_bound"].values[np.isfinite(ds["lower_bound"].values)]
+        finite_up = ds["upper_bound"].values[np.isfinite(ds["upper_bound"].values)]
+        assert (finite_lo >= 0).all()
+        assert (finite_lo <= 1).all()
+        assert (finite_up >= 0).all()
+        assert (finite_up <= 1).all()
+
+
+def test_build_n_sources_full_coverage(tmp_path: Path):
+    """All four sources present throughout → n_sources=4 everywhere (both outputs)."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    for fname in (
+        "soil_moisture_targets_monthly.nc",
+        "soil_moisture_targets_annual.nc",
+    ):
+        with xr.open_dataset(project.targets_dir() / fname) as ds:
+            assert (ds["n_sources"].values == 4).all(), f"{fname} has gaps"
+
+
+def test_build_monthly_normalize_per_calendar_month(tmp_path: Path):
+    """First year is per-month min, last year is per-month max.
+
+    With the synthetic year-over-year ramp (1.0 → 1.5x), every January
+    across years should normalize to [0, 1] where 2000-01 is the min (0)
+    and the last year's January is the max (1). Similarly for every other
+    calendar month.
+    """
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    ) as ds:
+        # Pick HRU 1's bounds; all sources scale together so lower == upper.
+        lo = ds["lower_bound"].values[:, 0]
+        # 36 months: indices 0,1,...,11 = year 2000 months 1..12
+        #            indices 12,...,23 = year 2001 months 1..12
+        #            indices 24,...,35 = year 2002 months 1..12
+        # Within each calendar-month group (e.g. all Januaries at indices 0, 12, 24),
+        # the ramp gives normalized values [0, 0.5, 1.0].
+        for month_idx in range(12):
+            jan_like = lo[month_idx::12]
+            np.testing.assert_allclose(jan_like, [0.0, 0.5, 1.0], atol=1e-6)
+
+
+def test_build_annual_aggregation_is_mean(tmp_path: Path):
+    """Annual aggregation collapses each year's 12 monthly values to a mean.
+
+    With the synthetic ramp scaling identically across calendar months
+    within a year, the annual mean equals the year's scale × base.
+    Normalization over 3 years gives [0, 0.5, 1.0].
+    """
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_annual.nc"
+    ) as ds:
+        lo = ds["lower_bound"].values[:, 0]
+        np.testing.assert_allclose(lo, [0.0, 0.5, 1.0], atol=1e-6)
+
+
+def test_build_source_attr_reflects_active_sources(tmp_path: Path):
+    """Dropping a source from config removes it from the output's source attr."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        sources=["merra2", "ncep_ncar"],
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(
+        project.targets_dir() / "soil_moisture_targets_monthly.nc"
+    ) as ds:
+        src_attr = ds.attrs["source"]
+        assert "MERRA-2" in src_attr
+        assert "NCEP/NCAR" in src_attr
+        assert "NLDAS" not in src_attr
+
+
+def test_build_unknown_source_raises(tmp_path: Path):
+    """soil_moisture.sources with an unknown key raises before any IO."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(
+        tmp_path,
+        period="2000-01-01/2002-12-31",
+        sources=["merra2", "not_a_real_source"],
+        nn_fill=False,
+    )
+    project = load(workdir)
+    with pytest.raises(ValueError, match="unknown source 'not_a_real_source'"):
+        build(project)
+
+
+def test_build_hru_mismatch_raises(tmp_path: Path):
+    """Source aggregated to a different HRU set than the fabric → raise."""
+    from nhf_spatial_targets.targets.som import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_som_project(tmp_path, period="2000-01-01/2002-12-31", nn_fill=False)
+    bad = workdir / "data" / "aggregated" / "merra2" / "merra2_2001_agg.nc"
+    times = pd.DatetimeIndex([f"2001-{m:02d}-15" for m in range(1, 13)])
+    hrus = [1, 2, 99]
+    arr = np.full((12, 3), 0.5, dtype=np.float32)
+    ds = xr.Dataset(
+        {"GWETTOP": (("time", "nhm_id"), arr)},
+        coords={"time": times, "nhm_id": hrus},
+    )
+    bad.unlink()
+    ds.to_netcdf(bad)
+
+    project = load(workdir)
+    with pytest.raises(ValueError, match="HRU coords differ.*as sets"):
+        build(project)


### PR DESCRIPTION
## Summary

Implements the normalized_minmax target bundle (recharge + soil_moisture), the last two of the five TM 6-B10 calibration targets that weren't yet built. Builds on the recently-landed SourceShim registry (#128) and centroids-only HRU helper (#129).

### normalize/methods.py primitives

- \`normalize_0_1(da, dim="time")\` — per-cell min/max normalize to [0, 1]. Constant series → NaN (no spurious midpoint).
- \`normalize_0_1_by_calendar_month(da)\` — per-cell per-calendar-month normalize for SOM monthly (TM 6-B10 §4 Appendix 1).

### Recharge

- 3 sources: reitz2017 (m/yr native annual), watergap22d (kg/m²/s monthly mean), era5_land ssro (m/month accumulation).
- Shim absorbs unit + time-axis transformation → all three produce mm/year at year-start (Option D from #128's review consider-2).
- Normalize 0-1 over \`recharge.normalize_period\` (default 2000-2009), reindex to \`recharge.period\`.
- Output: \`recharge_targets.nc\` (+ optional \`_nn_filled.nc\`).

### Soil moisture

- 4 sources: merra2 GWETTOP, ncep_ncar soilw_0_10cm, nldas_mosaic/noah SoilM_0_10cm.
- Shims pass-through (per-source 0-1 normalize cancels native unit offsets per recipes §4).
- Emits **two** target NCs from one \`output_file\` base:
  - \`<base>_monthly.nc\` — per-calendar-month normalize, monthly cadence
  - \`<base>_annual.nc\` — monthly→annual mean per source, whole-period normalize, year-start cadence
- Each variant gets a \`*_nn_filled.nc\` companion when \`nn_fill: true\`.

### Reuse

All build-time machinery from \`_common.py\` reused verbatim: \`SourceShim\` / \`shims_by_key\` / \`multi_source_nanminmax\` / \`compute_hru_centroids\` / \`read_aggregated_source\` / \`reindex_to_month_start\` / \`write_target_nc\` / the canonical id_col-sort check / \`nn_fill_bounds\`.

## Test plan

- [x] \`pixi run -e dev fmt\` — clean
- [x] \`pixi run -e dev lint\` — clean
- [x] \`pytest tests/test_normalize_methods.py tests/test_targets_rch.py tests/test_targets_som.py\` — **37 passed** (per-source shims with magnitude checks, per-calendar-month normalization correctness, annual-mean aggregation correctness, [0,1] bound assertions, source-attr config control, unknown-source guards, HRU mismatch error, NN-fill effect)
- [x] Full targets-test sweep — **146 passed** across normalize / common / run / aet / rch / som / cli (no regressions in the earlier targets)
- [ ] CI green
- [ ] Smoke-test against gfv2 once merged (recipe in inline notes)

## What's left after this PR

- The remaining target is \`sca\` (modis_ci) — single-source, blocked on the CI-bounds formula gap (PRMSobjfun.f not publicly available). Separate small PR with documented placeholder later.
- SWE target (\`targets/swe.py\`) — still stub; needs margulis + era5 sd downloads to finish before implementing.
- Follow-up #130 (catalog-units sanity check on SourceShim) — natural pairing with \`SourceShim\`; can land any time.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)