### PR TITLE
refactor(targets): separate SourceShim.catalog_source_key from config_label (#142)

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -74,6 +74,15 @@ class SourceShim:
         catalog name (``"era5_land"``) — this keeps target builders
         free of any parallel label→storage dict that could drift from
         the SHIMS registry.
+    catalog_source_key
+        Optional ``catalog/sources.yml`` key for the source. Defaults
+        to ``config_label`` if set, else ``source_key``. Used by
+        :func:`validate_source_units` to look up the catalog
+        ``cf_units`` for ``aggregated_var``. Set this only when the
+        catalog key is genuinely independent of both the on-disk
+        storage key and the user-facing config alias — e.g. a shim
+        named ``foo_v2`` with ``config_label="legacy_foo"`` (a config
+        alias) but catalog data still under ``foo_v2``.
     expected_cf_units
         Optional CF-style units string this shim was written against.
         When set, :func:`validate_source_units` (called by every
@@ -91,6 +100,7 @@ class SourceShim:
     description: str
     to_common_units: Callable[[xr.DataArray], xr.DataArray]
     config_label: str | None = None
+    catalog_source_key: str | None = None
     expected_cf_units: str | None = None
 
 
@@ -122,8 +132,8 @@ def validate_source_units(
     ``["era5_land", "gldas_noah_v21_monthly"]`` from the project config)
     to its :class:`SourceShim`, then looks up the catalog ``cf_units``
     for the shim's ``aggregated_var`` under the shim's catalog source
-    key (``config_label`` if set, else ``source_key`` — same convention
-    :func:`shims_by_config_label` uses) and raises if the strings differ.
+    key (``catalog_source_key`` if set, else ``config_label``, else
+    ``source_key``) and raises if the strings differ.
 
     Called at the top of every target builder's ``build()`` so a
     post-hoc catalog correction (PR #68 caught four such corrections)
@@ -169,7 +179,7 @@ def validate_source_units(
         shim = by_label[label]
         if shim.expected_cf_units is None:
             continue
-        catalog_key = shim.config_label or shim.source_key
+        catalog_key = shim.catalog_source_key or shim.config_label or shim.source_key
         try:
             actual = cat.source_var_cf_units(catalog_key, shim.aggregated_var)
         except KeyError as exc:

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -854,6 +854,75 @@ def test_validate_source_units_uses_config_label_for_catalog_lookup():
     validate_source_units(SWE_SHIMS, ["era5_land"])
 
 
+def test_source_shim_catalog_source_key_defaults_to_none():
+    """`catalog_source_key` defaults to None; existing shims keep the
+    config_label-or-source_key fallback (issue #142)."""
+    from nhf_spatial_targets.targets._common import SourceShim
+
+    shim = SourceShim(
+        source_key="x",
+        aggregated_var="y",
+        description="d",
+        to_common_units=_identity_shim,
+    )
+    assert shim.catalog_source_key is None
+
+
+def test_validate_source_units_routes_through_catalog_source_key(monkeypatch):
+    """All three of source_key / config_label / catalog_source_key may
+    differ; the validator must route the catalog lookup through
+    catalog_source_key, not the user-facing alias (issue #142)."""
+    from nhf_spatial_targets import catalog as cat
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    # Track what catalog key the validator passes to source_var_cf_units.
+    seen: list[tuple[str, str]] = []
+    original = cat.source_var_cf_units
+
+    def spy(source_key: str, var_name: str) -> str:
+        seen.append((source_key, var_name))
+        return original(source_key, var_name)
+
+    monkeypatch.setattr(cat, "source_var_cf_units", spy)
+
+    shims = (
+        SourceShim(
+            source_key="storage_only_key",  # on-disk dir only
+            aggregated_var="ro",
+            description="d",
+            to_common_units=_identity_shim,
+            config_label="user_facing_alias",  # what the config writes
+            catalog_source_key="era5_land",  # real catalog source
+            expected_cf_units="m",  # matches catalog era5_land/ro
+        ),
+    )
+    validate_source_units(shims, ["user_facing_alias"])
+    assert seen == [("era5_land", "ro")], (
+        f"Expected catalog lookup against catalog_source_key='era5_land', got {seen!r}"
+    )
+
+
+def test_validate_source_units_catalog_key_falls_back_to_config_label():
+    """When `catalog_source_key` is None, the lookup precedence still
+    falls back to `config_label`, then `source_key` — preserving
+    behaviour for every existing shim (issue #142)."""
+    from nhf_spatial_targets.targets._common import SourceShim, validate_source_units
+
+    # No catalog_source_key set; config_label="era5_land" carries the
+    # catalog key for a synthetic on-disk storage layout.
+    shims = (
+        SourceShim(
+            source_key="era5_land_sd",
+            aggregated_var="sd",
+            description="d",
+            to_common_units=_identity_shim,
+            config_label="era5_land",
+            expected_cf_units="m",
+        ),
+    )
+    validate_source_units(shims, ["era5_land"])
+
+
 def test_validate_source_units_raises_when_catalog_lacks_cf_units():
     """A shim pointing at a flat-string catalog entry raises with guidance."""
     from nhf_spatial_targets.targets._common import SourceShim, validate_source_units


### PR DESCRIPTION
## Summary

PR #141's [validate_source_units](src/nhf_spatial_targets/targets/_common.py) overloaded ``SourceShim.config_label`` as the catalog source key:

```python
catalog_key = shim.config_label or shim.source_key
```

This worked because the only shim setting ``config_label`` (SWE's ``era5_land_sd``) happened to use the catalog key and the user-facing alias interchangeably. A future shim with a true alias case — e.g. ``config_label="legacy_foo"`` but catalog data still under ``foo_v2`` — would either ``KeyError`` out or, worse, silently look up the wrong catalog entry.

This PR adds an explicit ``catalog_source_key: str | None = None`` field on [SourceShim](src/nhf_spatial_targets/targets/_common.py). The validator's lookup becomes:

```python
catalog_key = (
    shim.catalog_source_key
    or shim.config_label
    or shim.source_key
)
```

- Default precedence is unchanged for every existing shim — no behaviour change.
- The SHIMS registries (`run.py` / `aet.py` / `swe.py` / `rch.py` / `som.py`) don't need to change today.
- Future shims with a genuine alias case can now pin the catalog key independently.

Closes #142.

## Test plan

Three new tests in [tests/test_targets_common.py](tests/test_targets_common.py):

- [ ] ``test_source_shim_catalog_source_key_defaults_to_none``
- [ ] ``test_validate_source_units_routes_through_catalog_source_key`` — monkeypatches ``catalog.source_var_cf_units`` to confirm the validator calls it with ``"era5_land"`` (the ``catalog_source_key``) when ``source_key``, ``config_label``, and ``catalog_source_key`` are all distinct.
- [ ] ``test_validate_source_units_catalog_key_falls_back_to_config_label`` — pins the unchanged default precedence (SWE's ``era5_land_sd`` shim shape).

CI must run the existing ``validate_source_units`` test set and pass against the unchanged default precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)