### PR TITLE
fix(notebooks)+chore(slurm): inspect_target_*.ipynb project_dir + render array (#198)

### DIFF
--- a/notebooks/targets/inspect_target_aet.ipynb
+++ b/notebooks/targets/inspect_target_aet.ipynb
@@ -121,7 +121,7 @@
     "TARGET_TIME = f\"{TARGET_YEAR}-{TARGET_MONTH:02d}-01\"\n",
     "\n",
     "# Four points spanning the wet/dry x cold/warm AET regimes.\n",
-    "REPRESENTATIVE_POINTS = load_representative_points(project_dir, TARGET) or {\n",
+    "REPRESENTATIVE_POINTS = load_representative_points(PROJECT_DIR, TARGET) or {\n",
     "    \"Iowa cropland (high summer ET, rainfed maize)\": (-93.6, 42.0),\n",
     "    \"Southern Appalachians (Eastern broadleaf)\": (-83.5, 35.5),\n",
     "    \"Phoenix metro (arid SW, low ET)\": (-112.1, 33.4),\n",

--- a/notebooks/targets/inspect_target_recharge.ipynb
+++ b/notebooks/targets/inspect_target_recharge.ipynb
@@ -120,7 +120,7 @@
     "TARGET_TIME = f\"{TARGET_YEAR}-01-01\"\n",
     "\n",
     "# Four points spanning the wet / dry x cold / warm recharge regimes.\n",
-    "REPRESENTATIVE_POINTS = load_representative_points(project_dir, TARGET) or {\n",
+    "REPRESENTATIVE_POINTS = load_representative_points(PROJECT_DIR, TARGET) or {\n",
     "    \"Olympic Peninsula (PNW conifer; high subsurface flow)\": (-123.5, 47.8),\n",
     "    \"Iowa cropland (Midwest; recharge dominated by snowmelt + spring rain)\": (-93.6, 42.0),\n",
     "    \"Phoenix metro (arid SW; near-zero recharge)\": (-112.1, 33.4),\n",

--- a/notebooks/targets/inspect_target_runoff.ipynb
+++ b/notebooks/targets/inspect_target_runoff.ipynb
@@ -112,7 +112,7 @@
     "TARGET_MONTH = 4  # April -- snowmelt-driven peak, n_sources == 3 everywhere\n",
     "TARGET_TIME = f\"{TARGET_YEAR}-{TARGET_MONTH:02d}-01\"\n",
     "\n",
-    "REPRESENTATIVE_POINTS = load_representative_points(project_dir, TARGET) or {\n",
+    "REPRESENTATIVE_POINTS = load_representative_points(PROJECT_DIR, TARGET) or {\n",
     "    \"Olympic Peninsula (PNW mountains)\": (-123.5, 47.8),\n",
     "    \"Iowa cropland (Midwest)\": (-93.6, 42.0),\n",
     "    \"Phoenix metro (arid SW)\": (-112.1, 33.4),\n",

--- a/notebooks/targets/inspect_target_soil_moisture.ipynb
+++ b/notebooks/targets/inspect_target_soil_moisture.ipynb
@@ -110,7 +110,7 @@
     "TARGET_TIME_MONTHLY = f\"{TARGET_YEAR}-{TARGET_MONTH:02d}-01\"\n",
     "TARGET_TIME_ANNUAL = f\"{TARGET_YEAR}-01-01\"\n",
     "\n",
-    "REPRESENTATIVE_POINTS = load_representative_points(project_dir, TARGET) or {\n",
+    "REPRESENTATIVE_POINTS = load_representative_points(PROJECT_DIR, TARGET) or {\n",
     "    \"Iowa cropland (root-zone storage)\": (-93.6, 42.0),\n",
     "    \"Southern Appalachians (Eastern forest)\": (-83.5, 35.5),\n",
     "    \"Phoenix metro (arid SW)\": (-112.1, 33.4),\n",

--- a/notebooks/targets/inspect_target_swe.ipynb
+++ b/notebooks/targets/inspect_target_swe.ipynb
@@ -141,7 +141,7 @@
     "#                     # --mem first; ~11 GB per file)\n",
     "\n",
     "# Four snow-bearing regions spanning the major CONUS snowpack regimes.\n",
-    "REPRESENTATIVE_POINTS = load_representative_points(project_dir, TARGET) or {\n",
+    "REPRESENTATIVE_POINTS = load_representative_points(PROJECT_DIR, TARGET) or {\n",
     "    \"Sierra Nevada (deep maritime snowpack)\": (-119.0, 38.0),\n",
     "    \"Colorado Rockies (alpine continental)\": (-106.8, 39.5),\n",
     "    \"Cascades (PNW maritime, heavy SWE)\": (-121.5, 47.0),\n",

--- a/slurm/project_gfv2/render_gfv2.slurm
+++ b/slurm/project_gfv2/render_gfv2.slurm
@@ -2,52 +2,40 @@
 #SBATCH --job-name=nhf-render-gfv2
 #SBATCH --account=impd
 #SBATCH --partition=cpu
+#SBATCH --array=0-2
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=192G
 #SBATCH --time=8:00:00
-#SBATCH --output=logs/render_%j.out
-#SBATCH --error=logs/render_%j.err
+#SBATCH --output=logs/render_%a_%A.out
+#SBATCH --error=logs/render_%a_%A.err
 
-# Render gfv2 inspection figures via scripts/render_figures.py (PR #187).
-# Walks consolidated/, aggregated/, and targets/ notebooks and writes PNGs to
-# docs/figures/{consolidated,aggregated,targets}/gfv2-spatial-targets/. Uses
-# --project-dir so the temp-notebook code path is exercised symmetrically with
-# Oregon — the committed notebooks' embedded outputs are not overwritten on
-# each render (unlike the older slurm/shared/inspect_*.slurm scripts, which
-# nbconvert --inplace and modify the notebook itself).
+# gfv2 (gfv2-spatial-targets) figure-render array — one task per
+# notebook group (consolidated/aggregated/targets). Thin wrapper over the
+# shared render dispatch; only PROJECT_DIR differs from
+# slurm/project_or/render_or.slurm.
+#
+# Re-render one group without re-running the others:
+#   sbatch --array=2   slurm/project_gfv2/render_gfv2.slurm   # targets only
+#   sbatch --array=1-2 slurm/project_gfv2/render_gfv2.slurm   # aggregated + targets
 #
 # Usage (from the repo root so logs/ resolves there):
 #   mkdir -p logs
 #   sbatch slurm/project_gfv2/render_gfv2.slurm
-#   # Just one group:
-#   GROUP=targets sbatch slurm/project_gfv2/render_gfv2.slurm
 
 set -euo pipefail
-export PYTHONUNBUFFERED=1
 
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
-GROUP="${GROUP:-all}"
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {
     echo "ERROR: could not resolve REPO_DIR; set REPO_DIR=/path/to/repo and resubmit" >&2
     exit 1
 }
 
-DRIVER="$REPO_DIR/scripts/render_figures.py"
-if [ ! -f "$DRIVER" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
-    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $DRIVER. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
+BODY="$REPO_DIR/slurm/shared/render_all.body.sh"
+if [ ! -f "$BODY" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
+    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $BODY. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
     exit 1
 fi
 
-cd "$REPO_DIR"
-
-echo "=== nhf-targets render-figures ==="
-echo "=== Project: $PROJECT_DIR ==="
-echo "=== Group:   $GROUP ==="
-echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
-echo "=== Host:    $(hostname) ==="
-
-pixi run -e dev render-figures -- --group "$GROUP" --project-dir "$PROJECT_DIR"
-
-echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+source "$BODY"

--- a/slurm/project_or/README.md
+++ b/slurm/project_or/README.md
@@ -25,8 +25,12 @@ sbatch slurm/project_or/run_or.slurm
 
 # 4. Render the per-project inspection figures (consolidated + aggregated +
 #    targets) to docs/figures/.../or-spatial-targets/. Submit after the
-#    targets above have built. Pass GROUP=targets for a faster subset.
-sbatch slurm/project_or/render_or.slurm
+#    targets above have built. Array indices: 0=consolidated, 1=aggregated,
+#    2=targets — submit a subset to re-render one group without redoing
+#    the others.
+sbatch slurm/project_or/render_or.slurm                # all 3 groups
+sbatch --array=2   slurm/project_or/render_or.slurm    # targets only
+sbatch --array=1-2 slurm/project_or/render_or.slurm    # aggregated + targets
 ```
 
 Notes:

--- a/slurm/project_or/render_or.slurm
+++ b/slurm/project_or/render_or.slurm
@@ -2,58 +2,49 @@
 #SBATCH --job-name=nhf-render-or
 #SBATCH --account=impd
 #SBATCH --partition=cpu
+#SBATCH --array=0-2
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=192G
 #SBATCH --time=8:00:00
-#SBATCH --output=logs/render_%j.out
-#SBATCH --error=logs/render_%j.err
+#SBATCH --output=logs/render_%a_%A.out
+#SBATCH --error=logs/render_%a_%A.err
 
-# Render Oregon inspection figures via scripts/render_figures.py (PR #187).
-# Walks consolidated/, aggregated/, and targets/ notebooks and writes PNGs to
-# docs/figures/{consolidated,aggregated,targets}/or-spatial-targets/ — without
-# committing per-project .ipynb (the committed gfv2-pinned notebooks are
-# repointed via a temp copy at execute time).
+# Oregon (or-spatial-targets) figure-render array — one task per
+# notebook group (consolidated/aggregated/targets). Thin wrapper over the
+# shared render dispatch; only PROJECT_DIR differs from
+# slurm/project_gfv2/render_gfv2.slurm.
 #
-# Memory ceiling matches inspect_consolidated.slurm (the heaviest group is
-# CONUS gridded pre-aggregation). Targets render uses much less; one job for
-# all three groups is simpler than per-group arrays.
+# Re-render one group without re-running the others:
+#   sbatch --array=2   slurm/project_or/render_or.slurm   # targets only
+#   sbatch --array=1-2 slurm/project_or/render_or.slurm   # aggregated + targets
+#
+# The --mem ceiling matches the heaviest group (consolidated, CONUS-gridded
+# source data); aggregated + targets tasks request the same but use only a
+# fraction. Per-task --mem differentiation isn't worth the array-script
+# complexity at 3 groups.
 #
 # Usage (from the repo root so logs/ resolves there):
 #   mkdir -p logs
 #   sbatch slurm/project_or/render_or.slurm
-#   # Just one group (faster iteration):
-#   GROUP=targets sbatch slurm/project_or/render_or.slurm
 
 set -euo pipefail
-export PYTHONUNBUFFERED=1
 
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets}"
-GROUP="${GROUP:-all}"
-# Resolve the repo from the submit cwd (sbatch spool-copies the script — #174).
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {
     echo "ERROR: could not resolve REPO_DIR; set REPO_DIR=/path/to/repo and resubmit" >&2
     exit 1
 }
 
-# Same identity guard as the agg/run wrappers (#184 review): require the repo
-# to look like nhf-spatial-targets so a stale clone or wrong-repo submit fails
-# loudly instead of running the wrong driver.
-DRIVER="$REPO_DIR/scripts/render_figures.py"
-if [ ! -f "$DRIVER" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
-    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $DRIVER. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
+# Wrong-repo guard (matches run_or.slurm / agg_all_or.slurm): require the
+# shared body to exist and the tree to identify as nhf-spatial-targets before
+# sourcing, so a stale clone fails loudly instead of silently running the
+# wrong code.
+BODY="$REPO_DIR/slurm/shared/render_all.body.sh"
+if [ ! -f "$BODY" ] || ! grep -q 'name = "nhf-spatial-targets"' "$REPO_DIR/pyproject.toml" 2>/dev/null; then
+    echo "ERROR: REPO_DIR=$REPO_DIR (resolved from ${SLURM_SUBMIT_DIR:-$PWD}) is not an nhf-spatial-targets checkout with $BODY. Set REPO_DIR=/path/to/nhf-spatial-targets and resubmit." >&2
     exit 1
 fi
 
-cd "$REPO_DIR"
-
-echo "=== nhf-targets render-figures ==="
-echo "=== Project: $PROJECT_DIR ==="
-echo "=== Group:   $GROUP ==="
-echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
-echo "=== Host:    $(hostname) ==="
-
-pixi run -e dev render-figures -- --group "$GROUP" --project-dir "$PROJECT_DIR"
-
-echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+source "$BODY"

--- a/slurm/shared/render_all.body.sh
+++ b/slurm/shared/render_all.body.sh
@@ -1,0 +1,44 @@
+# Shared body for the per-fabric figure-render array wrappers
+# (slurm/project_*/render_*.slurm). NOT submitted directly — it is `source`d by
+# a wrapper that has already declared the #SBATCH headers and set PROJECT_DIR +
+# REPO_DIR.
+#
+# Submits one SLURM array task per inspection-notebook group (3 total):
+#   0 — consolidated  (datastore NCs; CONUS-gridded, memory ceiling)
+#   1 — aggregated    (per-source HRU NCs)
+#   2 — targets       (per-target HRU NCs)
+#
+# Groups are independent — re-render one without re-running the others via:
+#   sbatch --array=2 slurm/project_<fabric>/render_<fabric>.slurm   # targets only
+#   sbatch --array=1-2 slurm/project_<fabric>/render_<fabric>.slurm # aggregated + targets
+
+export PYTHONUNBUFFERED=1
+
+cd "$REPO_DIR" || {
+    echo "ERROR: REPO_DIR=$REPO_DIR not found" >&2
+    exit 1
+}
+
+# Map array index -> render-figures group name. Order chosen so the heaviest
+# group (consolidated, CONUS-gridded source data) runs on index 0 — a "submit
+# just the first one" smoke test exercises the memory ceiling first.
+RENDER_GROUPS=(
+    "consolidated"   # 0 — datastore NC inspection (gridded pre-aggregation)
+    "aggregated"     # 1 — per-source aggregated HRU NC inspection
+    "targets"        # 2 — per-target HRU NC inspection
+)
+
+if ((SLURM_ARRAY_TASK_ID < 0 || SLURM_ARRAY_TASK_ID >= ${#RENDER_GROUPS[@]})); then
+    echo "ERROR: SLURM_ARRAY_TASK_ID=$SLURM_ARRAY_TASK_ID out of range [0, ${#RENDER_GROUPS[@]})" >&2
+    exit 2
+fi
+
+GROUP="${RENDER_GROUPS[$SLURM_ARRAY_TASK_ID]}"
+echo "=== Array task $SLURM_ARRAY_TASK_ID: render-figures --group $GROUP ==="
+echo "=== Project: $PROJECT_DIR ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+pixi run -e dev render-figures -- --group "$GROUP" --project-dir "$PROJECT_DIR"
+
+echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/tests/test_inspect_notebooks_parse.py
+++ b/tests/test_inspect_notebooks_parse.py
@@ -1,17 +1,24 @@
-"""Regression: every committed inspect_*.ipynb code cell parses as Python.
+"""Regression: every committed inspect_*.ipynb code cell parses as Python,
+and the per-project rep-points wrap doesn't reference a name before it's bound.
 
-A bug in #192's notebook-rewrite script doubled an import-block trailing
-comma in all 11 inspect_aggregated_* + inspect_target_* notebooks, so the
-first cell raised ``SyntaxError`` during render. The fix would have been
-caught immediately by this test — it ``compile()``s every code cell of
-every committed inspect_*.ipynb. Cheap (no kernel, no I/O beyond reading
-the notebook), and it generalizes: any future broken-syntax notebook
-edit fails CI before burning HPC time.
+* SyntaxError guard: #192's notebook-rewrite script doubled an import-block
+  trailing comma in all 11 inspect_*.ipynb so the first cell raised
+  ``SyntaxError`` during render. ``test_inspect_notebook_code_cells_compile``
+  ``compile()``s every code cell — any future broken-syntax notebook edit
+  fails CI before burning HPC time.
+* NameError guard (#198): the same regex also wrapped
+  ``REPRESENTATIVE_POINTS = { ... }`` with ``load_representative_points(project_dir, TARGET) or { ... }``.
+  In the 5 inspect_target_*.ipynb the original cell layout put
+  ``load_project_paths(PROJECT_DIR)`` *below* the rep-points block, so the
+  wrap read ``project_dir`` before it was defined → ``NameError`` at render
+  time. ``test_inspect_notebook_rep_points_arg_is_defined`` catches the
+  pattern statically without executing.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -41,4 +48,56 @@ def test_inspect_notebook_code_cells_compile(nb_path):
             pytest.fail(
                 f"{nb_path.name} cell {i} fails to compile: "
                 f"{exc.msg} at line {exc.lineno}\n--- cell ---\n{text}"
+            )
+
+
+# Match: load_representative_points(<name>, ...)  — capture the first arg name.
+_LRP_CALL = re.compile(r"load_representative_points\(\s*(\w+)\b")
+# Match: an assignment to project_dir at line start, either tuple-unpack
+# (``project_dir, datastore_dir, ... =``) or bare (``project_dir =``).
+_ASSIGN_PROJECT_DIR = re.compile(r"^\s*project_dir\s*[,=]", re.MULTILINE)
+
+
+@pytest.mark.parametrize("nb_path", INSPECT_NOTEBOOKS, ids=lambda p: p.name)
+def test_inspect_notebook_rep_points_arg_is_defined(nb_path):
+    """``load_representative_points(<arg>, …)`` must not read an undefined name.
+
+    Allowed:
+      - ``load_representative_points(PROJECT_DIR, TARGET)`` — ``PROJECT_DIR``
+        is the user-edited ``Path`` literal at the top of every setup cell.
+      - ``load_representative_points(project_dir, TARGET)`` *iff* the same
+        cell defines ``project_dir`` earlier (typically via
+        ``project_dir, datastore_dir, fabric_cfg = load_project_paths(PROJECT_DIR)``).
+
+    Disallowed: any other first argument, or lowercase ``project_dir``
+    without a preceding binding in the same cell.
+    """
+    nb = json.loads(nb_path.read_text())
+    for i, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell["source"]
+        text = "".join(src) if isinstance(src, list) else src
+        m = _LRP_CALL.search(text)
+        if not m:
+            continue
+        first_arg = m.group(1)
+        if first_arg == "PROJECT_DIR":
+            continue
+        if first_arg != "project_dir":
+            pytest.fail(
+                f"{nb_path.name} cell {i}: "
+                f"load_representative_points({first_arg}, …) — pass "
+                f"PROJECT_DIR (the Path literal) or project_dir (the "
+                f"load_project_paths return) instead."
+            )
+        # lowercase project_dir — require an earlier assignment in the cell.
+        before = text[: m.start()]
+        if not _ASSIGN_PROJECT_DIR.search(before):
+            pytest.fail(
+                f"{nb_path.name} cell {i}: "
+                f"load_representative_points(project_dir, …) references "
+                f"project_dir before it's bound. Either pass PROJECT_DIR "
+                f"or move `project_dir, … = load_project_paths(PROJECT_DIR)` "
+                f"above the rep-points block (#198)."
             )


### PR DESCRIPTION
## Summary

Two coupled fixes to unblock the OR target-notebook render:

**1. Notebook fix (commit 1)** — Render of OR target notebooks died on every \`inspect_target_*.ipynb\` setup cell with \`NameError: name 'project_dir' is not defined\` (\`logs/render_21940302.err\`). Same PR #192 regex that broke aggregated notebooks with double-comma SyntaxError; here the wrap reads \`project_dir\` before \`load_project_paths(PROJECT_DIR)\` defines it (the target notebooks' original cell ordering puts the latter below the rep-points block, unlike the aggregated notebooks where it's above). Fix: pass \`PROJECT_DIR\` (the \`Path\` literal at the top of every setup cell) instead of lowercase \`project_dir\` — both resolve to the same dir for \`load_representative_points\`' config.yml read. New regression test in \`tests/test_inspect_notebooks_parse.py\` catches the use-before-def pattern statically.

**2. SLURM refactor (commit 2)** — Refactor \`render_{or,gfv2}.slurm\` into a job array by notebook group (mirrors \`run_*.slurm\` / \`agg_all_*.slurm\`). Extracts the body into \`slurm/shared/render_all.body.sh\` (array dispatch on \`SLURM_ARRAY_TASK_ID\` 0..2 → consolidated/aggregated/targets). Verifying the notebook fix on OR no longer requires re-rendering consolidated+aggregated:

\`\`\`bash
sbatch --array=2   slurm/project_or/render_or.slurm   # targets only
sbatch --array=1-2 slurm/project_or/render_or.slurm   # aggregated + targets
\`\`\`

The old \`GROUP=<name> sbatch ...\` env-var pattern is replaced by \`sbatch --array=<idx> ...\` — the established pattern from \`run_or.slurm\` / \`agg_all_or.slurm\`.

Closes #198. Refs #182, #192, #197.

## Test plan

- [x] \`pixi run -e dev fmt && pixi run -e dev lint\` — clean
- [x] \`pixi run -e dev pytest tests/test_inspect_notebooks_parse.py -q\` — 34 passed
- [x] \`bash -n\` on \`render_all.body.sh\`, \`render_or.slurm\`, \`render_gfv2.slurm\` — clean
- [ ] CI green
- [ ] User submits \`sbatch --array=2 slurm/project_or/render_or.slurm\` and the 5 OR target notebooks render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)