### PR TITLE
perf(targets): migrate write_target_nc to io_nc.build_encoding (#165 ST2)

### DIFF
--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -185,9 +185,11 @@ def build_encoding(
             "complevel": compression_level,
             "chunksizes": chunksizes,
             "_FillValue": _fill_value_for(dtype),
+            # Set shuffle explicitly for both kinds: netCDF4-python defaults
+            # shuffle=True whenever zlib is on, so omitting the key for floats
+            # would silently enable it on disk, contradicting the policy.
+            "shuffle": bool(np.issubdtype(dtype, np.integer)),
         }
-        if np.issubdtype(dtype, np.integer):
-            var_enc["shuffle"] = True
         encoding[name] = var_enc
 
     for tvar in ("time", "time_bnds"):

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -587,6 +587,37 @@ def compute_hru_area_and_centroids(project: Project) -> "pd.DataFrame":
     return df
 
 
+def _target_encoding_without_chunks(
+    ds: xr.Dataset, var_dtype: dict[str, str]
+) -> dict[str, dict]:
+    """Target encoding (dtype/zlib/fill/time) minus per-HRU ``chunksizes``.
+
+    Only used by :func:`write_target_nc` when no ``sort_dim``/``id_col`` is
+    supplied, so the per-HRU chunk dimension is unknown and HDF5 auto-chunks.
+    Reuses ``io_nc``'s fill-value and time policy so this fallback stays
+    consistent with the chunked ``build_encoding`` path.
+    """
+    from nhf_spatial_targets.io_nc import _TIME_ENCODING, _fill_value_for
+
+    encoding: dict[str, dict] = {}
+    for name, dt in var_dtype.items():
+        dtype = np.dtype(dt)
+        enc: dict = {
+            "dtype": str(dtype),
+            "zlib": True,
+            "complevel": 4,
+            "_FillValue": _fill_value_for(dtype),
+            # Explicit shuffle: netCDF4 defaults it True under zlib (see
+            # io_nc.build_encoding), so omitting it for floats would enable it.
+            "shuffle": bool(np.issubdtype(dtype, np.integer)),
+        }
+        encoding[name] = enc
+    for tvar in ("time", "time_bnds"):
+        if tvar in ds.variables:
+            encoding[tvar] = dict(_TIME_ENCODING)
+    return encoding
+
+
 def write_target_nc(
     ds: xr.Dataset,
     output_path: Path,
@@ -600,10 +631,15 @@ def write_target_nc(
     coordinates (``time_bnds``, ``centroid_lat``, ``centroid_lon``), and
     per-variable attrs (``units``, ``long_name``, ``cell_methods``, etc.).
     This helper sets the global ``Conventions`` / ``title`` / ``history`` /
-    ``software_version`` attrs, applies float32+zlib encoding for the bound
-    variables and int8+zlib encoding for the diagnostic variables, and
-    writes via tempfile + rename so a partial NetCDF never lands at the
-    final path.
+    ``software_version`` attrs, then delegates encoding to
+    :func:`io_nc.build_encoding` (``layer="target"``): float32+zlib bounds,
+    int8+zlib diagnostics, the pinned ``proleptic_gregorian`` time axis, and
+    per-HRU-time-series ``chunksizes`` so a single HRU's calibration read is
+    one ~1 MiB chunk (issue #165 ST2). The write goes through
+    :func:`io_nc.atomic_to_netcdf` (tempfile + rename) so a partial NetCDF
+    never lands at the final path. When ``sort_dim`` is omitted the HRU
+    chunk dim is unknown, so the same dtype/compression/time policy is applied
+    without per-HRU chunking.
 
     When ``sort_dim`` is given, the Dataset is sorted ascending on that
     dimension before write. Target builders pass ``project.id_col`` here
@@ -633,43 +669,30 @@ def write_target_nc(
     if extra_global_attrs:
         ds.attrs.update(extra_global_attrs)
 
-    encoding: dict = {}
-    for v in ("lower_bound", "upper_bound"):
-        if v in ds.data_vars:
-            encoding[v] = {
-                "dtype": "float32",
-                "zlib": True,
-                "complevel": 4,
-                "_FillValue": np.float32("nan"),
-            }
-    for v in ("n_sources", "nn_filled"):
-        if v in ds.data_vars:
-            encoding[v] = {
-                "dtype": "int8",
-                "zlib": True,
-                "complevel": 4,
-                "_FillValue": None,
-            }
-    if "time" in ds.coords or "time" in ds.dims or "time" in ds.variables:
-        encoding["time"] = {
-            "dtype": "float64",
-            "units": "days since 1970-01-01 00:00:00",
-            "calendar": "proleptic_gregorian",
-        }
-    if "time_bnds" in ds.variables:
-        encoding["time_bnds"] = {
-            "dtype": "float64",
-            "units": "days since 1970-01-01 00:00:00",
-            "calendar": "proleptic_gregorian",
-        }
+    from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
 
-    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
-    try:
-        ds.to_netcdf(tmp, format="NETCDF4", encoding=encoding)
-        tmp.rename(output_path)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
+    # Pin the on-disk dtype for each known target var: float32 bounds, int8
+    # diagnostics. build_encoding derives _FillValue / shuffle from the dtype
+    # (NaN + no-shuffle for floats, no-fill + shuffle for the int8 diagnostics).
+    target_dtypes = {
+        v: "float32" for v in ("lower_bound", "upper_bound") if v in ds.data_vars
+    }
+    target_dtypes.update(
+        {v: "int8" for v in ("n_sources", "nn_filled") if v in ds.data_vars}
+    )
+
+    if sort_dim is not None:
+        encoding = build_encoding(
+            ds, layer="target", hru_dim=sort_dim, var_dtype=target_dtypes
+        )
+    else:
+        # No id_col known — production target builders always pass sort_dim, so
+        # this is only the bare ``write_target_nc(ds, out, title=...)`` path.
+        # Apply the same dtype/compression/time policy minus per-HRU chunking
+        # (HDF5 auto-chunks), since the HRU dim name is unavailable here.
+        encoding = _target_encoding_without_chunks(ds, target_dtypes)
+
+    atomic_to_netcdf(ds, output_path, encoding=encoding)
     logger.info("Wrote %s (%.1f MB)", output_path, output_path.stat().st_size / 1e6)
 
 

--- a/tests/test_io_nc.py
+++ b/tests/test_io_nc.py
@@ -39,8 +39,9 @@ def test_aggregated_float_var_gets_chunks_and_compression():
     assert enc["ro"]["zlib"] is True
     assert enc["ro"]["complevel"] == 4
     assert enc["ro"]["dtype"] == "float32"
-    # floats do not get the byte-shuffle filter
-    assert enc["ro"].get("shuffle", False) is False
+    # floats get shuffle explicitly disabled (netCDF4 would default it True
+    # under zlib, so the key must be present, not merely omitted)
+    assert enc["ro"]["shuffle"] is False
     assert np.isnan(enc["ro"]["_FillValue"])
 
 
@@ -252,6 +253,7 @@ def test_on_disk_chunking_matches_encoding(tmp_path: Path):
     from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
 
     ds = _make_aggregated_ds(n_time=365, n_hru=50_000)
+    ds["n_sources"] = (("time", "nhm_id"), np.ones(ds["ro"].shape, dtype="int8"))
     enc = build_encoding(
         ds, layer="aggregated", hru_dim="nhm_id", timesteps_per_file=365
     )
@@ -260,3 +262,8 @@ def test_on_disk_chunking_matches_encoding(tmp_path: Path):
 
     with netCDF4.Dataset(out) as nc:
         assert tuple(nc.variables["ro"].chunking()) == enc["ro"]["chunksizes"]
+        # shuffle policy must hold on disk, not just in the encoding dict:
+        # netCDF4 defaults shuffle=True under zlib, so the float must come
+        # back shuffle=False and the int8 shuffle=True.
+        assert nc.variables["ro"].filters()["shuffle"] is False
+        assert nc.variables["n_sources"].filters()["shuffle"] is True

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -462,6 +462,51 @@ def test_write_target_nc_atomic_no_partial_on_failure(tmp_path: Path, monkeypatc
     assert not out.exists()
 
 
+def test_write_target_nc_applies_target_layer_chunking(tmp_path: Path):
+    """write_target_nc delegates to io_nc.build_encoding (#165 ST2).
+
+    Uses a fabric large enough that the per-HRU-time-series chunk formula
+    (chunk_hru = ceil(1 MiB / (n_time * 4))) differs from netCDF4's default
+    auto-chunking, so this asserts the policy actually reached HDF5.
+    """
+    import math
+
+    import netCDF4
+
+    from nhf_spatial_targets.targets._common import write_target_nc
+
+    n_time, n_hru = 12, 50_000
+    times = pd.date_range("2000-01-01", periods=n_time, freq="MS")
+    hrus = np.arange(1, n_hru + 1, dtype="int64")
+    rng = np.random.default_rng(0)
+    lower = rng.random((n_time, n_hru)).astype("float32")
+    ds = xr.Dataset(
+        {
+            "lower_bound": (("time", "nhm_id"), lower),
+            "upper_bound": (("time", "nhm_id"), lower + 1.0),
+            "n_sources": (("time", "nhm_id"), np.ones((n_time, n_hru), dtype="int8")),
+        },
+        coords={"time": times, "nhm_id": hrus},
+    )
+    out = tmp_path / "big_target.nc"
+    write_target_nc(ds, out, title="chunk test", sort_dim="nhm_id")
+
+    # chunk_hru is dtype-specific: float32 (4 B) caps the byte budget at ~21846
+    # HRUs; int8 (1 B) fits all 50000 HRUs in one sub-1-MiB chunk.
+    exp_f32 = min(math.ceil(1_048_576 / (n_time * 4)), n_hru)  # 21846
+    exp_i8 = min(math.ceil(1_048_576 / (n_time * 1)), n_hru)  # 50000
+    with netCDF4.Dataset(out) as nc:
+        for v in ("lower_bound", "upper_bound"):
+            assert tuple(nc.variables[v].chunking()) == (n_time, exp_f32)
+        assert tuple(nc.variables["n_sources"].chunking()) == (n_time, exp_i8)
+        # dtype + compression policy preserved from the pre-#165 writer.
+        assert nc.variables["lower_bound"].dtype == np.float32
+        assert nc.variables["n_sources"].dtype == np.int8
+        # Integer diagnostics gain the byte-shuffle filter under the new policy.
+        assert nc.variables["n_sources"].filters()["shuffle"] is True
+        assert nc.variables["lower_bound"].filters()["shuffle"] is False
+
+
 def test_reindex_to_month_start_rejects_non_ms_freq():
     """A freq='ME' master_index must raise, not silently produce all-NaN."""
     from nhf_spatial_targets.targets._common import reindex_to_month_start


### PR DESCRIPTION
Second stage of the #165 trunk. Migrates the in-memory target writer onto the shared `io_nc` helper landed in #167, and fixes a shuffle-policy bug that helper had.

## What changed

**`targets/_common.py::write_target_nc`** now delegates to `io_nc.build_encoding(layer="target", hru_dim=sort_dim)` + `io_nc.atomic_to_netcdf`, replacing the hand-rolled float32/int8 + zlib + time encoding and the tempfile+rename block.
- Bound/diagnostic vars gain per-HRU-time-series `chunksizes` → a single HRU's calibration read is ~1 chunk. `chunk_hru` is dtype-specific: float32 bounds cap the 1 MiB budget (`(n_time, ~21846)` at 50k HRUs); the int8 diagnostics pack more HRUs per chunk.
- Pinned `proleptic_gregorian`/`float64` time encoding and the atomic-write contract are unchanged.
- **No-`sort_dim` fallback**: the bare `write_target_nc(ds, out, title=...)` path (only that one path — production builders always pass `project.id_col`) can't know the HRU chunk dim, so a small helper applies the same dtype/compression/time policy without `chunksizes`.

**`io_nc.build_encoding` bug fix** (surfaced by this first real consumer): netCDF4-python defaults `shuffle=True` whenever `zlib` is on, so *omitting* the shuffle key for floats silently enabled it on disk — contradicting the documented "shuffle for ints, off for floats" policy. `build_encoding` now emits `shuffle` explicitly (`True` ints / `False` floats). The io_nc on-disk test now asserts shuffle via `netCDF4 .filters()`, not just the encoding dict.

## Scope (deliberate)
`stitch_year_chunks_to_target` (the SWE daily streaming writer) is **deferred to ST3**. Imposing full-time HRU-columnar HDF5 chunks on its year-slab streaming write would thrash the compressor; the coherent fix is to flip its dask read-chunks to HRU-columns, which pairs naturally with ST3's planned `read_aggregated_source` `{"time": -1, id_col: chunk_hru}` flip and needs 11 GB SWE-scale verification. Tracking it there keeps that one risky change in a single PR with its verification.

## Tests
- New `test_write_target_nc_applies_target_layer_chunking` — asserts dtype-specific on-disk `chunking()` (proves the policy reached HDF5; pre-migration was whole-array) + on-disk shuffle filter per dtype.
- io_nc float-shuffle assertions tightened to the explicit key + on-disk `.filters()`.
- Full `test_targets_*.py` + `test_io_nc.py`: **183 passed**. All existing target tests pass unmodified.

## Not in this PR
ST3 (aggregated `_atomic_write_netcdf` + `read_aggregated_source` + stitch columnar flip), ST5 (rechunk CLI), ST6 (docs). #158 implements the `consolidated` branch of `build_encoding`.

Part of #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)