### PR TITLE
fix(notebooks): load_fabric dispatches parquet vs read_file (#182)

### DIFF
--- a/notebooks/aggregated/_helpers.py
+++ b/notebooks/aggregated/_helpers.py
@@ -149,8 +149,17 @@ def load_fabric(fabric_cfg: dict) -> gpd.GeoDataFrame:
     Kept in EPSG:4326 for plotting; downstream area calculations
     re-project to EPSG:5070 (CONUS Albers) so we don't pay that cost
     on every map.
+
+    Dispatches on the file suffix to mirror :mod:`validate`: parquet/
+    geoparquet use the geopandas-native ``read_parquet`` so this works
+    even when the GDAL build lacks the ``ogr_Parquet`` plugin. Anything
+    else (.gpkg, .shp, …) goes through ``read_file``/pyogrio.
     """
-    gdf = gpd.read_file(fabric_cfg["path"])
+    path = Path(fabric_cfg["path"])
+    if path.suffix.lower() in (".parquet", ".geoparquet"):
+        gdf = gpd.read_parquet(path)
+    else:
+        gdf = gpd.read_file(path)
     gdf = gdf.set_index(fabric_cfg["id_col"])
     return gdf
 

--- a/notebooks/targets/_helpers.py
+++ b/notebooks/targets/_helpers.py
@@ -113,7 +113,14 @@ def load_fabric(
     aggregation, prefer reloading without simplification or accept the
     rounding error (sub-1% per polygon).
     """
-    gdf = gpd.read_file(fabric_cfg["path"])
+    # Dispatch on suffix (mirrors validate._gather_fabric_meta): parquet
+    # fabrics use geopandas-native read_parquet so this works even when GDAL
+    # lacks the ogr_Parquet plugin; everything else goes through pyogrio.
+    path = Path(fabric_cfg["path"])
+    if path.suffix.lower() in (".parquet", ".geoparquet"):
+        gdf = gpd.read_parquet(path)
+    else:
+        gdf = gpd.read_file(path)
     gdf = gdf.set_index(fabric_cfg["id_col"])
     if simplify_tolerance_deg is not None and simplify_tolerance_deg > 0:
         gdf = gdf.copy()

--- a/tests/test_aggregated_helpers.py
+++ b/tests/test_aggregated_helpers.py
@@ -355,3 +355,32 @@ def test_save_figure_no_subdir_when_project_none(helpers, tmp_path, monkeypatch)
         helpers.save_figure(fig, "test_no_project")
     plt.close(fig)
     assert (tmp_path / "figures" / "test_no_project.png").exists()
+
+
+# --- load_fabric: parquet vs gpkg dispatch (Oregon fabric is parquet) -------
+
+
+def _tiny_fabric_gdf(id_col: str = "nhm_id") -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {id_col: [10, 20, 30]},
+        geometry=[box(0, 0, 1, 1), box(1, 0, 2, 1), box(2, 0, 3, 1)],
+        crs="EPSG:4326",
+    )
+
+
+def test_load_fabric_reads_parquet_without_gdal_plugin(helpers, tmp_path):
+    """Oregon's fabric is .parquet — must use gpd.read_parquet (geopandas-
+    native), not gpd.read_file (which would need the ogr_Parquet GDAL
+    plugin). Regression for the render_or.slurm crash in #182."""
+    path = tmp_path / "fabric.parquet"
+    _tiny_fabric_gdf().to_parquet(path)
+    gdf = helpers.load_fabric({"path": str(path), "id_col": "nhm_id"})
+    assert list(gdf.index) == [10, 20, 30]
+
+
+def test_load_fabric_still_reads_gpkg(helpers, tmp_path):
+    """gfv2's .gpkg path must keep working (read_file/pyogrio)."""
+    path = tmp_path / "fabric.gpkg"
+    _tiny_fabric_gdf().to_file(path, driver="GPKG")
+    gdf = helpers.load_fabric({"path": str(path), "id_col": "nhm_id"})
+    assert list(gdf.index) == [10, 20, 30]

--- a/tests/test_target_helpers.py
+++ b/tests/test_target_helpers.py
@@ -134,3 +134,34 @@ def test_open_target_nc_window_clips_to_available_range(helpers, daily_target_nc
     times = pd.DatetimeIndex(ds["time"].values)
     assert times.min() == pd.Timestamp("2009-10-01")
     assert times.max() == pd.Timestamp("2009-10-31")
+
+
+# --- load_fabric: parquet vs gpkg dispatch (Oregon fabric is parquet) -------
+
+
+def _tiny_fabric_gdf():
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    return gpd.GeoDataFrame(
+        {"nhm_id": [10, 20, 30]},
+        geometry=[box(0, 0, 1, 1), box(1, 0, 2, 1), box(2, 0, 3, 1)],
+        crs="EPSG:4326",
+    )
+
+
+def test_load_fabric_reads_parquet_without_gdal_plugin(helpers, tmp_path):
+    """Oregon's fabric is .parquet — must use gpd.read_parquet (geopandas-
+    native), not gpd.read_file. Regression for #182 render_or.slurm crash."""
+    path = tmp_path / "fabric.parquet"
+    _tiny_fabric_gdf().to_parquet(path)
+    gdf = helpers.load_fabric({"path": str(path), "id_col": "nhm_id"})
+    assert list(gdf.index) == [10, 20, 30]
+
+
+def test_load_fabric_still_reads_gpkg(helpers, tmp_path):
+    """gfv2's .gpkg path must keep working (read_file/pyogrio)."""
+    path = tmp_path / "fabric.gpkg"
+    _tiny_fabric_gdf().to_file(path, driver="GPKG")
+    gdf = helpers.load_fabric({"path": str(path), "id_col": "nhm_id"})
+    assert list(gdf.index) == [10, 20, 30]


### PR DESCRIPTION
## What

\`render_or.slurm\` got past the consolidated group (#190 fixed the kernel-CWD import problem) and crashed on the first aggregated notebook with:

\`\`\`
DataSourceError: 'model_layers_9_nhru.parquet' not recognized as being in a
supported file format. It could have been recognized by driver Parquet, but
plugin ogr_Parquet.so is not available in your installation.
\`\`\`

## Root cause

OR's fabric is **\`.parquet\`**; gfv2's is **\`.gpkg\`**. The notebook helpers in both \`notebooks/aggregated/_helpers.py\` and \`notebooks/targets/_helpers.py\` unconditionally call \`gpd.read_file(...)\` → pyogrio → GDAL → needs the \`ogr_Parquet\` plugin. Production \`src/nhf_spatial_targets/validate.py:393-396\` already dispatches:

\`\`\`python
if fabric_path.suffix.lower() in (".parquet", ".geoparquet"):
    gdf = gpd.read_parquet(fabric_path)
else:
    gdf = gpd.read_file(fabric_path, rows=None)
\`\`\`

The notebook helpers never got the same branch.

## Fix

Mirror the production dispatch in both \`_helpers.load_fabric\`. \`gpd.read_parquet\` is geopandas-native (PyArrow-backed) and works without the GDAL plugin; \`.gpkg\`/\`.shp\`/etc still go through \`read_file\`. No new deps.

## Tests

\`tests/test_aggregated_helpers.py\` + \`tests/test_target_helpers.py\` each get:
- \`test_load_fabric_reads_parquet_without_gdal_plugin\` — Oregon path
- \`test_load_fabric_still_reads_gpkg\` — gfv2 path

42/42 green; \`fmt\` + \`lint\` clean.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)