### PR TITLE
chore(targets): remove dead unknown-source checks after validator (#143)

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -162,12 +162,9 @@ def validate_source_units(
     by_label = shims_by_config_label(shims)
     for label in sources:
         if label not in by_label:
-            # Phrase that surfaces "unknown source '<name>'" so the downstream
-            # builder tests that asserted on the prior in-builder check still
-            # match against this earlier, generic validator.
             raise ValueError(
-                f"validate_source_units: unknown source {label!r} — no "
-                f"matching SourceShim. Known labels: {sorted(by_label)}."
+                f"validate_source_units: no matching SourceShim for source "
+                f"{label!r}. Known labels: {sorted(by_label)}."
             )
         shim = by_label[label]
         if shim.expected_cf_units is None:

--- a/src/nhf_spatial_targets/targets/aet.py
+++ b/src/nhf_spatial_targets/targets/aet.py
@@ -244,10 +244,6 @@ def build(project: Project) -> None:
     shims = shims_by_key(SHIMS)
     sources_in_day: dict[str, xr.DataArray] = {}
     for src in sources:
-        if src not in shims:
-            raise ValueError(
-                f"aet.sources includes unknown source '{src}'. Known: {sorted(shims)}"
-            )
         shim = shims[src]
         # For MOD16A2 the time dim is 8-day; slicing by the requested
         # monthly period is still correct because xr.sel(time=slice(...))

--- a/src/nhf_spatial_targets/targets/run.py
+++ b/src/nhf_spatial_targets/targets/run.py
@@ -184,11 +184,6 @@ def build(project: Project) -> None:
     shims = shims_by_key(SHIMS)
     sources_cfs: dict[str, xr.DataArray] = {}
     for src in sources:
-        if src not in shims:
-            raise ValueError(
-                f"runoff.sources includes unknown source '{src}'. "
-                f"Known: {sorted(shims)}"
-            )
         shim = shims[src]
         da_native = read_aggregated_source(
             project,

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -221,17 +221,13 @@ def build(project: Project) -> None:
     fabric_token = fabric_cfg.get("token")
     shims = shims_by_config_label(SHIMS)
 
-    # Validate every requested source against the SHIMS registry BEFORE
-    # any catalog or fabric_scope lookups, so an unknown source name
-    # surfaces a "Known: ..." message rather than a confusing KeyError
-    # from the catalog or a "zero sources after filtering" message
-    # after silent drops.
-    for src in requested_sources:
-        if src not in shims:
-            raise ValueError(
-                f"snow_water_equivalent.sources includes unknown source "
-                f"'{src}'. Known: {sorted(shims)}"
-            )
+    # Fail loud at startup if a requested source has no matching shim or
+    # if a catalog cf_units string has drifted from a shim's hardcoded
+    # conversion factor (issue #130). Run on `requested_sources` (before
+    # fabric-scope filtering) so an unknown source surfaces a clear
+    # "no matching SourceShim" message rather than a KeyError from the
+    # catalog lookup inside `_filter_sources_by_fabric_scope`.
+    validate_source_units(SHIMS, requested_sources)
 
     # Validate the project's fabric token if set, to catch typos like
     # "oregon" instead of "or" before silently filtering every fabric-
@@ -250,12 +246,6 @@ def build(project: Project) -> None:
             f"zero sources after fabric_scope filtering (fabric token="
             f"{fabric_token!r}). Add a non-scoped source or set fabric.token."
         )
-
-    # Fail loud at startup if a catalog cf_units string has drifted from
-    # any per-source shim's hardcoded conversion factor (issue #130).
-    # Run after fabric-scope filtering so we only validate sources that
-    # will actually be read.
-    validate_source_units(SHIMS, sources)
 
     logger.info(
         "Building SWE target: %d sources (%s) [requested %d (%s)], "

--- a/tests/test_targets_aet.py
+++ b/tests/test_targets_aet.py
@@ -453,7 +453,9 @@ def test_build_unknown_source_raises(tmp_path: Path):
         nn_fill=False,
     )
     project = load(workdir)
-    with pytest.raises(ValueError, match="unknown source 'not_a_real_source'"):
+    with pytest.raises(
+        ValueError, match="no matching SourceShim for source 'not_a_real_source'"
+    ):
         build(project)
 
 

--- a/tests/test_targets_swe.py
+++ b/tests/test_targets_swe.py
@@ -389,7 +389,9 @@ def test_build_unknown_source_raises(tmp_path: Path):
         nn_fill=False,
     )
     project = load(workdir)
-    with pytest.raises(ValueError, match="unknown source 'not_a_real_source'"):
+    with pytest.raises(
+        ValueError, match="no matching SourceShim for source 'not_a_real_source'"
+    ):
         build(project)
 
 


### PR DESCRIPTION
## Summary

- Deletes the in-builder ``if src not in shims: raise`` blocks in [aet.py](src/nhf_spatial_targets/targets/aet.py), [swe.py](src/nhf_spatial_targets/targets/swe.py), and [run.py](src/nhf_spatial_targets/targets/run.py) — all unreachable because PR #141's ``validate_source_units(SHIMS, sources)`` at the top of each builder already raises ``ValueError`` on any source label not in the SHIMS registry. (#143 only listed aet/swe; run.py has the identical dead pattern, bundled here.)
- In [swe.py](src/nhf_spatial_targets/targets/swe.py), moves ``validate_source_units(SHIMS, requested_sources)`` to run *before* ``_filter_sources_by_fabric_scope``. That filter calls ``catalog.source(src)`` which would ``KeyError`` on an unknown source before the validator's clear "no matching SourceShim" message could fire.
- Drops the brittle "Phrase that surfaces 'unknown source <name>'..." comment in [_common.py](src/nhf_spatial_targets/targets/_common.py) and rewords the validator error from ``unknown source 'X' — no matching SourceShim`` to the cleaner ``no matching SourceShim for source 'X'``.
- Updates [test_targets_aet.py:456](tests/test_targets_aet.py#L456) and [test_targets_swe.py:392](tests/test_targets_swe.py#L392) to assert against the validator's actual phrasing.

No behaviour change for valid inputs. Unknown source labels still raise ``ValueError`` at startup with a clear message and the list of known labels.

Closes #143.

## Test plan

- [x] CI: ``test_targets_aet.py::test_build_unknown_source_raises`` passes against new phrasing
- [x] CI: ``test_targets_swe.py::test_build_unknown_source_raises`` passes against new phrasing
- [x] CI: full ``pytest`` + ``ruff`` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)