### PR TITLE
fix(aggregate): mask netCDF default-fill cells at write + read boundaries (#204)

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -433,7 +433,20 @@ def _atomic_write_netcdf(
     """
     ds = _normalize_cf_fabric_metadata(ds, id_col=id_col, cadence=time_bounds_cadence)
 
-    from nhf_spatial_targets.io_nc import atomic_to_netcdf, build_encoding
+    from nhf_spatial_targets.io_nc import (
+        atomic_to_netcdf,
+        build_encoding,
+        mask_netcdf_default_fills,
+    )
+
+    # Substitute gdptools' missing-coverage sentinel (NC_FILL_DOUBLE) with NaN
+    # so the on-disk values agree with the declared `_FillValue=NaN` for floats
+    # in `io_nc._fill_value_for`. Without this, xarray decode leaves the
+    # ~1e36 cells as legitimate data and they poison multi-source `np.fmax`
+    # downstream. Mirrored at the read boundary in
+    # `targets/_common.py:read_aggregated_source` so existing on-disk NCs
+    # written before this fix decode correctly without a rewrite. Issue #204.
+    ds = mask_netcdf_default_fills(ds)
 
     if id_col is not None:
         encoding = build_encoding(

--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -50,6 +50,55 @@ _TIME_ENCODING = {
 }
 
 
+def mask_netcdf_default_fills(ds: xr.Dataset) -> xr.Dataset:
+    """Replace netCDF default-fill cells (per-dtype) with NaN on float data vars.
+
+    netCDF's per-dtype default fill (``NC_FILL_FLOAT == NC_FILL_DOUBLE ==
+    9.969209968386869e+36``, ``NC_FILL_INT``, etc., per
+    :data:`netCDF4.default_fillvals` and netCDF NUG Annex A) is what some
+    upstreams emit verbatim into in-memory arrays for missing values without
+    attaching a matching ``_FillValue`` attribute. Notably, gdptools'
+    ``AggGen`` writes ``NC_FILL_DOUBLE`` for HRUs whose geometry has no
+    overlap with the source grid (regional fabrics that poke outside a
+    CONUS-only source's data extent). Our writer policy in
+    :func:`_fill_value_for` declares ``_FillValue=NaN`` for floats, so an
+    on-disk cell holding the sentinel survives ``decode_cf`` (xarray masks via
+    value-equality, NaN never equals anything) — silently surviving as
+    ``~1e36`` real data and contaminating any ``np.fmax`` downstream
+    (issue #204).
+
+    This helper is the single-source policy that both the **write boundary**
+    (aggregate/_driver.py:_atomic_write_netcdf — substitutes the sentinel
+    before write, so future NCs have ``data=NaN`` matching the declared
+    ``_FillValue=NaN``) and the **read boundary** (targets/_common.py:
+    read_aggregated_source — substitutes after load, so existing on-disk NCs
+    with the encoding mismatch decode correctly without rewrite) call.
+
+    Today only floats are substituted — the aggregated layer doesn't emit
+    integer data vars from gdptools. The :data:`default_fillvals` lookup is
+    keyed by dtype, so a future int-data-var path is a one-line addition.
+
+    CF grid-mapping containers (variables carrying ``grid_mapping_name``) are
+    skipped — they're metadata, not measurements. Returns a shallow copy with
+    substituted data vars; input is not mutated.
+    """
+    from netCDF4 import default_fillvals
+
+    ds = ds.copy()
+    for name, da in ds.data_vars.items():
+        if "grid_mapping_name" in da.attrs:
+            continue
+        # default_fillvals keys are dtype strings without endianness ('f4','f8',
+        # 'i4', ...). dtype.str is e.g. '<f8'; strip the byte-order prefix.
+        sentinel = default_fillvals.get(da.dtype.str.lstrip("<>=|"))
+        if sentinel is None or not np.issubdtype(da.dtype, np.floating):
+            continue
+        # `.where(cond)` keeps cells where `cond` is True, NaN-masks elsewhere.
+        # Equality is exact: the sentinel is a bit-pattern constant.
+        ds[name] = da.where(da != sentinel)
+    return ds
+
+
 def _fill_value_for(dtype: np.dtype) -> Any:
     """Layer-agnostic ``_FillValue`` policy keyed on the encoded dtype.
 

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -337,6 +337,18 @@ def read_aggregated_source(
     # in VPU-grouped batch order — this defensive sort keeps positional
     # checks against the fabric correct without forcing a re-aggregate.
     ds = ds.sortby(project.id_col)
+    # Substitute netCDF default-fill cells (NC_FILL_DOUBLE etc.) with NaN.
+    # Aggregated NCs written before issue #204's fix declare _FillValue=NaN
+    # but hold the ~1e36 sentinel in cells gdptools couldn't fill (e.g. OR
+    # HRUs outside MWBM CONUS extent). xarray's decode masks via value
+    # equality and NaN never matches, so the sentinel survives and poisons
+    # downstream np.fmax. Mirrors the write-side fix in
+    # aggregate/_driver.py:_atomic_write_netcdf — keeping both means
+    # existing on-disk NCs decode correctly without a rewrite while fresh
+    # writes are self-consistent on disk.
+    from nhf_spatial_targets.io_nc import mask_netcdf_default_fills
+
+    ds = mask_netcdf_default_fills(ds)
     sliced = ds[var].sel(time=slice(period[0], period[1]))
     if sliced.sizes.get("time", 0) == 0:
         # Years parsed from sorted filenames -- avoids triggering dask compute

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -13,7 +13,11 @@ import xarray as xr
 import yaml
 from shapely.geometry import box
 
-from nhf_spatial_targets.aggregate._driver import update_manifest
+from nhf_spatial_targets.aggregate._driver import (
+    _atomic_write_netcdf,
+    update_manifest,
+)
+from nhf_spatial_targets.io_nc import mask_netcdf_default_fills
 from nhf_spatial_targets.workspace import load as load_project
 
 
@@ -2292,3 +2296,130 @@ def test_defaults_fabric_batch_size_is_500():
     # apply_defaults falls back to default when unset.
     merged = apply_defaults({"fabric": {}})
     assert merged["fabric"]["batch_size"] == 500
+
+
+# --- mask_netcdf_default_fills (#204) -----------------------------------------
+
+
+class TestMaskNetcdfDefaultFills:
+    """gdptools writes NC_FILL_DOUBLE into the in-memory array for missing-
+    coverage HRUs, but our writer declares ``_FillValue=NaN``. Without this
+    helper the on-disk cell holds the netCDF default sentinel while metadata
+    says NaN, and xarray decode leaves it as legitimate data ~1e36 — which
+    poisons multi-source ``np.fmax`` downstream (#204)."""
+
+    @staticmethod
+    def _fill_f8():
+        """Float64 netCDF default fill (9.969209968386869e+36)."""
+        from netCDF4 import default_fillvals
+
+        return default_fillvals["f8"]
+
+    def test_substitutes_float_sentinel_with_nan(self):
+        sentinel = self._fill_f8()
+        ds = xr.Dataset(
+            {
+                "aet": (
+                    ("time", "nhm_id"),
+                    np.array([[1.0, sentinel, 3.0]], dtype="float64"),
+                ),
+            },
+            coords={"time": [0], "nhm_id": [1, 2, 3]},
+        )
+        out = mask_netcdf_default_fills(ds)
+        assert out["aet"].values[0, 0] == 1.0
+        assert np.isnan(out["aet"].values[0, 1])
+        assert out["aet"].values[0, 2] == 3.0
+
+    def test_preserves_legitimate_finite_data(self):
+        # No sentinels — should round-trip unchanged.
+        ds = xr.Dataset(
+            {"x": (("nhm_id",), np.array([0.0, 30.5, -1.2, 999.0]))},
+            coords={"nhm_id": [1, 2, 3, 4]},
+        )
+        out = mask_netcdf_default_fills(ds)
+        np.testing.assert_array_equal(out["x"].values, ds["x"].values)
+
+    def test_preserves_pre_existing_nan(self):
+        # NaN cells (e.g. from a pre_aggregate_hook fill mask) survive.
+        ds = xr.Dataset(
+            {"x": (("nhm_id",), np.array([1.0, np.nan, 3.0]))},
+            coords={"nhm_id": [1, 2, 3]},
+        )
+        out = mask_netcdf_default_fills(ds)
+        assert out["x"].values[0] == 1.0
+        assert np.isnan(out["x"].values[1])
+        assert out["x"].values[2] == 3.0
+
+    def test_skips_grid_mapping_container(self):
+        # A CF grid-mapping variable carries the sentinel-shaped grid info;
+        # we must not NaN-mask it just because some attr value matches.
+        sentinel = self._fill_f8()
+        ds = xr.Dataset(
+            {
+                "crs": xr.DataArray(
+                    np.float64(sentinel),  # absurd, but exercises the guard
+                    attrs={
+                        "grid_mapping_name": "latitude_longitude",
+                        "longitude_of_prime_meridian": 0.0,
+                    },
+                ),
+                "aet": (("nhm_id",), np.array([1.0, sentinel])),
+            },
+            coords={"nhm_id": [1, 2]},
+        )
+        out = mask_netcdf_default_fills(ds)
+        # crs untouched (grid mapping marker preserved); aet sentinel masked.
+        assert float(out["crs"].values) == sentinel
+        assert out["aet"].values[0] == 1.0
+        assert np.isnan(out["aet"].values[1])
+
+    def test_skips_integer_dtypes(self):
+        # Today we don't NaN-mask ints (no NaN equivalent for int); future
+        # work can substitute the project -9999 sentinel. The helper must
+        # at least not crash on int data vars.
+        ds = xr.Dataset(
+            {"n_sources": (("nhm_id",), np.array([0, 1, 2, 3], dtype="int8"))},
+            coords={"nhm_id": [1, 2, 3, 4]},
+        )
+        out = mask_netcdf_default_fills(ds)
+        np.testing.assert_array_equal(out["n_sources"].values, [0, 1, 2, 3])
+
+    def test_does_not_mutate_input(self):
+        sentinel = self._fill_f8()
+        arr = np.array([1.0, sentinel])
+        ds = xr.Dataset(
+            {"x": (("nhm_id",), arr)},
+            coords={"nhm_id": [1, 2]},
+        )
+        before = ds["x"].values.copy()
+        _ = mask_netcdf_default_fills(ds)
+        np.testing.assert_array_equal(ds["x"].values, before)
+
+    def test_atomic_write_decodes_to_nan_on_read(self, tmp_path):
+        """End-to-end: a Dataset with a sentinel cell, written via the
+        aggregator's atomic writer, round-trips through xarray decode as NaN —
+        proving the substitution + the io_nc encoding agree on disk."""
+        sentinel = self._fill_f8()
+        nc = tmp_path / "agg.nc"
+        ds = xr.Dataset(
+            {
+                "aet": (
+                    ("time", "nhm_id"),
+                    np.array([[1.0, sentinel]], dtype="float64"),
+                ),
+            },
+            coords={
+                "time": pd.date_range("2000-01-01", periods=1, freq="MS"),
+                "nhm_id": np.array([1, 2], dtype="int64"),
+            },
+        )
+        _atomic_write_netcdf(ds, nc, id_col="nhm_id", time_bounds_cadence="monthly")
+        rt = xr.open_dataset(nc)
+        try:
+            assert rt["aet"].values[0, 0] == 1.0
+            assert np.isnan(rt["aet"].values[0, 1])
+            # Encoding metadata declares NaN — invariant the helper preserves.
+            assert np.isnan(rt["aet"].encoding["_FillValue"])
+        finally:
+            rt.close()

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -1528,3 +1528,64 @@ def test_stitch_atomic_write_no_partial_on_failure(tmp_path: Path, monkeypatch):
     assert not leftover, f"tempfile leak: {leftover}"
     # restore (paranoia — monkeypatch undoes it but be explicit)
     monkeypatch.setattr(xr.Dataset, "to_netcdf", real_to_netcdf)
+
+
+# --- read_aggregated_source: netCDF default-fill masking (#204) -------------
+
+
+def test_read_aggregated_source_masks_netcdf_default_fill_cells(tmp_path: Path):
+    """An aggregated NC with gdptools' NC_FILL_DOUBLE sentinel cells decodes
+    as NaN through the reader, even when ``_FillValue=NaN`` is declared (the
+    pre-fix encoding mismatch that contaminated OR runoff/aet/swe before #204).
+    Mirrors the write-side fix; ensures existing on-disk NCs work without
+    rewrite.
+    """
+    from netCDF4 import default_fillvals
+
+    from nhf_spatial_targets.targets._common import read_aggregated_source
+
+    sentinel = default_fillvals["f8"]  # NC_FILL_DOUBLE == 9.969209968386869e+36
+
+    workdir = make_minimal_project(tmp_path)
+    src = "mwbm_climgrid"
+    var = "aet"
+    src_dir = workdir / "data" / "aggregated" / src
+    src_dir.mkdir(parents=True)
+
+    # One-year NC matching the broken-on-disk state: data carries the sentinel
+    # in some cells, encoding declares _FillValue=NaN (the bug shape — xarray
+    # would not mask it on decode without our reader-side helper).
+    times = pd.date_range("2000-01-01", periods=12, freq="MS")
+    hrus = np.array([10, 20, 30], dtype="int64")
+    data = np.full((12, 3), 25.0, dtype="float64")
+    data[:, 1] = sentinel  # HRU 20 is "outside coverage" — fill sentinel
+    ds = xr.Dataset(
+        {var: (("time", "nhm_id"), data)},
+        coords={"time": times, "nhm_id": hrus},
+    )
+    ds.to_netcdf(
+        src_dir / f"{src}_2000_agg.nc",
+        encoding={var: {"_FillValue": np.nan}},  # the pre-#204 declaration
+    )
+
+    # Confirm the file is in fact in the "broken" state before the reader
+    # touches it: data has sentinel, encoding declares NaN, xarray's own
+    # decode_cf does NOT mask the sentinel.
+    raw = xr.open_dataset(src_dir / f"{src}_2000_agg.nc")
+    try:
+        assert raw[var].values[0, 1] == sentinel
+        assert not np.isnan(raw[var].values[0, 1])
+    finally:
+        raw.close()
+
+    # Now exercise the reader — our mask_netcdf_default_fills call inside
+    # read_aggregated_source should convert the sentinel cells to NaN.
+    project = load(workdir)
+    da = read_aggregated_source(
+        project, src, var, period=("2000-01-01", "2000-12-31"), chunks={"time": 12}
+    )
+    vals = da.values
+    assert vals.shape == (12, 3)
+    assert np.all(vals[:, 0] == 25.0)
+    assert np.all(np.isnan(vals[:, 1]))  # the masked HRU
+    assert np.all(vals[:, 2] == 25.0)


### PR DESCRIPTION
## Summary

Closes #204. gdptools' \`AggGen\` writes \`NC_FILL_DOUBLE\` (== \`9.969209968386869e+36\`, per \`netCDF4.default_fillvals\`) into the in-memory array for HRUs whose geometry has no overlap with the source grid. Our writer policy in \`io_nc._fill_value_for\` declares \`_FillValue=NaN\` for floats, so on-disk cells held the sentinel while metadata claimed NaN. xarray's CF decode masks via value-equality and NaN never equals anything, so the sentinel survived as legitimate ~1e36 data and poisoned every multi-source \`np.fmax\` downstream.

Bug never fired on gfv2 (361k CONUS HRUs all fit inside every source's data extent). OR exposed it on 6 sources: mwbm_climgrid, era5_land_sd, gldas_noah_v21_monthly, margulis_wus_sr, nldas_mosaic, nldas_noah. \`aet_targets.nc\` / \`runoff_targets.nc\` / \`swe_targets.nc\` already on \`main\` are contaminated (lower_bound and upper_bound carry sentinel-shaped data).

## Why two boundaries

Fix is symmetric so existing OR aggregated NCs don't need a rebuild:

- **Write-side** (\`aggregate/_driver.py:_atomic_write_netcdf\`) — calls \`mask_netcdf_default_fills\` before write so **new** aggregated NCs are self-consistent on disk (data=NaN matching declared _FillValue=NaN).
- **Read-side** (\`targets/_common.py:read_aggregated_source\`) — calls it after load so **existing** on-disk NCs with the encoding mismatch decode correctly via the target builder — no rewrite of aggregated NCs.

## Approach

\`io_nc.mask_netcdf_default_fills(ds)\` is the new single-source helper. Per-dtype sentinel lookup via \`netCDF4.default_fillvals\` (the canonical NUG Annex A table — generalizes to \`f4\`/\`f8\`/\`i4\`/\`i2\`/... automatically; today only floats are substituted since the aggregated layer doesn't emit ints from gdptools). CF grid-mapping containers skip.

## Tests (8 added, all pass)

\`TestMaskNetcdfDefaultFills\` (7):
- substitutes float sentinel with NaN
- preserves legitimate finite data unchanged
- preserves pre-existing NaN cells (e.g. from \`pre_aggregate_hook\` fill masks)
- skips CF grid-mapping containers (\`crs\` etc.)
- skips integer dtypes (no NaN equivalent — leaves the int path obvious)
- does not mutate input dataset
- write + read round-trip through \`_atomic_write_netcdf\` decodes to NaN with \`_FillValue=NaN\` preserved

\`test_read_aggregated_source_masks_netcdf_default_fill_cells\` (1):
- end-to-end: writes a NC in the broken pre-fix state (data=sentinel, declared \`_FillValue=NaN\`), reads via \`read_aggregated_source\`, asserts the sentinel cell decodes as NaN. Proves existing on-disk NCs work without rewrite.

Smoke-tested live against actual \`/caldera/.../or-spatial-targets/data/aggregated/mwbm_climgrid/mwbm_climgrid_1979_agg.nc\` — 2232 contaminated cells per variable correctly mask to NaN, finite values preserved (0-453 mm/mo physical ranges).

## Test plan

- [x] \`pixi run -e dev fmt && pixi run -e dev lint\` clean
- [x] \`pixi run -e dev pytest tests/test_aggregate_driver.py::TestMaskNetcdfDefaultFills tests/test_targets_common.py::test_read_aggregated_source_masks_netcdf_default_fill_cells -v\` — 8 passed
- [ ] CI green on full suite
- [ ] After merge: operator re-runs \`run-aet\` / \`run-runoff\` / \`run-swe\` for OR; new target NCs lose the \`~1e34\` upper-bound contamination; figures re-render clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)