### PR TITLE
Catalog cf_units drift guard at target-builder startup (#130)

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -203,7 +203,15 @@ sources:
       endpoint: https://usgs.osn.mghpcc.org/
       zarr_store: s3://mdmf/gdp/ssebopeta_monthly.zarr/
     variables:
-      - et
+      - name: et
+        long_name: actual evapotranspiration
+        cf_units: "mm"
+        cell_methods: "time: sum"
+        notes: >
+          Monthly accumulation of actual ET in mm water-equivalent. The
+          source-level ``units: mm/month`` (kept for backwards readability)
+          is recovered by combining ``cf_units: mm`` with the time-axis
+          aggregation declared in ``cell_methods``.
     time_step: monthly
     period: "2000/2023"
     spatial_extent: CONUS

--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -49,6 +49,57 @@ def variable(name: str) -> dict:
     return all_vars[name]
 
 
+def source_var_cf_units(source_key: str, var_name: str) -> str:
+    """Return the ``cf_units`` string for ``var_name`` under source ``source_key``.
+
+    Resolves the variable entry by ``name`` first and falls back to
+    ``file_variable`` (the on-disk name carried by sources like Reitz 2017
+    whose distribution variables differ from the catalog name). Only the
+    dict-form variables shape is supported — flat-string variable lists
+    have no per-variable units field and are kept only on superseded
+    sources; target builders that pin units must consume sources that
+    declare ``cf_units`` explicitly.
+
+    Used by target builders at startup to assert that catalog-declared
+    per-pixel units still match the per-source unit-shim's expectation
+    (issue #130). Catching drift here turns a silent magnitude bug into
+    a loud startup failure with the source-and-units context the
+    operator needs to fix it.
+
+    Parameters
+    ----------
+    source_key
+        Catalog source key (e.g. ``"era5_land"``).
+    var_name
+        Variable name to look up; matched against each entry's ``name``,
+        then ``file_variable``.
+
+    Raises
+    ------
+    KeyError
+        Source has no variable matching ``var_name``, or the matching
+        entry is in flat-string form (no ``cf_units`` available).
+    """
+    src = source(source_key)
+    for entry in src.get("variables", []):
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") == var_name or entry.get("file_variable") == var_name:
+            cf_units = entry.get("cf_units")
+            if cf_units is None:
+                raise KeyError(
+                    f"Catalog source {source_key!r} variable {var_name!r} "
+                    f"has no 'cf_units' field. Add cf_units to "
+                    f"catalog/sources.yml so target builders can validate "
+                    f"unit drift at startup."
+                )
+            return cf_units
+    raise KeyError(
+        f"Variable {var_name!r} not found (as 'name' or 'file_variable') "
+        f"in catalog source {source_key!r}."
+    )
+
+
 # Allowed `fabric_scope.fabrics` tokens. Keep this set in sync with the
 # fabrics this pipeline targets — adding a new fabric should be
 # accompanied by extending this allow-list and the matching

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -74,6 +74,16 @@ class SourceShim:
         catalog name (``"era5_land"``) — this keeps target builders
         free of any parallel label→storage dict that could drift from
         the SHIMS registry.
+    expected_cf_units
+        Optional CF-style units string this shim was written against.
+        When set, :func:`validate_source_units` (called by every
+        target builder at startup) asserts the catalog's ``cf_units``
+        for ``aggregated_var`` matches exactly. Catches drift between
+        the catalog and the shim's hardcoded conversion factor — e.g.
+        a post-hoc cf_units correction that the shim hasn't been
+        updated for. ``None`` opts out of the check (used for
+        synthetic source keys whose aggregated variable is not the
+        same name as anything in the catalog).
     """
 
     source_key: str
@@ -81,6 +91,7 @@ class SourceShim:
     description: str
     to_common_units: Callable[[xr.DataArray], xr.DataArray]
     config_label: str | None = None
+    expected_cf_units: str | None = None
 
 
 def shims_by_key(shims: "tuple[SourceShim, ...]") -> "dict[str, SourceShim]":
@@ -99,6 +110,83 @@ def shims_by_key(shims: "tuple[SourceShim, ...]") -> "dict[str, SourceShim]":
             )
         out[shim.source_key] = shim
     return out
+
+
+def validate_source_units(
+    shims: "tuple[SourceShim, ...]",
+    sources: "list[str] | tuple[str, ...]",
+) -> None:
+    """Assert each requested source's catalog ``cf_units`` matches the shim.
+
+    Resolves each entry in ``sources`` (a list of config labels, e.g.
+    ``["era5_land", "gldas_noah_v21_monthly"]`` from the project config)
+    to its :class:`SourceShim`, then looks up the catalog ``cf_units``
+    for the shim's ``aggregated_var`` under the shim's catalog source
+    key (``config_label`` if set, else ``source_key`` — same convention
+    :func:`shims_by_config_label` uses) and raises if the strings differ.
+
+    Called at the top of every target builder's ``build()`` so a
+    post-hoc catalog correction (PR #68 caught four such corrections)
+    fails loud at startup rather than silently producing values off by
+    the missed conversion factor. Per-source unit shims encode an
+    assumption — e.g. ``gldas_to_mm_per_month`` assumes ``cf_units:
+    "kg m-2"`` so it can apply ``× 8 × days_in_month``. If the catalog
+    is corrected to a different string (or the shim's conversion is
+    updated without touching ``expected_cf_units``) this validator
+    raises with both strings so the operator can decide which side
+    needs to follow the other.
+
+    Shims with ``expected_cf_units=None`` opt out (e.g. legacy stubs
+    pending unit harmonisation). Unknown source labels raise too —
+    catching a project-config typo at startup is the same drift class
+    this validator guards.
+
+    Parameters
+    ----------
+    shims
+        The target's ``SHIMS`` tuple.
+    sources
+        Project-config-side source labels for which the build is
+        about to read data. Typically ``runoff_cfg["sources"]``,
+        ``aet_cfg["sources"]``, etc.
+
+    Raises
+    ------
+    ValueError
+        Catalog ``cf_units`` differs from ``shim.expected_cf_units``
+        for any requested source, or a requested source label has no
+        matching shim.
+    """
+    from nhf_spatial_targets import catalog as cat
+
+    by_label = shims_by_config_label(shims)
+    for label in sources:
+        if label not in by_label:
+            raise ValueError(
+                f"validate_source_units: source label {label!r} has no "
+                f"matching SourceShim. Known labels: {sorted(by_label)}."
+            )
+        shim = by_label[label]
+        if shim.expected_cf_units is None:
+            continue
+        catalog_key = shim.config_label or shim.source_key
+        try:
+            actual = cat.source_var_cf_units(catalog_key, shim.aggregated_var)
+        except KeyError as exc:
+            raise ValueError(
+                f"validate_source_units: cannot resolve cf_units for "
+                f"{catalog_key!r}/{shim.aggregated_var!r}: {exc}. Either "
+                f"add cf_units to catalog/sources.yml or set "
+                f"expected_cf_units=None on the shim to opt out."
+            ) from exc
+        if actual != shim.expected_cf_units:
+            raise ValueError(
+                f"Catalog cf_units drift for {catalog_key!r}/"
+                f"{shim.aggregated_var!r}: catalog has {actual!r}, "
+                f"shim {shim.source_key!r} expects "
+                f"{shim.expected_cf_units!r}. Update the shim if the "
+                f"units changed intentionally, or correct the catalog."
+            )
 
 
 def shims_by_config_label(

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -162,8 +162,11 @@ def validate_source_units(
     by_label = shims_by_config_label(shims)
     for label in sources:
         if label not in by_label:
+            # Phrase that surfaces "unknown source '<name>'" so the downstream
+            # builder tests that asserted on the prior in-builder check still
+            # match against this earlier, generic validator.
             raise ValueError(
-                f"validate_source_units: source label {label!r} has no "
+                f"validate_source_units: unknown source {label!r} — no "
                 f"matching SourceShim. Known labels: {sorted(by_label)}."
             )
         shim = by_label[label]

--- a/src/nhf_spatial_targets/targets/aet.py
+++ b/src/nhf_spatial_targets/targets/aet.py
@@ -46,6 +46,7 @@ from nhf_spatial_targets.targets._common import (
     read_aggregated_source,
     reindex_to_month_start,
     shims_by_key,
+    validate_source_units,
     write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
@@ -165,18 +166,21 @@ SHIMS: tuple[SourceShim, ...] = (
             "MOD16A2 v061 ET_500m (8-day kg m-2; overlap-weighted to mm/month)"
         ),
         to_common_units=mod16a2_to_mm_per_month,
+        expected_cf_units="kg m-2",
     ),
     SourceShim(
         source_key="ssebop",
         aggregated_var="et",
         description="SSEBop et (mm/month, native)",
         to_common_units=ssebop_to_mm_per_month,
+        expected_cf_units="mm",
     ),
     SourceShim(
         source_key="mwbm_climgrid",
         aggregated_var="aet",
         description="MWBM ClimGrid aet (mm/month, native)",
         to_common_units=mwbm_to_mm_per_month,
+        expected_cf_units="mm",
     ),
 )
 
@@ -208,6 +212,10 @@ def build(project: Project) -> None:
     period = parse_period(aet_cfg["period"])
     sources = list(aet_cfg["sources"])
     chunk_months = int(aet_cfg["chunk_months"])
+
+    # Fail loud at startup if a catalog cf_units string has drifted from
+    # the per-source shim's hardcoded conversion factor (issue #130).
+    validate_source_units(SHIMS, sources)
 
     logger.info(
         "Building AET target: %d sources (%s), period %s .. %s, fabric=%s",

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -35,6 +35,7 @@ from nhf_spatial_targets.targets._common import (
     read_aggregated_source,
     reindex_to_month_start,
     shims_by_key,
+    validate_source_units,
     write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
@@ -94,6 +95,7 @@ SHIMS: tuple[SourceShim, ...] = (
         aggregated_var="ro",
         description="ERA5-Land ro",
         to_common_units=era5_to_mm_per_month,
+        expected_cf_units="m",
     ),
     SourceShim(
         source_key="gldas_noah_v21_monthly",
@@ -102,12 +104,14 @@ SHIMS: tuple[SourceShim, ...] = (
             "GLDAS-2.1 NOAH runoff_total (Qs_acc + Qsb_acc, summed at consolidation)"
         ),
         to_common_units=gldas_to_mm_per_month,
+        expected_cf_units="kg m-2",
     ),
     SourceShim(
         source_key="mwbm_climgrid",
         aggregated_var="runoff",
         description="MWBM ClimGrid runoff",
         to_common_units=mwbm_to_mm_per_month,
+        expected_cf_units="mm",
     ),
 )
 
@@ -141,6 +145,10 @@ def build(project: Project) -> None:
     period = parse_period(runoff_cfg["period"])
     sources = list(runoff_cfg["sources"])
     chunk_months = int(runoff_cfg["chunk_months"])
+
+    # Fail loud at startup if a catalog cf_units string has drifted from
+    # the per-source shim's hardcoded conversion factor (issue #130).
+    validate_source_units(SHIMS, sources)
 
     logger.info(
         "Building runoff target: %d sources (%s), period %s .. %s, fabric=%s",

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -62,6 +62,7 @@ from nhf_spatial_targets.targets._common import (
     reindex_to_day_start,
     shims_by_config_label,
     stitch_year_chunks_to_target,
+    validate_source_units,
     write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
@@ -124,12 +125,14 @@ SHIMS: tuple[SourceShim, ...] = (
         aggregated_var="swe",
         description="Daymet V4 R1 swe (kg/m² ≡ mm, daily)",
         to_common_units=daymet_to_mm,
+        expected_cf_units="kg m-2",
     ),
     SourceShim(
         source_key="snodas",
         aggregated_var="swe",
         description="SNODAS swe (kg/m² ≡ mm, daily)",
         to_common_units=snodas_to_mm,
+        expected_cf_units="kg m-2",
     ),
     SourceShim(
         source_key="era5_land_sd",
@@ -137,12 +140,14 @@ SHIMS: tuple[SourceShim, ...] = (
         description="ERA5-Land sd (m → mm, daily snapshot)",
         to_common_units=era5_sd_to_mm,
         config_label="era5_land",
+        expected_cf_units="m",
     ),
     SourceShim(
         source_key="margulis_wus_sr",
         aggregated_var="SWE",
         description="Margulis WUS-SR SWE (m → mm, daily; OR fabric only)",
         to_common_units=margulis_to_mm,
+        expected_cf_units="m",
     ),
 )
 
@@ -245,6 +250,12 @@ def build(project: Project) -> None:
             f"zero sources after fabric_scope filtering (fabric token="
             f"{fabric_token!r}). Add a non-scoped source or set fabric.token."
         )
+
+    # Fail loud at startup if a catalog cf_units string has drifted from
+    # any per-source shim's hardcoded conversion factor (issue #130).
+    # Run after fabric-scope filtering so we only validate sources that
+    # will actually be read.
+    validate_source_units(SHIMS, sources)
 
     logger.info(
         "Building SWE target: %d sources (%s) [requested %d (%s)], "

--- a/tests/test_aggregated_helpers.py
+++ b/tests/test_aggregated_helpers.py
@@ -41,9 +41,17 @@ def test_unit_from_catalog_dict_variables(helpers):
 
 
 def test_unit_from_catalog_flat_variables(helpers):
-    # ssebop has a flat variables list and a source-level units field
+    # merra_land (superseded) retains the original flat variables list:
+    # ``variables: [SFMC]`` with the unit at the source level.
+    units = helpers.unit_from_catalog("merra_land", "SFMC")
+    src_units = helpers.cat.source("merra_land")["units"]
+    assert units == src_units
+
+
+def test_unit_from_catalog_ssebop_resolves_via_cf_units(helpers):
+    """SSEBop now uses the dict-form variables shape with cf_units."""
     units = helpers.unit_from_catalog("ssebop", "et")
-    assert units == "mm/month"
+    assert units == "mm"
 
 
 def test_unit_from_catalog_unknown_variable_raises(helpers):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -306,3 +306,52 @@ def test_validate_fabric_scope_none_is_ok():
     from nhf_spatial_targets.catalog import validate_fabric_scope
 
     validate_fabric_scope("test_src", None)
+
+
+# ---------------------------------------------------------------------------
+# source_var_cf_units (issue #130 — target-builder unit-drift guard)
+# ---------------------------------------------------------------------------
+
+
+def test_source_var_cf_units_resolves_dict_form():
+    """Standard dict-form variables resolve via the `name` key."""
+    from nhf_spatial_targets.catalog import source_var_cf_units
+
+    assert source_var_cf_units("era5_land", "ro") == "m"
+    assert source_var_cf_units("gldas_noah_v21_monthly", "runoff_total") == "kg m-2"
+    assert source_var_cf_units("mwbm_climgrid", "runoff") == "mm"
+
+
+def test_source_var_cf_units_resolves_via_file_variable():
+    """Reitz 2017 distributes `TotalRecharge` but stores it under `total_recharge`."""
+    from nhf_spatial_targets.catalog import source_var_cf_units
+
+    assert source_var_cf_units("reitz2017", "TotalRecharge") == "m yr-1"
+    assert source_var_cf_units("reitz2017", "total_recharge") == "m yr-1"
+
+
+def test_source_var_cf_units_raises_on_unknown_variable():
+    from nhf_spatial_targets.catalog import source_var_cf_units
+
+    with pytest.raises(KeyError, match="not found"):
+        source_var_cf_units("era5_land", "no_such_var")
+
+
+def test_source_var_cf_units_raises_on_flat_string_variable():
+    """Flat-string entries (kept only on superseded sources) have no cf_units."""
+    from nhf_spatial_targets.catalog import source_var_cf_units
+
+    # merra_land is superseded and still uses the original `variables: [SFMC]`
+    # flat-list shape. Target builders that point at it would need to add
+    # cf_units to the catalog or opt out via expected_cf_units=None.
+    with pytest.raises(KeyError, match="not found"):
+        source_var_cf_units("merra_land", "SFMC")
+
+
+def test_ssebop_et_resolves_to_mm():
+    """SSEBop migrated from flat-string to dict form with cf_units: mm
+    so the AET target builder can validate units at startup (issue #130).
+    """
+    from nhf_spatial_targets.catalog import source_var_cf_units
+
+    assert source_var_cf_units("ssebop", "et") == "mm"

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -724,6 +724,156 @@ def test_shims_by_key_empty_tuple_returns_empty_dict():
     assert shims_by_key(()) == {}
 
 
+# ---------------------------------------------------------------------------
+# validate_source_units (issue #130 — catalog-vs-shim unit drift guard)
+# ---------------------------------------------------------------------------
+
+
+def test_source_shim_accepts_expected_cf_units_field():
+    """SourceShim grew an optional `expected_cf_units` field (issue #130)."""
+    from nhf_spatial_targets.targets._common import SourceShim
+
+    shim = SourceShim(
+        source_key="era5_land",
+        aggregated_var="ro",
+        description="test",
+        to_common_units=_identity_shim,
+        expected_cf_units="m",
+    )
+    assert shim.expected_cf_units == "m"
+
+
+def test_source_shim_expected_cf_units_defaults_to_none():
+    """Defaulting to None preserves opt-out semantics for legacy shims."""
+    from nhf_spatial_targets.targets._common import SourceShim
+
+    shim = SourceShim(
+        source_key="x",
+        aggregated_var="y",
+        description="t",
+        to_common_units=_identity_shim,
+    )
+    assert shim.expected_cf_units is None
+
+
+def test_validate_source_units_passes_when_catalog_matches_shim():
+    """Happy path: real SHIMS registries pass against the real catalog."""
+    from nhf_spatial_targets.targets._common import validate_source_units
+    from nhf_spatial_targets.targets.run import SHIMS as RUN_SHIMS
+
+    # Should not raise.
+    validate_source_units(
+        RUN_SHIMS, ["era5_land", "gldas_noah_v21_monthly", "mwbm_climgrid"]
+    )
+
+
+def test_validate_source_units_raises_on_catalog_drift():
+    """A shim declaring different expected_cf_units from catalog raises."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    drifted = (
+        SourceShim(
+            source_key="era5_land",
+            aggregated_var="ro",
+            description="d",
+            to_common_units=_identity_shim,
+            expected_cf_units="DRIFTED",
+        ),
+    )
+    with pytest.raises(ValueError, match="Catalog cf_units drift"):
+        validate_source_units(drifted, ["era5_land"])
+
+
+def test_validate_source_units_message_includes_both_units():
+    """The error message must surface both strings so the operator can decide."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    drifted = (
+        SourceShim(
+            source_key="era5_land",
+            aggregated_var="ro",
+            description="d",
+            to_common_units=_identity_shim,
+            expected_cf_units="kg m-2",
+        ),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        validate_source_units(drifted, ["era5_land"])
+    msg = str(exc_info.value)
+    assert "'m'" in msg  # catalog says "m"
+    assert "'kg m-2'" in msg  # shim claims "kg m-2"
+
+
+def test_validate_source_units_skips_when_expected_is_none():
+    """expected_cf_units=None opts out of the check entirely."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    # If validation ran, this would raise (catalog says "m", not "wrong").
+    # expected_cf_units=None means the check is skipped.
+    opted_out = (
+        SourceShim(
+            source_key="era5_land",
+            aggregated_var="ro",
+            description="d",
+            to_common_units=_identity_shim,
+            expected_cf_units=None,
+        ),
+    )
+    validate_source_units(opted_out, ["era5_land"])
+
+
+def test_validate_source_units_raises_on_unknown_source_label():
+    """An unknown config label (typo) surfaces as a startup error."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    shims = (
+        SourceShim(
+            source_key="x",
+            aggregated_var="v",
+            description="d",
+            to_common_units=_identity_shim,
+            expected_cf_units="m",
+        ),
+    )
+    with pytest.raises(ValueError, match="no matching SourceShim"):
+        validate_source_units(shims, ["not_in_registry"])
+
+
+def test_validate_source_units_uses_config_label_for_catalog_lookup():
+    """When config_label is set, catalog lookup goes through that key.
+
+    SWE's era5_land_sd shim stores under a synthetic source_key but the
+    catalog key is the canonical "era5_land"; validate_source_units must
+    look up against the catalog under config_label, not source_key.
+    """
+    from nhf_spatial_targets.targets._common import validate_source_units
+    from nhf_spatial_targets.targets.swe import SHIMS as SWE_SHIMS
+
+    # The label "era5_land" resolves to the era5_land_sd shim; catalog
+    # cf_units for era5_land/sd is "m", which matches expected_cf_units="m".
+    validate_source_units(SWE_SHIMS, ["era5_land"])
+
+
+def test_validate_source_units_raises_when_catalog_lacks_cf_units():
+    """A shim pointing at a flat-string catalog entry raises with guidance."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    # merra_land is superseded and uses flat-list `variables: [SFMC]` (no
+    # cf_units). A target that pointed at it must either gain catalog
+    # cf_units or opt out via expected_cf_units=None.
+    shims = (
+        SourceShim(
+            source_key="merra_land",
+            aggregated_var="SFMC",
+            description="d",
+            to_common_units=_identity_shim,
+            expected_cf_units="m3/m3",
+        ),
+    )
+    with pytest.raises(ValueError, match="cannot resolve cf_units"):
+        validate_source_units(shims, ["merra_land"])
+
+
 def test_run_target_module_exposes_well_formed_shims():
     """targets/run.py SHIMS registry has the expected source keys and aggregated vars."""
     from nhf_spatial_targets.targets.run import SHIMS
@@ -745,6 +895,16 @@ def test_run_target_module_exposes_well_formed_shims():
         assert out.attrs.get("units") == "mm"
 
 
+def test_run_target_shims_declare_expected_cf_units():
+    """Issue #130: every runoff shim pins its expected catalog cf_units."""
+    from nhf_spatial_targets.targets.run import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert by_key["era5_land"].expected_cf_units == "m"
+    assert by_key["gldas_noah_v21_monthly"].expected_cf_units == "kg m-2"
+    assert by_key["mwbm_climgrid"].expected_cf_units == "mm"
+
+
 def test_aet_target_module_exposes_well_formed_shims():
     """targets/aet.py SHIMS registry has the expected source keys and aggregated vars."""
     from nhf_spatial_targets.targets.aet import SHIMS
@@ -764,6 +924,27 @@ def test_aet_target_module_exposes_well_formed_shims():
     for key in ("ssebop", "mwbm_climgrid"):
         out = by_key[key].to_common_units(da)
         assert out.attrs.get("units") == "mm"
+
+
+def test_aet_target_shims_declare_expected_cf_units():
+    """Issue #130: every AET shim pins its expected catalog cf_units."""
+    from nhf_spatial_targets.targets.aet import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert by_key["mod16a2_v061"].expected_cf_units == "kg m-2"
+    assert by_key["ssebop"].expected_cf_units == "mm"
+    assert by_key["mwbm_climgrid"].expected_cf_units == "mm"
+
+
+def test_swe_target_shims_declare_expected_cf_units():
+    """Issue #130: every SWE shim pins its expected catalog cf_units."""
+    from nhf_spatial_targets.targets.swe import SHIMS
+
+    by_key = {s.source_key: s for s in SHIMS}
+    assert by_key["daymet"].expected_cf_units == "kg m-2"
+    assert by_key["snodas"].expected_cf_units == "kg m-2"
+    assert by_key["era5_land_sd"].expected_cf_units == "m"
+    assert by_key["margulis_wus_sr"].expected_cf_units == "m"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #130.

## Summary

- Add `SourceShim.expected_cf_units` and `targets/_common.py:validate_source_units`. Every multi-source target builder calls the validator at the top of `build()` against its `SHIMS` registry and the project-config `sources` list. A post-hoc catalog correction to `cf_units` that doesn't match the per-source unit shim now fails loud at startup with both strings in the error.
- Populate `expected_cf_units` on every shim in `run.py`, `aet.py`, `swe.py` (e.g. ERA5-Land ro `× 1000` m→mm expects `"m"`; GLDAS runoff_total `× 8 × days_in_month` expects `"kg m-2"`).
- Add `catalog.source_var_cf_units(source_key, var_name)` helper. Resolves by `name`, falls back to `file_variable` (Reitz 2017 distributes `TotalRecharge` but stores it as `total_recharge`).
- Migrate the SSEBop catalog entry from the flat-string `variables: [et]` shape to dict-form with `cf_units: "mm"` so the AET builder can validate units at startup. SSEBop was the only current source still using the legacy shape; superseded sources keep it. `unit_from_catalog` helper test updated to exercise the flat-list fallback against `merra_land` instead.

The validator uses `config_label` (defaulting to `source_key`) as the catalog lookup key, so SWE's synthetic `era5_land_sd` shim correctly resolves against catalog source `era5_land`, variable `sd`.

Smoke-tested against the real catalog: all three current builders' SHIMS round-trip the validator cleanly.

## Test plan

- [x] `pixi run -e dev fmt` (clean)
- [x] `pixi run -e dev lint` (clean)
- [x] Smoke import: `validate_source_units(RUN_SHIMS, [...])` + AET + SWE all pass against real catalog
- [ ] CI: full pytest suite (skipped locally per HPC convention)
- [ ] Manual mutate test: change a catalog `cf_units` to a different string; confirm the next `pixi run run-runoff` raises with both strings in the message