### PR TITLE
chore(slurm): bump target-rechunk --mem to 160G (SWE OOM)

### DIFF
--- a/rechunk_gfv2_targets.slurm
+++ b/rechunk_gfv2_targets.slurm
@@ -4,7 +4,7 @@
 #SBATCH --partition=cpu
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=64G
+#SBATCH --mem=160G
 #SBATCH --time=2:00:00
 #SBATCH --output=logs/rechunk_tgt_%j.out
 #SBATCH --error=logs/rechunk_tgt_%j.err
@@ -12,9 +12,16 @@
 # Convert a project's target NCs to the canonical columnar layout (#165 ST3b).
 # The 11 GB swe_targets.nc + nn_filled written by the old streaming stitch carry
 # time-slab chunks; shape-aware rechunk (PR #172) converts them so a per-HRU
-# calibration read is 1 chunk instead of ~39. --mem=64G covers loading an 11 GB
-# file whole (+ tmp write + read-back bit-identity verify). Idempotent +
-# value-checked per file; safe to re-run (already-canonical targets are skipped).
+# calibration read is 1 chunk instead of ~39. Idempotent + value-checked per
+# file; safe to re-run (already-canonical targets are skipped).
+#
+# --mem=160G: rechunk_file is EAGER — it `.load()`s the whole dataset, then the
+# verify loop reads each var back from the tmp file to compare. The gfv2 SWE
+# targets are ~11 GB on disk but ~55 GB DECOMPRESSED (16802 x 361471 float32
+# bounds x2 + int8 n_sources), so peak RSS is ~load(55) + largest-var read-back
+# (~24) + numpy temporaries ~= 100 GB. 64G OOM-killed it at the SWE step (job
+# 21635275); 160G leaves headroom on the 512 GB cn nodes. A project whose
+# largest target is smaller can drop this back down.
 #
 # USAGE
 #   mkdir -p logs


### PR DESCRIPTION
## Problem

The target-layer rechunk job (`rechunk_gfv2_targets.slurm`) was OOM-killed on the gfv2 SWE targets (job 21635275, `OUT_OF_MEMORY`). It converted the 10 smaller targets fine, then died at `swe_targets.nc`.

`rechunk_file` is **eager**, not streaming:
- [`rechunk.py:160`](../blob/main/src/nhf_spatial_targets/rechunk.py#L160) — `ds = ds_lazy.load()` pulls the entire dataset into RAM.
- [`rechunk.py:170-173`](../blob/main/src/nhf_spatial_targets/rechunk.py#L170-L173) — the verify loop reads each var back from the tmp file and compares it against the in-memory copy.

The gfv2 SWE targets are ~11 GB on disk but **~55 GB decompressed** (`16802 × 361471` float32 `lower_bound`/`upper_bound` + int8 `n_sources`). Peak RSS ≈ load(55) + largest-var read-back(24) + numpy temporaries ≈ **100 GB**, well past the old `--mem=64G`. The original comment ("covers loading an 11 GB file whole") didn't account for decompression or the read-back verify.

## Fix

- `--mem=64G → 160G` — comfortable headroom over the ~100 GB peak; the `cn` nodes have 512 GB.
- Rewrote the comment to state the real footprint and why, and noted a project with smaller targets can dial it back down.

This is a memory-sizing fix, not a code change — `rechunk_file`'s eager load is fine for a one-time backfill; turning it into a chunk-wise verify would be over-engineering. No Python touched; pre-commit `types: [python]` hooks skip.

## Verification

- `bash -n` clean.
- Sizing confirmed by inspecting the actual SWE NC (54.66 GB decompressed across the three data vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)