### PR TITLE
chore(slurm): fix rechunk REPO_DIR derivation under sbatch

### DIFF
--- a/rechunk_gfv2.slurm
+++ b/rechunk_gfv2.slurm
@@ -32,12 +32,17 @@
 set -euo pipefail
 export PYTHONUNBUFFERED=1
 
-# REPO_DIR defaults to the repo this script lives in (resolved from the script
-# path), so it works from any checkout. Override to point at a different
-# checkout if you prefer. The checkout must have the #165 rechunk command.
-REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)}"
+# REPO_DIR defaults to the repo you ran `sbatch` from. sbatch copies the script
+# to a spool dir before executing, so ${BASH_SOURCE[0]} does NOT point at the
+# repo under SLURM — use $SLURM_SUBMIT_DIR (the submit cwd), falling back to
+# $PWD when run directly. The 2>/dev/null||true lets the friendly cd/guard
+# message below fire instead of a raw git error. Override REPO_DIR to point at
+# a different checkout if you prefer; it must have the #165 rechunk command.
+REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 
+[ -n "$REPO_DIR" ] || { echo "ERROR: could not resolve REPO_DIR (not a git" \
+    "checkout?). Set REPO_DIR=... explicitly." >&2; exit 1; }
 cd "$REPO_DIR" || { echo "ERROR: REPO_DIR=$REPO_DIR not found" >&2; exit 1; }
 [ -f src/nhf_spatial_targets/rechunk.py ] || {
     echo "ERROR: $REPO_DIR lacks the #165 rechunk command. Checkout main or" \

--- a/rechunk_gfv2_targets.slurm
+++ b/rechunk_gfv2_targets.slurm
@@ -25,10 +25,16 @@
 set -euo pipefail
 export PYTHONUNBUFFERED=1
 
-# REPO_DIR defaults to the repo this script lives in; override if desired.
-REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)}"
+# REPO_DIR defaults to the repo you ran `sbatch` from. sbatch copies the script
+# to a spool dir before executing, so ${BASH_SOURCE[0]} does NOT point at the
+# repo under SLURM — use $SLURM_SUBMIT_DIR (the submit cwd), falling back to
+# $PWD when run directly. The 2>/dev/null||true lets the friendly cd/guard
+# message below fire instead of a raw git error. Override REPO_DIR if desired.
+REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 
+[ -n "$REPO_DIR" ] || { echo "ERROR: could not resolve REPO_DIR (not a git" \
+    "checkout?). Set REPO_DIR=... explicitly." >&2; exit 1; }
 cd "$REPO_DIR" || { echo "ERROR: REPO_DIR=$REPO_DIR not found" >&2; exit 1; }
 [ -f src/nhf_spatial_targets/rechunk.py ] || {
     echo "ERROR: $REPO_DIR lacks the #165 rechunk command. Checkout main or" \


### PR DESCRIPTION
## Problem

The target-layer rechunk job (`rechunk_gfv2_targets.slurm`) from #173 died immediately with:

```
fatal: not a git repository (or any of the parent directories): .git
```

`sbatch` copies the batch script to a spool directory before executing it, so `${BASH_SOURCE[0]}` points at the spool copy — **not** the repo. `git rev-parse --show-toplevel` from there fails, and `set -e` kills the job before the rechunk command runs. The `BASH_SOURCE` trick (added in #173) only works when a script is run in place; it is wrong for an `sbatch` script.

The aggregated-layer array job worked earlier only because it was run with a hand-edited local copy; the committed #173 version was never actually exercised under `sbatch`.

## Fix

Both `rechunk_gfv2.slurm` and `rechunk_gfv2_targets.slurm` now derive `REPO_DIR` the SLURM-native way:

```bash
REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
```

- `$SLURM_SUBMIT_DIR` is the cwd `sbatch` was launched from (the repo root, where these scripts live) and survives the spool copy. Falls back to `$PWD` when the script is run directly (not via `sbatch`).
- `2>/dev/null || true` prevents `set -e` from aborting on a raw git error, so the friendly guard message fires instead.
- Added an explicit `[ -n "$REPO_DIR" ]` check, because `cd ""` is a no-op that *succeeds* — without it an unresolved `REPO_DIR` would slip past the `cd` guard.

## Verification

- `bash -n` clean on both scripts.
- Simulated spool exec (`SLURM_SUBMIT_DIR` set, cwd elsewhere) resolves `REPO_DIR` correctly.
- Simulated non-git submit dir → empty `REPO_DIR` → guard fires with a clear message.

No Python changed; pre-commit hooks (`types: [python]`) skip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)