### PR TITLE
fix(render-figures): log logical notebook path, not temp file (#182)

### DIFF
--- a/scripts/render_figures.py
+++ b/scripts/render_figures.py
@@ -98,7 +98,6 @@ def _execute(nb_path: Path, startup: Path, timeout: int) -> None:
     ]
     env = os.environ.copy()
     env["PYTHONSTARTUP"] = str(startup)
-    print(f"=== executing {nb_path.relative_to(REPO_ROOT)} ===", flush=True)
     subprocess.run(cmd, check=True, cwd=REPO_ROOT, env=env)
 
 
@@ -176,6 +175,18 @@ def render_group(
         with fh:
             fh.write(_startup_payload(cfg["helpers_dir"], project))
         for nb in notebooks:
+            # Print the *logical* notebook name (the committed path under the
+            # repo). On the --project-dir path the actual file handed to
+            # nbconvert is a /tmp temp copy, which isn't under REPO_ROOT;
+            # showing its temp filename in the log would be noise (and used to
+            # crash on `.relative_to(REPO_ROOT)`, issue #182 follow-up). Fall
+            # back to the bare path for notebooks outside the repo (tests,
+            # scratch fixtures).
+            try:
+                display = nb.relative_to(REPO_ROOT)
+            except ValueError:
+                display = nb
+            print(f"=== executing {display} ===", flush=True)
             if project_dir is None:
                 _execute(nb, startup_path, timeout)
                 continue

--- a/tests/test_render_figures.py
+++ b/tests/test_render_figures.py
@@ -188,3 +188,40 @@ def test_render_group_with_project_dir_uses_temp(render, tmp_path, monkeypatch):
     assert not seen[0].exists()
     # Committed notebook is untouched on disk.
     assert "/data/gfv2-spatial-targets" in nb_path.read_text()
+
+
+def test_render_group_logs_logical_notebook_not_temp(
+    render, tmp_path, monkeypatch, capsys
+):
+    """The `=== executing ... ===` line shows the committed nb, not /tmp/...
+
+    Regression for an early --project-dir build that called
+    ``temp_nb.relative_to(REPO_ROOT)`` and crashed with ``ValueError`` because
+    the temp lives under /tmp. Two contracts: (1) the print does not raise,
+    and (2) it names the logical notebook so the operator can see which
+    inspect_* notebook is running.
+    """
+    nb_path = tmp_path / "inspect_consolidated_aet.ipynb"
+    nb_path.write_text(
+        json.dumps(_make_nb(['PROJECT_DIR = Path("/data/gfv2-spatial-targets")\n']))
+    )
+    monkeypatch.setattr(
+        render,
+        "GROUPS",
+        {"consolidated": {"dir": tmp_path, "helpers_dir": "notebooks/consolidated"}},
+    )
+    monkeypatch.setattr(render, "_execute", lambda *a, **k: None)
+    render.render_group(
+        "consolidated",
+        timeout=1,
+        project="or-spatial-targets",
+        project_dir="/data/or-spatial-targets",
+    )
+    out = capsys.readouterr().out
+    # The logical fixture path is logged ...
+    assert str(nb_path) in out
+    # ... and the random-suffixed temp from _make_project_dir_temp_notebook
+    # (prefix "inspect_consolidated_aet.<HEX>.ipynb") is NOT.
+    import re as _re
+
+    assert not _re.search(r"inspect_consolidated_aet\.[A-Za-z0-9_]+\.ipynb", out), out


### PR DESCRIPTION
## What

\`render_figures --project-dir\` crashed with \`ValueError\` on every notebook:

\`\`\`
'/tmp/inspect_consolidated_aet.<HEX>.ipynb' is not in the subpath of
'/caldera/.../nhf-spatial-targets'
\`\`\`

Reproduced by \`logs/render_21929476.err\`. \`_execute\` printed \`nb_path.relative_to(REPO_ROOT)\`, which raises when the notebook is the \`/tmp\` temp from \`_make_project_dir_temp_notebook\` (introduced in #187).

## Fix

Move the print from \`_execute\` to \`render_group\` so the **logical** (committed) notebook path is logged, with a tolerant \`try/except ValueError\` fallback for notebooks outside REPO_ROOT (tests, scratch fixtures). The temp filename is an implementation detail and was never useful in the log.

## Regression test

\`test_render_group_logs_logical_notebook_not_temp\` — asserts (1) the print doesn't raise, and (2) it names the committed notebook, not the random-suffixed temp. \`14/14\` pass under \`-W error::UserWarning\`.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)