### PR TITLE
chore(init): stub fabric.token + representative_points in new-project template (#182)

### DIFF
--- a/config/pipeline.yml
+++ b/config/pipeline.yml
@@ -19,6 +19,12 @@ fabric:
   # across every source's aggregation. CLI --batch-size overrides
   # per-run; changing this value invalidates cached weight CSVs.
   batch_size: 500
+  # Optional fabric-scope token. Sources tagged with `fabric_scope` in
+  # catalog/sources.yml (e.g. margulis_wus_sr -> [or]) are silently skipped
+  # at both agg and target stages when this is unset. Set to one of
+  # catalog.FABRIC_SCOPE_TOKENS (currently {"or"}) on fabric-restricted
+  # projects to opt in.
+  # token: or
   # Optional: subset to specific HRU IDs for testing
   # subset_ids: [1, 2, 3]
 
@@ -139,3 +145,26 @@ targets:
     output_file: swe_targets.nc
     nn_fill: true
     nn_max_candidates: 10
+
+# ---------------------------------------------------------------------------
+# Inspection-notebook overrides (optional)
+# ---------------------------------------------------------------------------
+# Per-target representative HRU points used by the inspect_* notebooks'
+# time-series cells. When unset, each notebook falls back to its hardcoded
+# CONUS-spanning defaults (Olympic / Iowa / Phoenix / Appalachians) — fine
+# for gfv2, but those points lie outside regional fabrics (e.g. Oregon's PNW
+# extent) and lookup_hrus_by_points will raise. Set per-target lists of
+# `"label": [lon, lat]` inside the fabric to override. YAML anchors keep
+# one set across all targets if desired.
+#
+# representative_points:
+#   aet: &rep_pts
+#     "Region A": [-121.7, 45.4]
+#     "Region B": [-123.0, 44.6]
+#     "Region C": [-118.6, 42.7]
+#     "Region D": [-123.5, 45.0]
+#   runoff: *rep_pts
+#   recharge: *rep_pts
+#   soil_moisture: *rep_pts
+#   snow_covered_area: *rep_pts
+#   swe: *rep_pts

--- a/notebooks/aggregated/inspect_aggregated_aet.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_aet.ipynb
@@ -62,7 +62,7 @@
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
     "    select_month,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/aggregated/inspect_aggregated_recharge.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_recharge.ipynb
@@ -61,7 +61,7 @@
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
     "    select_month,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/aggregated/inspect_aggregated_runoff.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_runoff.ipynb
@@ -60,7 +60,7 @@
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
     "    select_month,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/aggregated/inspect_aggregated_snow_covered_area.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_snow_covered_area.ipynb
@@ -62,7 +62,7 @@
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
     "    select_month,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/aggregated/inspect_aggregated_soil_moisture.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_soil_moisture.ipynb
@@ -63,7 +63,7 @@
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
     "    select_month,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/aggregated/inspect_aggregated_swe.ipynb
+++ b/notebooks/aggregated/inspect_aggregated_swe.ipynb
@@ -70,7 +70,7 @@
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
-    "    unit_from_catalog,,\n",
+    "    unit_from_catalog,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/targets/inspect_target_aet.ipynb
+++ b/notebooks/targets/inspect_target_aet.ipynb
@@ -101,7 +101,7 @@
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
-    "    select_month,,\n",
+    "    select_month,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/targets/inspect_target_recharge.ipynb
+++ b/notebooks/targets/inspect_target_recharge.ipynb
@@ -99,7 +99,7 @@
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
-    "    select_month,,\n",
+    "    select_month,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/targets/inspect_target_runoff.ipynb
+++ b/notebooks/targets/inspect_target_runoff.ipynb
@@ -93,7 +93,7 @@
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
-    "    select_month,,\n",
+    "    select_month,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/targets/inspect_target_soil_moisture.ipynb
+++ b/notebooks/targets/inspect_target_soil_moisture.ipynb
@@ -88,7 +88,7 @@
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
     "    save_figure,\n",
-    "    select_month,,\n",
+    "    select_month,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/notebooks/targets/inspect_target_swe.ipynb
+++ b/notebooks/targets/inspect_target_swe.ipynb
@@ -110,7 +110,7 @@
     "    plot_categorical_choropleth,\n",
     "    plot_hru_choropleth,\n",
     "    plot_nan_hrus,\n",
-    "    save_figure,,\n",
+    "    save_figure,\n",
     "    load_representative_points\n",
     ")\n",
     "\n",

--- a/src/nhf_spatial_targets/init_run.py
+++ b/src/nhf_spatial_targets/init_run.py
@@ -21,6 +21,12 @@ fabric:
   # Equal-area CRS used for HRU area + NN-fill distances. EPSG:5070 is
   # CONUS Albers — override for AK / HI / PR (e.g. EPSG:3338 for Alaska).
   area_crs: "EPSG:5070"
+  # Optional fabric-scope token. Sources tagged with `fabric_scope` in
+  # catalog/sources.yml (e.g. margulis_wus_sr -> [or]) are silently skipped
+  # at both agg and target stages when this is unset. Set to one of
+  # catalog.FABRIC_SCOPE_TOKENS (currently {"or"}) on fabric-restricted
+  # projects to opt in.
+  # token: or
   # KD-tree partition target HRUs/batch. The same partition is reused
   # across every source's aggregation. Override per-run with CLI
   # --batch-size. Changing this value invalidates any cached weight
@@ -139,6 +145,29 @@ targets:
     output_file: swe_targets.nc
     nn_fill: true
     nn_max_candidates: 10
+
+# ---------------------------------------------------------------------------
+# Inspection-notebook overrides (optional)
+# ---------------------------------------------------------------------------
+# Per-target representative HRU points used by the inspect_* notebooks'
+# time-series cells. When unset, each notebook falls back to its hardcoded
+# CONUS-spanning defaults (Olympic / Iowa / Phoenix / Appalachians) — fine
+# for gfv2, but those points lie outside regional fabrics (e.g. Oregon's PNW
+# extent) and lookup_hrus_by_points will raise. Set per-target lists of
+# `"label": [lon, lat]` inside the fabric to override. YAML anchors keep
+# one set across all targets if desired.
+#
+# representative_points:
+#   aet: &rep_pts
+#     "Region A": [-121.7, 45.4]
+#     "Region B": [-123.0, 44.6]
+#     "Region C": [-118.6, 42.7]
+#     "Region D": [-123.5, 45.0]
+#   runoff: *rep_pts
+#   recharge: *rep_pts
+#   soil_moisture: *rep_pts
+#   snow_covered_area: *rep_pts
+#   swe: *rep_pts
 """
 
 _CREDENTIALS_TEMPLATE = {

--- a/tests/test_init_run.py
+++ b/tests/test_init_run.py
@@ -63,3 +63,46 @@ def test_init_no_data_raw(tmp_path):
     workdir = tmp_path / "ws"
     init_project(workdir)
     assert not (workdir / "data" / "raw").exists()
+
+
+# --- commented-out stubs in the init template (#182 follow-up) --------------
+
+
+def test_init_config_template_parses_as_valid_yaml(tmp_path):
+    """The shipped template (incl. the new commented stubs) is valid YAML."""
+    workdir = tmp_path / "ws"
+    init_project(workdir)
+    cfg = yaml.safe_load((workdir / "config.yml").read_text())
+    assert cfg["fabric"]["id_col"] == "nhm_id"
+    # The commented stubs are not active by default:
+    assert "token" not in cfg["fabric"]
+    assert "representative_points" not in cfg
+
+
+def test_init_config_template_carries_fabric_token_stub(tmp_path):
+    """The fabric.token stub is present (commented) and points operators
+    at FABRIC_SCOPE_TOKENS — without this we silently skipped Margulis on
+    Oregon (#182)."""
+    workdir = tmp_path / "ws"
+    init_project(workdir)
+    text = (workdir / "config.yml").read_text()
+    assert "# token: or" in text
+    assert "FABRIC_SCOPE_TOKENS" in text
+
+
+def test_init_config_template_carries_representative_points_stub(tmp_path):
+    """The representative_points stub teaches operators about the per-target
+    notebook override before lookup_hrus_by_points raises mid-render (#192)."""
+    workdir = tmp_path / "ws"
+    init_project(workdir)
+    text = (workdir / "config.yml").read_text()
+    assert "# representative_points:" in text
+    for tgt in (
+        "aet",
+        "runoff",
+        "recharge",
+        "soil_moisture",
+        "snow_covered_area",
+        "swe",
+    ):
+        assert tgt in text

--- a/tests/test_inspect_notebooks_parse.py
+++ b/tests/test_inspect_notebooks_parse.py
@@ -1,0 +1,44 @@
+"""Regression: every committed inspect_*.ipynb code cell parses as Python.
+
+A bug in #192's notebook-rewrite script doubled an import-block trailing
+comma in all 11 inspect_aggregated_* + inspect_target_* notebooks, so the
+first cell raised ``SyntaxError`` during render. The fix would have been
+caught immediately by this test — it ``compile()``s every code cell of
+every committed inspect_*.ipynb. Cheap (no kernel, no I/O beyond reading
+the notebook), and it generalizes: any future broken-syntax notebook
+edit fails CI before burning HPC time.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSPECT_NOTEBOOKS = sorted(
+    list((REPO_ROOT / "notebooks" / "consolidated").glob("inspect_*.ipynb"))
+    + list((REPO_ROOT / "notebooks" / "aggregated").glob("inspect_*.ipynb"))
+    + list((REPO_ROOT / "notebooks" / "targets").glob("inspect_*.ipynb"))
+)
+
+
+@pytest.mark.parametrize("nb_path", INSPECT_NOTEBOOKS, ids=lambda p: p.name)
+def test_inspect_notebook_code_cells_compile(nb_path):
+    """Every code cell in *nb_path* parses (no SyntaxError / IndentationError)."""
+    nb = json.loads(nb_path.read_text())
+    for i, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell["source"]
+        text = "".join(src) if isinstance(src, list) else src
+        if not text.strip():
+            continue
+        try:
+            compile(text, f"{nb_path.name}:cell{i}", "exec")
+        except SyntaxError as exc:  # pragma: no cover - the assertion is the message
+            pytest.fail(
+                f"{nb_path.name} cell {i} fails to compile: "
+                f"{exc.msg} at line {exc.lineno}\n--- cell ---\n{text}"
+            )


### PR DESCRIPTION
## What

Bundles two related #182 fixes:

### 1. Init template stubs (original scope)

Two operator footguns from the Oregon build are now documented in the \`config.yml\` that \`nhf-targets init\` scaffolds, as **commented stubs** — default behavior unchanged, but a new operator sees the option (and the reason) instead of discovering it only when something fails silently or mid-render.

- **\`fabric.token\`** — \`catalog/sources.yml\` \`fabric_scope\` filtering silently skips sources at agg + target stages when unset. We hit this on Oregon: Margulis was downloaded, the array task ran, the SWE target built, but Margulis was missing from \`data/aggregated/\` and SWE was 3-source instead of 4 (INFO log only).
- **\`representative_points\`** — the per-target notebook override (#192). Without it, \`inspect_*\` notebooks fall back to CONUS-spanning defaults that lie outside regional fabrics, and \`lookup_hrus_by_points\` raises mid-render.

Mirror both stubs into \`config/pipeline.yml\` (the reference example).

### 2. Double-comma fix + parse-regression test (added to this PR)

The notebook-rewrite script in #192 appended \`,\n    load_representative_points\` to the multi-line \`from _helpers import (...)\` block. Those blocks already ended with a trailing comma, so all 11 notebooks ended up with \`unit_from_catalog,,\` → SyntaxError on every aggregated/target render (\`logs/render_21934154.err\`). HPC time wasted before the trace surfaced.

- Remove the extra comma from all 11 affected notebooks.
- New \`tests/test_inspect_notebooks_parse.py\` parametrizes over every committed \`inspect_*.ipynb\` (17 total) and \`compile()\`s each code cell. Catches this whole class of bug at PR time, not render time. **Cheap** (no kernel, no I/O beyond the read) and generalizes to any future broken-syntax notebook edit.

## Tests

27 green (10 init + 17 notebook-parse) under \`-W error::UserWarning\`; fmt + lint clean.

Refs #182, #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)