### PR TITLE
fix(cf): CF-1.6 compliance at aggregation + target writers (#182)

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_adapter.py
+++ b/src/nhf_spatial_targets/aggregate/_adapter.py
@@ -66,6 +66,15 @@ class SourceAdapter:
     stat_method: str = "mean"
     catalog_key: str | None = None
     raw_dir_key: str | None = None
+    #: Cadence of the *emitted* aggregated NC, driving CF time_bnds at the
+    #: write boundary. This is the adapter's authoritative output cadence — NOT
+    #: the catalog ``time_step`` free-text (which is unreliable: one entry can
+    #: serve two adapters, e.g. era5_land's monthly runoff vs daily SWE, and
+    #: "8-day (aggregate to monthly)" describes intent, not the emitted stamps).
+    #: ``monthly``/``annual`` get reconstructed calendar-period bounds; the
+    #: instantaneous/composite cadences (``daily``/``8-day``) and ``None`` get
+    #: none. See aggregate/_driver.py:_cadence_to_period_freq.
+    output_cadence: str | None = None
 
     def __post_init__(self) -> None:
         # Coerce list → tuple so callers can pass list literals.
@@ -100,6 +109,13 @@ class SourceAdapter:
                 f"SourceAdapter.stat_method={self.stat_method!r} is not a "
                 f"gdptools STATSMETHODS value; expected one of "
                 f"{sorted(_ALLOWED_STAT_METHODS)}"
+            )
+        _ALLOWED_CADENCES = {None, "monthly", "annual", "daily", "8-day"}
+        if self.output_cadence not in _ALLOWED_CADENCES:
+            raise ValueError(
+                f"SourceAdapter.output_cadence={self.output_cadence!r} is not "
+                f"recognized; expected one of {sorted(c for c in _ALLOWED_CADENCES if c)} "
+                f"or None"
             )
         # Named invariant: which declared variable is used to infer the source
         # grid for WeightGen. Defaults to the first variable; drivers/tests that

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -308,21 +308,33 @@ def _infer_hru_dim(ds: xr.Dataset) -> str | None:
 
 
 def _cadence_to_period_freq(cadence: str | None) -> str | None:
-    """Map a catalog ``time_step`` phrase to a pandas period freq for time_bnds.
+    """Map a :class:`SourceAdapter` ``output_cadence`` to a pandas period freq.
 
     Returns ``"M"`` / ``"Y"`` for monthly/annual aggregated outputs (so the
     bound brackets the calendar month/year regardless of where the timestamp
-    sits within it), or ``None`` for daily/instantaneous (point) sources,
-    which represent an instant and carry no averaging interval.
+    sits within it), or ``None`` for ``daily``/``8-day`` (instantaneous or
+    composite) outputs and unset cadence — these carry no calendar-period
+    averaging interval, so no ``time_bnds`` is fabricated.
+
+    Raises on an unrecognized non-empty value rather than silently returning
+    ``None`` (which would also strip a legitimate ``bounds`` attr): a bad
+    cadence is a programming error, not a no-op. SourceAdapter validates the
+    vocabulary at construction, so this only fires for the few call sites that
+    pass a literal (e.g. ssebop).
     """
-    if not cadence:
+    if cadence is None:
         return None
-    c = cadence.lower()
-    if "monthly" in c:
+    c = cadence.strip().lower()
+    if c == "monthly":
         return "M"
-    if "annual" in c:
+    if c == "annual":
         return "Y"
-    return None
+    if c in ("daily", "8-day"):
+        return None
+    raise ValueError(
+        f"unrecognized output cadence {cadence!r}; expected one of "
+        "monthly, annual, daily, 8-day (or None)"
+    )
 
 
 def _normalize_cf_fabric_metadata(
@@ -378,6 +390,14 @@ def _normalize_cf_fabric_metadata(
     if hru and hru in ds.variables:
         ds[hru].attrs.pop("units", None)
         ds[hru].attrs["long_name"] = "HRU Index"
+    elif id_col is None:
+        # Inference failed (≠1 non-time dim) on the id_col-less path. Surface
+        # it rather than silently shipping an unlabeled HRU coordinate.
+        logger.warning(
+            "could not uniquely identify the HRU dimension among %s; "
+            "skipping HRU index labeling (CF §3). Pass id_col explicitly.",
+            [d for d in ds.sizes if d not in ("time", "nv", "bnds", "nbnds")],
+        )
     return ds
 
 
@@ -405,10 +425,11 @@ def _atomic_write_netcdf(
     no float64→float32 downcast happens here (that would be a values change,
     not a storage-layer change).
 
-    When ``id_col`` is ``None`` the Dataset is written without added
-    encoding (the pre-#165 behavior). The daymet (zarr) and ssebop (STAC)
-    aggregators take this path: their outputs are produced from already-chunked
-    remote sources and are intentionally left as-is.
+    When ``id_col`` is ``None`` (the daymet/ssebop path), per-HRU chunking and
+    zlib compression are skipped — those outputs come from already-chunked
+    remote sources. Only the storage-layer chunking differs: the CF metadata
+    normalization above and the pinned time-axis encoding still apply on this
+    path.
     """
     ds = _normalize_cf_fabric_metadata(ds, id_col=id_col, cadence=time_bounds_cadence)
 
@@ -665,8 +686,12 @@ def aggregate_year(
     # downstream consumers a stable invariant.
     year_ds = year_ds.sortby(id_col)
 
+    # Cadence comes from the adapter's authoritative output_cadence, NOT the
+    # catalog time_step free-text (unreliable: one entry serves era5_land's
+    # monthly runoff + daily SWE, and "8-day (aggregate to monthly)" describes
+    # intent, not emitted stamps — see SourceAdapter.output_cadence).
     _atomic_write_netcdf(
-        year_ds, out_path, id_col=id_col, time_bounds_cadence=meta.get("time_step")
+        year_ds, out_path, id_col=id_col, time_bounds_cadence=adapter.output_cadence
     )
     logger.info("%s: year %d: wrote %s", adapter.source_key, year, out_path)
     return out_path

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -301,10 +301,101 @@ def per_year_output_path(project: Project, source_key: str, year: int) -> Path:
     )
 
 
+def _infer_hru_dim(ds: xr.Dataset) -> str | None:
+    """Best-effort HRU dimension name when ``id_col`` isn't passed in."""
+    cand = [d for d in ds.sizes if d not in ("time", "nv", "bnds", "nbnds")]
+    return cand[0] if len(cand) == 1 else None
+
+
+def _cadence_to_period_freq(cadence: str | None) -> str | None:
+    """Map a catalog ``time_step`` phrase to a pandas period freq for time_bnds.
+
+    Returns ``"M"`` / ``"Y"`` for monthly/annual aggregated outputs (so the
+    bound brackets the calendar month/year regardless of where the timestamp
+    sits within it), or ``None`` for daily/instantaneous (point) sources,
+    which represent an instant and carry no averaging interval.
+    """
+    if not cadence:
+        return None
+    c = cadence.lower()
+    if "monthly" in c:
+        return "M"
+    if "annual" in c:
+        return "Y"
+    return None
+
+
+def _normalize_cf_fabric_metadata(
+    ds: xr.Dataset, *, id_col: str | None = None, cadence: str | None = None
+) -> xr.Dataset:
+    """Make an aggregated Dataset CF-1.6 clean at the write boundary.
+
+    Three fixes, all driven by how gdptools + the per-batch merge shape the
+    output (issue #178 / #182):
+
+    - **crs (CF §5.6).** gdptools' ``crs`` attrs are correct, but the per-batch
+      ``xr.concat`` merge broadcasts the scalar onto a dimension (``id_col``
+      *or* ``time``, depending on the merge). Collapse it back to a 0-dim
+      grid-mapping variable, preserving its attrs.
+    - **time bounds (CF §7.1).** gdptools drops ``time_bnds`` during aggregation
+      but leaves the source's ``time:bounds`` attr, dangling. Reconstruct the
+      averaging interval for monthly/annual ``cadence``; strip the dangling
+      attr for instantaneous (point/daily) sources.
+    - **HRU index (CF §3).** Label the id coordinate; it is an identifier, not
+      a measurement, so it carries no units.
+    """
+    ds = ds.copy()
+
+    if "crs" in ds.variables and ds["crs"].ndim > 0:
+        ds["crs"] = xr.DataArray(np.int32(0), attrs=dict(ds["crs"].attrs))
+
+    if "time" in ds.variables:
+        freq = _cadence_to_period_freq(cadence)
+        bounds_attr = ds["time"].attrs.get("bounds")
+        if freq is not None:
+            name = bounds_attr or "time_bnds"
+            if name not in ds.variables:
+                times = pd.DatetimeIndex(np.asarray(ds["time"].values))
+                periods = times.to_period(freq)
+                tb = xr.DataArray(
+                    np.stack(
+                        [periods.start_time.values, (periods + 1).start_time.values],
+                        axis=1,
+                    ),
+                    dims=("time", "nv"),
+                    coords={"time": ds["time"].values},
+                    name=name,
+                )
+                ds[name] = tb
+                ds = ds.set_coords(name)
+                ds["time"].attrs["bounds"] = name
+        elif bounds_attr and bounds_attr not in ds.variables:
+            # Instantaneous source: no averaging interval. Drop the dangling
+            # reference the aggregation left behind.
+            ds["time"].attrs.pop("bounds", None)
+
+    hru = id_col or _infer_hru_dim(ds)
+    if hru and hru in ds.variables:
+        ds[hru].attrs.pop("units", None)
+        ds[hru].attrs["long_name"] = "HRU Index"
+    return ds
+
+
 def _atomic_write_netcdf(
-    ds: xr.Dataset, path: Path, *, id_col: str | None = None
+    ds: xr.Dataset,
+    path: Path,
+    *,
+    id_col: str | None = None,
+    time_bounds_cadence: str | None = None,
 ) -> None:
     """Atomically write an aggregated Dataset via tempfile + rename.
+
+    CF metadata is normalized at this boundary regardless of the encoding path
+    (see :func:`_normalize_cf_fabric_metadata`): the grid-mapping ``crs`` is
+    collapsed to a 0-dim scalar, the inherited ``time:bounds`` is made whole
+    (``time_bnds`` reconstructed for monthly/annual ``time_bounds_cadence``, or
+    the dangling attr stripped for instantaneous sources), and the HRU index
+    coordinate is labeled.
 
     When ``id_col`` is given, encoding is delegated to
     :func:`io_nc.build_encoding` (``layer="aggregated"``) so the per-year NC is
@@ -312,14 +403,15 @@ def _atomic_write_netcdf(
     per-HRU-time-series reads (issue #165 ST3). Native variable dtypes are
     preserved — the aggregated layer keeps the source's native units/values, so
     no float64→float32 downcast happens here (that would be a values change,
-    not a storage-layer change), and the grid-mapping container (``crs``) is
-    left untouched.
+    not a storage-layer change).
 
     When ``id_col`` is ``None`` the Dataset is written without added
     encoding (the pre-#165 behavior). The daymet (zarr) and ssebop (STAC)
     aggregators take this path: their outputs are produced from already-chunked
     remote sources and are intentionally left as-is.
     """
+    ds = _normalize_cf_fabric_metadata(ds, id_col=id_col, cadence=time_bounds_cadence)
+
     from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
 
     if id_col is not None:
@@ -330,7 +422,19 @@ def _atomic_write_netcdf(
             timesteps_per_file=ds.sizes.get("time"),
         )
     else:
-        encoding = None
+        # Unchunked path (daymet/ssebop): no per-HRU chunking, but still pin the
+        # CF time axis so a reconstructed time_bnds shares time's units (xarray
+        # otherwise derives them independently — counter to CF §7.1) and carries
+        # no _FillValue.
+        from nhf_spatial_targets.io_nc import _TIME_ENCODING
+
+        encoding = {
+            tvar: dict(_TIME_ENCODING)
+            for tvar in ("time", "time_bnds")
+            if tvar in ds.variables
+        }
+        if "time_bnds" in encoding:
+            encoding["time_bnds"]["_FillValue"] = None
     atomic_to_netcdf(ds, path, encoding=encoding)
 
 
@@ -561,7 +665,9 @@ def aggregate_year(
     # downstream consumers a stable invariant.
     year_ds = year_ds.sortby(id_col)
 
-    _atomic_write_netcdf(year_ds, out_path, id_col=id_col)
+    _atomic_write_netcdf(
+        year_ds, out_path, id_col=id_col, time_bounds_cadence=meta.get("time_step")
+    )
     logger.info("%s: year %d: wrote %s", adapter.source_key, year, out_path)
     return out_path
 

--- a/src/nhf_spatial_targets/aggregate/era5_land.py
+++ b/src/nhf_spatial_targets/aggregate/era5_land.py
@@ -31,6 +31,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="era5_land",
+    output_cadence="monthly",
     output_name="era5_land_agg.nc",
     variables=("ro", "sro", "ssro"),
     # No x_coord/y_coord overrides: the monthly NCs carry CF axis attrs
@@ -50,6 +51,7 @@ ADAPTER = SourceAdapter(
 # adapter reading from <datastore>/era5_land/daily/*.nc.
 ADAPTER_SD = SourceAdapter(
     source_key="era5_land_sd",
+    output_cadence="daily",
     catalog_key="era5_land",
     raw_dir_key="era5_land",
     output_name="era5_land_sd_agg.nc",

--- a/src/nhf_spatial_targets/aggregate/gldas.py
+++ b/src/nhf_spatial_targets/aggregate/gldas.py
@@ -26,6 +26,7 @@ def _derive_runoff_total(ds: xr.Dataset) -> xr.Dataset:
 
 ADAPTER = SourceAdapter(
     source_key=_SOURCE_KEY,
+    output_cadence="monthly",
     output_name="gldas_agg.nc",
     variables=("Qs_acc", "Qsb_acc", "runoff_total"),
     files_glob="gldas_noah_v21_monthly*.nc",

--- a/src/nhf_spatial_targets/aggregate/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/aggregate/margulis_wus_sr.py
@@ -31,6 +31,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="margulis_wus_sr",
+    output_cadence="daily",
     output_name="margulis_wus_sr_agg.nc",
     variables=("SWE",),
     source_crs="EPSG:4326",

--- a/src/nhf_spatial_targets/aggregate/merra2.py
+++ b/src/nhf_spatial_targets/aggregate/merra2.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="merra2",
+    output_cadence="monthly",
     output_name="merra2_agg.nc",
     variables=["GWETTOP", "GWETROOT", "GWETPROF"],
 )

--- a/src/nhf_spatial_targets/aggregate/mod10c1.py
+++ b/src/nhf_spatial_targets/aggregate/mod10c1.py
@@ -171,6 +171,7 @@ def _rename_valid_mask(year_ds: xr.Dataset) -> xr.Dataset:
 
 ADAPTER = SourceAdapter(
     source_key=_SOURCE_KEY,
+    output_cadence="daily",
     output_name=_OUTPUT_NAME,
     variables=("Day_CMG_Snow_Cover", "Day_CMG_Clear_Index", "valid_mask"),
     grid_variable="Day_CMG_Snow_Cover",

--- a/src/nhf_spatial_targets/aggregate/mod16a2.py
+++ b/src/nhf_spatial_targets/aggregate/mod16a2.py
@@ -51,6 +51,7 @@ def _mask_et_fill(ds: xr.Dataset) -> xr.Dataset:
 
 ADAPTER = SourceAdapter(
     source_key="mod16a2_v061",
+    output_cadence="8-day",
     output_name="mod16a2_agg.nc",
     variables=["ET_500m"],
     source_crs="EPSG:4326",  # consolidate_mod16a2 reprojects tiles to WGS84

--- a/src/nhf_spatial_targets/aggregate/mwbm_climgrid.py
+++ b/src/nhf_spatial_targets/aggregate/mwbm_climgrid.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="mwbm_climgrid",
+    output_cadence="monthly",
     output_name="mwbm_climgrid_agg.nc",
     variables=("runoff", "aet", "soilstorage", "swe"),
     files_glob="ClimGrid_WBM.nc",

--- a/src/nhf_spatial_targets/aggregate/ncep_ncar.py
+++ b/src/nhf_spatial_targets/aggregate/ncep_ncar.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="ncep_ncar",
+    output_cadence="monthly",
     output_name="ncep_ncar_agg.nc",
     variables=["soilw_0_10cm", "soilw_10_200cm"],
 )

--- a/src/nhf_spatial_targets/aggregate/nldas_mosaic.py
+++ b/src/nhf_spatial_targets/aggregate/nldas_mosaic.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="nldas_mosaic",
+    output_cadence="monthly",
     output_name="nldas_mosaic_agg.nc",
     variables=["SoilM_0_10cm", "SoilM_10_40cm", "SoilM_40_200cm"],
 )

--- a/src/nhf_spatial_targets/aggregate/nldas_noah.py
+++ b/src/nhf_spatial_targets/aggregate/nldas_noah.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="nldas_noah",
+    output_cadence="monthly",
     output_name="nldas_noah_agg.nc",
     variables=[
         "SoilM_0_10cm",

--- a/src/nhf_spatial_targets/aggregate/reitz2017.py
+++ b/src/nhf_spatial_targets/aggregate/reitz2017.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="reitz2017",
+    output_cadence="annual",
     output_name="reitz2017_agg.nc",
     variables=("total_recharge", "eff_recharge"),
     source_crs="EPSG:4269",  # NAD83 geographic; overrides EPSG:4326 default — not reprojected at fetch

--- a/src/nhf_spatial_targets/aggregate/snodas.py
+++ b/src/nhf_spatial_targets/aggregate/snodas.py
@@ -53,6 +53,7 @@ def _mask_snodas_fill(ds: xr.Dataset) -> xr.Dataset:
 
 ADAPTER = SourceAdapter(
     source_key="snodas",
+    output_cadence="daily",
     output_name="snodas_agg.nc",
     variables=("swe",),
     # Pre-projected at consolidate time (issue #121); matches the

--- a/src/nhf_spatial_targets/aggregate/ssebop.py
+++ b/src/nhf_spatial_targets/aggregate/ssebop.py
@@ -320,8 +320,9 @@ def aggregate_ssebop(
         _attach_cf_global_attrs(year_ds, _SOURCE_KEY, meta)
         # Canonical id_col-ascending row order on emission (issue #93).
         year_ds = year_ds.sortby(id_col)
-        # ssebop outputs are left as-is (#165 ST3): no added chunking/compression.
-        _atomic_write_netcdf(year_ds, out_path)
+        # ssebop outputs are left as-is (#165 ST3): no added chunking/compression
+        # (so no id_col passed). ssebop is monthly ET — reconstruct time_bnds.
+        _atomic_write_netcdf(year_ds, out_path, time_bounds_cadence="monthly")
         logger.info("ssebop: year %d: wrote %s", year, out_path)
         per_year_paths.append(out_path)
 

--- a/src/nhf_spatial_targets/aggregate/watergap22d.py
+++ b/src/nhf_spatial_targets/aggregate/watergap22d.py
@@ -10,6 +10,7 @@ from nhf_spatial_targets.aggregate._driver import aggregate_source
 
 ADAPTER = SourceAdapter(
     source_key="watergap22d",
+    output_cadence="monthly",
     output_name="watergap22d_agg.nc",
     variables=["qrdif"],
     files_glob="*_cf.nc",

--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -200,6 +200,10 @@ def build_encoding(
     for tvar in ("time", "time_bnds"):
         if tvar in ds.variables:
             encoding[tvar] = dict(_TIME_ENCODING)
+    # time_bnds is a CF boundary variable and must not carry _FillValue
+    # (CF §7.1). xarray adds a default _FillValue=NaN unless we pin it off.
+    if "time_bnds" in ds.variables:
+        encoding["time_bnds"]["_FillValue"] = None
 
     return encoding
 

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -648,6 +648,10 @@ def _target_encoding_without_chunks(
     for tvar in ("time", "time_bnds"):
         if tvar in ds.variables:
             encoding[tvar] = dict(_TIME_ENCODING)
+    # time_bnds is a CF boundary variable and must not carry _FillValue
+    # (CF §7.1); mirror io_nc.build_encoding and pin it off.
+    if "time_bnds" in ds.variables:
+        encoding["time_bnds"]["_FillValue"] = None
     return encoding
 
 
@@ -701,6 +705,26 @@ def write_target_nc(
     ds.attrs.setdefault("software_version", __version__)
     if extra_global_attrs:
         ds.attrs.update(extra_global_attrs)
+
+    # CF §5.6: anchor the spatial reference. Target bound vars carry
+    # grid_mapping="crs" (inherited from the aggregated sources), but no crs
+    # container flows through the multi-source combine, leaving the reference
+    # dangling. The HRU centroid coords (centroid_lat/lon) are EPSG:4326, so
+    # mint a 0-dim WGS84 latitude_longitude grid-mapping variable to match.
+    from pyproj import CRS as _CRS
+
+    _wgs84 = _CRS.from_epsg(4326)
+    _crs_attrs = dict(_wgs84.to_cf())
+    _crs_attrs.setdefault("crs_wkt", _wgs84.to_wkt())
+    ds["crs"] = xr.DataArray(np.int32(0), attrs=_crs_attrs)
+    for _v in ("lower_bound", "upper_bound", "n_sources", "nn_filled"):
+        if _v in ds.data_vars:
+            ds[_v].attrs["grid_mapping"] = "crs"
+    # CF §3: the HRU index coordinate is an identifier, not a measurement —
+    # label it and carry no units.
+    if sort_dim is not None and sort_dim in ds.variables:
+        ds[sort_dim].attrs.pop("units", None)
+        ds[sort_dim].attrs["long_name"] = "HRU Index"
 
     from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
 
@@ -824,7 +848,9 @@ def build_n_sources_attrs(
     return {
         "units": "1",
         "long_name": "number of finite source contributions",
-        "flag_values": list(range(0, n_sources_count + 1)),
+        # int8 to match the on-disk n_sources dtype (CF §3.5 requires
+        # flag_values dtype == parent variable dtype).
+        "flag_values": np.array(range(0, n_sources_count + 1), dtype="int8"),
         "flag_meanings": " ".join(flag_labels[: n_sources_count + 1]),
         "coordinates": ancillary_coords,
     }
@@ -1018,7 +1044,8 @@ def write_bounds_target(
         {
             "units": "1",
             "long_name": "nearest-neighbor fill flag",
-            "flag_values": [0, 1],
+            # int8 to match the on-disk nn_filled dtype (CF §3.5).
+            "flag_values": np.array([0, 1], dtype="int8"),
             "flag_meanings": "not_filled filled",
             "coordinates": "centroid_lat centroid_lon",
         }

--- a/tests/test_cf_compliance.py
+++ b/tests/test_cf_compliance.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import netCDF4 as nc
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 ID_COL = "nat_hru_id"
@@ -132,6 +133,55 @@ def _make_aggregated_ds(*, n_time: int, broadcast_crs: bool = True) -> xr.Datase
     ds["time"].attrs.update({"standard_name": "time", "bounds": "time_bnds"})
     ds[ID_COL].attrs["feature_id"] = ID_COL
     return ds
+
+
+# --------------------------------------------------------------------------
+# cadence → period freq (E) — the parser that drives time_bnds reconstruction
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cadence,expected",
+    [
+        ("monthly", "M"),
+        ("annual", "Y"),
+        ("daily", None),  # instantaneous: no calendar-period bound
+        ("8-day", None),  # composite: no clean calendar period (don't fabricate)
+        (None, None),
+    ],
+)
+def test_cadence_to_period_freq_known_values(cadence, expected):
+    from nhf_spatial_targets.aggregate._driver import _cadence_to_period_freq
+
+    assert _cadence_to_period_freq(cadence) == expected
+
+
+def test_cadence_to_period_freq_rejects_unknown():
+    # A bad cadence must raise, not silently return None (which would also
+    # strip a legitimate bounds attr) — the era5_land_sd-class bug guard.
+    from nhf_spatial_targets.aggregate._driver import _cadence_to_period_freq
+
+    with pytest.raises(ValueError):
+        _cadence_to_period_freq("hourly (aggregated to daily and monthly)")
+
+
+def test_every_adapter_output_cadence_is_resolvable():
+    """All adapter output_cadence values parse (no live source mis-mapped)."""
+    import importlib
+    import pkgutil
+
+    import nhf_spatial_targets.aggregate as agg
+    from nhf_spatial_targets.aggregate._adapter import SourceAdapter
+    from nhf_spatial_targets.aggregate._driver import _cadence_to_period_freq
+
+    seen = 0
+    for mod in pkgutil.iter_modules(agg.__path__):
+        m = importlib.import_module(f"nhf_spatial_targets.aggregate.{mod.name}")
+        for obj in vars(m).values():
+            if isinstance(obj, SourceAdapter):
+                _cadence_to_period_freq(obj.output_cadence)  # must not raise
+                seen += 1
+    assert seen >= 14  # all module-level adapters validated
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cf_compliance.py
+++ b/tests/test_cf_compliance.py
@@ -1,0 +1,313 @@
+"""CF-1.6 regression tests for the aggregation + target NetCDF writers.
+
+Covers the defects a ``cfchecks`` shakedown found at the shared write-sites
+(issues #178 / #182). Each test reproduces the pre-fix structure and asserts
+the writer now emits CF-clean metadata:
+
+- **A** scalar (0-dim) ``crs`` grid-mapping anchor — minted on targets,
+  collapsed back from the per-batch-merge broadcast on aggregated NCs.
+- **B** ``flag_values`` dtype matches its int8 parent variable (CF §3.5).
+- **C** ``time_bnds`` carries no ``_FillValue`` (CF §7.1).
+- **E** ``time_bnds`` reconstructed for monthly/annual aggregates; dangling
+  ``time:bounds`` stripped for instantaneous sources.
+- **F** the HRU index coordinate is labeled and carries no units.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import netCDF4 as nc
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+ID_COL = "nat_hru_id"
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+def _make_target_ds() -> xr.Dataset:
+    """A minimal multi-source-minmax target Dataset as the builders assemble it.
+
+    Bound vars carry ``grid_mapping="crs"`` inherited from the aggregated
+    sources (the dangling reference, defect A) but no ``crs`` container.
+    """
+    from nhf_spatial_targets.targets._common import build_n_sources_attrs
+
+    ids = np.array([10, 20, 30], dtype="int64")
+    time = pd.date_range("2000-01-01", periods=3, freq="MS")
+    tb = xr.DataArray(
+        list(zip(time.values, (time + pd.offsets.MonthBegin(1)).values)),
+        dims=("time", "nv"),
+        coords={"time": time.values},
+        name="time_bnds",
+    )
+
+    def bound(name: str) -> xr.DataArray:
+        da = xr.DataArray(
+            np.ones((3, 3), dtype="float32"),
+            dims=("time", ID_COL),
+            coords={"time": time.values, ID_COL: ids},
+            attrs={"units": "mm", "grid_mapping": "crs"},
+        )
+        da.name = name
+        return da
+
+    n_sources = xr.DataArray(
+        np.array([[1, 2, 3]] * 3, dtype="int8"),
+        dims=("time", ID_COL),
+        coords={"time": time.values, ID_COL: ids},
+    )
+    n_sources.attrs.update(build_n_sources_attrs(3))
+    n_sources.name = "n_sources"
+    clat = xr.DataArray(
+        np.array([40.0, 41.0, 42.0]),
+        dims=(ID_COL,),
+        coords={ID_COL: ids},
+        attrs={"units": "degrees_north", "standard_name": "latitude"},
+    )
+    clon = xr.DataArray(
+        np.array([-120.0, -121.0, -122.0]),
+        dims=(ID_COL,),
+        coords={ID_COL: ids},
+        attrs={"units": "degrees_east", "standard_name": "longitude"},
+    )
+    ds = xr.Dataset(
+        {
+            "lower_bound": bound("lower_bound"),
+            "upper_bound": bound("upper_bound"),
+            "n_sources": n_sources,
+        },
+        coords={
+            "time": time,
+            ID_COL: ids,
+            "time_bnds": tb,
+            "centroid_lat": clat,
+            "centroid_lon": clon,
+        },
+    )
+    ds["time"].attrs["bounds"] = "time_bnds"
+    return ds
+
+
+def _make_aggregated_ds(*, n_time: int, broadcast_crs: bool = True) -> xr.Dataset:
+    """A minimal aggregated Dataset reproducing the gdptools + merge artifacts.
+
+    ``time`` carries an inherited ``bounds="time_bnds"`` with no ``time_bnds``
+    variable (defect E), and ``crs`` is broadcast along the HRU dim by the
+    per-batch ``xr.concat`` merge (defect A).
+    """
+    from pyproj import CRS
+
+    ids = np.array([10, 20, 30], dtype="int64")
+    time = pd.date_range("2000-01-01", periods=n_time, freq="MS")
+    data = np.ones((n_time, 3), dtype="float64")
+    crs_attrs = dict(CRS.from_epsg(4326).to_cf())
+    crs = (
+        xr.DataArray(
+            np.zeros(3, dtype="int32"),
+            dims=(ID_COL,),
+            coords={ID_COL: ids},
+            attrs=crs_attrs,
+        )
+        if broadcast_crs
+        else xr.DataArray(np.int32(0), attrs=crs_attrs)
+    )
+    ds = xr.Dataset(
+        {
+            "runoff_total": xr.DataArray(
+                data,
+                dims=("time", ID_COL),
+                coords={"time": time.values, ID_COL: ids},
+                attrs={"units": "mm", "grid_mapping": "crs"},
+            ),
+            "crs": crs,
+        },
+        coords={"time": time, ID_COL: ids},
+    )
+    ds["time"].attrs.update({"standard_name": "time", "bounds": "time_bnds"})
+    ds[ID_COL].attrs["feature_id"] = ID_COL
+    return ds
+
+
+# --------------------------------------------------------------------------
+# io_nc — C
+# --------------------------------------------------------------------------
+
+
+def test_build_encoding_pins_time_bnds_fill_value_none():
+    from nhf_spatial_targets.io_nc import build_encoding
+
+    ids = np.array([1, 2, 3], dtype="int64")
+    time = pd.date_range("2000-01-01", periods=2, freq="MS")
+    tb = xr.DataArray(
+        np.zeros((2, 2)), dims=("time", "nv"), coords={"time": time.values}
+    )
+    ds = xr.Dataset(
+        {"ro": (("time", ID_COL), np.ones((2, 3), dtype="float32"))},
+        coords={"time": time, ID_COL: ids, "time_bnds": tb},
+    )
+    enc = build_encoding(ds, layer="aggregated", hru_dim=ID_COL)
+    assert "time_bnds" in enc
+    assert enc["time_bnds"]["_FillValue"] is None
+
+
+# --------------------------------------------------------------------------
+# target writer — A, B, C, F
+# --------------------------------------------------------------------------
+
+
+def test_target_writer_anchors_grid_mapping_with_scalar_crs(tmp_path: Path):
+    from nhf_spatial_targets.targets._common import write_target_nc
+
+    out = tmp_path / "recharge_targets.nc"
+    write_target_nc(_make_target_ds(), out, title="t", sort_dim=ID_COL)
+    ds = xr.open_dataset(out, decode_times=False)
+    assert "crs" in ds.variables
+    assert ds["crs"].ndim == 0  # CF §5.6: grid mapping var is 0-dim
+    assert ds["crs"].attrs.get("grid_mapping_name") == "latitude_longitude"
+    for v in ("lower_bound", "upper_bound", "n_sources"):
+        assert ds[v].attrs.get("grid_mapping") == "crs"
+
+
+def test_target_n_sources_flag_values_are_int8(tmp_path: Path):
+    from nhf_spatial_targets.targets._common import (
+        build_n_sources_attrs,
+        write_target_nc,
+    )
+
+    assert build_n_sources_attrs(3)["flag_values"].dtype == np.dtype("int8")
+    out = tmp_path / "recharge_targets.nc"
+    write_target_nc(_make_target_ds(), out, title="t", sort_dim=ID_COL)
+    with nc.Dataset(out) as ncf:
+        # CF §3.5: flag_values dtype must match its parent variable (int8).
+        assert ncf["n_sources"].flag_values.dtype == np.dtype("int8")
+
+
+def test_target_time_bnds_has_no_fill_value(tmp_path: Path):
+    from nhf_spatial_targets.targets._common import write_target_nc
+
+    out = tmp_path / "recharge_targets.nc"
+    write_target_nc(_make_target_ds(), out, title="t", sort_dim=ID_COL)
+    with nc.Dataset(out) as ncf:
+        assert "_FillValue" not in ncf["time_bnds"].ncattrs()
+
+
+def test_target_hru_index_labeled_without_units(tmp_path: Path):
+    from nhf_spatial_targets.targets._common import write_target_nc
+
+    out = tmp_path / "recharge_targets.nc"
+    write_target_nc(_make_target_ds(), out, title="t", sort_dim=ID_COL)
+    ds = xr.open_dataset(out, decode_times=False)
+    assert ds[ID_COL].attrs.get("long_name") == "HRU Index"
+    assert "units" not in ds[ID_COL].attrs
+
+
+# --------------------------------------------------------------------------
+# aggregated writer — A, E, F
+# --------------------------------------------------------------------------
+
+
+def test_aggregated_writer_collapses_broadcast_crs(tmp_path: Path):
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    out = tmp_path / "agg.nc"
+    _atomic_write_netcdf(
+        _make_aggregated_ds(n_time=12),
+        out,
+        id_col=ID_COL,
+        time_bounds_cadence="monthly",
+    )
+    ds = xr.open_dataset(out, decode_times=False)
+    assert ds["crs"].ndim == 0  # collapsed from the (id_col,) broadcast
+    # gdptools' correct attrs are preserved through the collapse.
+    assert ds["crs"].attrs.get("grid_mapping_name") == "latitude_longitude"
+
+
+def test_aggregated_writer_reconstructs_monthly_time_bnds(tmp_path: Path):
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    out = tmp_path / "agg.nc"
+    _atomic_write_netcdf(
+        _make_aggregated_ds(n_time=12),
+        out,
+        id_col=ID_COL,
+        time_bounds_cadence="monthly",
+    )
+    ds = xr.open_dataset(out)
+    assert "time_bnds" in ds.variables
+    assert ds["time"].attrs.get("bounds") == "time_bnds"
+    # Jan 2000 bound brackets the calendar month.
+    lo, hi = ds["time_bnds"].values[0]
+    assert pd.Timestamp(lo) == pd.Timestamp("2000-01-01")
+    assert pd.Timestamp(hi) == pd.Timestamp("2000-02-01")
+
+
+def test_aggregated_writer_reconstructs_annual_time_bnds(tmp_path: Path):
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    # Annual source: a single timestamp per file (spacing can't infer freq).
+    ds_in = _make_aggregated_ds(n_time=1)
+    ds_in["time"].attrs.pop("bounds")  # reitz-style: no inherited bounds attr
+    out = tmp_path / "agg.nc"
+    _atomic_write_netcdf(ds_in, out, id_col=ID_COL, time_bounds_cadence="annual")
+    ds = xr.open_dataset(out)
+    assert "time_bnds" in ds.variables
+    lo, hi = ds["time_bnds"].values[0]
+    assert pd.Timestamp(lo) == pd.Timestamp("2000-01-01")
+    assert pd.Timestamp(hi) == pd.Timestamp("2001-01-01")
+
+
+def test_aggregated_writer_strips_dangling_bounds_for_point_source(tmp_path: Path):
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    out = tmp_path / "agg.nc"
+    # Daily/instantaneous: no cadence -> no averaging interval.
+    _atomic_write_netcdf(
+        _make_aggregated_ds(n_time=3),
+        out,
+        id_col=ID_COL,
+        time_bounds_cadence="daily",
+    )
+    ds = xr.open_dataset(out, decode_times=False)
+    assert "time_bnds" not in ds.variables
+    assert "bounds" not in ds["time"].attrs  # dangling reference stripped
+
+
+def test_unchunked_path_pins_time_bnds_encoding(tmp_path: Path, recwarn):
+    """ssebop/daymet (id_col=None): reconstructed time_bnds shares time's units.
+
+    Without pinned time encoding on this path, xarray derives time and
+    time_bnds units independently and warns (CF §7.1). Assert the write is
+    clean and time_bnds carries no _FillValue.
+    """
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    out = tmp_path / "ssebop_agg.nc"
+    _atomic_write_netcdf(
+        _make_aggregated_ds(n_time=12), out, time_bounds_cadence="monthly"
+    )
+    msgs = [str(w.message) for w in recwarn]
+    assert not any("units encodings for time" in m for m in msgs), msgs
+    with nc.Dataset(out) as ncf:
+        assert "time_bnds" in ncf.variables
+        assert "_FillValue" not in ncf["time_bnds"].ncattrs()
+
+
+def test_aggregated_writer_labels_hru_index(tmp_path: Path):
+    from nhf_spatial_targets.aggregate._driver import _atomic_write_netcdf
+
+    out = tmp_path / "agg.nc"
+    _atomic_write_netcdf(
+        _make_aggregated_ds(n_time=12),
+        out,
+        id_col=ID_COL,
+        time_bounds_cadence="monthly",
+    )
+    ds = xr.open_dataset(out, decode_times=False)
+    assert ds[ID_COL].attrs.get("long_name") == "HRU Index"
+    assert "units" not in ds[ID_COL].attrs

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -1194,7 +1194,9 @@ def test_build_n_sources_attrs_three_sources():
     attrs = build_n_sources_attrs(3)
     assert attrs["units"] == "1"
     assert attrs["long_name"] == "number of finite source contributions"
-    assert attrs["flag_values"] == [0, 1, 2, 3]
+    # int8 to match the on-disk n_sources dtype (CF §3.5, issue #182).
+    assert attrs["flag_values"].dtype == np.dtype("int8")
+    assert list(attrs["flag_values"]) == [0, 1, 2, 3]
     assert attrs["flag_meanings"] == "none one two three"
     assert attrs["coordinates"] == "centroid_lat centroid_lon"
 
@@ -1204,7 +1206,8 @@ def test_build_n_sources_attrs_one_source():
     from nhf_spatial_targets.targets._common import build_n_sources_attrs
 
     attrs = build_n_sources_attrs(1)
-    assert attrs["flag_values"] == [0, 1]
+    assert attrs["flag_values"].dtype == np.dtype("int8")
+    assert list(attrs["flag_values"]) == [0, 1]
     assert attrs["flag_meanings"] == "none one"
 
 

--- a/tests/test_targets_run.py
+++ b/tests/test_targets_run.py
@@ -495,3 +495,12 @@ def test_build_nn_fill_actually_fills_nan_cells(tmp_path: Path):
             filled["lower_bound"].values[:, 1],
             filled["lower_bound"].values[:, 0],
         )
+
+    # CF-1.6 on the real nn_filled flag (issue #182): on-disk flag_values dtype
+    # matches the int8 parent (§3.5), and the spatial reference is anchored.
+    import netCDF4 as _nc
+
+    with _nc.Dataset(nn_path) as ncf:
+        assert ncf["nn_filled"].flag_values.dtype == np.dtype("int8")
+        assert ncf["nn_filled"].grid_mapping == "crs"
+        assert "crs" in ncf.variables and ncf["crs"].ndim == 0


### PR DESCRIPTION
## What

Fixes the CF-1.6 defects a `cfchecks` shakedown (#178) found in pipeline
output, at the shared write choke points so every aggregated source and
target NC is **born compliant** — Phase 1 of the Oregon workflow (#182), so
Oregon's NCs need no later regenerate.

| | Fix | Layer | CF § |
|---|---|---|---|
| **A** | mint 0-dim WGS84 `crs` on targets (resolves inherited `grid_mapping="crs"`); collapse the per-batch-merge broadcast of gdptools' `crs` back to a 0-dim scalar on aggregated NCs, preserving its attrs | both | §5.6 |
| **B** | `n_sources` / `nn_filled` `flag_values` → `int8` (match parent var) | target | §3.5 |
| **C** | pin `time_bnds` `_FillValue=None` (boundary vars carry no fill) | both | §7.1 |
| **E** | reconstruct aggregated `time_bnds` from catalog `time_step` cadence (monthly→month span, annual→year span); strip dangling `bounds` for instantaneous sources | aggregated | §7.1 |
| **F** | `nat_hru_id` → `long_name="HRU Index"`, no units | both | §3 |

The A collapse is **dimension-agnostic**: the `xr.concat` batch merge can broadcast `crs` onto `id_col` *or* `time`, so it's reduced to a scalar regardless. E also fixes the reitz2017 annual case (single timestamp/file, where spacing can't infer cadence) and adds bounds where they were absent. A follow-on pins time encoding on the unchunked ssebop/daymet path so the reconstructed `time_bnds` shares `time`'s units (silenced a real CF §7.1 xarray warning).

## Why

CF-1.6 is a hard requirement (CLAUDE.md). gdptools' `crs` **attrs are correct** — only its dimensionality (from the batch merge) was wrong, so we collapse rather than rebuild it.

## Verification

- `cfchecks` on regenerated target + aggregated NCs: **0 ERRORS** (was 4 + 1).
- New `tests/test_cf_compliance.py` (11 tests, green under `-W error::UserWarning`); updated 2 existing `flag_values` assertions for the int8 type.
- `fmt` + `lint` clean.

## Out of scope (deferred)

- Defect **D** (`standard_name="unknown"` on era5 `ro`/`sro`/`ssro`) is in `fetch/consolidate.py` — the consolidated/fetch layer, not aggregation/target. Separate follow-up.
- #178 documented **non-issues** (stale pre-#93 monotonic artifact, gdptools `crs`/`cf_role` cosmetics, `time_bnds` decoded-dtype false positive) are untouched by design.

Refs #182, #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)