### PR TITLE
feat(cli): upgrade-config reports optional-config drift; CLAUDE.md disciplines schema additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,25 @@ tests/
 - **Docstrings** on public functions only (not stubs)
 - **Ruff** for lint and format (line length 88); run before committing
 
+## Config schema additions
+
+When you add a new optional parameter to the project config (top-level key
+or nested commented stub), update all four in the same PR. The first three
+keep new projects current; the fourth keeps existing projects discoverable.
+
+1. **`src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE`** — add the
+   parameter as a commented stub (schema + example value + reason it's
+   optional).
+2. **`config/pipeline.yml`** — mirror the addition.
+3. **`tests/test_init_run.py`** — assert the new key (or commented-stub
+   line) appears in the rendered template.
+4. **`src/nhf_spatial_targets/upgrade_config.py:OPTIONAL_CONFIG_FEATURES`**
+   — append an `OptionalConfigFeature` entry so existing-project operators
+   discover the addition via `nhf-targets upgrade-config -d <dir>`.
+
+`upgrade-config` is **report-only** — it never mutates an operator's
+`config.yml`; it prints what's missing and the literal block to paste.
+
 ## Data & Catalog Conventions
 
 - All data source metadata lives in `catalog/sources.yml` — do not hardcode URLs or product names in Python modules

--- a/docs/superpowers/specs/2026-05-23-upgrade-config-design.md
+++ b/docs/superpowers/specs/2026-05-23-upgrade-config-design.md
@@ -1,0 +1,156 @@
+# `upgrade-config` — report optional-config drift from the init template
+
+## Motivation
+
+PR #193 added two commented-out stubs to the project config template
+(`fabric.token`, `representative_points`) after both surfaced as silent
+footguns on the Oregon build (umbrella #182). Those stubs help **new**
+operators (they see the option at `nhf-targets init` time) but do **nothing**
+for operators of **existing** projects, who keep using a config that pre-dates
+the addition and never discover the new optional features until something
+fails or quietly produces wrong output.
+
+This spec adds:
+1. A `nhf-targets upgrade-config -d <project-dir>` CLI that **reports** which
+   optional features documented in the init template are missing from a
+   project's `config.yml`. **Report-only** — never mutates operator files.
+2. A small explicit **registry** of optional features in code so the report
+   message and the paste-block stay precise and reviewable.
+3. CLAUDE.md guidance that ties the registry into the existing template /
+   reference / test update discipline — one new step.
+
+Non-goals: applying changes to operator files; auto-parsing arbitrary YAML
+comments; managing required-config schema migration. All deferred.
+
+## Component map
+
+```
+src/nhf_spatial_targets/upgrade_config.py     (new)
+  OptionalConfigFeature                       (frozen dataclass)
+  OPTIONAL_CONFIG_FEATURES                    (list[OptionalConfigFeature])
+  check_drift(project_dir) -> list[OptionalConfigFeature]
+
+src/nhf_spatial_targets/cli.py                (extend)
+  @app.command("upgrade-config")
+  def upgrade_config_cmd(workdir, ...): rich-table report + exit 0/1
+
+tests/test_upgrade_config.py                  (new)
+  detection clean + drift cases, CLI exit codes
+
+CLAUDE.md                                     (extend)
+  "Config schema additions" — 4-step checklist
+```
+
+## Data shape
+
+```python
+@dataclass(frozen=True)
+class OptionalConfigFeature:
+    name: str          # e.g. "fabric.token", "representative_points"
+    detect: str        # regex; matches against the project's config.yml TEXT.
+                       # Must allow commented-stub form (^\s*#?\s*<key>:) so an
+                       # operator who already pasted the stub isn't reported.
+    block: str         # literal template block to paste — kept in sync with
+                       # _CONFIG_TEMPLATE by CLAUDE.md discipline (step 4).
+    added: str         # "2026-05-23 (#193)" — provenance shown in the table.
+    why: str           # one-line operator-facing reason (table column).
+```
+
+Initial registry entries (both from #193): `fabric.token`, `representative_points`.
+
+## Detection contract
+
+`check_drift(project_dir)` reads `<project_dir>/config.yml` as text and walks
+`OPTIONAL_CONFIG_FEATURES`. For each feature, the `detect` regex runs against
+the file text in MULTILINE mode. A feature is **in sync** if the regex
+matches (either the live key or the commented stub form). Otherwise the
+feature is returned as drift.
+
+The regex form `(?m)^\s*#?\s*<key>\s*:` matches all three states an operator
+might be in:
+- live key (`token: or`)
+- commented stub the operator pasted but hasn't enabled (`# token: or`)
+- commented stub from the latest template (`# token: or`)
+
+If the project's `config.yml` doesn't exist, `check_drift` raises
+`FileNotFoundError` (the project dir is invalid; same error class as the
+other CLI commands' "project not found" path).
+
+## CLI contract
+
+```
+$ nhf-targets upgrade-config -d <project-dir>
+
+[in sync]   → exit 0, prints "Project config is in sync with the latest
+              optional-feature stubs in the init template."
+
+[drift]     → exit 1, prints a rich Table (Feature / Added / Why) followed by
+              the literal paste-block for each missing feature.
+```
+
+Exit 1 on drift lets CI scripts (e.g. a future "audit our known project dirs"
+heartbeat) detect drift without parsing stdout.
+
+## CLAUDE.md addition
+
+A new subsection under **Code Conventions** (after the existing
+"Test Coverage Rule" or similar):
+
+```markdown
+## Config schema additions
+
+When you add a new optional parameter to the project config (top-level key
+or nested commented stub), update all four in the same PR:
+
+1. `src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE` — add the
+   parameter as a commented stub (schema + example + reason it's optional).
+2. `config/pipeline.yml` — mirror the addition.
+3. `tests/test_init_run.py` — assert the new key/stub appears in the
+   rendered template.
+4. `src/nhf_spatial_targets/upgrade_config.py:OPTIONAL_CONFIG_FEATURES` —
+   append an `OptionalConfigFeature` entry so existing-project operators
+   see the addition via `nhf-targets upgrade-config -d <dir>`.
+
+Steps 1-3 keep new projects current; step 4 keeps existing projects
+discoverable.
+```
+
+## Tests
+
+`tests/test_upgrade_config.py`:
+
+- `test_check_drift_reports_missing_when_absent` — tmp project config with
+  neither `fabric.token` nor `representative_points` → both reported.
+- `test_check_drift_clean_when_live_value_present` — config with a real
+  `representative_points: {...}` block → not reported.
+- `test_check_drift_clean_when_commented_stub_present` — config with
+  `# representative_points:` (operator pasted but hasn't enabled) → not
+  reported.
+- `test_check_drift_raises_when_config_missing` — bogus project dir →
+  FileNotFoundError.
+- `test_cli_exits_nonzero_on_drift` — Cyclopts invocation; assert exit code
+  1 and that the missing feature's name appears in stdout.
+- `test_cli_exits_zero_when_in_sync` — all features matched → exit 0,
+  "in sync" message.
+
+## Tradeoffs
+
+- **Discipline-dependent.** A contributor who forgets step 4 of the
+  CLAUDE.md checklist leaves drift undetected for their addition. Mitigation
+  for a follow-up: a CI check that diffs the template's commented-stub
+  lines against `OPTIONAL_CONFIG_FEATURES` and fails the build on
+  mismatch. Out of scope for v1.
+- **String matching, not YAML parsing.** Comment-preserving YAML round-trip
+  is fragile; the recent #192 regex bug is fresh evidence. The registry
+  pattern keeps the detection narrow and reviewable. Deeply-nested optional
+  features (beyond the simple `fabric.token` pattern) would warrant
+  revisiting.
+- **No `--apply`.** Operators copy-paste manually. Trades convenience for
+  zero risk of clobbering their customizations or comments.
+
+## References
+
+- #193 (init template stubs — the trigger for needing this)
+- #182 (Oregon umbrella — operator-experience source for the registry's
+  initial entries)
+- #194 (validate silent-skip warnings — complementary preventive infra)

--- a/src/nhf_spatial_targets/cli.py
+++ b/src/nhf_spatial_targets/cli.py
@@ -367,6 +367,68 @@ def reconcile_manifest_cmd(
     )
 
 
+@app.command(name="upgrade-config")
+def upgrade_config_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir", "-d"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+):
+    """Report optional-config features missing from the project's config.yml.
+
+    Existing projects don't pick up new optional features (e.g. fabric.token,
+    representative_points) added to the init template, because they were
+    created before those features existed. This command compares the project's
+    config.yml against the registry in upgrade_config.OPTIONAL_CONFIG_FEATURES
+    and prints the literal commented block to paste for each missing feature.
+
+    Report-only: never mutates the operator's config.yml. Exits 0 if in sync,
+    1 on drift (so scripted heartbeats can detect it).
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    from nhf_spatial_targets.upgrade_config import check_drift
+
+    console = Console()
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        missing = check_drift(workdir)
+    except FileNotFoundError as e:
+        print(f"upgrade-config failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not missing:
+        console.print(
+            "[bold green]Project config is in sync with the latest "
+            "optional-feature stubs in the init template.[/bold green]"
+        )
+        return
+
+    table = Table(title="Optional features missing from this project's config.yml")
+    table.add_column("feature", style="bold")
+    table.add_column("added")
+    table.add_column("why")
+    for feat in missing:
+        table.add_row(feat.name, feat.added, feat.why)
+    console.print(table)
+
+    console.print(
+        "\nPaste each block below into config.yml (or see "
+        "src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE for context). "
+        "This command never edits your file.\n"
+    )
+    for feat in missing:
+        console.print(f"[bold]# --- {feat.name} ---[/bold]")
+        console.print(feat.block)
+    sys.exit(1)
+
+
 @app.command
 def init(
     workdir: Annotated[

--- a/src/nhf_spatial_targets/upgrade_config.py
+++ b/src/nhf_spatial_targets/upgrade_config.py
@@ -1,0 +1,132 @@
+"""Report optional-config drift between a project's config.yml and the latest
+init template.
+
+Existing projects don't pick up new optional features (e.g. ``fabric.token``,
+``representative_points``) added to the init template, because they were
+created before those features existed. This module is the operator-facing
+discovery path: ``nhf-targets upgrade-config -d <dir>`` lists what's missing,
+with the literal commented block to paste.
+
+**Report-only.** This module never mutates the operator's config.yml.
+
+When you add a new optional config parameter (update
+``init_run.py:_CONFIG_TEMPLATE`` + ``config/pipeline.yml`` +
+``tests/test_init_run.py`` per the CLAUDE.md "Config schema additions"
+checklist), also append an :class:`OptionalConfigFeature` entry to
+:data:`OPTIONAL_CONFIG_FEATURES` below so existing-project operators see it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class OptionalConfigFeature:
+    """A single optional-config addition tracked for drift reporting.
+
+    Attributes
+    ----------
+    name
+        The dotted key path as the operator should think of it
+        (``fabric.token``, ``representative_points``). Shown in the table.
+    detect
+        A regex applied to the project's ``config.yml`` text in MULTILINE
+        mode. The feature is considered in-sync if it matches **any** form:
+        the live value, the commented-stub form the operator pasted, or the
+        commented stub left from a fresh init. The canonical pattern is
+        ``(?m)^\\s*#?\\s*<key>\\s*:``.
+    block
+        The literal commented stub from ``_CONFIG_TEMPLATE`` — what the
+        operator sees in the ``--upgrade-config`` paste output. Kept in
+        sync with the init template by the CLAUDE.md discipline.
+    added
+        Provenance shown in the report table (``"2026-05-23 (#193)"``).
+    why
+        One-line operator-facing reason this feature exists. Shown in the
+        report table.
+    """
+
+    name: str
+    detect: str
+    block: str
+    added: str
+    why: str
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+#
+# Append new entries here whenever a new optional config parameter lands in
+# init_run.py:_CONFIG_TEMPLATE. See CLAUDE.md "Config schema additions" for
+# the full update checklist.
+#
+# Detection regexes use ``(?m)^\s*#?\s*<key>\s*:`` so commented-stub forms
+# (operator pasted but hasn't enabled) and live values both count as in-sync.
+
+OPTIONAL_CONFIG_FEATURES: list[OptionalConfigFeature] = [
+    OptionalConfigFeature(
+        name="fabric.token",
+        # Nested under `fabric:`; we match the leaf key only because there is
+        # no other `token:` field in the schema today. If that changes,
+        # tighten this to require fabric: context (e.g. multi-line lookbehind).
+        detect=r"(?m)^\s*#?\s*token\s*:",
+        block=(
+            "  # Optional fabric-scope token. Sources tagged with `fabric_scope` in\n"
+            "  # catalog/sources.yml (e.g. margulis_wus_sr -> [or]) are silently skipped\n"
+            "  # at both agg and target stages when this is unset. Set to one of\n"
+            '  # catalog.FABRIC_SCOPE_TOKENS (currently {"or"}) on fabric-restricted\n'
+            "  # projects to opt in. Paste under the `fabric:` block.\n"
+            "  # token: or\n"
+        ),
+        added="2026-05-23 (#193)",
+        why="opt-in for fabric_scope sources (e.g. margulis_wus_sr on the OR fabric)",
+    ),
+    OptionalConfigFeature(
+        name="representative_points",
+        detect=r"(?m)^\s*#?\s*representative_points\s*:",
+        block=(
+            "# Per-target representative HRU points used by the inspect_* notebooks'\n"
+            "# time-series cells. When unset, notebooks fall back to hardcoded CONUS\n"
+            "# defaults that lie outside regional fabrics (lookup_hrus_by_points\n"
+            '# raises). Set per-target lists of `"label": [lon, lat]` inside the\n'
+            "# fabric to override. YAML anchors keep one set across targets.\n"
+            "#\n"
+            "# representative_points:\n"
+            "#   aet: &rep_pts\n"
+            '#     "Region A": [-121.7, 45.4]\n'
+            '#     "Region B": [-123.0, 44.6]\n'
+            '#     "Region C": [-118.6, 42.7]\n'
+            '#     "Region D": [-123.5, 45.0]\n'
+            "#   runoff: *rep_pts\n"
+            "#   recharge: *rep_pts\n"
+            "#   soil_moisture: *rep_pts\n"
+            "#   snow_covered_area: *rep_pts\n"
+            "#   swe: *rep_pts\n"
+        ),
+        added="2026-05-23 (#193)",
+        why="per-target REPRESENTATIVE_POINTS for inspect_* notebooks (#192)",
+    ),
+]
+
+
+def check_drift(project_dir: Path) -> list[OptionalConfigFeature]:
+    """Return the optional features missing from ``<project_dir>/config.yml``.
+
+    A feature is considered present if its ``detect`` regex matches anywhere
+    in the project's config text (live value or commented stub).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``<project_dir>/config.yml`` does not exist — the project dir is
+        invalid for upgrade purposes (init it first, or fix the path).
+    """
+    cfg_path = Path(project_dir) / "config.yml"
+    text = cfg_path.read_text()  # raises FileNotFoundError naturally
+    return [
+        feat for feat in OPTIONAL_CONFIG_FEATURES if not re.search(feat.detect, text)
+    ]

--- a/tests/test_upgrade_config.py
+++ b/tests/test_upgrade_config.py
@@ -1,0 +1,138 @@
+"""Tests for nhf-targets upgrade-config (#193 follow-up).
+
+Detection is the contract: a feature is in sync if its `detect` regex matches
+the project's config.yml text in any form — live value, the commented stub
+operator pasted, or the commented stub from a fresh init template.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nhf_spatial_targets.upgrade_config import (
+    OPTIONAL_CONFIG_FEATURES,
+    OptionalConfigFeature,
+    check_drift,
+)
+
+
+def _write_minimal_config(project_dir: Path, body: str = "") -> None:
+    """Write a syntactically-valid project config with optional extra body."""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    text = f"fabric:\n  path: /x.gpkg\n  id_col: nhm_id\ndatastore: /x\n{body}"
+    (project_dir / "config.yml").write_text(text)
+
+
+# --- check_drift detection ---------------------------------------------------
+
+
+def test_check_drift_reports_all_features_when_none_present(tmp_path):
+    _write_minimal_config(tmp_path)
+    missing = check_drift(tmp_path)
+    names = {f.name for f in missing}
+    # Both shipped features (PR #193) should be reported on a bare config.
+    assert {"fabric.token", "representative_points"} <= names
+
+
+def test_check_drift_clean_when_live_value_present(tmp_path):
+    """A real `representative_points:` block counts as in-sync."""
+    _write_minimal_config(
+        tmp_path,
+        body=('representative_points:\n  aet:\n    "Region A": [-121.7, 45.4]\n'),
+    )
+    missing = check_drift(tmp_path)
+    assert "representative_points" not in {f.name for f in missing}
+
+
+def test_check_drift_clean_when_commented_stub_present(tmp_path):
+    """Operator pasted the stub but hasn't enabled — still in-sync (the
+    addition is discoverable in their file, which is the whole point)."""
+    _write_minimal_config(
+        tmp_path,
+        body="# representative_points:\n#   aet:\n#     X: [-120, 45]\n",
+    )
+    missing = check_drift(tmp_path)
+    assert "representative_points" not in {f.name for f in missing}
+
+
+def test_check_drift_detects_nested_fabric_token_commented(tmp_path):
+    """fabric.token is a nested key; both `# token: or` and `token: or`
+    (under the fabric: block) count as in-sync."""
+    _write_minimal_config(tmp_path, body="")
+    # Append the stub form the operator would paste under fabric:
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(cfg.read_text().rstrip() + "\n  # token: or\n")
+    missing = check_drift(tmp_path)
+    assert "fabric.token" not in {f.name for f in missing}
+
+
+def test_check_drift_raises_when_config_missing(tmp_path):
+    """Invalid project dir (no config.yml) raises rather than silently passing."""
+    with pytest.raises(FileNotFoundError):
+        check_drift(tmp_path / "does-not-exist")
+
+
+# --- registry shape ---------------------------------------------------------
+
+
+def test_each_registry_feature_has_actionable_metadata():
+    """Every registered feature carries enough to render a useful report:
+    a non-trivial detect regex, a non-empty block, and provenance."""
+    for feat in OPTIONAL_CONFIG_FEATURES:
+        assert isinstance(feat, OptionalConfigFeature)
+        assert feat.name
+        assert feat.detect and ":" in feat.detect  # regex covers a yaml key
+        assert feat.block.strip()
+        assert feat.added  # provenance shown in the report
+        assert feat.why
+
+
+# --- CLI: exit codes ---------------------------------------------------------
+#
+# Cyclopts apps are callable as ``app([...])`` and exit via SystemExit, so we
+# invoke in-process (matching tests/test_cli_agg.py's pattern) rather than
+# spawning a subprocess.
+
+
+def test_cli_exits_one_on_drift(tmp_path, capsys):
+    from nhf_spatial_targets.cli import app
+
+    _write_minimal_config(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        app(["upgrade-config", "--project-dir", str(tmp_path)])
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    # The missing feature names appear in stdout so the operator can act.
+    assert "representative_points" in out
+
+
+def test_cli_exits_zero_when_in_sync(tmp_path, capsys):
+    from nhf_spatial_targets.cli import app
+
+    # Operator pasted both commented stubs from the latest template.
+    (tmp_path / "config.yml").write_text(
+        "fabric:\n"
+        "  path: /x.gpkg\n"
+        "  id_col: nhm_id\n"
+        "  # token: or\n"
+        "datastore: /x\n"
+        "# representative_points:\n"
+    )
+    # Cyclopts wraps even successful returns in SystemExit(0).
+    with pytest.raises(SystemExit) as exc:
+        app(["upgrade-config", "--project-dir", str(tmp_path)])
+    assert exc.value.code in (None, 0)
+    out = capsys.readouterr().out
+    assert "in sync" in out.lower()
+
+
+def test_cli_exits_two_when_project_missing(tmp_path, capsys):
+    from nhf_spatial_targets.cli import app
+
+    with pytest.raises(SystemExit) as exc:
+        app(["upgrade-config", "--project-dir", str(tmp_path / "no-such")])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "not found" in err.lower()


### PR DESCRIPTION
## What

PR #193 added two commented stubs (\`fabric.token\`, \`representative_points\`) to the init template after both surfaced as silent footguns on the Oregon build. Those stubs help **new** operators (they see them at init time) but do nothing for operators of **existing** projects, who keep using a pre-existing config and never discover new optional features. This adds a **report-only** CLI for that gap, plus a 4-step contributor discipline so future additions stay discoverable.

## Approach

Brainstormed two design forks; the merged choices are:
1. **Tool scope = report-only** (safest, no mutation). Operator copy-pastes from output.
2. **Detection = explicit registry** in code (avoids fragile auto-parse of multi-line YAML/comments — the #192 regex bug is fresh evidence of how brittle that path is).

## Components

- **\`src/nhf_spatial_targets/upgrade_config.py\`** (new) — \`@dataclass OptionalConfigFeature\`, \`OPTIONAL_CONFIG_FEATURES\` list (initial entries: the two #193 stubs), \`check_drift(project_dir) -> list[OptionalConfigFeature]\`. Detection regex \`(?m)^\s*#?\s*<key>\s*:\` matches live values AND commented-stub forms (operator pasted but hasn't enabled).
- **\`nhf-targets upgrade-config -d <project-dir>\`** (cli.py) — rich Table report. Exit codes: **0** in sync, **1** on drift (CI/heartbeat-friendly), **2** if project dir missing. Never mutates operator files.
- **CLAUDE.md \"Config schema additions\"** (new short section) — 4-step discipline: update template, mirror to \`config/pipeline.yml\`, assert in \`test_init_run.py\`, **append to \`OPTIONAL_CONFIG_FEATURES\`** (the new step that closes the existing-projects gap).
- **\`tests/test_upgrade_config.py\`** — detection clean + drift cases (live value present, commented stub present, nested \`fabric.token\` under \`fabric:\`); registry-shape sanity; CLI exit codes via \`app([...])\` (matching \`tests/test_cli_agg.py\` pattern).
- **\`docs/superpowers/specs/2026-05-23-upgrade-config-design.md\`** — full design spec.

## Operator UX

\`\`\`
$ nhf-targets upgrade-config -d /path/to/or-spatial-targets
                Optional features missing from this project's config.yml
╭───────────────────────┬───────────────────┬────────────────────────────╮
│ feature               │ added             │ why                        │
├───────────────────────┼───────────────────┼────────────────────────────┤
│ representative_points │ 2026-05-23 (#193) │ per-target REP_POINTS …    │
╰───────────────────────┴───────────────────┴────────────────────────────╯

Paste each block below into config.yml (or see ...):

# --- representative_points ---
# representative_points:
#   aet: &rep_pts
#     ...
\`\`\`

## Verification

- 9/9 new tests in \`test_upgrade_config.py\` green; 27/27 init/parse tests still green.
- \`fmt\` + \`lint\` clean.
- Manually checked: \`upgrade-config -d <fresh init project>\` correctly reports both stubs absent; pasting the blocks brings it to \"in sync\".

## Refs

- #182 (Oregon umbrella that surfaced the operator pain)
- #193 (init template stubs — the trigger for needing this)
- #194 (validate silent-skip warnings — complementary preventive infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)