### PR TITLE
fix(rechunk): gc.collect() between files to cap peak RSS

### DIFF
--- a/src/nhf_spatial_targets/rechunk.py
+++ b/src/nhf_spatial_targets/rechunk.py
@@ -31,6 +31,7 @@ Guarantees:
 
 from __future__ import annotations
 
+import gc
 import logging
 from pathlib import Path
 from typing import Any
@@ -241,4 +242,14 @@ def rechunk_project(
                     "size_after": None,
                 }
             )
+        finally:
+            # rechunk_file eagerly `.load()`s the whole dataset; xarray Datasets
+            # form reference cycles, so the just-processed file's arrays linger
+            # until the cyclic collector runs rather than being freed on the
+            # function return. Force a collect between files so peak RSS stays
+            # at ~one file's footprint instead of accumulating across files —
+            # without this, two large targets in one process roughly double the
+            # peak (the gfv2 SWE pair OOM-killed a 160G job at ~154 GB RSS,
+            # though each file alone fits comfortably).
+            gc.collect()
     return results

--- a/tests/test_rechunk.py
+++ b/tests/test_rechunk.py
@@ -430,6 +430,43 @@ def test_rechunk_invalid_layer_raises(tmp_path: Path):
         rechunk_project(load(workdir), layer="bogus")
 
 
+def test_rechunk_project_collects_between_files(tmp_path: Path, monkeypatch):
+    """A gc.collect() fires once per file so peak RSS doesn't accumulate.
+
+    rechunk_file eagerly loads whole datasets; xarray's reference cycles keep a
+    just-processed file's arrays alive until the cyclic collector runs. Without
+    a collect between files, two large targets in one process roughly double the
+    peak (the gfv2 SWE pair OOM-killed a 160G job). The collect lives in the
+    loop's ``finally``, so it must also fire when a file fails.
+    """
+    from nhf_spatial_targets import rechunk as R
+    from nhf_spatial_targets.workspace import load
+
+    workdir = make_minimal_project(tmp_path)
+    a = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2000_agg.nc"
+    b = workdir / "data" / "aggregated" / "era5_land" / "era5_land_2001_agg.nc"
+    write_year_nc(a, 2000, "ro")
+    write_year_nc(b, 2001, "ro")
+
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        R.gc, "collect", lambda *a, **k: calls.__setitem__("n", calls["n"] + 1)
+    )
+
+    real = R.rechunk_file
+
+    def _flaky(path, layer, id_col, *, dry_run=False):
+        if path.name.endswith("2000_agg.nc"):
+            raise RuntimeError("boom")
+        return real(path, layer, id_col, dry_run=dry_run)
+
+    monkeypatch.setattr(R, "rechunk_file", _flaky)
+    R.rechunk_project(load(workdir), layer="aggregated")
+
+    # One collect per file — including the one that raised (finally path).
+    assert calls["n"] == 2
+
+
 # --- CLI error/summary paths --------------------------------------------
 
 


### PR DESCRIPTION
## Problem

The target-layer rechunk OOM-killed the gfv2 SWE pair even at `--mem=160G` (job 21671224, `MaxRSS ≈ 154 GB`). It converted `swe_targets.nc` fine, then died loading `swe_targets_nn_filled.nc` — two identical-size files, one fit and one didn't.

Root cause: `rechunk_file` eagerly `.load()`s the whole dataset, and **xarray Datasets form reference cycles**, so a just-processed file's arrays are *not* freed when the function returns — they linger until CPython's cyclic collector runs. Processing two large targets in one process therefore roughly doubles peak RSS:

- one SWE file ≈ load(55 GB) + verify read-back(24) + temporaries ≈ **100 GB** (fits 160G — file 1 proved it)
- two in a row ≈ file-1-residual(55) + file-2 peak(100) ≈ **154 GB** → OOM

## Fix

`gc.collect()` between files in `rechunk_project`'s loop, in a `finally` so it also fires when a file fails. Peak now stays at ~one file's footprint regardless of how many large targets a project has — which keeps the `--mem=160G` slurm default (PR #175) honest for a fresh from-scratch run, instead of only working because earlier files were already converted.

This is the smaller, more correct alternative to bumping the default mem higher: mem-bumping can't be sized confidently from a killed run (it only gives a lower bound), and the peak would still grow with target count.

## Test

`test_rechunk_project_collects_between_files` monkeypatches `rechunk.gc.collect` with a counter and asserts it fires once per file across a 2-file project — including a file that raises, verifying the `finally` path. All 22 `test_rechunk.py` tests pass locally.

(Note: `tests/test_auth.py` fails to *collect* in a fresh worktree env due to an unrelated aiohttp/aiobotocore version mismatch; CI's environment runs the full suite cleanly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)