### PR TITLE
refactor(era5_land): derive _VARIABLE_KIND from catalog cell_methods (#101)

### DIFF
--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -100,6 +100,53 @@ def source_var_cf_units(source_key: str, var_name: str) -> str:
     )
 
 
+def source_var_cell_methods(source_key: str, var_name: str) -> str | None:
+    """Return the ``cell_methods`` string for ``var_name`` under ``source_key``.
+
+    Mirrors :func:`source_var_cf_units` but returns the CF ``cell_methods``
+    string (e.g. ``"time: sum"`` for accumulated fields,
+    ``"time: point"`` for instantaneous snapshots). Returns ``None`` when
+    the variable entry exists but does not declare ``cell_methods`` —
+    callers decide whether to raise on missing metadata, since some
+    superseded sources omit it.
+
+    Used by fetchers and aggregators that need to dispatch on whether
+    a variable is accumulated vs instantaneous (e.g. ERA5-Land's
+    hourly→daily and daily→monthly reducers) without duplicating the
+    accumulated/instantaneous mapping in Python.
+
+    Parameters
+    ----------
+    source_key
+        Catalog source key (e.g. ``"era5_land"``).
+    var_name
+        Variable name to look up; matched against each entry's ``name``,
+        then ``file_variable``.
+
+    Returns
+    -------
+    str or None
+        The ``cell_methods`` string, or ``None`` when the entry exists
+        but has no ``cell_methods`` field.
+
+    Raises
+    ------
+    KeyError
+        Source has no variable matching ``var_name``, or the matching
+        entry is in flat-string form (no per-variable metadata).
+    """
+    src = source(source_key)
+    for entry in src.get("variables", []):
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") == var_name or entry.get("file_variable") == var_name:
+            return entry.get("cell_methods")
+    raise KeyError(
+        f"Variable {var_name!r} not found (as 'name' or 'file_variable') "
+        f"in catalog source {source_key!r}."
+    )
+
+
 # Allowed `fabric_scope.fabrics` tokens. Keep this set in sync with the
 # fabrics this pipeline targets — adding a new fabric should be
 # accompanied by extending this allow-list and the matching

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -49,15 +49,43 @@ VARIABLES = ("ro", "sro", "ssro", "sd")
 #                 daily→monthly sum.
 #   instantaneous : point-in-time field with no midnight reset; aggregate
 #                   via .mean() at both hourly→daily and daily→monthly.
-# The accumulated reducer applied to an instantaneous field would produce
-# physically meaningless values; the dispatch in consolidate_year and
-# daily_to_monthly is keyed on this table.
-_VARIABLE_KIND = {
-    "ro": "accumulated",
-    "sro": "accumulated",
-    "ssro": "accumulated",
-    "sd": "instantaneous",
+# Derived from the catalog's per-variable ``cell_methods`` so the catalog
+# remains the single source of truth: ``time: sum`` → accumulated,
+# ``time: point`` → instantaneous. The accumulated reducer applied to an
+# instantaneous field would produce physically meaningless values; the
+# dispatch in consolidate_year and daily_to_monthly is keyed on this
+# table.
+_CELL_METHODS_TO_KIND = {
+    "time: sum": "accumulated",
+    "time: point": "instantaneous",
 }
+
+
+def _derive_variable_kind() -> dict[str, str]:
+    """Build {var: kind} from the catalog's ``cell_methods`` for each VARIABLES entry.
+
+    Raises ``ValueError`` if a variable's ``cell_methods`` is missing or
+    is not one of the two known forms — adding a new ERA5-Land variable
+    with a different aggregation flavour must be a deliberate edit
+    (update :data:`_CELL_METHODS_TO_KIND`), not a silent
+    miscategorization.
+    """
+    out: dict[str, str] = {}
+    for var in VARIABLES:
+        cm = _catalog.source_var_cell_methods("era5_land", var)
+        if cm not in _CELL_METHODS_TO_KIND:
+            raise ValueError(
+                f"era5_land catalog variable {var!r} has cell_methods="
+                f"{cm!r}; expected one of {sorted(_CELL_METHODS_TO_KIND)} "
+                f"so the hourly→daily / daily→monthly reducer can "
+                f"dispatch. Either correct catalog/sources.yml or extend "
+                f"_CELL_METHODS_TO_KIND in fetch/era5_land.py."
+            )
+        out[var] = _CELL_METHODS_TO_KIND[cm]
+    return out
+
+
+_VARIABLE_KIND = _derive_variable_kind()
 
 
 def hourly_to_daily(da: xr.DataArray) -> xr.DataArray:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -355,3 +355,32 @@ def test_ssebop_et_resolves_to_mm():
     from nhf_spatial_targets.catalog import source_var_cf_units
 
     assert source_var_cf_units("ssebop", "et") == "mm"
+
+
+def test_source_var_cell_methods_returns_string():
+    """Per-variable cell_methods is exposed for catalog-driven dispatch (#101)."""
+    from nhf_spatial_targets.catalog import source_var_cell_methods
+
+    assert source_var_cell_methods("era5_land", "ro") == "time: sum"
+    assert source_var_cell_methods("era5_land", "sd") == "time: point"
+
+
+def test_source_var_cell_methods_returns_none_when_absent():
+    """Variables with no cell_methods declared return None, not raise.
+
+    Reitz 2017 annual recharge entries carry cf_units but no
+    cell_methods; callers decide whether None is acceptable for
+    their dispatch.
+    """
+    from nhf_spatial_targets.catalog import source_var_cell_methods
+
+    assert source_var_cell_methods("reitz2017", "total_recharge") is None
+    # Also via file_variable (the on-disk name).
+    assert source_var_cell_methods("reitz2017", "TotalRecharge") is None
+
+
+def test_source_var_cell_methods_raises_on_unknown_variable():
+    from nhf_spatial_targets.catalog import source_var_cell_methods
+
+    with pytest.raises(KeyError, match="not found"):
+        source_var_cell_methods("era5_land", "no_such_var")

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -1574,3 +1574,52 @@ def test_consolidate_year_dispatches_by_variable_kind(tmp_path):
             0.30,
             rtol=1e-9,
         )
+
+
+# ---- _VARIABLE_KIND derived from catalog cell_methods (#101) ----------------
+
+
+def test_variable_kind_derived_from_catalog():
+    """Module-level _VARIABLE_KIND comes from catalog cell_methods, not a
+    hardcoded dict. Pins the expected accumulated/instantaneous mapping
+    for all four VARIABLES (ro/sro/ssro/sd) so a future catalog edit that
+    flips one would surface here before reaching the reducer dispatch."""
+    from nhf_spatial_targets.fetch.era5_land import _VARIABLE_KIND, VARIABLES
+
+    assert set(_VARIABLE_KIND) == set(VARIABLES)
+    assert _VARIABLE_KIND["ro"] == "accumulated"
+    assert _VARIABLE_KIND["sro"] == "accumulated"
+    assert _VARIABLE_KIND["ssro"] == "accumulated"
+    assert _VARIABLE_KIND["sd"] == "instantaneous"
+
+
+def test_derive_variable_kind_raises_on_unknown_cell_methods(monkeypatch):
+    """If the catalog grows a variable with cell_methods outside the
+    known set, _derive_variable_kind() raises rather than silently
+    miscategorizing — a new aggregation flavour must be a deliberate
+    extension of _CELL_METHODS_TO_KIND."""
+    from nhf_spatial_targets.fetch import era5_land
+
+    def fake_cell_methods(source_key: str, var_name: str):
+        return "time: maximum"  # not in _CELL_METHODS_TO_KIND
+
+    monkeypatch.setattr(
+        era5_land._catalog, "source_var_cell_methods", fake_cell_methods
+    )
+    with pytest.raises(ValueError, match="cell_methods='time: maximum'"):
+        era5_land._derive_variable_kind()
+
+
+def test_derive_variable_kind_raises_on_missing_cell_methods(monkeypatch):
+    """A None return from the catalog (variable entry exists but lacks
+    cell_methods) must raise — every ERA5-Land variable needs an
+    explicit accumulated-vs-instantaneous declaration."""
+    from nhf_spatial_targets.fetch import era5_land
+
+    monkeypatch.setattr(
+        era5_land._catalog,
+        "source_var_cell_methods",
+        lambda source_key, var_name: None,
+    )
+    with pytest.raises(ValueError, match="cell_methods=None"):
+        era5_land._derive_variable_kind()


### PR DESCRIPTION
## Summary

The accumulated-vs-instantaneous mapping that drives the hourly→daily and daily→monthly reducers in [fetch/era5_land.py](src/nhf_spatial_targets/fetch/era5_land.py) was a hardcoded dict that duplicated information the catalog already encoded via ``cell_methods`` (``"time: sum"`` for ``ro``/``sro``/``ssro``, ``"time: point"`` for ``sd``). The #101 umbrella's hygiene block explicitly called this out:

> **Derive ``_VARIABLE_KIND`` from the catalog.** ``src/nhf_spatial_targets/fetch/era5_land.py`` currently duplicates the instantaneous-vs-accumulated split that the catalog already encodes via ``cell_methods``.

This PR makes the catalog the single source of truth:

- Adds [catalog.source_var_cell_methods](src/nhf_spatial_targets/catalog.py) mirroring ``source_var_cf_units``. Returns the string or ``None`` if not declared; raises ``KeyError`` on unknown variable. Callers decide whether ``None`` is acceptable for their dispatch (Reitz 2017's annual recharge entries are an example of catalog variables that legitimately omit ``cell_methods``).
- Replaces [fetch/era5_land.py](src/nhf_spatial_targets/fetch/era5_land.py)'s hardcoded ``_VARIABLE_KIND`` with ``_derive_variable_kind()`` which reads catalog ``cell_methods`` for each entry in ``VARIABLES`` and maps ``"time: sum"`` → ``"accumulated"``, ``"time: point"`` → ``"instantaneous"`` via ``_CELL_METHODS_TO_KIND``. Raises ``ValueError`` on missing or unrecognised ``cell_methods`` so a future variable with a new aggregation flavour forces a deliberate extension of the mapping rather than silent miscategorization.

No behaviour change for the existing four variables — ``_VARIABLE_KIND`` still resolves to the same dict at module import.

Ticks one of the two remaining hygiene checkboxes on #101 (the other, the Margulis CMR ``earthaccess.search_data`` smoke, will be handled when #101 is closed).

## Test plan

- [x] CI: ``tests/test_catalog.py`` — three new tests: helper happy path (``era5_land/ro`` → ``"time: sum"``), ``None`` return for cell_methods-less variables (reitz2017 annual recharge), and ``KeyError`` on unknown variable.
- [x] CI: ``tests/test_era5_land.py`` — pins the derived ``_VARIABLE_KIND`` map (ro/sro/ssro accumulated, sd instantaneous), plus two drift guards (monkeypatched catalog raises on unknown cell_methods, raises on ``None``).
- [x] CI: existing ``test_consolidate_year_dispatches_by_variable_kind`` and the daily/monthly reducer tests still pass — the derived map is identical to the previously-hardcoded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)