### PR TITLE
chore(slurm): add render_<fabric>.slurm wrappers (Phase 3 entry point) (#182)

### DIFF
--- a/slurm/project_gfv2/render_gfv2.slurm
+++ b/slurm/project_gfv2/render_gfv2.slurm
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-render-gfv2
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=192G
+#SBATCH --time=8:00:00
+#SBATCH --output=logs/render_%j.out
+#SBATCH --error=logs/render_%j.err
+
+# Render gfv2 inspection figures via scripts/render_figures.py (PR #187).
+# Walks consolidated/, aggregated/, and targets/ notebooks and writes PNGs to
+# docs/figures/{consolidated,aggregated,targets}/gfv2-spatial-targets/. Uses
+# --project-dir so the temp-notebook code path is exercised symmetrically with
+# Oregon — the committed notebooks' embedded outputs are not overwritten on
+# each render (unlike the older slurm/shared/inspect_*.slurm scripts, which
+# nbconvert --inplace and modify the notebook itself).
+#
+# Usage (from the repo root so logs/ resolves there):
+#   mkdir -p logs
+#   sbatch slurm/project_gfv2/render_gfv2.slurm
+#   # Just one group:
+#   GROUP=targets sbatch slurm/project_gfv2/render_gfv2.slurm
+
+set -euo pipefail
+export PYTHONUNBUFFERED=1
+
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
+GROUP="${GROUP:-all}"
+REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$REPO_DIR" ] || {
+    echo "ERROR: could not resolve REPO_DIR; set REPO_DIR=/path/to/repo and resubmit" >&2
+    exit 1
+}
+
+DRIVER="$REPO_DIR/scripts/render_figures.py"
+if [ ! -f "$DRIVER" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
+    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $DRIVER. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+echo "=== nhf-targets render-figures ==="
+echo "=== Project: $PROJECT_DIR ==="
+echo "=== Group:   $GROUP ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+pixi run -e dev render-figures -- --group "$GROUP" --project-dir "$PROJECT_DIR"
+
+echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/slurm/project_or/README.md
+++ b/slurm/project_or/README.md
@@ -22,6 +22,11 @@ PROJECT_DIR=$OR sbatch slurm/shared/agg_daymet.slurm   # edit --region (na) insi
 # 3. Build the 5 implemented targets (runoff/aet/rch/som/swe; sca self-skips).
 #    Submit after the aggregations above have completed.
 sbatch slurm/project_or/run_or.slurm
+
+# 4. Render the per-project inspection figures (consolidated + aggregated +
+#    targets) to docs/figures/.../or-spatial-targets/. Submit after the
+#    targets above have built. Pass GROUP=targets for a faster subset.
+sbatch slurm/project_or/render_or.slurm
 ```
 
 Notes:

--- a/slurm/project_or/render_or.slurm
+++ b/slurm/project_or/render_or.slurm
@@ -1,0 +1,59 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-render-or
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=192G
+#SBATCH --time=8:00:00
+#SBATCH --output=logs/render_%j.out
+#SBATCH --error=logs/render_%j.err
+
+# Render Oregon inspection figures via scripts/render_figures.py (PR #187).
+# Walks consolidated/, aggregated/, and targets/ notebooks and writes PNGs to
+# docs/figures/{consolidated,aggregated,targets}/or-spatial-targets/ — without
+# committing per-project .ipynb (the committed gfv2-pinned notebooks are
+# repointed via a temp copy at execute time).
+#
+# Memory ceiling matches inspect_consolidated.slurm (the heaviest group is
+# CONUS gridded pre-aggregation). Targets render uses much less; one job for
+# all three groups is simpler than per-group arrays.
+#
+# Usage (from the repo root so logs/ resolves there):
+#   mkdir -p logs
+#   sbatch slurm/project_or/render_or.slurm
+#   # Just one group (faster iteration):
+#   GROUP=targets sbatch slurm/project_or/render_or.slurm
+
+set -euo pipefail
+export PYTHONUNBUFFERED=1
+
+PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets}"
+GROUP="${GROUP:-all}"
+# Resolve the repo from the submit cwd (sbatch spool-copies the script — #174).
+REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -n "$REPO_DIR" ] || {
+    echo "ERROR: could not resolve REPO_DIR; set REPO_DIR=/path/to/repo and resubmit" >&2
+    exit 1
+}
+
+# Same identity guard as the agg/run wrappers (#184 review): require the repo
+# to look like nhf-spatial-targets so a stale clone or wrong-repo submit fails
+# loudly instead of running the wrong driver.
+DRIVER="$REPO_DIR/scripts/render_figures.py"
+if [ ! -f "$DRIVER" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
+    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $DRIVER. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+echo "=== nhf-targets render-figures ==="
+echo "=== Project: $PROJECT_DIR ==="
+echo "=== Group:   $GROUP ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+pixi run -e dev render-figures -- --group "$GROUP" --project-dir "$PROJECT_DIR"
+
+echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="


### PR DESCRIPTION
## What

Phase 3 SLURM entry point for the Oregon workflow (#182). PR #187 added \`render_figures.py --project-dir\`; this wires it into HPC submission so the per-project figure render is one \`sbatch\` away.

- **\`slurm/project_or/render_or.slurm\`** — single job (\`--mem=192G --time=8h\`), drives \`render-figures --group all --project-dir \$OR\`. \`GROUP=targets\` overrides for faster iteration.
- **\`slurm/project_gfv2/render_gfv2.slurm\`** — symmetric for gfv2. Uses \`--project-dir\` so committed notebooks are not mutated on each render (unlike \`slurm/shared/inspect_*.slurm\` which \`--inplace\`-overwrites the notebook outputs).
- Identity guard (script-existence + \`pyproject\` sniff) mirrors the agg/run wrappers (#184 review).
- \`slurm/project_or/README.md\` gets a step 4 (render) so the full Oregon submit order is documented end-to-end.

## Usage (Oregon now has all targets built)

\`\`\`bash
cd <repo root>
mkdir -p logs
sbatch slurm/project_or/render_or.slurm                       # all groups
GROUP=targets sbatch slurm/project_or/render_or.slurm         # just targets
# -> docs/figures/{consolidated,aggregated,targets}/or-spatial-targets/*.png
\`\`\`

## Verification

\`bash -n\` clean on both wrappers. Dry-run with a \`pixi\` shim:
- default → \`pixi run -e dev render-figures -- --group all --project-dir \$OR\`
- \`GROUP=targets\` → \`--group targets …\`
- \`REPO_DIR=/tmp\` → identity guard rejects loudly (no dispatch).

## Notes

- The older \`slurm/shared/inspect_aggregated.slurm\` / \`inspect_consolidated.slurm\` are left untouched. They serve a different use case (regenerate the committed gfv2 notebook outputs in place via \`nbconvert --inplace\`). The new \`render_<fabric>.slurm\` is the right tool for producing the per-project figure set the deck (Phase 4) consumes.
- Memory headroom (192GB) matches the heaviest group (consolidated CONUS gridded). Targets render uses much less; one job for all three groups keeps the submit flow simple.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)