### PR TITLE
feat(rechunk): nhf-targets rechunk CLI to backfill chunked layout (#165 ST5)

### DIFF
--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -216,9 +216,9 @@ def rechunk(
     """Backfill existing aggregated/target NCs to the chunked+compressed layout.
 
     Rewrites contiguous/uncompressed NetCDFs (built before #165) in place to the
-    canonical io_nc layout: bit-identical, atomic, and idempotent. Does not touch
-    the shared datastore's consolidated NCs, nor the daymet/ssebop aggregated
-    outputs (left as-is by #165 ST3a).
+    canonical io_nc layout: value-preserving, atomic, and idempotent. Does not
+    touch the shared datastore's consolidated NCs, nor the daymet/ssebop
+    aggregated outputs (left as-is by #165 ST3).
     """
     from nhf_spatial_targets.rechunk import rechunk_project
     from nhf_spatial_targets.workspace import load as load_project
@@ -246,18 +246,28 @@ def rechunk(
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    # A mistyped --source would otherwise be a silent no-op; fail loudly.
+    if source is not None and not (project.aggregated_dir() / source).is_dir():
+        print(
+            f"Error: no aggregated source directory '{source}' under "
+            f"{project.aggregated_dir()}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     results = rechunk_project(project, layer=layer, source=source, dry_run=dry_run)
 
     rechunked = [r for r in results if r["status"] == "rechunked"]
-    skipped = [r for r in results if r["status"] == "skipped"]
+    skipped = [r for r in results if r["status"].startswith("skipped")]
     planned = [r for r in results if r["status"] == "would-rechunk"]
+    failed = [r for r in results if r["status"] == "failed"]
     total_before = sum(r["size_before"] for r in results)
     total_after = sum(r["size_after"] for r in results if r["size_after"] is not None)
 
     if dry_run:
         print(
             f"[dry-run] {len(planned)} file(s) would be rechunked, "
-            f"{len(skipped)} already chunked "
+            f"{len(skipped)} skipped "
             f"({total_before / 1e9:.2f} GB candidate)."
         )
     else:
@@ -265,10 +275,16 @@ def rechunk(
         reclaimed_from = sum(r["size_before"] for r in rechunked)
         pct = 100.0 * saved / reclaimed_from if reclaimed_from else 0.0
         print(
-            f"Rechunked {len(rechunked)} file(s), skipped {len(skipped)} "
-            f"already-chunked. Reclaimed {saved / 1e9:.2f} GB "
+            f"Rechunked {len(rechunked)} file(s), skipped {len(skipped)}. "
+            f"Reclaimed {saved / 1e9:.2f} GB "
             f"({pct:.0f}% of the rewritten files)."
         )
+
+    if failed:
+        print(f"Error: {len(failed)} file(s) failed to rechunk:", file=sys.stderr)
+        for r in failed:
+            print(f"  {r['path'].name}: {r.get('error')}", file=sys.stderr)
+        sys.exit(1)
 
 
 @app.command

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -183,6 +183,95 @@ def _dispatch(
 
 
 @app.command
+def rechunk(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir", "-d"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    layer: Annotated[
+        str | None,
+        Parameter(
+            name=["--layer"],
+            help="Restrict to 'aggregated' or 'target' (default: both).",
+        ),
+    ] = None,
+    source: Annotated[
+        str | None,
+        Parameter(
+            name=["--source"],
+            help="Restrict the aggregated layer to one source key.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        Parameter(
+            name=["--dry-run"],
+            help="Report what would be rechunked without writing.",
+        ),
+    ] = False,
+):
+    """Backfill existing aggregated/target NCs to the chunked+compressed layout.
+
+    Rewrites contiguous/uncompressed NetCDFs (built before #165) in place to the
+    canonical io_nc layout: bit-identical, atomic, and idempotent. Does not touch
+    the shared datastore's consolidated NCs, nor the daymet/ssebop aggregated
+    outputs (left as-is by #165 ST3a).
+    """
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load as load_project
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+    if not (workdir / "fabric.json").exists():
+        print(
+            f"Error: fabric.json not found in {workdir}. "
+            "Run 'nhf-targets validate' first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if layer is not None and layer not in ("aggregated", "target"):
+        print(
+            f"Error: invalid --layer {layer!r}; expected 'aggregated' or 'target'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    try:
+        project = load_project(workdir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    results = rechunk_project(project, layer=layer, source=source, dry_run=dry_run)
+
+    rechunked = [r for r in results if r["status"] == "rechunked"]
+    skipped = [r for r in results if r["status"] == "skipped"]
+    planned = [r for r in results if r["status"] == "would-rechunk"]
+    total_before = sum(r["size_before"] for r in results)
+    total_after = sum(r["size_after"] for r in results if r["size_after"] is not None)
+
+    if dry_run:
+        print(
+            f"[dry-run] {len(planned)} file(s) would be rechunked, "
+            f"{len(skipped)} already chunked "
+            f"({total_before / 1e9:.2f} GB candidate)."
+        )
+    else:
+        saved = total_before - total_after if rechunked else 0
+        reclaimed_from = sum(r["size_before"] for r in rechunked)
+        pct = 100.0 * saved / reclaimed_from if reclaimed_from else 0.0
+        print(
+            f"Rechunked {len(rechunked)} file(s), skipped {len(skipped)} "
+            f"already-chunked. Reclaimed {saved / 1e9:.2f} GB "
+            f"({pct:.0f}% of the rewritten files)."
+        )
+
+
+@app.command
 def init(
     workdir: Annotated[
         Path,

--- a/src/nhf_spatial_targets/rechunk.py
+++ b/src/nhf_spatial_targets/rechunk.py
@@ -3,22 +3,30 @@
 The #165 writers only chunk+compress NCs they newly write; projects built
 before ST2/ST3 still hold contiguous, uncompressed NetCDFs. ``rechunk_project``
 rewrites those in place to the canonical chunked+zlib layout produced by
-:func:`io_nc.build_encoding`, reclaiming disk (≈85% on sparse daily sources)
-without re-aggregating.
+:func:`io_nc.build_encoding`, reclaiming substantial disk (largest on
+sparse/NaN-heavy daily sources, where contiguous storage dominated) without
+re-aggregating.
 
 Guarantees:
 
-- **Idempotent** — a file whose data variables are already chunked+compressed
-  is skipped (detected via ``netCDF4.Variable.chunking()`` / ``.filters()``).
+- **Idempotent** — a file is skipped only when *every* field variable is
+  already chunked+compressed (detected via ``netCDF4.Variable.chunking()`` /
+  ``.filters()``); a mixed-state file is rewritten.
 - **Atomic** — each file is rewritten to ``<file>.rechunk.tmp`` then renamed,
   so an interrupted run never leaves a half-written NC at the canonical path.
-- **Bit-identical** — every data variable is compared (NaN-aware for floats)
-  against the original before the rename; a mismatch aborts that file. Native
-  dtypes are preserved, so rechunking changes storage layout only.
+- **Value-preserving** — every variable (data vars *and* coordinates,
+  including the re-encoded ``time`` / ``time_bnds``) is compared decoded and
+  NaN-aware against the original before the rename; a mismatch aborts that file
+  with no replacement. Native dtypes are preserved, so the change is
+  storage-layout only (the on-disk bytes differ — chunking, zlib, and an added
+  ``_FillValue`` — but the decoded values do not).
 - **Scoped** — operates only on a project's ``data/aggregated/`` and
   ``targets/`` trees. It never touches the shared datastore's *consolidated*
   NCs (those use issue #158's per-source tile sizes, a different policy), and
-  it skips the daymet/ssebop aggregated outputs left as-is by ST3a.
+  it skips the daymet/ssebop aggregated outputs left as-is by ST3.
+- **Per-file isolated** — one file's failure (bit-identity mismatch, disk
+  full, a stray NC missing the HRU dim) is recorded and the run continues; the
+  CLI surfaces failures and exits non-zero.
 """
 
 from __future__ import annotations
@@ -38,26 +46,33 @@ logger = logging.getLogger(__name__)
 
 _VALID_LAYERS = ("aggregated", "target")
 
-#: Aggregated sources intentionally left unchunked by ST3a (already chunked,
+#: Aggregated sources intentionally left unchunked by ST3 (already chunked,
 #: remote-sourced) — rechunk skips them for the same reason.
 _SKIP_SOURCES = frozenset({"daymet", "ssebop"})
 
 
-def _first_field_var(nc: netCDF4.Dataset) -> netCDF4.Variable | None:
-    """The first ``>=2D`` data variable — representative for chunk detection."""
-    for v in nc.variables.values():
-        if v.ndim >= 2:
-            return v
-    return None
-
-
 def is_rechunked(path: Path) -> bool:
-    """True if *path*'s field variables are already chunked + zlib-compressed."""
+    """True only if *every* field (>=2D) variable is chunked + zlib-compressed.
+
+    Checking all field variables — not just the first — is essential: a file
+    where one variable is chunked but another is still contiguous (e.g. an
+    interrupted earlier run) must be rewritten, not silently skipped. A
+    mixed-chunk-state file is logged at WARNING and reported as not-yet-rechunked.
+    """
     with netCDF4.Dataset(path) as nc:
-        v = _first_field_var(nc)
-        if v is None:
+        field_vars = [v for v in nc.variables.values() if v.ndim >= 2]
+        if not field_vars:
             return False
-        return v.chunking() != "contiguous" and bool(v.filters().get("zlib"))
+        states = [
+            v.chunking() != "contiguous" and bool(v.filters().get("zlib"))
+            for v in field_vars
+        ]
+        if any(states) and not all(states):
+            logger.warning(
+                "%s has mixed chunk state across field variables; will rechunk.",
+                path,
+            )
+        return all(states)
 
 
 def _arrays_equal(a: np.ndarray, b: np.ndarray) -> bool:
@@ -96,8 +111,10 @@ def rechunk_file(
 ) -> dict[str, Any]:
     """Rewrite one NC to the io_nc chunked layout; return a result record.
 
-    ``status`` is one of ``"skipped"`` (already chunked), ``"would-rechunk"``
-    (dry run), or ``"rechunked"``. Raises if the bit-identity check fails.
+    ``status`` is one of ``"skipped"`` (already chunked), ``"skipped-no-hru"``
+    (no HRU dim — not a fabric-aligned NC), ``"would-rechunk"`` (dry run), or
+    ``"rechunked"``. Raises if the write fails or the value-preservation check
+    detects a mismatch (the original is left untouched in that case).
     """
     size_before = path.stat().st_size
     if is_rechunked(path):
@@ -116,6 +133,15 @@ def rechunk_file(
         }
 
     with xr.open_dataset(path) as ds_lazy:
+        # A stray, non-fabric NC (no HRU dim) can't be chunked by the
+        # aggregated/target formula — skip it rather than crash build_encoding.
+        if id_col not in ds_lazy.dims:
+            return {
+                "path": path,
+                "status": "skipped-no-hru",
+                "size_before": size_before,
+                "size_after": size_before,
+            }
         ds = ds_lazy.load()
     encoding = build_encoding(
         ds, layer=layer, hru_dim=id_col, timesteps_per_file=ds.sizes.get("time")
@@ -124,8 +150,12 @@ def rechunk_file(
     try:
         ds.to_netcdf(tmp, format="NETCDF4", encoding=encoding)
         with xr.open_dataset(tmp) as got:
-            for name, da in ds.data_vars.items():
-                if not _arrays_equal(da.values, got[name].values):
+            # Compare every variable — data vars AND coordinates. time/time_bnds
+            # are re-encoded (float64 epoch), so verifying coords is not optional.
+            for name in ds.variables:
+                if not _arrays_equal(
+                    np.asarray(ds[name].values), np.asarray(got[name].values)
+                ):
                     raise RuntimeError(
                         f"rechunk altered values for '{name}' in {path}; "
                         f"aborting (no file replaced)."
@@ -177,8 +207,23 @@ def rechunk_project(
             f"invalid layer {layer!r}; expected one of {_VALID_LAYERS} or None"
         )
     id_col = project.id_col
-    results = [
-        rechunk_file(path, file_layer, id_col, dry_run=dry_run)
-        for path, file_layer in _iter_layer_files(project, layer, source)
-    ]
+    results: list[dict[str, Any]] = []
+    for path, file_layer in _iter_layer_files(project, layer, source):
+        try:
+            results.append(rechunk_file(path, file_layer, id_col, dry_run=dry_run))
+        except Exception as exc:
+            # Per-file isolation: one bad file (mismatch, disk full, corrupt
+            # source) is recorded and the run continues. The original is left
+            # untouched by rechunk_file's atomic guard; the CLI surfaces the
+            # failure and exits non-zero so it can't pass silently.
+            logger.error("rechunk failed for %s: %s", path, exc)
+            results.append(
+                {
+                    "path": path,
+                    "status": "failed",
+                    "error": str(exc),
+                    "size_before": path.stat().st_size if path.exists() else 0,
+                    "size_after": None,
+                }
+            )
     return results

--- a/src/nhf_spatial_targets/rechunk.py
+++ b/src/nhf_spatial_targets/rechunk.py
@@ -1,0 +1,184 @@
+"""Backfill existing aggregated/target NCs to the io_nc chunked layout (#165 ST5).
+
+The #165 writers only chunk+compress NCs they newly write; projects built
+before ST2/ST3 still hold contiguous, uncompressed NetCDFs. ``rechunk_project``
+rewrites those in place to the canonical chunked+zlib layout produced by
+:func:`io_nc.build_encoding`, reclaiming disk (≈85% on sparse daily sources)
+without re-aggregating.
+
+Guarantees:
+
+- **Idempotent** — a file whose data variables are already chunked+compressed
+  is skipped (detected via ``netCDF4.Variable.chunking()`` / ``.filters()``).
+- **Atomic** — each file is rewritten to ``<file>.rechunk.tmp`` then renamed,
+  so an interrupted run never leaves a half-written NC at the canonical path.
+- **Bit-identical** — every data variable is compared (NaN-aware for floats)
+  against the original before the rename; a mismatch aborts that file. Native
+  dtypes are preserved, so rechunking changes storage layout only.
+- **Scoped** — operates only on a project's ``data/aggregated/`` and
+  ``targets/`` trees. It never touches the shared datastore's *consolidated*
+  NCs (those use issue #158's per-source tile sizes, a different policy), and
+  it skips the daymet/ssebop aggregated outputs left as-is by ST3a.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import netCDF4
+import numpy as np
+import xarray as xr
+
+from nhf_spatial_targets.io_nc import build_encoding
+from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
+
+_VALID_LAYERS = ("aggregated", "target")
+
+#: Aggregated sources intentionally left unchunked by ST3a (already chunked,
+#: remote-sourced) — rechunk skips them for the same reason.
+_SKIP_SOURCES = frozenset({"daymet", "ssebop"})
+
+
+def _first_field_var(nc: netCDF4.Dataset) -> netCDF4.Variable | None:
+    """The first ``>=2D`` data variable — representative for chunk detection."""
+    for v in nc.variables.values():
+        if v.ndim >= 2:
+            return v
+    return None
+
+
+def is_rechunked(path: Path) -> bool:
+    """True if *path*'s field variables are already chunked + zlib-compressed."""
+    with netCDF4.Dataset(path) as nc:
+        v = _first_field_var(nc)
+        if v is None:
+            return False
+        return v.chunking() != "contiguous" and bool(v.filters().get("zlib"))
+
+
+def _arrays_equal(a: np.ndarray, b: np.ndarray) -> bool:
+    """Exact equality, NaN-aware for floating dtypes."""
+    if np.issubdtype(a.dtype, np.floating):
+        return np.array_equal(a, b, equal_nan=True)
+    return np.array_equal(a, b)
+
+
+def _iter_layer_files(
+    project: Project, layer: str | None, source: str | None
+) -> list[tuple[Path, str]]:
+    """Per-file work list of ``(path, layer)`` for the requested scope."""
+    files: list[tuple[Path, str]] = []
+    if layer in (None, "aggregated"):
+        agg = project.aggregated_dir()
+        if agg.is_dir():
+            for src_dir in sorted(p for p in agg.iterdir() if p.is_dir()):
+                key = src_dir.name
+                if source is not None and key != source:
+                    continue
+                if key in _SKIP_SOURCES:
+                    continue
+                files.extend(
+                    (f, "aggregated") for f in sorted(src_dir.glob(f"{key}_*_agg.nc"))
+                )
+    if layer in (None, "target") and source is None:
+        tdir = project.targets_dir()
+        if tdir.is_dir():
+            files.extend((f, "target") for f in sorted(tdir.glob("*.nc")))
+    return files
+
+
+def rechunk_file(
+    path: Path, layer: str, id_col: str, *, dry_run: bool = False
+) -> dict[str, Any]:
+    """Rewrite one NC to the io_nc chunked layout; return a result record.
+
+    ``status`` is one of ``"skipped"`` (already chunked), ``"would-rechunk"``
+    (dry run), or ``"rechunked"``. Raises if the bit-identity check fails.
+    """
+    size_before = path.stat().st_size
+    if is_rechunked(path):
+        return {
+            "path": path,
+            "status": "skipped",
+            "size_before": size_before,
+            "size_after": size_before,
+        }
+    if dry_run:
+        return {
+            "path": path,
+            "status": "would-rechunk",
+            "size_before": size_before,
+            "size_after": None,
+        }
+
+    with xr.open_dataset(path) as ds_lazy:
+        ds = ds_lazy.load()
+    encoding = build_encoding(
+        ds, layer=layer, hru_dim=id_col, timesteps_per_file=ds.sizes.get("time")
+    )
+    tmp = path.with_suffix(path.suffix + ".rechunk.tmp")
+    try:
+        ds.to_netcdf(tmp, format="NETCDF4", encoding=encoding)
+        with xr.open_dataset(tmp) as got:
+            for name, da in ds.data_vars.items():
+                if not _arrays_equal(da.values, got[name].values):
+                    raise RuntimeError(
+                        f"rechunk altered values for '{name}' in {path}; "
+                        f"aborting (no file replaced)."
+                    )
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    size_after = path.stat().st_size
+    logger.info(
+        "rechunked %s: %.1f MB -> %.1f MB (%.0f%% smaller)",
+        path.name,
+        size_before / 1e6,
+        size_after / 1e6,
+        100.0 * (1 - size_after / size_before) if size_before else 0.0,
+    )
+    return {
+        "path": path,
+        "status": "rechunked",
+        "size_before": size_before,
+        "size_after": size_after,
+    }
+
+
+def rechunk_project(
+    project: Project,
+    *,
+    layer: str | None = None,
+    source: str | None = None,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    """Rechunk every in-scope NC for *project*; return per-file result records.
+
+    Parameters
+    ----------
+    project:
+        Loaded project.
+    layer:
+        ``"aggregated"``, ``"target"``, or ``None`` for both.
+    source:
+        Restrict the aggregated layer to a single source key. Ignored for the
+        target layer (targets are not per-source).
+    dry_run:
+        Report planned work without writing.
+    """
+    if layer is not None and layer not in _VALID_LAYERS:
+        raise ValueError(
+            f"invalid layer {layer!r}; expected one of {_VALID_LAYERS} or None"
+        )
+    id_col = project.id_col
+    results = [
+        rechunk_file(path, file_layer, id_col, dry_run=dry_run)
+        for path, file_layer in _iter_layer_files(project, layer, source)
+    ]
+    return results

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -1,0 +1,168 @@
+"""Tests for the rechunk backfill CLI (issue #165 ST5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import netCDF4
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from tests.conftest import make_minimal_project, write_year_nc
+
+
+def _write_contiguous_target(path: Path, id_col: str = "nhm_id") -> None:
+    """A target-style NC written plain (contiguous, uncompressed)."""
+    n_time, n_hru = 12, 200
+    times = pd.date_range("2000-01-01", periods=n_time, freq="MS")
+    lower = np.random.default_rng(0).random((n_time, n_hru)).astype("float32")
+    ds = xr.Dataset(
+        {
+            "lower_bound": (("time", id_col), lower),
+            "upper_bound": (("time", id_col), lower + 1.0),
+            "n_sources": (("time", id_col), np.ones((n_time, n_hru), dtype="int8")),
+        },
+        coords={"time": times, id_col: np.arange(1, n_hru + 1)},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _data_var_chunked(path: Path) -> bool:
+    with netCDF4.Dataset(path) as nc:
+        for v in nc.variables.values():
+            if v.ndim >= 2:
+                return v.chunking() != "contiguous" and bool(v.filters().get("zlib"))
+    return False
+
+
+# --- core rechunk behavior ----------------------------------------------
+
+
+def test_rechunk_converts_contiguous_aggregated_to_chunked(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")  # contiguous, uncompressed
+    assert not _data_var_chunked(f)
+
+    project = load(workdir)
+    results = rechunk_project(project, layer="aggregated")
+
+    assert _data_var_chunked(f)  # now chunked + compressed
+    statuses = {r["path"].name: r["status"] for r in results}
+    assert statuses[f.name] == "rechunked"
+
+
+def test_rechunk_is_bit_identical(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+    before = xr.open_dataset(f).load()
+
+    project = load(workdir)
+    rechunk_project(project, layer="aggregated")
+
+    after = xr.open_dataset(f).load()
+    np.testing.assert_array_equal(before["ro"].values, after["ro"].values)
+
+
+def test_rechunk_is_idempotent(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+    project = load(workdir)
+
+    rechunk_project(project, layer="aggregated")
+    results2 = rechunk_project(project, layer="aggregated")  # second pass
+
+    assert all(r["status"] == "skipped" for r in results2)
+
+
+def test_rechunk_dry_run_does_not_write(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+    mtime_before = f.stat().st_mtime_ns
+
+    project = load(workdir)
+    results = rechunk_project(project, layer="aggregated", dry_run=True)
+
+    assert f.stat().st_mtime_ns == mtime_before  # untouched
+    assert not _data_var_chunked(f)
+    assert all(r["status"] == "would-rechunk" for r in results)
+
+
+def test_rechunk_skips_daymet_and_ssebop(tmp_path: Path):
+    """daymet/ssebop outputs are intentionally left as-is (#165 ST3a)."""
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    dm = workdir / "data" / "aggregated" / "daymet" / "daymet_2000_agg.nc"
+    write_year_nc(dm, 2000, "swe")
+    project = load(workdir)
+
+    results = rechunk_project(project, layer="aggregated")
+
+    assert not _data_var_chunked(dm)  # untouched
+    assert dm.name not in {r["path"].name for r in results}
+
+
+def test_rechunk_target_layer(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    t = workdir / "targets" / "runoff_targets.nc"
+    _write_contiguous_target(t)
+    assert not _data_var_chunked(t)
+
+    project = load(workdir)
+    rechunk_project(project, layer="target")
+
+    assert _data_var_chunked(t)
+
+
+def test_cli_rechunk_command_runs(tmp_path: Path, capsys):
+    """The CLI command wires through to rechunk_project (dry-run smoke)."""
+    from nhf_spatial_targets import cli
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+
+    cli.rechunk(workdir, dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    assert not _data_var_chunked(f)  # dry-run leaves the file untouched
+
+
+def test_rechunk_source_filter(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    a = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    b = workdir / "data" / "aggregated" / "gldas" / "gldas_2000_agg.nc"
+    write_year_nc(a, 2000, "ro")
+    write_year_nc(b, 2000, "ro")
+
+    project = load(workdir)
+    rechunk_project(project, layer="aggregated", source="era5_land")
+
+    assert _data_var_chunked(a)
+    assert not _data_var_chunked(b)  # filtered out

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -7,9 +7,37 @@ from pathlib import Path
 import netCDF4
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from tests.conftest import make_minimal_project, write_year_nc
+
+
+def _write_realistic_aggregated(path: Path, id_col: str = "nhm_id") -> None:
+    """Aggregated-style NC: float64 field (+NaN), int8 diagnostic, crs container,
+    lat/lon coords, and a re-encoded ``time`` axis — the real on-disk shape."""
+    n_time, n_hru = 12, 300
+    times = pd.date_range("2000-01-01", periods=n_time, freq="MS")
+    rng = np.random.default_rng(1)
+    ro = rng.random((n_time, n_hru))  # float64
+    ro[0, 0] = np.nan
+    ds = xr.Dataset(
+        {
+            "ro": (("time", id_col), ro),
+            "n_sources": (("time", id_col), np.ones((n_time, n_hru), dtype="int8")),
+            "crs": ((), np.int32(0)),
+        },
+        coords={
+            "time": times,
+            id_col: np.arange(1, n_hru + 1),
+            "lat": ((id_col,), np.linspace(25.0, 49.0, n_hru)),
+            "lon": ((id_col,), np.linspace(-124.0, -67.0, n_hru)),
+        },
+    )
+    ds["crs"].attrs["grid_mapping_name"] = "latitude_longitude"
+    ds["ro"].attrs["grid_mapping"] = "crs"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
 
 
 def _write_contiguous_target(path: Path, id_col: str = "nhm_id") -> None:
@@ -106,7 +134,7 @@ def test_rechunk_dry_run_does_not_write(tmp_path: Path):
 
 
 def test_rechunk_skips_daymet_and_ssebop(tmp_path: Path):
-    """daymet/ssebop outputs are intentionally left as-is (#165 ST3a)."""
+    """daymet/ssebop outputs are intentionally left as-is (#165 ST3)."""
     from nhf_spatial_targets.rechunk import rechunk_project
     from nhf_spatial_targets.workspace import load
 
@@ -166,3 +194,198 @@ def test_rechunk_source_filter(tmp_path: Path):
 
     assert _data_var_chunked(a)
     assert not _data_var_chunked(b)  # filtered out
+
+
+# --- safety paths surfaced by PR #170 review ----------------------------
+
+
+def test_is_rechunked_detects_mixed_chunk_state(tmp_path: Path):
+    """A file with one chunked + one contiguous field var is NOT 'rechunked'."""
+    from nhf_spatial_targets.rechunk import is_rechunked
+
+    p = tmp_path / "mixed.nc"
+    n_time, n_hru = 12, 50
+    ds = xr.Dataset(
+        {
+            "a": (("time", "nhm_id"), np.ones((n_time, n_hru))),
+            "b": (("time", "nhm_id"), np.ones((n_time, n_hru))),
+        },
+        coords={
+            "time": pd.date_range("2000-01-01", periods=n_time, freq="MS"),
+            "nhm_id": np.arange(n_hru),
+        },
+    )
+    # Chunk+compress only 'a'; leave 'b' contiguous → mixed state.
+    ds.to_netcdf(
+        p, encoding={"a": {"zlib": True, "complevel": 1, "chunksizes": (n_time, n_hru)}}
+    )
+    assert not is_rechunked(p)  # would have been True under first-var-only check
+
+
+def test_rechunk_file_aborts_on_value_mismatch_leaving_original(
+    tmp_path: Path, monkeypatch
+):
+    from nhf_spatial_targets import rechunk as R
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+    before = f.read_bytes()
+    tmp = f.with_suffix(f.suffix + ".rechunk.tmp")
+
+    monkeypatch.setattr(R, "_arrays_equal", lambda a, b: False)
+    with pytest.raises(RuntimeError, match="aborting"):
+        R.rechunk_file(f, "aggregated", "nhm_id")
+
+    assert f.read_bytes() == before  # original untouched
+    assert not tmp.exists()  # tmp cleaned
+
+
+def test_rechunk_file_cleans_tmp_on_write_failure(tmp_path: Path, monkeypatch):
+    from nhf_spatial_targets import rechunk as R
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+    before = f.read_bytes()
+    tmp = f.with_suffix(f.suffix + ".rechunk.tmp")
+
+    def _boom(self, *a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(xr.Dataset, "to_netcdf", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        R.rechunk_file(f, "aggregated", "nhm_id")
+
+    assert f.read_bytes() == before
+    assert not tmp.exists()
+
+
+def test_rechunk_preserves_coords_crs_and_int8(tmp_path: Path):
+    """Coords (lat/lon/time), the crs container, and int8 diagnostics survive."""
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    _write_realistic_aggregated(f)
+    before = xr.open_dataset(f).load()
+
+    rechunk_project(load(workdir), layer="aggregated")
+
+    after = xr.open_dataset(f).load()
+    assert np.array_equal(before["ro"].values, after["ro"].values, equal_nan=True)
+    np.testing.assert_array_equal(before["n_sources"].values, after["n_sources"].values)
+    assert after["n_sources"].dtype == np.int8
+    np.testing.assert_array_equal(before["lat"].values, after["lat"].values)
+    np.testing.assert_array_equal(before["lon"].values, after["lon"].values)
+    np.testing.assert_array_equal(before["time"].values, after["time"].values)
+    assert after["crs"].attrs.get("grid_mapping_name") == "latitude_longitude"
+    with netCDF4.Dataset(f) as nc:
+        assert nc.variables["crs"].filters()["zlib"] is False  # container untouched
+        assert nc.variables["ro"].filters()["zlib"] is True  # field compressed
+
+
+def test_rechunk_project_isolates_failure(tmp_path: Path, monkeypatch):
+    """One file's failure is recorded as 'failed'; others still rechunk."""
+    from nhf_spatial_targets import rechunk as R
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    a = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    b = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2001_agg.nc"
+    write_year_nc(a, 2000, "ro")
+    write_year_nc(b, 2001, "ro")
+
+    real = R.rechunk_file
+
+    def _flaky(path, layer, id_col, *, dry_run=False):
+        if path.name.endswith("2000_agg.nc"):
+            raise RuntimeError("boom")
+        return real(path, layer, id_col, dry_run=dry_run)
+
+    monkeypatch.setattr(R, "rechunk_file", _flaky)
+    results = R.rechunk_project(load(workdir), layer="aggregated")
+    statuses = {r["path"].name: r["status"] for r in results}
+    assert statuses["era5_land_2000_agg.nc"] == "failed"
+    assert statuses["era5_land_2001_agg.nc"] == "rechunked"
+
+
+def test_rechunk_skips_stray_non_fabric_nc(tmp_path: Path):
+    """A targets-dir NC without the HRU dim is skipped, not crashed on."""
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    stray = workdir / "targets" / "weird.nc"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    xr.Dataset(
+        {"x": (("a", "b"), np.ones((2, 3)))},
+        coords={"a": [0, 1], "b": [0, 1, 2]},
+    ).to_netcdf(stray)
+
+    results = rechunk_project(load(workdir), layer="target")
+    assert any(
+        r["status"] == "skipped-no-hru" and r["path"].name == "weird.nc"
+        for r in results
+    )
+
+
+def test_rechunk_layer_none_does_both_layers(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    a = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    t = workdir / "targets" / "runoff_targets.nc"
+    write_year_nc(a, 2000, "ro")
+    _write_contiguous_target(t)
+
+    rechunk_project(load(workdir), layer=None)
+
+    assert _data_var_chunked(a)
+    assert _data_var_chunked(t)
+
+
+def test_rechunk_invalid_layer_raises(tmp_path: Path):
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    with pytest.raises(ValueError, match="layer"):
+        rechunk_project(load(workdir), layer="bogus")
+
+
+# --- CLI error/summary paths --------------------------------------------
+
+
+def test_cli_rechunk_bad_layer_exits_2(tmp_path: Path):
+    from nhf_spatial_targets import cli
+
+    workdir = make_minimal_project(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        cli.rechunk(workdir, layer="bogus")
+    assert exc.value.code == 2
+
+
+def test_cli_rechunk_bad_source_exits_2(tmp_path: Path):
+    from nhf_spatial_targets import cli
+
+    workdir = make_minimal_project(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        cli.rechunk(workdir, source="does_not_exist", dry_run=True)
+    assert exc.value.code == 2
+
+
+def test_cli_rechunk_real_run_reports_and_chunks(tmp_path: Path, capsys):
+    from nhf_spatial_targets import cli
+
+    workdir = make_minimal_project(tmp_path)
+    f = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    write_year_nc(f, 2000, "ro")
+
+    cli.rechunk(workdir, layer="aggregated")
+
+    out = capsys.readouterr().out
+    assert "Rechunked" in out
+    assert _data_var_chunked(f)


### PR DESCRIPTION
ST5 of the #165 trunk: a CLI to backfill **existing** aggregated/target NCs to the chunked+compressed `io_nc` layout — so projects built before ST2/ST3 reclaim disk **without re-aggregating** (the slow, multi-day SLURM alternative). It also produces the chunked NCs needed to finally exercise the new chunked-*read* path at scale (which ST3a's verification couldn't, since gfv2's NCs are still contiguous).

## What it does
`src/nhf_spatial_targets/rechunk.py` + `nhf-targets rechunk`:

```
nhf-targets rechunk --project-dir <dir> [--layer aggregated|target] [--source <key>] [--dry-run]
```

- **Idempotent** — files already chunked+zlib are skipped (via `netCDF4 .chunking()/.filters()`), so re-runs are no-ops.
- **Atomic** — each file is rewritten to `<file>.rechunk.tmp` then renamed; an interrupted run never leaves a half-written NC.
- **Bit-identical** — every data var is compared (NaN-aware for floats) against the original before the rename; a mismatch aborts that file with no replacement. Native dtypes preserved → storage-layout change only.
- **Scoped** — only the project's `data/aggregated/` and `targets/` trees. Never touches the datastore's **consolidated** NCs (issue #158's separate tile policy), and **skips daymet/ssebop** aggregated outputs (left as-is by ST3a).
- `--dry-run` reports candidates without writing; a real run prints reclaimed-GB + skipped count.

## Tests
`tests/test_rechunk.py`: contiguous→chunked conversion, bit-identity, idempotent re-run, dry-run no-write, daymet/ssebop skip, target-layer, source filter, CLI smoke. rechunk + io_nc green (28); existing CLI suite unaffected (66).

## Operator notes
- Memory: rechunk loads one file fully before rewriting. Per-year aggregated files are ~1 GB; the 11 GB SWE target needs a correspondingly larger `--mem`. Size the SLURM job per the largest file in scope.
- Existing files are only rewritten when run; no automatic migration.

Part of #165. Remaining: ST3b (SWE stitch flip), ST6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)