### PR TITLE
feat(targets): promote sca.py to MOD10C1 CI-bounded implementation (#210)

### DIFF
--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -10,23 +10,20 @@ from MOD10C1's native 0-100 integer scale to fractional [0, 1]:
     ci      = Day_CMG_Clear_Index / 100
 
 For each (HRU, day) where the HRU-mean clear index passes the configured
-threshold (``ci >= snow_covered_area.ci_threshold``, default 0.70 — same
-constant the Fortran hardcodes)::
+threshold (``ci >= snow_covered_area.ci_threshold``, default 0.70 — the
+fractional equivalent of the Fortran ``70.0`` on the native scale)::
 
     lower = ci * sca_obs
     upper = lower + (1 - ci)
 
-``upper`` is algebraically capped at 1.0 (sca_obs ∈ [0, 1], ci ∈ [0, 1]).
+``upper`` is algebraically capped at 1.0:
+``ci*sca + (1-ci) ≤ ci*1 + (1-ci) = 1`` for any ``sca`` in ``[0, 1]``.
 Cells whose HRU-mean CI is below threshold produce NaN bounds.
 
 July and August are forced to ``(lower, upper) = (0, 0)`` for every CI-
 passing HRU, again mirroring calcSCA. This is honest in the PNW where
 the snowpack is gone by July; it is questionable in deep-snowpack HRUs
-(Cascades high-elevation) where late-summer snow persists. The forcing
-is hardcoded here (rather than configurable) because it matches the
-calibration reference exactly — making it a knob is a follow-up if a
-future fabric needs it (a config-schema addition that would touch
-init_run, defaults, upgrade_config, and tests in lockstep per CLAUDE.md).
+(Cascades high-elevation) where late-summer snow persists.
 
 **Pre-pipeline gate vs. post-aggregation gate.** ``aggregate/mod10c1.py``
 already applies a *per-pixel* ``CI > 70`` gate inside
@@ -39,14 +36,26 @@ of a partly-cloudy day survived). Re-gating at HRU scale matches what
 ``calcSCA`` does with the per-HRU input it sees.
 
 **Single-source ``n_sources`` semantics.** With one source the
-``n_sources`` diagnostic is binary: 0 where the CI gate dropped the
-cell (either at pre-aggregation, leaving NaN snow, or at this stage),
-1 where a bound was produced. The shared write helper writes int8 with
-flag_values ``[0, 1]`` and flag_meanings ``"none one"``.
+``n_sources`` diagnostic is binary: 1 where a finite bound was produced
+(CI gate passed AND ``sca_obs`` is finite), 0 elsewhere. The shared
+write helper writes int8 with flag_values ``[0, 1]`` and flag_meanings
+``"none one"``.
 
 If ``snow_covered_area.nn_fill`` is True (default), a second file
 ``<output>_nn_filled.nc`` is written with NaN bounds filled by the
 nearest finite HRU's bound at the same day.
+
+.. warning::
+
+   Per-year intermediates under ``<project>/targets/.sca_intermediates/``
+   are keyed by year only — they are NOT fingerprinted by
+   ``ci_threshold`` or by the code version that wrote them. After
+   changing ``ci_threshold`` or after any change to this module that
+   alters the formula, ``rm -rf <project>/targets/.sca_intermediates/``
+   before re-running, otherwise stale intermediates will be silently
+   reused. The active ``ci_threshold`` is logged whenever the per-year
+   skip branch fires so operators can cross-check. Tracked for a
+   shared-with-SWE automatic fix in issue #213.
 """
 
 from __future__ import annotations
@@ -72,16 +81,21 @@ from nhf_spatial_targets.workspace import Project
 
 logger = logging.getLogger(__name__)
 
-# MOD10C1 v061 is the only source. The catalog key, on-disk aggregated
-# subdir, and per-year filename prefix all match this string.
 _MOD10C1_KEY = "mod10c1_v061"
 _SCA_VAR = "Day_CMG_Snow_Cover"
 _CI_VAR = "Day_CMG_Clear_Index"
 
-# July/August are hardcoded to a (0, 0) bound per PRMSobjfun.f90:calcSCA
-# lines 1056-1059. Captured as a constant so the global attr in the output
-# NC can name the months explicitly.
+# Captured as a constant so the output NC's global ``summer_zero_months``
+# attr can name the months explicitly. Matches PRMSobjfun.f90:calcSCA.
 _SUMMER_ZERO_MONTHS = (7, 8)
+
+# Operator-visible warning threshold: if fewer than this fraction of
+# (HRU, day) cells in a year produce a valid bound, the build emits a
+# WARNING with the actual fraction. Mirrors the per-year warning shape
+# in aggregate/mod10c1.py:_log_low_valid_coverage so an upstream
+# regression (all-NaN CI, fabric mismatch, fully-cloudy season) is
+# loud rather than silently producing an all-zero n_sources year.
+_LOW_VALID_WARN_FRACTION = 0.01
 
 
 def build(project: Project) -> None:
@@ -91,9 +105,8 @@ def build(project: Project) -> None:
     computes per-day bounds, and writes a per-year intermediate. The
     intermediates are then stitched into the canonical
     ``sca_targets.nc``. Year chunking bounds peak memory regardless of
-    period length — important for full-CONUS fabrics where the 25-year
-    daily build of two source variables would otherwise materialise
-    ~30 GB in one shot.
+    period length — for a multi-decade CONUS-scale daily build the
+    single-shot alternative would materialise O(10s of GB).
     """
     sca_cfg = project.target("snow_covered_area")
     if list(sca_cfg["sources"]) != [_MOD10C1_KEY]:
@@ -232,7 +245,19 @@ def _build_year(
     year_unfilled = intermediates_dir / f"sca_targets_{year}.nc"
     year_nn = intermediates_dir / f"sca_targets_{year}_nn_filled.nc"
     if year_unfilled.exists() and ((not nn_fill) or year_nn.exists()):
-        logger.info("Year %d intermediates exist; skipping", year)
+        # Intermediates are path-keyed only — not fingerprinted by
+        # ci_threshold or code version. Log the active threshold so an
+        # operator re-reading the run output can cross-check it against
+        # the file's global attrs (see module docstring warning).
+        logger.info(
+            "Year %d intermediates exist; skipping. Active ci_threshold=%.2f "
+            "— if it has changed since the intermediates were written, "
+            "rm %s/sca_targets_%d*.nc and re-run.",
+            year,
+            ci_threshold,
+            intermediates_dir,
+            year,
+        )
         return
 
     year_master_idx = pd.date_range(year_period[0], year_period[1], freq="D")
@@ -280,10 +305,31 @@ def _build_year(
     lower = xr.where(summer & valid, 0.0, lower)
     upper = xr.where(summer & valid, 0.0, upper)
 
-    # Single-source binary diagnostic: 1 where the bound is finite, 0
-    # otherwise. build_n_sources_attrs(1) → flag_values=[0, 1],
-    # flag_meanings="none one".
-    n_sources = valid.astype(np.int8)
+    # Single-source binary diagnostic: 1 where a FINITE bound was
+    # produced (CI gate passed AND sca_obs is finite), 0 elsewhere.
+    # ``valid`` alone would mis-flag the rare case where CI passed at
+    # HRU scale but the pre-aggregation per-pixel CI gate dropped every
+    # snow pixel — there the bound is NaN even though ``valid`` is True.
+    # build_n_sources_attrs(1) → flag_values=[0, 1], flag_meanings="none one".
+    valid_bound = valid & sca_obs.notnull()
+    n_sources = valid_bound.astype(np.int8)
+
+    # Operator-visible warning when an upstream regression or
+    # genuinely fully-cloudy season produces near-zero coverage for
+    # the year. Cheap single-scalar reduction; mirrors the per-year
+    # warning shape in aggregate/mod10c1.py:_log_low_valid_coverage.
+    frac_valid = float(valid_bound.mean().compute())
+    if frac_valid < _LOW_VALID_WARN_FRACTION:
+        logger.warning(
+            "sca year %d: only %.4f%% of (HRU, day) cells produced a "
+            "valid CI-passing bound (threshold for warning: %.2f%%). "
+            "Either the aggregated mod10c1 NC is degenerate for this year "
+            "or ci_threshold=%.2f is too strict.",
+            year,
+            frac_valid * 100,
+            _LOW_VALID_WARN_FRACTION * 100,
+            ci_threshold,
+        )
 
     write_bounds_target(
         project=project,

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -1,18 +1,307 @@
-"""Build snow-covered area calibration targets from MOD10C1."""
+"""Build snow-covered area calibration targets from MOD10C1 v061.
 
-# Sources:  mod10c1 (or v061)
-# Method:   modis_ci (CI-based bounds, threshold 70%)
-# Variable: snowcov_area
-# Timestep: daily
+Single-source CI-bounded build. The bound formula is taken verbatim from
+``PRMSobjfun.f90:calcSCA`` (`docs/references/PRMSobjfun.f90` lines
+1052-1061) — the original PRMS calibration objective function this
+pipeline's targets are designed to feed. Both inputs are first scaled
+from MOD10C1's native 0-100 integer scale to fractional [0, 1]:
+
+    sca_obs = Day_CMG_Snow_Cover / 100
+    ci      = Day_CMG_Clear_Index / 100
+
+For each (HRU, day) where the HRU-mean clear index passes the configured
+threshold (``ci >= snow_covered_area.ci_threshold``, default 0.70 — same
+constant the Fortran hardcodes)::
+
+    lower = ci * sca_obs
+    upper = lower + (1 - ci)
+
+``upper`` is algebraically capped at 1.0 (sca_obs ∈ [0, 1], ci ∈ [0, 1]).
+Cells whose HRU-mean CI is below threshold produce NaN bounds.
+
+July and August are forced to ``(lower, upper) = (0, 0)`` for every CI-
+passing HRU, again mirroring calcSCA. This is honest in the PNW where
+the snowpack is gone by July; it is questionable in deep-snowpack HRUs
+(Cascades high-elevation) where late-summer snow persists. The forcing
+is hardcoded here (rather than configurable) because it matches the
+calibration reference exactly — making it a knob is a follow-up if a
+future fabric needs it (a config-schema addition that would touch
+init_run, defaults, upgrade_config, and tests in lockstep per CLAUDE.md).
+
+**Pre-pipeline gate vs. post-aggregation gate.** ``aggregate/mod10c1.py``
+already applies a *per-pixel* ``CI > 70`` gate inside
+``pre_aggregate_hook`` — pixels with CI ≤ 70 are NaN'd before the
+area-weighted mean, then ``stat_method="masked_mean"`` averages only
+the survivors. The target-stage gate here is in addition: even when
+some pixels passed pre-aggregation, the resulting HRU-mean CI can drop
+below ``ci_threshold`` (e.g. an HRU where only the highest-CI fragment
+of a partly-cloudy day survived). Re-gating at HRU scale matches what
+``calcSCA`` does with the per-HRU input it sees.
+
+**Single-source ``n_sources`` semantics.** With one source the
+``n_sources`` diagnostic is binary: 0 where the CI gate dropped the
+cell (either at pre-aggregation, leaving NaN snow, or at this stage),
+1 where a bound was produced. The shared write helper writes int8 with
+flag_values ``[0, 1]`` and flag_meanings ``"none one"``.
+
+If ``snow_covered_area.nn_fill`` is True (default), a second file
+``<output>_nn_filled.nc`` is written with NaN bounds filled by the
+nearest finite HRU's bound at the same day.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from pathlib import Path
 
-if TYPE_CHECKING:
-    from nhf_spatial_targets.workspace import Project
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from nhf_spatial_targets.targets._common import (
+    check_hru_coords,
+    compute_hru_centroids,
+    iter_period_years,
+    parse_period,
+    read_aggregated_source,
+    reindex_to_day_start,
+    stitch_year_chunks_to_target,
+    write_bounds_target,
+)
+from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
+
+# MOD10C1 v061 is the only source. The catalog key, on-disk aggregated
+# subdir, and per-year filename prefix all match this string.
+_MOD10C1_KEY = "mod10c1_v061"
+_SCA_VAR = "Day_CMG_Snow_Cover"
+_CI_VAR = "Day_CMG_Clear_Index"
+
+# July/August are hardcoded to a (0, 0) bound per PRMSobjfun.f90:calcSCA
+# lines 1056-1059. Captured as a constant so the global attr in the output
+# NC can name the months explicitly.
+_SUMMER_ZERO_MONTHS = (7, 8)
 
 
-def build(project: "Project") -> None:
-    """Build SCA target dataset."""
-    raise NotImplementedError
+def build(project: Project) -> None:
+    """Build the SCA calibration target.
+
+    Year-chunked: each year reads its own slice of the aggregated NCs,
+    computes per-day bounds, and writes a per-year intermediate. The
+    intermediates are then stitched into the canonical
+    ``sca_targets.nc``. Year chunking bounds peak memory regardless of
+    period length — important for full-CONUS fabrics where the 25-year
+    daily build of two source variables would otherwise materialise
+    ~30 GB in one shot.
+    """
+    sca_cfg = project.target("snow_covered_area")
+    if list(sca_cfg["sources"]) != [_MOD10C1_KEY]:
+        raise ValueError(
+            f"snow_covered_area.sources={sca_cfg['sources']!r}; the "
+            f"modis_ci range method requires exactly one source: "
+            f"[{_MOD10C1_KEY!r}]. Adjust the project config."
+        )
+    period = parse_period(sca_cfg["period"])
+    ci_threshold = float(sca_cfg["ci_threshold"])
+    if not (0.0 <= ci_threshold <= 1.0):
+        raise ValueError(
+            f"snow_covered_area.ci_threshold={ci_threshold!r} must be in "
+            f"[0.0, 1.0] (fractional). The native-scale Fortran constant "
+            f"70 corresponds to 0.70 here."
+        )
+
+    logger.info(
+        "Building SCA target: source=%s, period=%s..%s, ci_threshold=%.2f, fabric=%s",
+        _MOD10C1_KEY,
+        period[0],
+        period[1],
+        ci_threshold,
+        project.config["fabric"]["path"],
+    )
+
+    hru_meta = compute_hru_centroids(project)
+    id_col = project.id_col
+    fabric_hru_ids = hru_meta.index.values
+
+    extra_attrs = {
+        "source": (
+            "MOD10C1 v061 Day_CMG_Snow_Cover + Day_CMG_Clear_Index "
+            "(CI-bounded per TM 6-B10 / PRMSobjfun.f90:calcSCA)"
+        ),
+        "references": (
+            "Hay et al. 2022, doi:10.3133/tm6B10; "
+            "PRMSobjfun.f90 calcSCA (docs/references/PRMSobjfun.f90)"
+        ),
+        "fabric": project.config["fabric"]["path"],
+        "fabric_sha256": project.fabric.get("sha256", ""),
+        "period": sca_cfg["period"],
+        "area_crs": project.area_crs,
+        "ci_threshold": ci_threshold,
+        "summer_zero_months": ",".join(str(m) for m in _SUMMER_ZERO_MONTHS),
+    }
+
+    year_specs = iter_period_years(period[0], period[1])
+    if not year_specs:
+        raise ValueError(
+            f"snow_covered_area.period {sca_cfg['period']} produces no years to build."
+        )
+
+    intermediates_dir = project.targets_dir() / ".sca_intermediates"
+    intermediates_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "Year-chunked build: %d years, intermediates -> %s "
+        "(retained after stitch for forensic value; rm to reclaim disk)",
+        len(year_specs),
+        intermediates_dir,
+    )
+
+    nn_fill = bool(sca_cfg["nn_fill"])
+    nn_max_candidates = int(sca_cfg["nn_max_candidates"])
+
+    for year, year_start, year_end in year_specs:
+        _build_year(
+            project=project,
+            year=year,
+            year_period=(year_start, year_end),
+            ci_threshold=ci_threshold,
+            hru_meta=hru_meta,
+            fabric_hru_ids=fabric_hru_ids,
+            id_col=id_col,
+            extra_attrs=extra_attrs,
+            intermediates_dir=intermediates_dir,
+            nn_fill=nn_fill,
+            nn_max_candidates=nn_max_candidates,
+        )
+
+    output_path = project.targets_dir() / sca_cfg["output_file"]
+    unfilled_files = sorted(
+        intermediates_dir.glob("sca_targets_[0-9][0-9][0-9][0-9].nc")
+    )
+    stitch_year_chunks_to_target(
+        unfilled_files,
+        output_path,
+        title=(
+            "NHM SCA calibration target (CI-bounded fractional 0-1; "
+            "lower/upper from MOD10C1 v061)"
+        ),
+        extra_global_attrs=extra_attrs,
+        sort_dim=id_col,
+    )
+
+    if nn_fill:
+        nn_files = sorted(
+            intermediates_dir.glob("sca_targets_[0-9][0-9][0-9][0-9]_nn_filled.nc")
+        )
+        nn_path = output_path.with_name(
+            output_path.stem + "_nn_filled" + output_path.suffix
+        )
+        nn_attrs = dict(extra_attrs)
+        nn_attrs["nn_fill_max_candidates"] = nn_max_candidates
+        nn_attrs["nn_fill_distance_crs"] = project.area_crs
+        stitch_year_chunks_to_target(
+            nn_files,
+            nn_path,
+            title=("NHM SCA calibration target (NN-filled, fractional 0-1)"),
+            extra_global_attrs=nn_attrs,
+            sort_dim=id_col,
+        )
+
+
+def _build_year(
+    *,
+    project: Project,
+    year: int,
+    year_period: tuple[str, str],
+    ci_threshold: float,
+    hru_meta: pd.DataFrame,
+    fabric_hru_ids: np.ndarray,
+    id_col: str,
+    extra_attrs: dict,
+    intermediates_dir: Path,
+    nn_fill: bool,
+    nn_max_candidates: int,
+) -> None:
+    """Build SCA bounds for one calendar year and write per-year NCs.
+
+    Idempotent: if both expected per-year NCs already exist
+    (``sca_targets_<year>.nc`` and, when ``nn_fill``,
+    ``sca_targets_<year>_nn_filled.nc``), the build is skipped — useful
+    when re-running after a partial OOM mid-period.
+    """
+    year_unfilled = intermediates_dir / f"sca_targets_{year}.nc"
+    year_nn = intermediates_dir / f"sca_targets_{year}_nn_filled.nc"
+    if year_unfilled.exists() and ((not nn_fill) or year_nn.exists()):
+        logger.info("Year %d intermediates exist; skipping", year)
+        return
+
+    year_master_idx = pd.date_range(year_period[0], year_period[1], freq="D")
+    if len(year_master_idx) == 0:
+        raise ValueError(
+            f"Year {year}: empty master index from period {year_period!r}."
+        )
+
+    # Read both vars from the same aggregated source. Chunk the time dim
+    # to the year length so a single read per file fills one dask chunk.
+    snow_native = read_aggregated_source(
+        project,
+        _MOD10C1_KEY,
+        _SCA_VAR,
+        year_period,
+        chunks={"time": 366, id_col: -1},
+    )
+    ci_native = read_aggregated_source(
+        project,
+        _MOD10C1_KEY,
+        _CI_VAR,
+        year_period,
+        chunks={"time": 366, id_col: -1},
+    )
+    check_hru_coords(snow_native, fabric_hru_ids, id_col, _MOD10C1_KEY)
+    check_hru_coords(ci_native, fabric_hru_ids, id_col, _MOD10C1_KEY)
+
+    # Scale to fractional [0, 1] (catalog/variables.yml:snow_covered_area
+    # units = "fraction (0-1)") and reindex onto the canonical day-start
+    # master index so days missing from the source contribute NaN.
+    sca_obs = reindex_to_day_start(snow_native / 100.0, year_master_idx)
+    ci = reindex_to_day_start(ci_native / 100.0, year_master_idx)
+
+    # HRU-mean CI gate. NaN ci compares False so already-pre-gated NaN
+    # days correctly fall through to NaN bounds.
+    valid = ci >= ci_threshold
+    lower = xr.where(valid, ci * sca_obs, np.nan)
+    upper = xr.where(valid, lower + (1.0 - ci), np.nan)
+
+    # July/August force to (0, 0) per calcSCA. Applied only where the
+    # CI gate passed — invalid days stay NaN, not zero, so downstream
+    # consumers can still distinguish "no observation" from "observed
+    # bare ground."
+    summer = lower["time"].dt.month.isin(list(_SUMMER_ZERO_MONTHS))
+    lower = xr.where(summer & valid, 0.0, lower)
+    upper = xr.where(summer & valid, 0.0, upper)
+
+    # Single-source binary diagnostic: 1 where the bound is finite, 0
+    # otherwise. build_n_sources_attrs(1) → flag_values=[0, 1],
+    # flag_meanings="none one".
+    n_sources = valid.astype(np.int8)
+
+    write_bounds_target(
+        project=project,
+        lower=lower,
+        upper=upper,
+        n_sources=n_sources,
+        n_sources_count=1,
+        time_index=year_master_idx,
+        time_offset_unit=pd.offsets.Day(1),
+        bounds_units="1",
+        bounds_long_name_kind="daily fractional snow-covered area",
+        cell_methods="time: point",
+        output_path=year_unfilled,
+        title=f"NHM SCA calibration target year {year} (intermediate)",
+        nn_title=(f"NHM SCA calibration target year {year} (NN-filled intermediate)"),
+        extra_global_attrs={**extra_attrs, "year_chunk": year},
+        hru_meta=hru_meta,
+        nn_fill=nn_fill,
+        nn_max_candidates=nn_max_candidates,
+        id_col=id_col,
+    )

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -91,10 +91,18 @@ _SUMMER_ZERO_MONTHS = (7, 8)
 
 # Operator-visible warning threshold: if fewer than this fraction of
 # (HRU, day) cells in a year produce a valid bound, the build emits a
-# WARNING with the actual fraction. Mirrors the per-year warning shape
-# in aggregate/mod10c1.py:_log_low_valid_coverage so an upstream
-# regression (all-NaN CI, fabric mismatch, fully-cloudy season) is
-# loud rather than silently producing an all-zero n_sources year.
+# WARNING with the actual fraction. Catches all-NaN CI, fabric mismatch,
+# and fully-cloudy-season cases that would otherwise silently produce an
+# all-zero n_sources year.
+#
+# 1% (not the 10% threshold at ``aggregate/mod10c1.py:_LOW_COVERAGE_WARN_THRESHOLD``)
+# because the two count different things: the aggregator's 10% counts
+# zero-valid-area cells (a per-pixel HRU-coverage statistic), while this
+# 1% counts surviving finite bounds (the downstream target's usable
+# product). A healthy MOD10C1 year clears 1% trivially even in heavily
+# clouded regions where the aggregator's HRU-coverage already sits near
+# the 10% warn line — so the two thresholds are intentionally calibrated
+# to fire on different failure classes, not redundantly on the same one.
 _LOW_VALID_WARN_FRACTION = 0.01
 
 
@@ -246,13 +254,16 @@ def _build_year(
     year_nn = intermediates_dir / f"sca_targets_{year}_nn_filled.nc"
     if year_unfilled.exists() and ((not nn_fill) or year_nn.exists()):
         # Intermediates are path-keyed only — not fingerprinted by
-        # ci_threshold or code version. Log the active threshold so an
-        # operator re-reading the run output can cross-check it against
-        # the file's global attrs (see module docstring warning).
+        # ci_threshold, sources list, code version, or any other config.
+        # Log the active threshold so an operator re-reading the run
+        # output can cross-check it against the file's global attrs
+        # (see module docstring warning). Tracked for an automatic
+        # cross-target fix in #213.
         logger.info(
-            "Year %d intermediates exist; skipping. Active ci_threshold=%.2f "
-            "— if it has changed since the intermediates were written, "
-            "rm %s/sca_targets_%d*.nc and re-run.",
+            "Year %d intermediates exist; skipping. Active ci_threshold=%.2f. "
+            "Any change to sca config or to the builder module since the "
+            "intermediates were written invalidates them — "
+            "rm %s/sca_targets_%d*.nc and re-run if so.",
             year,
             ci_threshold,
             intermediates_dir,
@@ -307,9 +318,13 @@ def _build_year(
 
     # Single-source binary diagnostic: 1 where a FINITE bound was
     # produced (CI gate passed AND sca_obs is finite), 0 elsewhere.
-    # ``valid`` alone would mis-flag the rare case where CI passed at
-    # HRU scale but the pre-aggregation per-pixel CI gate dropped every
-    # snow pixel — there the bound is NaN even though ``valid`` is True.
+    # ``valid`` alone would mis-flag the case where a small set of
+    # high-CI pixels lifts the area-weighted CI mean above threshold
+    # while the snow variable's per-pixel mask (``aggregate/mod10c1.py``
+    # ``stat_method="masked_mean"`` after the strict ``CI > 70`` gate)
+    # had already annihilated coverage — there the bound is NaN even
+    # though ``valid`` is True. Guarded by
+    # ``test_n_sources_contract_when_ci_passes_but_snow_nan``.
     # build_n_sources_attrs(1) → flag_values=[0, 1], flag_meanings="none one".
     valid_bound = valid & sca_obs.notnull()
     n_sources = valid_bound.astype(np.int8)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,13 +145,14 @@ def test_run_skips_not_implemented_targets(tmp_path, capsys):
     assert "WARNING" in err and "aet" in err and "skipping" in err
 
 
-def test_run_sca_target_routes_to_stub_and_skips(tmp_path, capsys):
-    """SCA routes through the real _dispatch to the sca stub and is skipped.
+def test_run_sca_target_dispatches(tmp_path):
+    """--target snow_covered_area routes to the sca builder via _dispatch.
 
-    Exercises the builders-dict entry without mocking _dispatch, so a
-    mis-keyed registration would surface as an exit-1 crash here. SCA
-    is the last remaining target stub (PRMSobjfun.f CI-bounds formula
-    unconfirmed — see CLAUDE.md "Known Gaps").
+    Mirrors test_run_single_target's pattern: mock _dispatch so a
+    mis-keyed registration in the builders dict would surface as an
+    AssertionError on the first-positional check. The real builder is
+    not invoked here (it needs a full fabric fixture); end-to-end SCA
+    behavior is covered in tests/test_targets_sca.py.
     """
     workdir = _make_minimal_project(
         tmp_path,
@@ -161,10 +162,15 @@ def test_run_sca_target_routes_to_stub_and_skips(tmp_path, capsys):
         "    period: 2000-01-01/2010-12-31\n",
     )
 
-    _run("run", "--project-dir", str(workdir), "--target", "snow_covered_area")
+    with patch("nhf_spatial_targets.cli._dispatch") as mock_dispatch:
+        _run("run", "--project-dir", str(workdir), "--target", "snow_covered_area")
 
-    err = capsys.readouterr().err
-    assert "WARNING" in err and "snow_covered_area" in err and "skipping" in err
+    mock_dispatch.assert_called_once()
+    args = mock_dispatch.call_args[0]
+    assert args[0] == "snow_covered_area"
+    from nhf_spatial_targets.workspace import Project
+
+    assert isinstance(args[1], Project)
 
 
 # ---- init command ----------------------------------------------------------

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -439,10 +439,13 @@ def test_idempotent_skip_existing_year(tmp_path: Path, caplog):
     workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
     project = load(workdir)
     build(project)
-    # Second build: intermediates exist; should log "skipping".
+    # Second build: intermediates exist; should log "skipping" AND
+    # name the active ci_threshold so a re-running operator can
+    # cross-check against the cached value (#213 follow-up).
     with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     assert "skipping" in caplog.text
+    assert "ci_threshold=0.70" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -506,6 +509,10 @@ def test_heterogeneous_ci_across_hrus(tmp_path: Path):
     project = load(workdir)
     build(project)
     with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        # Explicit time-dim sanity: a single-day period must produce
+        # exactly one time step on disk (catches a regression where the
+        # period filter silently collapses or drops the dim).
+        assert ds.sizes["time"] == 1
         # HRU 1: ci=0.90, sca=0.60 → lower=0.54, upper=0.64
         np.testing.assert_allclose(
             ds["lower_bound"].sel(nhm_id=1).values, 0.54, rtol=1e-5
@@ -582,9 +589,15 @@ def test_n_sources_value_set_is_zero_or_one(tmp_path: Path):
 def test_nn_fill_companion_actually_fills_nan_cells(tmp_path: Path):
     """The ``_nn_filled.nc`` companion replaces NaN bounds with neighbor values.
 
-    HRU 1 has a finite bound, HRU 2 has NaN (CI < threshold). The NN
-    fill should propagate HRU 1's bound to HRU 2 in the companion file,
-    while the unfilled file retains HRU 2's NaN.
+    HRU 1 and HRU 3 have finite bounds; HRU 2 has NaN (CI < threshold).
+    The NN fill should propagate a neighbor's bound to HRU 2 in the
+    companion file, while the unfilled file retains HRU 2's NaN.
+
+    The fabric in ``_write_synthetic_fabric`` places HRUs 1 and 3 as
+    equidistant neighbors of HRU 2; both donors carry ``lower=0.54``,
+    so the asserted value is tie-safe by construction — the cKDTree
+    donor walk in ``normalize/methods.py:nn_fill_bounds`` may pick
+    either, but both produce the same result.
     """
     from nhf_spatial_targets.targets.sca import build
     from nhf_spatial_targets.workspace import load
@@ -700,11 +713,13 @@ def test_idempotent_skip_with_nn_fill(tmp_path: Path, caplog):
     workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-15", nn_fill=True)
     project = load(workdir)
     build(project)
-    # Second build with both intermediates present → skip.
+    # Second build with both intermediates present → skip, naming the
+    # active ci_threshold so a re-running operator can cross-check.
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     assert "skipping" in caplog.text
+    assert "ci_threshold=0.70" in caplog.text
     # Delete only the nn intermediate; the predicate must fall through
     # and re-do the year (which regenerates the nn file).
     nn_intermediate = (
@@ -737,8 +752,11 @@ def test_missing_aggregated_file_surfaces_clear_error(tmp_path: Path):
     for nc in agg_dir.glob("*.nc"):
         nc.unlink()
     project = load(workdir)
-    with pytest.raises(FileNotFoundError, match="mod10c1_v061"):
+    # The error must name the source key AND the corrective ``agg``
+    # command so the operator can act on the message directly.
+    with pytest.raises(FileNotFoundError, match="mod10c1_v061") as exc_info:
         build(project)
+    assert "agg" in str(exc_info.value)
 
 
 def test_hru_coord_mismatch_surfaces_clear_error(tmp_path: Path):
@@ -794,3 +812,59 @@ def test_low_valid_coverage_emits_warning(tmp_path: Path, caplog):
     with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     assert any("valid CI-passing bound" in r.message for r in caplog.records)
+
+
+def test_healthy_coverage_does_not_emit_warning(tmp_path: Path, caplog):
+    """Negative-case guard: a healthy year (all-passing CI) must NOT log
+    the low-coverage warning. Without this, a refactor that inverted the
+    comparison (``>`` instead of ``<``) or dropped the threshold guard
+    would flip the warning into an always-on fire and still pass the
+    positive-case test above."""
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-01/2005-03-31",
+        snow_native=60.0,
+        ci_native=90.0,  # fully above threshold for the whole year
+    )
+    project = load(workdir)
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert not any("valid CI-passing bound" in r.message for r in caplog.records)
+
+
+def test_low_valid_coverage_partial_pass_no_warning(tmp_path: Path, caplog):
+    """The warning predicate is strict ``<`` against ``_LOW_VALID_WARN_FRACTION``
+    (0.01). 1/3 of HRUs passing on every day produces ~33% coverage —
+    well above 1% — so the warning must NOT fire. Catches an off-by-one
+    boundary regression (``>`` for ``<``) that would silently flip the
+    warning to fire on every healthy year.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # 1/3 HRUs pass on every day → frac_valid ≈ 0.33, well above 0.01.
+    ci = np.array([[90.0, 50.0, 50.0]], dtype=np.float32)
+    snow = np.array([[60.0, 60.0, 60.0]], dtype=np.float32)
+    times_per_year = pd.date_range("2005-01-01", "2005-12-31", freq="D")
+    ci_full = np.tile(ci, (len(times_per_year), 1))
+    snow_full = np.tile(snow, (len(times_per_year), 1))
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-01/2005-03-31",
+        snow_native=snow_full,
+        ci_native=ci_full,
+    )
+    project = load(workdir)
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert not any("valid CI-passing bound" in r.message for r in caplog.records), (
+        "1/3 coverage should clear the 1% threshold without warning"
+    )

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -468,3 +468,329 @@ def test_upper_bound_never_exceeds_one(tmp_path: Path):
         np.testing.assert_allclose(ds["lower_bound"].values, 0.70, rtol=1e-5)
         np.testing.assert_allclose(ds["upper_bound"].values, 1.00, rtol=1e-5)
         assert (ds["upper_bound"].values <= 1.0 + 1e-6).all()
+
+
+# ---------------------------------------------------------------------------
+# Heterogeneous coverage: mixed CI across HRUs in a single build
+# ---------------------------------------------------------------------------
+
+
+def test_heterogeneous_ci_across_hrus(tmp_path: Path):
+    """One day, three HRUs with different CI/snow values.
+
+    Exercises the dim-broadcasting path that scalar-fill tests skip:
+    HRU 1 has passing CI, HRU 2 has failing CI, HRU 3 has NaN CI from
+    upstream (the pre-aggregation gate dropped every pixel). Verifies
+    per-HRU outcomes differ correctly in a single open.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # (time=1, hru=3) arrays: HRU 1 = passing CI, HRU 2 = failing,
+    # HRU 3 = NaN CI from upstream.
+    snow = np.array([[60.0, 60.0, np.nan]], dtype=np.float32)
+    ci = np.array([[90.0, 50.0, np.nan]], dtype=np.float32)
+    # Single-day window: _write_mod10c1_year writes a full year, so we
+    # rely on the broadcaster to fill all 365 days with the same row.
+    # Reshape arrays to a full-year shape.
+    times_per_year = pd.date_range("2005-01-01", "2005-12-31", freq="D")
+    snow_full = np.tile(snow, (len(times_per_year), 1))
+    ci_full = np.tile(ci, (len(times_per_year), 1))
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=snow_full,
+        ci_native=ci_full,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        # HRU 1: ci=0.90, sca=0.60 → lower=0.54, upper=0.64
+        np.testing.assert_allclose(
+            ds["lower_bound"].sel(nhm_id=1).values, 0.54, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            ds["upper_bound"].sel(nhm_id=1).values, 0.64, rtol=1e-5
+        )
+        assert ds["n_sources"].sel(nhm_id=1).values == 1
+        # HRU 2: ci=0.50 < threshold → NaN bounds, n_sources=0
+        assert np.isnan(ds["lower_bound"].sel(nhm_id=2).values).all()
+        assert np.isnan(ds["upper_bound"].sel(nhm_id=2).values).all()
+        assert ds["n_sources"].sel(nhm_id=2).values == 0
+        # HRU 3: NaN CI → NaN bounds, n_sources=0
+        assert np.isnan(ds["lower_bound"].sel(nhm_id=3).values).all()
+        assert np.isnan(ds["upper_bound"].sel(nhm_id=3).values).all()
+        assert ds["n_sources"].sel(nhm_id=3).values == 0
+
+
+def test_n_sources_contract_when_ci_passes_but_snow_nan(tmp_path: Path):
+    """CI passes at HRU scale but snow is NaN (pre-agg gate killed pixels).
+
+    The n_sources contract is "1 = a finite bound was produced." Without
+    the ``valid & sca_obs.notnull()`` guard, this scenario would write
+    n_sources=1 with a NaN bound — a contract violation.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=np.nan,
+        ci_native=90.0,  # CI gate passes
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert np.isnan(ds["lower_bound"].values).all()
+        assert np.isnan(ds["upper_bound"].values).all()
+        # Critical: n_sources must be 0, not 1 — no finite bound exists.
+        assert (ds["n_sources"].values == 0).all()
+
+
+def test_n_sources_value_set_is_zero_or_one(tmp_path: Path):
+    """Defensive: n_sources values are exactly {0, 1} on disk, no sentinel."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # Mixed scenario to cover both values.
+    ci = np.array([[90.0, 50.0, 80.0]], dtype=np.float32)
+    snow = np.array([[60.0, 60.0, 70.0]], dtype=np.float32)
+    times_per_year = pd.date_range("2005-01-01", "2005-12-31", freq="D")
+    snow_full = np.tile(snow, (len(times_per_year), 1))
+    ci_full = np.tile(ci, (len(times_per_year), 1))
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=snow_full,
+        ci_native=ci_full,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        unique_vals = set(np.unique(ds["n_sources"].values).tolist())
+        assert unique_vals <= {0, 1}, f"unexpected n_sources values: {unique_vals}"
+
+
+# ---------------------------------------------------------------------------
+# NN-fill companion content (not just file existence)
+# ---------------------------------------------------------------------------
+
+
+def test_nn_fill_companion_actually_fills_nan_cells(tmp_path: Path):
+    """The ``_nn_filled.nc`` companion replaces NaN bounds with neighbor values.
+
+    HRU 1 has a finite bound, HRU 2 has NaN (CI < threshold). The NN
+    fill should propagate HRU 1's bound to HRU 2 in the companion file,
+    while the unfilled file retains HRU 2's NaN.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    snow = np.array([[60.0, 60.0, 60.0]], dtype=np.float32)
+    ci = np.array([[90.0, 50.0, 90.0]], dtype=np.float32)  # HRU 2 fails gate
+    times_per_year = pd.date_range("2005-01-01", "2005-12-31", freq="D")
+    snow_full = np.tile(snow, (len(times_per_year), 1))
+    ci_full = np.tile(ci, (len(times_per_year), 1))
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=snow_full,
+        ci_native=ci_full,
+        nn_fill=True,
+    )
+    project = load(workdir)
+    build(project)
+    # Unfilled: HRU 2 still NaN.
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert np.isnan(ds["lower_bound"].sel(nhm_id=2).values).all()
+    # NN-filled: HRU 2 picks up a finite value from a neighbor (HRU 1
+    # or HRU 3, both with lower=0.54).
+    with xr.open_dataset(project.targets_dir() / "sca_targets_nn_filled.nc") as ds:
+        filled = ds["lower_bound"].sel(nhm_id=2).values
+        assert not np.isnan(filled).any(), "NN-fill should have replaced NaN"
+        np.testing.assert_allclose(filled, 0.54, rtol=1e-5)
+        # nn_filled flag variable should record HRU 2 as filled.
+        assert "nn_filled" in ds.variables
+        assert ds["nn_filled"].sel(nhm_id=2).values.any()
+
+
+# ---------------------------------------------------------------------------
+# Period spanning July/August boundary
+# ---------------------------------------------------------------------------
+
+
+def test_period_spanning_summer_boundary(tmp_path: Path):
+    """A multi-month period exercises the time-aware xor between summer
+    zero-forcing and the formula across month boundaries within one
+    per-year NC. Catches off-by-one or wrong-dim broadcasts that
+    single-day periods can't reach.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-06-28/2005-08-03",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        # June 28-30 (3 days): formula values (lower=0.54, upper=0.64).
+        june_slice = ds.sel(time=slice("2005-06-28", "2005-06-30"))
+        np.testing.assert_allclose(june_slice["lower_bound"].values, 0.54, rtol=1e-5)
+        np.testing.assert_allclose(june_slice["upper_bound"].values, 0.64, rtol=1e-5)
+        # July (31 days) + August 1-3 (3 days): forced to zero.
+        zero_slice = ds.sel(time=slice("2005-07-01", "2005-08-03"))
+        assert (zero_slice["lower_bound"].values == 0.0).all()
+        assert (zero_slice["upper_bound"].values == 0.0).all()
+        # n_sources stays 1 throughout — zero is the bound value, not a flag.
+        assert (ds["n_sources"].values == 1).all()
+
+
+# ---------------------------------------------------------------------------
+# Multi-year stitch continuity
+# ---------------------------------------------------------------------------
+
+
+def test_multi_year_stitch_is_continuous_and_sorted(tmp_path: Path):
+    """A period crossing Dec 31/Jan 1 must stitch with no gap, duplicate,
+    or time-coord reorder, and HRU axis stays sorted ascending."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-12-28/2006-01-05")
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        times = pd.DatetimeIndex(ds["time"].values)
+        # 9 consecutive days across the year boundary.
+        assert len(times) == 9
+        assert times[0] == pd.Timestamp("2005-12-28")
+        assert times[-1] == pd.Timestamp("2006-01-05")
+        # Time monotonic increasing.
+        assert (
+            np.diff(times.values).astype("timedelta64[D]") == np.timedelta64(1, "D")
+        ).all()
+        # HRU axis sorted ascending by id_col (issue #93 invariant).
+        hrus = ds["nhm_id"].values
+        assert (np.diff(hrus) > 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Idempotent skip with nn_fill=True
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_skip_with_nn_fill(tmp_path: Path, caplog):
+    """The compound skip predicate has two branches; the nn_fill=True
+    branch is exercised here. A second build with both intermediates
+    present must log "skipping"; if only the nn intermediate is missing,
+    the year must rebuild."""
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-15", nn_fill=True)
+    project = load(workdir)
+    build(project)
+    # Second build with both intermediates present → skip.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert "skipping" in caplog.text
+    # Delete only the nn intermediate; the predicate must fall through
+    # and re-do the year (which regenerates the nn file).
+    nn_intermediate = (
+        project.targets_dir() / ".sca_intermediates" / "sca_targets_2005_nn_filled.nc"
+    )
+    nn_intermediate.unlink()
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert "skipping" not in caplog.text
+    assert nn_intermediate.exists()
+
+
+# ---------------------------------------------------------------------------
+# Failure-path clarity
+# ---------------------------------------------------------------------------
+
+
+def test_missing_aggregated_file_surfaces_clear_error(tmp_path: Path):
+    """If MOD10C1 aggregated NCs are missing, the build raises with a
+    message that names the source key and points the operator at the
+    right ``agg`` command."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # _make_sca_project writes the aggregated NCs; delete them to
+    # simulate a project with no mod10c1 aggregation yet.
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
+    agg_dir = workdir / "data" / "aggregated" / "mod10c1_v061"
+    for nc in agg_dir.glob("*.nc"):
+        nc.unlink()
+    project = load(workdir)
+    with pytest.raises(FileNotFoundError, match="mod10c1_v061"):
+        build(project)
+
+
+def test_hru_coord_mismatch_surfaces_clear_error(tmp_path: Path):
+    """An aggregated NC built against a different HRU set must fail
+    loudly via check_hru_coords rather than silently mis-aligning."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
+    # Rewrite the 2005 aggregated NC with a different HRU set (1, 2, 4
+    # instead of 1, 2, 3).
+    nc_path = (
+        workdir / "data" / "aggregated" / "mod10c1_v061" / "mod10c1_v061_2005_agg.nc"
+    )
+    times = pd.date_range("2005-01-01", "2005-12-31", freq="D")
+    bad_hrus = [1, 2, 4]
+    snow = np.full((len(times), len(bad_hrus)), 60.0, dtype=np.float32)
+    ci = np.full((len(times), len(bad_hrus)), 90.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (("time", "nhm_id"), snow),
+            "Day_CMG_Clear_Index": (("time", "nhm_id"), ci),
+        },
+        coords={"time": times, "nhm_id": bad_hrus},
+    )
+    nc_path.unlink()
+    ds.to_netcdf(nc_path)
+    project = load(workdir)
+    with pytest.raises(ValueError, match="HRU coords"):
+        build(project)
+
+
+# ---------------------------------------------------------------------------
+# Operator-visible low-coverage warning
+# ---------------------------------------------------------------------------
+
+
+def test_low_valid_coverage_emits_warning(tmp_path: Path, caplog):
+    """A year with ~zero passing CI logs a WARNING (mirrors the per-year
+    warning in aggregate/mod10c1.py:_log_low_valid_coverage)."""
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-01/2005-03-31",
+        snow_native=60.0,
+        ci_native=10.0,  # fully below threshold for the whole year
+    )
+    project = load(workdir)
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert any("valid CI-passing bound" in r.message for r in caplog.records)

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -1,0 +1,470 @@
+"""Tests for the SCA target builder end-to-end.
+
+Covers the CI-bounded formula from ``PRMSobjfun.f90:calcSCA``:
+
+  - ``ci >= ci_threshold`` gate (HRU-mean CI, in addition to the
+    per-pixel CI > 70 gate already applied at aggregation time);
+  - ``lower = ci * sca_obs``, ``upper = lower + (1 - ci)`` (both inputs
+    on fractional [0, 1] after /100);
+  - July/August forced to ``(0, 0)`` wherever the CI gate passes;
+  - single-source ``n_sources`` binary diagnostic (1 = valid, 0 = NaN).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import yaml
+
+
+def _write_synthetic_fabric(path: Path, id_col: str = "nhm_id") -> None:
+    import geopandas as gpd
+    from shapely.geometry import box
+
+    gdf = gpd.GeoDataFrame(
+        {id_col: [1, 2, 3]},
+        geometry=[
+            box(-122.0, 44.0, -121.9, 44.1),
+            box(-121.9, 44.0, -121.8, 44.1),
+            box(-121.8, 44.0, -121.7, 44.1),
+        ],
+        crs="EPSG:4326",
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    gdf.to_file(path, driver="GPKG")
+
+
+def _write_mod10c1_year(
+    path: Path,
+    year: int,
+    *,
+    snow_native: float | np.ndarray,
+    ci_native: float | np.ndarray,
+    id_col: str = "nhm_id",
+) -> None:
+    """Write a per-year MOD10C1 aggregated NC.
+
+    Values are in MOD10C1's native 0-100 integer scale ("percent");
+    builder divides by 100 to fractional [0, 1]. Scalars broadcast over
+    (time, hru); arrays must already be (time, hru)-shaped.
+    """
+    times = pd.date_range(f"{year}-01-01", f"{year}-12-31", freq="D")
+    hrus = [1, 2, 3]
+    if np.isscalar(snow_native):
+        snow_arr = np.full((len(times), len(hrus)), snow_native, dtype=np.float32)
+    else:
+        snow_arr = np.asarray(snow_native, dtype=np.float32)
+    if np.isscalar(ci_native):
+        ci_arr = np.full((len(times), len(hrus)), ci_native, dtype=np.float32)
+    else:
+        ci_arr = np.asarray(ci_native, dtype=np.float32)
+    ds = xr.Dataset(
+        {
+            "Day_CMG_Snow_Cover": (("time", id_col), snow_arr),
+            "Day_CMG_Clear_Index": (("time", id_col), ci_arr),
+        },
+        coords={"time": times, id_col: hrus},
+    )
+    ds["Day_CMG_Snow_Cover"].attrs["units"] = "percent"
+    ds["Day_CMG_Clear_Index"].attrs["units"] = "percent"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def _make_sca_project(
+    tmp_path: Path,
+    *,
+    period: str = "2005-01-01/2005-12-31",
+    ci_threshold: float = 0.70,
+    nn_fill: bool = False,
+    snow_native: float | np.ndarray = 60.0,
+    ci_native: float | np.ndarray = 90.0,
+) -> Path:
+    """Build a project skeleton with synthetic fabric + MOD10C1 NCs.
+
+    Default values: snow=60% (sca_obs=0.60), ci=90% (ci=0.90), passing
+    threshold. Override for gate / July-Aug / NaN-coverage scenarios.
+    """
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    fabric_path = tmp_path / "fabric.gpkg"
+    _write_synthetic_fabric(fabric_path)
+    (workdir / "fabric.json").write_text(json.dumps({"id_col": "nhm_id"}))
+
+    cfg = {
+        "datastore": str(tmp_path / "store"),
+        "fabric": {"path": str(fabric_path), "id_col": "nhm_id", "token": "or"},
+        "targets": {
+            "snow_covered_area": {
+                "period": period,
+                "ci_threshold": ci_threshold,
+                "nn_fill": nn_fill,
+            },
+            "runoff": {"enabled": False},
+            "aet": {"enabled": False},
+            "recharge": {"enabled": False},
+            "soil_moisture": {"enabled": False},
+            "snow_water_equivalent": {"enabled": False},
+        },
+    }
+    (workdir / "config.yml").write_text(yaml.safe_dump(cfg))
+
+    agg_dir = workdir / "data" / "aggregated" / "mod10c1_v061"
+    years = list(
+        range(
+            pd.Timestamp(period.split("/")[0]).year,
+            pd.Timestamp(period.split("/")[1]).year + 1,
+        )
+    )
+    for year in years:
+        _write_mod10c1_year(
+            agg_dir / f"mod10c1_v061_{year}_agg.nc",
+            year,
+            snow_native=snow_native,
+            ci_native=ci_native,
+        )
+    return workdir
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_build_rejects_multi_source_config(tmp_path: Path):
+    """The modis_ci range method requires exactly mod10c1_v061."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path)
+    cfg_path = workdir / "config.yml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["targets"]["snow_covered_area"]["sources"] = [
+        "mod10c1_v061",
+        "some_other_source",
+    ]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    project = load(workdir)
+    with pytest.raises(ValueError, match="modis_ci range method requires"):
+        build(project)
+
+
+def test_build_rejects_out_of_range_threshold(tmp_path: Path):
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, ci_threshold=70.0)  # native, not fractional
+    project = load(workdir)
+    with pytest.raises(ValueError, match=r"ci_threshold=.*\[0\.0, 1\.0\]"):
+        build(project)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end build: output files + schema
+# ---------------------------------------------------------------------------
+
+
+def test_build_writes_unfilled_and_filled_files(tmp_path: Path):
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2005-01-31", nn_fill=True)
+    project = load(workdir)
+    build(project)
+    assert (project.targets_dir() / "sca_targets.nc").exists()
+    assert (project.targets_dir() / "sca_targets_nn_filled.nc").exists()
+
+
+def test_build_output_schema(tmp_path: Path):
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2005-01-31")
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert "lower_bound" in ds and "upper_bound" in ds
+        assert "n_sources" in ds
+        assert ds["lower_bound"].attrs["units"] == "1"
+        assert ds["upper_bound"].attrs["units"] == "1"
+        assert ds["lower_bound"].attrs["cell_methods"] == "time: point"
+        assert ds.attrs["Conventions"] == "CF-1.6"
+        assert ds["time"].attrs["bounds"] == "time_bnds"
+        assert "time_bnds" in ds.variables
+        assert ds["n_sources"].dtype == np.int8
+        # The n_sources flag attrs are int8 (CF §3.5).
+        assert ds["n_sources"].attrs["flag_values"].dtype == np.int8
+        # Single-source SCA: only "none"/"one" labels.
+        assert ds["n_sources"].attrs["flag_meanings"] == "none one"
+        assert ds.attrs["ci_threshold"] == 0.70
+        assert ds.attrs["summer_zero_months"] == "7,8"
+
+
+def test_build_daily_time_index(tmp_path: Path):
+    """One timestamp per day across the requested period (stitched)."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        times = pd.DatetimeIndex(ds["time"].values)
+        assert len(times) == 31
+        assert times[0] == pd.Timestamp("2005-03-01")
+        assert times[-1] == pd.Timestamp("2005-03-31")
+
+
+# ---------------------------------------------------------------------------
+# CI gate
+# ---------------------------------------------------------------------------
+
+
+def test_ci_above_threshold_passes_and_computes_bounds(tmp_path: Path):
+    """ci=0.90, sca_obs=0.60 → lower=0.54, upper=0.54+0.10=0.64."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # Limit to a single non-summer day so July/Aug zero-forcing doesn't
+    # confound the formula check.
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.54, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 0.64, rtol=1e-5)
+        assert (ds["n_sources"].values == 1).all()
+
+
+def test_ci_below_threshold_yields_nan_bounds(tmp_path: Path):
+    """ci=0.65 < 0.70 threshold → lower/upper NaN, n_sources=0."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=60.0,
+        ci_native=65.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert np.isnan(ds["lower_bound"].values).all()
+        assert np.isnan(ds["upper_bound"].values).all()
+        assert (ds["n_sources"].values == 0).all()
+
+
+def test_ci_at_threshold_passes(tmp_path: Path):
+    """ci=0.70 == threshold — Fortran uses `>=`, so this must pass."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=50.0,
+        ci_native=70.0,  # exactly threshold
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        # lower = 0.70 * 0.50 = 0.35; upper = 0.35 + 0.30 = 0.65
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.35, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 0.65, rtol=1e-5)
+        assert (ds["n_sources"].values == 1).all()
+
+
+def test_full_ci_collapses_bounds_to_point(tmp_path: Path):
+    """ci=1.00 → lower=upper=sca_obs (point estimate at full confidence)."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=40.0,
+        ci_native=100.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.40, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 0.40, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# July/August zero forcing
+# ---------------------------------------------------------------------------
+
+
+def test_july_august_forced_to_zero_when_ci_passes(tmp_path: Path):
+    """A July day with passing CI: bounds forced to (0, 0)."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-07-15/2005-07-15",
+        snow_native=60.0,
+        ci_native=90.0,  # CI gate passes; July rule forces 0
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_array_equal(ds["lower_bound"].values, 0.0)
+        np.testing.assert_array_equal(ds["upper_bound"].values, 0.0)
+        # CI gate still records this day as a valid (n_sources=1) bound —
+        # zero is the bound value, not "missing."
+        assert (ds["n_sources"].values == 1).all()
+
+
+def test_august_forced_to_zero_when_ci_passes(tmp_path: Path):
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-08-10/2005-08-10",
+        snow_native=80.0,
+        ci_native=95.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_array_equal(ds["lower_bound"].values, 0.0)
+        np.testing.assert_array_equal(ds["upper_bound"].values, 0.0)
+
+
+def test_july_with_failing_ci_stays_nan(tmp_path: Path):
+    """A July day with CI < threshold remains NaN, not forced to zero.
+
+    Distinguishes "observed bare ground" from "no observation" in the
+    output — the zero-forcing only kicks in when the CI gate actually
+    passed.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-07-15/2005-07-15",
+        snow_native=60.0,
+        ci_native=50.0,  # below threshold
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert np.isnan(ds["lower_bound"].values).all()
+        assert np.isnan(ds["upper_bound"].values).all()
+        assert (ds["n_sources"].values == 0).all()
+
+
+def test_june_with_passing_ci_is_not_zeroed(tmp_path: Path):
+    """Boundary check: June (month 6) is NOT in the zero-forced months."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-06-30/2005-06-30",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.54, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 0.64, rtol=1e-5)
+
+
+def test_september_with_passing_ci_is_not_zeroed(tmp_path: Path):
+    """Boundary check: September (month 9) is NOT in the zero-forced months."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-09-01/2005-09-01",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.54, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 0.64, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Year-chunked build mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_intermediates_written_per_year(tmp_path: Path):
+    """Two-year period → two per-year intermediates exist after build."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # Pick a non-summer window in each year so the intermediates contain
+    # non-zero bounds to inspect.
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2006-03-31")
+    project = load(workdir)
+    build(project)
+    intermediates_dir = project.targets_dir() / ".sca_intermediates"
+    yearly = sorted(intermediates_dir.glob("sca_targets_[0-9][0-9][0-9][0-9].nc"))
+    assert [p.name for p in yearly] == [
+        "sca_targets_2005.nc",
+        "sca_targets_2006.nc",
+    ]
+
+
+def test_idempotent_skip_existing_year(tmp_path: Path, caplog):
+    """Re-running with intermediates already on disk skips the per-year work."""
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
+    project = load(workdir)
+    build(project)
+    # Second build: intermediates exist; should log "skipping".
+    with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert "skipping" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Upper-bound algebraic cap (never exceeds 1.0)
+# ---------------------------------------------------------------------------
+
+
+def test_upper_bound_never_exceeds_one(tmp_path: Path):
+    """upper = ci*sca + (1-ci) ≤ ci*1 + (1-ci) = 1, for any sca in [0,1]."""
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=100.0,  # fully snowy
+        ci_native=70.0,  # min passing CI
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        # lower = 0.70 * 1.00 = 0.70; upper = 0.70 + 0.30 = 1.00
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.70, rtol=1e-5)
+        np.testing.assert_allclose(ds["upper_bound"].values, 1.00, rtol=1e-5)
+        assert (ds["upper_bound"].values <= 1.0 + 1e-6).all()


### PR DESCRIPTION
Closes #210. Caps the Oregon umbrella issue #182.

## Summary

Implements the SCA calibration target per the calcSCA formula in [`docs/references/PRMSobjfun.f90`](docs/references/PRMSobjfun.f90) (lines 1052-1061), the canonical reference that landed in #209:

```
valid = ci >= ci_threshold       # HRU-mean CI gate, in addition to the
                                  # per-pixel CI > 70 already applied in
                                  # aggregate/mod10c1.py:pre_aggregate_hook
lower = ci * sca_obs
upper = lower + (1 - ci)
if month in {7, 8} and valid: lower = upper = 0
```

Both inputs (`Day_CMG_Snow_Cover`, `Day_CMG_Clear_Index`) are scaled from MOD10C1's native 0–100 percent scale to fractional [0, 1] first. Output bounds are fractional 0–1, matching `catalog/variables.yml:snow_covered_area.units` and the PRMS `snowcov_area` PUNIT. `upper` is algebraically capped at 1.0 (proven by test).

## Design decisions

- **July/August zero forcing is hardcoded**, mirroring `calcSCA` exactly. The summer-PNW case is honest; the Cascades high-elevation caveat (per [`docs/references/prmsobjfun-summary.md`](docs/references/prmsobjfun-summary.md)) is captured in the docstring + the output NC's `summer_zero_months` global attr. Promoting to config is a follow-up if a future fabric needs it (would require lockstep edits to `init_run`, `defaults`, `upgrade_config`, and tests per CLAUDE.md's config-schema rule).
- **Year-chunked build mirroring [`targets/swe.py`](src/nhf_spatial_targets/targets/swe.py)**: per-year intermediates under `<project>/targets/.sca_intermediates/`, idempotent year-skip on re-run, stitched into the canonical `sca_targets.nc` (and optional `_nn_filled` companion). Bounds peak memory at one year regardless of period length — important for full-CONUS extensions where the 25-year daily build of two source variables would otherwise materialise ~30 GB in one shot.
- **Single-source `n_sources` semantics**: binary CI-pass diagnostic (0 = CI gate dropped the cell, 1 = valid bound), with `flag_meanings="none one"` via `build_n_sources_attrs(1)`. The July/August zero-forcing only applies to CI-passing cells, so days that failed the gate stay NaN — downstream consumers can distinguish "observed bare ground" from "no observation."

## Test plan

`tests/test_targets_sca.py` (14 tests, synthetic-NC pattern from `test_targets_swe.py`):
- [x] Config validation: multi-source rejection, threshold out-of-range
- [x] Output schema: CF-1.6 conventions, int8 `n_sources`, `flag_values` dtype + `flag_meanings`, global attrs (`ci_threshold`, `summer_zero_months`)
- [x] Daily time index spans the requested period after stitch
- [x] CI gate: above / at (`==0.70`) / below threshold; `ci=1.0` collapses bounds to point
- [x] July & August zero-forcing wherever CI passes; July with failing CI stays NaN
- [x] June / September boundary check (not zeroed)
- [x] Year-chunked mechanics: per-year intermediates present, second build skips
- [x] Upper bound algebraic cap (`upper ≤ 1.0`)

Run on caldera-style HPC: `pixi run -e dev fmt && pixi run -e dev lint` (clean locally); full pytest deferred to GH Actions per the slower-pixi-on-HPC convention.

## Operator usage

```bash
pixi run nhf-targets run-sca --project-dir /path/to/or-spatial-targets
```

Uses the existing dispatch wiring at [`src/nhf_spatial_targets/cli.py:166`](src/nhf_spatial_targets/cli.py#L166) (`"snow_covered_area": sca.build`); no CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)