### PR TITLE
fix(render-figures): absolute helpers + FIGURES_DIR for the /tmp kernel CWD (#182)

### DIFF
--- a/scripts/render_figures.py
+++ b/scripts/render_figures.py
@@ -46,14 +46,17 @@ GROUPS = {
     "consolidated": {
         "dir": REPO_ROOT / "notebooks" / "consolidated",
         "helpers_dir": "notebooks/consolidated",
+        "figures_subdir": "consolidated",
     },
     "aggregated": {
         "dir": REPO_ROOT / "notebooks" / "aggregated",
         "helpers_dir": "notebooks/aggregated",
+        "figures_subdir": "aggregated",
     },
     "targets": {
         "dir": REPO_ROOT / "notebooks" / "targets",
         "helpers_dir": "notebooks/targets",
+        "figures_subdir": "targets",
     },
 }
 
@@ -67,20 +70,37 @@ _PROJECT_DIR_RE = re.compile(
 )
 
 
-def _startup_payload(helpers_dir: str, project: str | None) -> str:
+def _startup_payload(
+    helpers_dir: str, project: str | None, figures_dir: str | None = None
+) -> str:
     """Build the PYTHONSTARTUP snippet that toggles save_figure for headless runs.
+
+    Both ``helpers_dir`` (the directory containing ``_helpers.py``, added to
+    ``sys.path``) and ``figures_dir`` (overrides ``_helpers.FIGURES_DIR``)
+    should be **absolute** paths. The kernel's working directory varies with
+    where the notebook lives — for the ``--project-dir`` path the notebook is
+    a /tmp temp, so any relative path here would resolve under /tmp instead of
+    the repo, breaking both the ``_helpers`` import and figure output paths.
 
     Uses ``repr()`` to quote the string values so that paths or project tags
     containing ``"``, ``\\``, or other Python-source-significant characters
     can't break the resulting payload (or worse, smuggle code into it).
     """
     project_line = f"_helpers.PROJECT = {project!r}\n" if project is not None else ""
+    figures_line = (
+        f"_helpers.FIGURES_DIR = Path({figures_dir!r})\n"
+        if figures_dir is not None
+        else ""
+    )
+    pathlib_import = "from pathlib import Path\n" if figures_dir is not None else ""
     return (
         "import sys\n"
+        f"{pathlib_import}"
         f"sys.path.insert(0, {helpers_dir!r})\n"
         "import _helpers\n"
         "_helpers.SAVE_FIGURES = True\n"
         f"{project_line}"
+        f"{figures_line}"
     )
 
 
@@ -173,7 +193,24 @@ def render_group(
     startup_path = Path(fh.name)
     try:
         with fh:
-            fh.write(_startup_payload(cfg["helpers_dir"], project))
+            # Both paths must be ABSOLUTE: the kernel's CWD on the
+            # --project-dir path is /tmp (the temp notebook's parent), so any
+            # relative helpers_dir or figures_dir would resolve under /tmp.
+            # figures_subdir is optional so tests can use minimal GROUPS dicts;
+            # the production entries always set it.
+            figures_subdir = cfg.get("figures_subdir")
+            figures_dir = (
+                str(REPO_ROOT / "docs" / "figures" / figures_subdir)
+                if figures_subdir
+                else None
+            )
+            fh.write(
+                _startup_payload(
+                    str(REPO_ROOT / cfg["helpers_dir"]),
+                    project,
+                    figures_dir=figures_dir,
+                )
+            )
         for nb in notebooks:
             # Print the *logical* notebook name (the committed path under the
             # repo). On the --project-dir path the actual file handed to

--- a/tests/test_render_figures.py
+++ b/tests/test_render_figures.py
@@ -75,6 +75,25 @@ def test_startup_payload_empty_string_project_is_emitted(render):
     assert "_helpers.PROJECT = ''" in payload
 
 
+def test_startup_payload_sets_absolute_figures_dir_when_passed(render):
+    # The kernel's CWD on the --project-dir path is /tmp; FIGURES_DIR must be
+    # overridden to an absolute path or save_figure would write under /tmp.
+    payload = render._startup_payload(
+        "/abs/helpers", "or-spatial-targets", figures_dir="/abs/docs/figures/aggregated"
+    )
+    assert "from pathlib import Path" in payload
+    assert "_helpers.FIGURES_DIR = Path('/abs/docs/figures/aggregated')" in payload
+    compile(payload, "<test>", "exec")
+
+
+def test_startup_payload_omits_figures_dir_when_unset(render):
+    # Back-compat: pre-figures_dir callers don't get a spurious FIGURES_DIR
+    # override (the notebooks would then load their own default).
+    payload = render._startup_payload("/abs/helpers", "p")
+    assert "_helpers.FIGURES_DIR" not in payload
+    assert "from pathlib import Path" not in payload
+
+
 def test_render_group_raises_on_empty_glob(render, tmp_path, monkeypatch):
     # Point GROUPS at an empty dir to simulate the "no notebooks found" case.
     fake_groups = {


### PR DESCRIPTION
## What

\`render_or.slurm\` failed every notebook (\`logs/render_21934031.err\`) with:

\`\`\`
WARNING | Unknown error in handling PYTHONSTARTUP file /tmp/...py
ModuleNotFoundError: No module named '_helpers'
\`\`\`

## Root cause

When \`--project-dir\` routes a notebook through a \`/tmp\` temp copy, nbconvert spawns the kernel with **CWD = the notebook's parent (\`/tmp\`)**, not the repo. The PYTHONSTARTUP payload's \`sys.path.insert(0, 'notebooks/<group>')\` was a **relative** path → resolved to \`/tmp/notebooks/<group>/\` → didn't exist → \`import _helpers\` silently failed (the WARNING). The notebook's own \`from _helpers import save_figure\` then died for real.

\`_helpers.FIGURES_DIR = Path('docs/figures/<group>')\` had the same latent bug — even with the import fixed, figures would have landed at \`/tmp/docs/figures/...\` instead of the repo.

## Fix

Make **both** paths absolute in the PYTHONSTARTUP payload so the kernel's CWD doesn't matter:

- \`_startup_payload\` gains a \`figures_dir\` kwarg that, when set, emits \`_helpers.FIGURES_DIR = Path('<abs>')\`.
- \`render_group\` resolves \`helpers_dir\` and \`figures_dir\` against \`REPO_ROOT\` and passes both into the payload.
- \`GROUPS\` gains an optional \`figures_subdir\` (real entries set it; test fixtures opt out via a fallback).

Regression tests: payload sets absolute \`FIGURES_DIR\` when passed; omits cleanly when not. 16/16 in \`tests/test_render_figures.py\` green under \`-W error::UserWarning\`.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)