### PR TITLE
chore(slurm): derive rechunk REPO_DIR from script path + add targets script

### DIFF
--- a/rechunk_gfv2.slurm
+++ b/rechunk_gfv2.slurm
@@ -32,12 +32,18 @@
 set -euo pipefail
 export PYTHONUNBUFFERED=1
 
-# REPO_DIR defaults to the #165 worktree (rechunk is on main; the worktree has
-# the code + a warm pixi env). Override to a main checkout if you prefer.
-REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets/.worktrees/feature-165}"
+# REPO_DIR defaults to the repo this script lives in (resolved from the script
+# path), so it works from any checkout. Override to point at a different
+# checkout if you prefer. The checkout must have the #165 rechunk command.
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)}"
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 
 cd "$REPO_DIR" || { echo "ERROR: REPO_DIR=$REPO_DIR not found" >&2; exit 1; }
+[ -f src/nhf_spatial_targets/rechunk.py ] || {
+    echo "ERROR: $REPO_DIR lacks the #165 rechunk command. Checkout main or" \
+         "rebase your branch onto origin/main first." >&2
+    exit 1
+}
 
 # Source keys = aggregated/ subdir names. daymet/ssebop excluded by design.
 SOURCES=(

--- a/rechunk_gfv2_targets.slurm
+++ b/rechunk_gfv2_targets.slurm
@@ -1,0 +1,45 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-rechunk-tgt
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=64G
+#SBATCH --time=2:00:00
+#SBATCH --output=logs/rechunk_tgt_%j.out
+#SBATCH --error=logs/rechunk_tgt_%j.err
+
+# Convert a project's target NCs to the canonical columnar layout (#165 ST3b).
+# The 11 GB swe_targets.nc + nn_filled written by the old streaming stitch carry
+# time-slab chunks; shape-aware rechunk (PR #172) converts them so a per-HRU
+# calibration read is 1 chunk instead of ~39. --mem=64G covers loading an 11 GB
+# file whole (+ tmp write + read-back bit-identity verify). Idempotent +
+# value-checked per file; safe to re-run (already-canonical targets are skipped).
+#
+# USAGE
+#   mkdir -p logs
+#   sbatch rechunk_gfv2_targets.slurm
+#   # preview (no writes; fine on the login node):
+#   pixi run nhf-targets rechunk --project-dir <gfv2> --layer target --dry-run
+
+set -euo pipefail
+export PYTHONUNBUFFERED=1
+
+# REPO_DIR defaults to the repo this script lives in; override if desired.
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)}"
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
+
+cd "$REPO_DIR" || { echo "ERROR: REPO_DIR=$REPO_DIR not found" >&2; exit 1; }
+[ -f src/nhf_spatial_targets/rechunk.py ] || {
+    echo "ERROR: $REPO_DIR lacks the #165 rechunk command. Checkout main or" \
+         "rebase your branch onto origin/main first." >&2
+    exit 1
+}
+
+echo "=== rechunk targets: $PROJECT_DIR ==="
+echo "=== Repo:    $REPO_DIR ($(git -C "$REPO_DIR" branch --show-current 2>/dev/null)) ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
+
+pixi run nhf-targets rechunk --project-dir "$PROJECT_DIR" --layer target
+
+echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="


### PR DESCRIPTION
Fixes a stale path in the rechunk operator script committed during #165, and adds the missing targets-layer script.

## Why
`rechunk_gfv2.slurm` (landed in #171 / ST6) hardcoded `REPO_DIR` to `.worktrees/feature-165` — the temporary worktree the trunk was developed in, now deleted. Anyone running it (or rebasing a branch onto main) hits a dead path.

## Changes
- **`rechunk_gfv2.slurm`**: `REPO_DIR` now derives from the script's own location (`git rev-parse --show-toplevel`), so it works from any checkout. Added a preflight guard that fails loudly if the checkout lacks `src/nhf_spatial_targets/rechunk.py` (i.e. doesn't have the #165 code yet) instead of a cryptic pixi error.
- **`rechunk_gfv2_targets.slurm`** (new): `--layer target` backfill, `--mem=64G` for loading the 11 GB SWE target whole; same robust `REPO_DIR` + guard. Created during ST3b but never committed.

Both `bash -n`-clean. Docs-only/ops change (no Python touched; ruff hooks skipped).