### PR TITLE
perf(aggregate): chunk+compress aggregated NCs + align reads (#165 ST3a)

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -301,17 +301,37 @@ def per_year_output_path(project: Project, source_key: str, year: int) -> Path:
     )
 
 
-def _atomic_write_netcdf(ds: xr.Dataset, path: Path) -> None:
-    """Atomically write a Dataset to disk via tempfile + rename."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".nc.tmp")
-    os.close(tmp_fd)
-    try:
-        ds.to_netcdf(tmp_path)
-        Path(tmp_path).replace(path)
-    except Exception:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
+def _atomic_write_netcdf(
+    ds: xr.Dataset, path: Path, *, id_col: str | None = None
+) -> None:
+    """Atomically write an aggregated Dataset via tempfile + rename.
+
+    When ``id_col`` is given, encoding is delegated to
+    :func:`io_nc.build_encoding` (``layer="aggregated"``) so the per-year NC is
+    zlib-compressed and chunked ``(time, chunk_hru)`` for fast
+    per-HRU-time-series reads (issue #165 ST3). Native variable dtypes are
+    preserved — the aggregated layer keeps the source's native units/values, so
+    no float64→float32 downcast happens here (that would be a values change,
+    not a storage-layer change), and the grid-mapping container (``crs``) is
+    left untouched.
+
+    When ``id_col`` is ``None`` the Dataset is written without added
+    encoding (the pre-#165 behavior). The daymet (zarr) and ssebop (STAC)
+    aggregators take this path: their outputs are produced from already-chunked
+    remote sources and are intentionally left as-is.
+    """
+    from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
+
+    if id_col is not None:
+        encoding = build_encoding(
+            ds,
+            layer="aggregated",
+            hru_dim=id_col,
+            timesteps_per_file=ds.sizes.get("time"),
+        )
+    else:
+        encoding = None
+    atomic_to_netcdf(ds, path, encoding=encoding)
 
 
 def _migrate_legacy_layout(project: Project, source_key: str) -> None:
@@ -541,7 +561,7 @@ def aggregate_year(
     # downstream consumers a stable invariant.
     year_ds = year_ds.sortby(id_col)
 
-    _atomic_write_netcdf(year_ds, out_path)
+    _atomic_write_netcdf(year_ds, out_path, id_col=id_col)
     logger.info("%s: year %d: wrote %s", adapter.source_key, year, out_path)
     return out_path
 

--- a/src/nhf_spatial_targets/aggregate/daymet.py
+++ b/src/nhf_spatial_targets/aggregate/daymet.py
@@ -373,6 +373,7 @@ def aggregate_daymet(
             year_ds.attrs["daymet_region"] = region
             # Canonical id_col-ascending row order on emission (issue #93).
             year_ds = year_ds.sortby(id_col)
+            # daymet outputs are left as-is (#165 ST3): no added chunking/compression.
             _atomic_write_netcdf(year_ds, out_path)
             logger.info("daymet: year %d: wrote %s", year, out_path)
             per_year_paths.append(out_path)

--- a/src/nhf_spatial_targets/aggregate/ssebop.py
+++ b/src/nhf_spatial_targets/aggregate/ssebop.py
@@ -320,6 +320,7 @@ def aggregate_ssebop(
         _attach_cf_global_attrs(year_ds, _SOURCE_KEY, meta)
         # Canonical id_col-ascending row order on emission (issue #93).
         year_ds = year_ds.sortby(id_col)
+        # ssebop outputs are left as-is (#165 ST3): no added chunking/compression.
         _atomic_write_netcdf(year_ds, out_path)
         logger.info("ssebop: year %d: wrote %s", year, out_path)
         per_year_paths.append(out_path)

--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -163,6 +163,11 @@ def build_encoding(
     for name, da in ds.data_vars.items():
         if hru_dim not in da.dims:
             continue
+        # A CF grid-mapping container (e.g. ``crs``) may carry the hru_dim in
+        # some aggregated NCs, but it is metadata, not a data field — adding
+        # chunksizes/zlib/_FillValue would corrupt it. Leave it untouched.
+        if "grid_mapping_name" in da.attrs:
+            continue
         dtype = np.dtype(var_dtype.get(name, da.dtype))
         # Size the HRU chunk against this variable's own time extent: a static
         # per-HRU var (no time dim) chunks on HRU alone rather than carrying a

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -223,6 +223,24 @@ def shims_by_config_label(
     return out
 
 
+_AGG_READ_CHUNK_BYTES = 256 * 1024 * 1024
+
+
+def _read_chunk_hru(
+    n_time: int, itemsize: int, target_bytes: int = _AGG_READ_CHUNK_BYTES
+) -> int:
+    """HRU-dim dask chunk length for reading aggregated NCs (#165 ST3).
+
+    Reads use full-time chunks (``{"time": -1}``) so a file's on-disk time
+    chunk is never split (which would re-inflate the same compressed chunk on
+    every time slab). The HRU dim is chunked to ~``target_bytes`` per chunk to
+    keep per-chunk memory and the dask graph reasonable — deliberately larger
+    than the on-disk ~1 MiB HRU chunk, trading chunk granularity for a smaller
+    graph on a full-source read.
+    """
+    return max(1, target_bytes // (max(n_time, 1) * itemsize))
+
+
 def read_aggregated_source(
     project: Project,
     source_key: str,
@@ -257,9 +275,11 @@ def read_aggregated_source(
         ``(start_iso, end_iso)`` tuple, both inclusive (e.g.
         ``("2000-01-01", "2010-12-31")``).
     chunks
-        Forwarded to ``xr.open_mfdataset``. Defaults to
-        ``{"time": 12, project.id_col: -1}`` (one calendar year per chunk,
-        all HRUs in one chunk).
+        Forwarded to ``xr.open_mfdataset``. When ``None``, defaults to
+        ``{"time": -1, project.id_col: <chunk_hru>}`` — full time per chunk,
+        HRU dim chunked to ~256 MiB — to align reads with the columnar
+        on-disk layout written by the aggregator (#165 ST3). Pass an explicit
+        dict to override.
 
     Raises
     ------
@@ -281,7 +301,20 @@ def read_aggregated_source(
         )
 
     if chunks is None:
-        chunks = {"time": 12, project.id_col: -1}
+        # Align dask chunks to the new columnar on-disk layout (#165 ST3):
+        # full time per chunk so a file's on-disk time chunk is never split
+        # (splitting would force the compressor to re-inflate the same chunk
+        # on every time slab — ~30x amplification on a daily source), with the
+        # HRU dim chunked to ~256 MiB. Works for both the new chunked NCs and
+        # legacy contiguous NCs (the latter read as bounded strided slabs, not
+        # a whole-array load). open_mfdataset chunks per file along the concat
+        # dim, so ``{"time": -1}`` yields one time chunk per file — size the
+        # HRU chunk from one file's time length (probed cheaply from the first
+        # file) so each per-file chunk lands near the byte budget.
+        with xr.open_dataset(paths[0], engine="netcdf4") as probe:
+            n_time = int(probe.sizes.get("time", 1))
+            itemsize = probe[var].dtype.itemsize if var in probe.data_vars else 8
+        chunks = {"time": -1, project.id_col: _read_chunk_hru(n_time, itemsize)}
 
     ds = xr.open_mfdataset(
         [str(p) for p in paths],

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -407,6 +407,63 @@ def test_aggregate_source_writes_multi_var_nc_and_manifest(tmp_path, tiny_fabric
     ]
 
 
+def test_atomic_write_netcdf_chunks_and_compresses_with_id_col(tmp_path):
+    """#165 ST3: id_col triggers io_nc aggregated chunking + compression.
+
+    Native float64 dtype is preserved (storage-only change), and the
+    grid-mapping container (``crs``) is left contiguous/uncompressed.
+    """
+    import math
+
+    import netCDF4
+
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    n_time, n_hru = 12, 50_000
+    times = pd.date_range("2000-01-01", periods=n_time, freq="MS")
+    rng = np.random.default_rng(0)
+    ds = xr.Dataset(
+        {
+            "ro": (("time", "hru_id"), rng.random((n_time, n_hru))),  # float64
+            "crs": (("hru_id",), np.zeros(n_hru, dtype="float64")),
+        },
+        coords={"time": times, "hru_id": np.arange(n_hru)},
+    )
+    ds["crs"].attrs["grid_mapping_name"] = "latitude_longitude"
+
+    out = tmp_path / "agg.nc"
+    _atomic_write_netcdf(ds, out, id_col="hru_id")
+
+    exp_hru = min(math.ceil(1_048_576 / (n_time * 8)), n_hru)  # 10923, float64
+    with netCDF4.Dataset(out) as nc:
+        assert tuple(nc.variables["ro"].chunking()) == (n_time, exp_hru)
+        assert nc.variables["ro"].filters()["zlib"] is True
+        assert nc.variables["ro"].dtype == np.float64  # native dtype preserved
+        # grid-mapping container is metadata — must stay untouched.
+        assert nc.variables["crs"].chunking() == "contiguous"
+        assert nc.variables["crs"].filters()["zlib"] is False
+
+
+def test_atomic_write_netcdf_plain_without_id_col(tmp_path):
+    """daymet/ssebop path: omitting id_col writes plain (no chunk/compression)."""
+    import netCDF4
+
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    ds = xr.Dataset(
+        {"ro": (("time", "hru_id"), np.ones((12, 1_000)))},
+        coords={
+            "time": pd.date_range("2000-01-01", periods=12, freq="MS"),
+            "hru_id": np.arange(1_000),
+        },
+    )
+    out = tmp_path / "plain.nc"
+    _atomic_write_netcdf(ds, out)
+    with netCDF4.Dataset(out) as nc:
+        assert nc.variables["ro"].filters()["zlib"] is False
+        assert nc.variables["ro"].chunking() == "contiguous"
+
+
 def test_aggregate_source_files_glob_supports_subdirectory(tmp_path, tiny_fabric):
     """files_glob accepts a directory component to handle multi-subdir
     datastores.

--- a/tests/test_io_nc.py
+++ b/tests/test_io_nc.py
@@ -115,6 +115,22 @@ def test_integer_dtype_gets_shuffle_and_no_nan_fill():
     assert enc["n_sources"]["_FillValue"] is None
 
 
+def test_skips_grid_mapping_container_var():
+    """A CF grid_mapping container (e.g. ``crs``) must not be compressed/filled.
+
+    The aggregated layer carries a ``crs`` data var with the hru_dim; adding
+    chunksizes/zlib/_FillValue to a grid_mapping container corrupts it.
+    """
+    from nhf_spatial_targets.io_nc import build_encoding
+
+    ds = _make_aggregated_ds(n_time=12, n_hru=5_000)
+    ds["crs"] = (("nhm_id",), np.zeros(5_000, dtype="float64"))
+    ds["crs"].attrs["grid_mapping_name"] = "latitude_longitude"
+    enc = build_encoding(ds, layer="aggregated", hru_dim="nhm_id")
+    assert "crs" not in enc  # skipped entirely
+    assert "ro" in enc  # real data var still encoded
+
+
 def test_per_var_dtype_override():
     from nhf_spatial_targets.io_nc import build_encoding
 

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -462,6 +462,38 @@ def test_write_target_nc_atomic_no_partial_on_failure(tmp_path: Path, monkeypatc
     assert not out.exists()
 
 
+def test_read_chunk_hru_sizes_to_byte_budget():
+    """HRU read-chunk shrinks as the time axis grows, capped at >=1 (#165 ST3)."""
+    from nhf_spatial_targets.targets._common import _read_chunk_hru
+
+    # 256 MiB budget, float64: daily multi-year -> a few thousand HRUs/chunk.
+    assert _read_chunk_hru(14_600, 8) == (256 * 1024 * 1024) // (14_600 * 8)
+    # Short monthly axis -> very wide HRU chunk.
+    assert _read_chunk_hru(12, 8) == (256 * 1024 * 1024) // (12 * 8)
+    # Never returns 0 even for an absurdly long axis.
+    assert _read_chunk_hru(10**9, 8) == 1
+
+
+def test_read_aggregated_source_uses_full_time_chunks(tmp_path: Path):
+    """Default read chunking is full-time columnar, not the old time-slab (#165 ST3)."""
+    from nhf_spatial_targets.targets._common import read_aggregated_source
+    from nhf_spatial_targets.workspace import load
+    from tests.conftest import make_minimal_project, write_year_nc
+
+    workdir = make_minimal_project(tmp_path)
+    src, var = "era5_land", "ro"
+    src_dir = workdir / "data" / "aggregated" / src
+    write_year_nc(src_dir / f"{src}_2000_agg.nc", 2000, var)
+    write_year_nc(src_dir / f"{src}_2001_agg.nc", 2001, var)
+
+    project = load(workdir)
+    da = read_aggregated_source(project, src, var, period=("2000-01-01", "2001-12-31"))
+    # open_mfdataset chunks per file along time, so each file's full 12-month
+    # span is one chunk — the on-disk time chunk is never split (no per-slab
+    # re-decompression). The old default split time into 12-step slabs.
+    assert da.chunksizes["time"] == (12, 12)
+
+
 def test_write_target_nc_applies_target_layer_chunking(tmp_path: Path):
     """write_target_nc delegates to io_nc.build_encoding (#165 ST2).
 


### PR DESCRIPTION
Third stage of the #165 trunk (split per maintainer request: this is the **aggregated writer + read alignment**; the SWE `stitch` columnar flip is the follow-up ST3b). Scope is the netCDF-backed sources that go through `aggregate/_driver.py`. **daymet (zarr) and ssebop (STAC) are intentionally left as-is** — already chunked, remote-sourced.

## Changes

**`aggregate/_driver.py::_atomic_write_netcdf`** — gains an optional `id_col`:
- With `id_col`: delegates to `io_nc.build_encoding(layer="aggregated")` → zlib4 + `(time, chunk_hru)` chunking. **Native dtypes preserved** (no float64→float32 downcast — aggregated layer keeps native units/values, so this stays storage-only), and the `crs` grid-mapping container is left untouched.
- Without `id_col`: plain write (pre-#165 behavior). The **daymet and ssebop callsites take this path** and are byte-for-byte unchanged.

**`io_nc.build_encoding`** — skip CF grid-mapping containers (vars with a `grid_mapping_name` attr); they carry the hru_dim in some aggregated NCs but must not be chunked/compressed/filled.

**`read_aggregated_source`** — the old `{"time": 12, id_col: -1}` time-slab default would force each on-disk chunk of a newly-compressed **daily** source to be re-inflated on every time slab (~30× amplification). New default `{"time": -1, id_col: chunk_hru}` reads one full-time chunk per file (`open_mfdataset` chunks per file along the concat dim) so a file's on-disk time chunk is never split. `chunk_hru` (`_read_chunk_hru`) targets ~256 MiB from one file's time length + dtype. Works for both new chunked NCs and legacy contiguous NCs.

## Empirical verification (real gfv2 NCs, rewritten with new encoding)
Bit-identity confirmed, float64 preserved:
| source | cadence | before | after | reduction |
|---|---|---|---|---|
| snodas | daily, sparse | 1060 MB | 158 MB | **85%** |
| era5_land | monthly, dense | 114 MB | 98 MB | 14% |

Per-HRU single-column read: **1.2–2.2×** faster, *not* 10× — zlib decompress offsets chunk-locality for the single-HRU pattern. The dominant, source-dependent win is **disk footprint** (large for sparse daily sources; caldera disk pressure was the stated motivation).

## ⚠️ Needs a real-build check before relying on it
`read_aggregated_source`'s new chunk shape changes every target build's dask memory profile. Unit tests cover the chunk math + full-time chunking, but **the memory/runtime on a real target build can't be unit-verified**. Recommend running one real build (e.g. `run-runoff` or SWE) on caldera and confirming healthy memory before this is leaned on. Flagged for reviewer.

## Operator note
Existing aggregated NCs stay contiguous/uncompressed until re-aggregated or rechunked (ST5). No forced migration; no immediate behavior change to existing files.

## Tests
io_nc grid-mapping skip; `_atomic_write_netcdf` chunked-vs-plain; `_read_chunk_hru` byte math; `read_aggregated_source` full-time chunking. Full aggregate + targets + io_nc suite: **252 passed**.

Part of #165. Follow-ups: ST3b (SWE stitch), ST5 (rechunk CLI), ST6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)