### PR TITLE
feat(targets): fingerprint year-chunked intermediates for SCA + SWE (#213)

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -16,6 +16,8 @@ keeps ``mm_per_month_to_cfs``); this module is unit-agnostic.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1109,6 +1111,179 @@ def iter_period_years(
         ye = min(end, pd.Timestamp(f"{year}-12-31"))
         out.append((year, ys.strftime("%Y-%m-%d"), ye.strftime("%Y-%m-%d")))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation for year-chunked intermediates (issue #213)
+# ---------------------------------------------------------------------------
+
+# Names of global attrs written to every per-year intermediate so the skip
+# branch can detect a stale cache. Kept as module-level constants so callers
+# (sca.build, swe.build) can pass the values into ``extra_global_attrs`` and
+# the on-disk schema is canonical.
+INTERMEDIATE_CONFIG_FINGERPRINT_ATTR = "config_fingerprint"
+INTERMEDIATE_CODE_VERSION_ATTR = "code_version"
+
+
+def target_config_fingerprint(project: Project, target_name: str) -> str:
+    """Stable hash of a target's config block + fabric identity.
+
+    Combines the target's config block from ``project.config["targets"]``,
+    the fabric path, and the fabric sha256 into a deterministic
+    sha256-truncated-to-12-hex-chars fingerprint. Used by the year-chunked
+    builders' skip predicate so that any change to the target's knobs
+    (sources, periods, thresholds, etc.) or a fabric swap invalidates the
+    on-disk per-year intermediates automatically.
+
+    The fabric identity is included because a fabric swap changes the HRU
+    set and CRS the target was built against — the same target config
+    against a different fabric produces semantically different output that
+    must not be silently reused.
+
+    Returns
+    -------
+    A 12-character hex string. 48 bits of entropy is more than enough to
+    distinguish realistic config variations; collisions are operationally
+    impossible.
+    """
+    target_cfg = project.config["targets"][target_name]
+    fabric_cfg = project.config.get("fabric") or {}
+    fabric_sha = (project.fabric or {}).get("sha256", "")
+    payload = {
+        "target": target_cfg,
+        "fabric_path": fabric_cfg.get("path", ""),
+        "fabric_sha256": fabric_sha,
+    }
+    canonical = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+
+
+def code_version_fingerprint() -> str:
+    """The package ``__version__`` used as a code-version cache tag.
+
+    Bumped on every release, so the per-year intermediates from one release
+    will not be reused after a version bump. Does NOT cover mid-version
+    edits during development — operators iterating on a target builder
+    must ``rm`` intermediates manually between code changes within the
+    same version (a known limitation; documented in each year-chunked
+    builder's module docstring).
+    """
+    from nhf_spatial_targets import __version__
+
+    return __version__
+
+
+def should_skip_year_build(
+    paths: "list[Path]",
+    *,
+    active_config_fingerprint: str,
+    active_code_version: str,
+    target_label: str,
+    year: int,
+    logger: logging.Logger,
+) -> "tuple[bool, dict | None]":
+    """Decide whether to skip rebuilding a year given existing intermediates.
+
+    Replaces the path-existence-only skip predicates that ``targets/sca.py``
+    and ``targets/swe.py`` carried before issue #213. Compares the cached
+    intermediate's ``config_fingerprint`` / ``code_version`` global attrs
+    against the active values; on mismatch (or on missing-attr / corrupt-
+    file), logs a WARNING naming both fingerprints, deletes the stale
+    intermediate(s), and falls through to a rebuild.
+
+    Parameters
+    ----------
+    paths
+        All per-year intermediate paths the caller would expect to find on
+        disk for a complete year build (the unfilled NC plus, when
+        ``nn_fill`` is on, the ``_nn_filled.nc`` companion). The first
+        path is treated as the primary attrs source; companions are read
+        only via ``.exists()``.
+    active_config_fingerprint
+        Output of :func:`target_config_fingerprint` for the current run.
+    active_code_version
+        Output of :func:`code_version_fingerprint` for the current run.
+    target_label
+        Short string used in log messages (e.g. ``"sca"``, ``"swe"``).
+    year
+        Calendar year being built; used in log messages.
+    logger
+        Caller's module logger so warnings appear under the right name.
+
+    Returns
+    -------
+    (skip, cached_attrs)
+        - ``(False, None)`` — at least one expected path missing; no cache to
+          examine; caller proceeds to build the year.
+        - ``(False, cached_attrs)`` — cached intermediate existed but was
+          stale or corrupt; this function has unlinked all paths and the
+          caller should rebuild. ``cached_attrs`` may be ``{}`` if the
+          file could not be opened.
+        - ``(True, cached_attrs)`` — cache is valid; caller may skip the
+          rebuild and use ``cached_attrs`` to re-emit any per-year
+          diagnostic warnings (e.g. low-coverage) so the operator sees
+          them on every run, not just the first.
+
+    Treats a cached intermediate that is missing the fingerprint attrs
+    as stale (pre-#213 intermediate) and triggers a rebuild — safe
+    default for the one-time upgrade transition. The cleanup pass uses
+    ``unlink(missing_ok=True)`` so a partial intermediate set (unfilled
+    present, _nn_filled missing) does not raise.
+    """
+    if not all(p.exists() for p in paths):
+        return False, None
+
+    primary = paths[0]
+    try:
+        with xr.open_dataset(primary) as cached:
+            cached_attrs = dict(cached.attrs)
+    except OSError as exc:
+        logger.warning(
+            "%s year %d: cached intermediate %s could not be opened "
+            "(%s); deleting and rebuilding.",
+            target_label,
+            year,
+            primary,
+            exc,
+        )
+        for p in paths:
+            p.unlink(missing_ok=True)
+        return False, {}
+
+    cached_fp = cached_attrs.get(INTERMEDIATE_CONFIG_FINGERPRINT_ATTR)
+    cached_ver = cached_attrs.get(INTERMEDIATE_CODE_VERSION_ATTR)
+    if cached_fp is None or cached_ver is None:
+        logger.warning(
+            "%s year %d: cached intermediate %s predates issue #213 "
+            "fingerprint support (missing %s/%s attrs); deleting and "
+            "rebuilding.",
+            target_label,
+            year,
+            primary,
+            INTERMEDIATE_CONFIG_FINGERPRINT_ATTR,
+            INTERMEDIATE_CODE_VERSION_ATTR,
+        )
+        for p in paths:
+            p.unlink(missing_ok=True)
+        return False, cached_attrs
+
+    if cached_fp != active_config_fingerprint or cached_ver != active_code_version:
+        logger.warning(
+            "%s year %d: cache fingerprint mismatch — cached config=%s "
+            "code=%s, active config=%s code=%s. Deleting stale "
+            "intermediates and rebuilding.",
+            target_label,
+            year,
+            cached_fp,
+            cached_ver,
+            active_config_fingerprint,
+            active_code_version,
+        )
+        for p in paths:
+            p.unlink(missing_ok=True)
+        return False, cached_attrs
+
+    return True, cached_attrs
 
 
 def stitch_year_chunks_to_target(

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -1142,9 +1142,8 @@ def target_config_fingerprint(project: Project, target_name: str) -> str:
 
     Returns
     -------
-    A 12-character hex string. 48 bits of entropy is more than enough to
-    distinguish realistic config variations; collisions are operationally
-    impossible.
+    A 12-character hex string. Collisions across realistic config-edit
+    volumes are negligible.
     """
     target_cfg = project.config["targets"][target_name]
     fabric_cfg = project.config.get("fabric") or {}
@@ -1161,12 +1160,11 @@ def target_config_fingerprint(project: Project, target_name: str) -> str:
 def code_version_fingerprint() -> str:
     """The package ``__version__`` used as a code-version cache tag.
 
-    Bumped on every release, so the per-year intermediates from one release
-    will not be reused after a version bump. Does NOT cover mid-version
-    edits during development — operators iterating on a target builder
-    must ``rm`` intermediates manually between code changes within the
-    same version (a known limitation; documented in each year-chunked
-    builder's module docstring).
+    Operators bumping ``__version__`` between runs get automatic
+    invalidation; commits that change builder logic without a version
+    bump do not. Mid-version edits therefore require a manual ``rm``
+    of the intermediates directory — a known limitation documented in
+    each year-chunked builder's module docstring.
     """
     from nhf_spatial_targets import __version__
 
@@ -1213,16 +1211,26 @@ def should_skip_year_build(
     Returns
     -------
     (skip, cached_attrs)
-        - ``(False, None)`` — at least one expected path missing; no cache to
-          examine; caller proceeds to build the year.
-        - ``(False, cached_attrs)`` — cached intermediate existed but was
-          stale or corrupt; this function has unlinked all paths and the
-          caller should rebuild. ``cached_attrs`` may be ``{}`` if the
-          file could not be opened.
-        - ``(True, cached_attrs)`` — cache is valid; caller may skip the
-          rebuild and use ``cached_attrs`` to re-emit any per-year
+        Four distinct return shapes, each with a specific caller contract:
+
+        - ``(False, None)`` — at least one expected path missing. No cache
+          to examine; caller builds the year fresh.
+        - ``(False, {})`` — cached intermediate exists but could not be
+          opened (corrupt / truncated NetCDF). All paths unlinked; caller
+          rebuilds.
+        - ``(False, file_attrs)`` — cached intermediate opened cleanly but
+          its fingerprint attrs were missing (pre-#213 file) or differed
+          from the active values. All paths unlinked; caller rebuilds.
+          ``file_attrs`` is the dict that was read off disk before the
+          unlink, kept for forensic logging.
+        - ``(True, file_attrs)`` — cache is valid; caller may skip the
+          rebuild and use ``file_attrs`` to re-emit any per-year
           diagnostic warnings (e.g. low-coverage) so the operator sees
           them on every run, not just the first.
+
+    Callers should defensively guard attr lookups with
+    ``(cached_attrs or {}).get(...)`` to handle the corrupt-file shape
+    without a special case.
 
     Treats a cached intermediate that is missing the fingerprint attrs
     as stale (pre-#213 intermediate) and triggers a rebuild — safe
@@ -1237,7 +1245,12 @@ def should_skip_year_build(
     try:
         with xr.open_dataset(primary) as cached:
             cached_attrs = dict(cached.attrs)
-    except OSError as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
+        # netCDF4-backed xr.open_dataset on a corrupt/truncated file may
+        # raise OSError (HDF5 layer), RuntimeError (libnetcdf bindings),
+        # or ValueError (CF decode failure). All three are "the cache is
+        # unusable" from this function's perspective — recovery is the
+        # same: warn, unlink, let the caller rebuild.
         logger.warning(
             "%s year %d: cached intermediate %s could not be opened "
             "(%s); deleting and rebuilding.",
@@ -1252,7 +1265,10 @@ def should_skip_year_build(
 
     cached_fp = cached_attrs.get(INTERMEDIATE_CONFIG_FINGERPRINT_ATTR)
     cached_ver = cached_attrs.get(INTERMEDIATE_CODE_VERSION_ATTR)
-    if cached_fp is None or cached_ver is None:
+    # ``not`` (rather than ``is None``) also catches the empty-string case,
+    # which a malformed upstream writer could produce — treat as missing
+    # rather than equal-to-active-if-active-is-also-empty.
+    if not cached_fp or not cached_ver:
         logger.warning(
             "%s year %d: cached intermediate %s predates issue #213 "
             "fingerprint support (missing %s/%s attrs); deleting and "
@@ -1367,10 +1383,15 @@ def stitch_year_chunks_to_target(
 
         # `combine_attrs="override"` (the open_mfdataset default) keeps
         # the first file's attrs, which include per-year-only attrs
-        # like ``year_chunk`` that don't apply to the stitched
+        # like ``year_chunk`` and ``frac_valid_bound`` (SCA's per-year
+        # low-coverage diagnostic) that don't apply to the stitched
         # multi-year output. Strip them before the canonical attrs are
-        # applied so the final NC reports its actual scope honestly.
-        ds.attrs.pop("year_chunk", None)
+        # applied so the final NC reports its actual scope honestly —
+        # otherwise an operator inspecting the stitched NC's attrs
+        # would trust a single-year statistic as if it were
+        # multi-year.
+        for per_year_attr in ("year_chunk", "frac_valid_bound"):
+            ds.attrs.pop(per_year_attr, None)
         ds.attrs.setdefault("Conventions", "CF-1.6")
         ds.attrs["title"] = title
         ds.attrs["history"] = (

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -49,13 +49,13 @@ nearest finite HRU's bound at the same day.
 ``<project>/targets/.sca_intermediates/`` carry two fingerprint global
 attrs (``config_fingerprint``, ``code_version``) that the skip branch
 compares against the active values. A mismatch — caused by a config
-edit (``ci_threshold``, sources, period), a fabric swap, or a code
-version bump — logs a WARNING, deletes the stale intermediate, and
-rebuilds the year. Operators do not need to manually ``rm`` after
-config or release-version changes; mid-version edits to this module
-(typical only during development) still require a manual ``rm`` since
-the ``code_version`` tag only changes on release bumps. The per-year
-low-valid-coverage WARNING is also persisted via the
+edit (``ci_threshold``, sources, period), a fabric swap, or a
+``__version__`` bump — logs a WARNING, deletes the stale intermediate,
+and rebuilds the year. Operators do not need to manually ``rm`` after
+config or version-bump changes; any commit that modifies builder logic
+WITHOUT a ``__version__`` bump still requires a manual ``rm`` because
+the ``code_version`` tag is tied to the package version string.
+The per-year low-valid-coverage WARNING is also persisted via the
 ``frac_valid_bound`` attr and re-emitted on the skip branch so it
 fires on every run, not just the first.
 """
@@ -99,7 +99,7 @@ _SUMMER_ZERO_MONTHS = (7, 8)
 # Global attr name written to every per-year intermediate that records
 # the actual fraction of (HRU, day) cells with a valid bound. Read on
 # the skip branch so the low-coverage warning can be re-emitted from a
-# cached intermediate (#213, closing PR #212 item I1).
+# cached intermediate (#213).
 _FRAC_VALID_BOUND_ATTR = "frac_valid_bound"
 
 # Operator-visible warning threshold: if fewer than this fraction of
@@ -158,10 +158,7 @@ def build(project: Project) -> None:
     id_col = project.id_col
     fabric_hru_ids = hru_meta.index.values
 
-    # Cache-invalidation fingerprints (#213). Compute once and pass through
-    # ``extra_attrs`` so they land on every per-year intermediate AND the
-    # stitched output. The skip predicate compares the cached values
-    # against these to detect a stale cache.
+    # Cache fingerprints — see should_skip_year_build (#213).
     config_fp = target_config_fingerprint(project, "snow_covered_area")
     code_ver = code_version_fingerprint()
 
@@ -256,10 +253,11 @@ def build(project: Project) -> None:
 def _warn_low_valid_coverage(year: int, frac_valid: float, ci_threshold: float) -> None:
     """Emit the per-year low-valid-coverage WARNING if below the floor.
 
-    Called from both first-build (computed ``frac_valid``) and skip-re-run
-    (cached ``frac_valid_bound`` global attr) paths, so an operator
-    re-running against a healthy-fingerprint cache continues to see the
-    alert that fired on the original build (#213, closing PR #212 item I1).
+    Called from ``_build_year`` after the live computation, and again
+    from the skip branch when ``should_skip_year_build`` returns a
+    cached ``frac_valid_bound``. Re-emitting from cache means an
+    operator re-running against a healthy-fingerprint cache continues
+    to see the alert that fired on the original build (#213).
     """
     if frac_valid < _LOW_VALID_WARN_FRACTION:
         logger.warning(

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -45,17 +45,19 @@ If ``snow_covered_area.nn_fill`` is True (default), a second file
 ``<output>_nn_filled.nc`` is written with NaN bounds filled by the
 nearest finite HRU's bound at the same day.
 
-.. warning::
-
-   Per-year intermediates under ``<project>/targets/.sca_intermediates/``
-   are keyed by year only — they are NOT fingerprinted by
-   ``ci_threshold`` or by the code version that wrote them. After
-   changing ``ci_threshold`` or after any change to this module that
-   alters the formula, ``rm -rf <project>/targets/.sca_intermediates/``
-   before re-running, otherwise stale intermediates will be silently
-   reused. The active ``ci_threshold`` is logged whenever the per-year
-   skip branch fires so operators can cross-check. Tracked for a
-   shared-with-SWE automatic fix in issue #213.
+**Cache invalidation.** Per-year intermediates under
+``<project>/targets/.sca_intermediates/`` carry two fingerprint global
+attrs (``config_fingerprint``, ``code_version``) that the skip branch
+compares against the active values. A mismatch — caused by a config
+edit (``ci_threshold``, sources, period), a fabric swap, or a code
+version bump — logs a WARNING, deletes the stale intermediate, and
+rebuilds the year. Operators do not need to manually ``rm`` after
+config or release-version changes; mid-version edits to this module
+(typical only during development) still require a manual ``rm`` since
+the ``code_version`` tag only changes on release bumps. The per-year
+low-valid-coverage WARNING is also persisted via the
+``frac_valid_bound`` attr and re-emitted on the skip branch so it
+fires on every run, not just the first.
 """
 
 from __future__ import annotations
@@ -68,13 +70,18 @@ import pandas as pd
 import xarray as xr
 
 from nhf_spatial_targets.targets._common import (
+    INTERMEDIATE_CODE_VERSION_ATTR,
+    INTERMEDIATE_CONFIG_FINGERPRINT_ATTR,
     check_hru_coords,
+    code_version_fingerprint,
     compute_hru_centroids,
     iter_period_years,
     parse_period,
     read_aggregated_source,
     reindex_to_day_start,
+    should_skip_year_build,
     stitch_year_chunks_to_target,
+    target_config_fingerprint,
     write_bounds_target,
 )
 from nhf_spatial_targets.workspace import Project
@@ -88,6 +95,12 @@ _CI_VAR = "Day_CMG_Clear_Index"
 # Captured as a constant so the output NC's global ``summer_zero_months``
 # attr can name the months explicitly. Matches PRMSobjfun.f90:calcSCA.
 _SUMMER_ZERO_MONTHS = (7, 8)
+
+# Global attr name written to every per-year intermediate that records
+# the actual fraction of (HRU, day) cells with a valid bound. Read on
+# the skip branch so the low-coverage warning can be re-emitted from a
+# cached intermediate (#213, closing PR #212 item I1).
+_FRAC_VALID_BOUND_ATTR = "frac_valid_bound"
 
 # Operator-visible warning threshold: if fewer than this fraction of
 # (HRU, day) cells in a year produce a valid bound, the build emits a
@@ -145,6 +158,13 @@ def build(project: Project) -> None:
     id_col = project.id_col
     fabric_hru_ids = hru_meta.index.values
 
+    # Cache-invalidation fingerprints (#213). Compute once and pass through
+    # ``extra_attrs`` so they land on every per-year intermediate AND the
+    # stitched output. The skip predicate compares the cached values
+    # against these to detect a stale cache.
+    config_fp = target_config_fingerprint(project, "snow_covered_area")
+    code_ver = code_version_fingerprint()
+
     extra_attrs = {
         "source": (
             "MOD10C1 v061 Day_CMG_Snow_Cover + Day_CMG_Clear_Index "
@@ -160,6 +180,8 @@ def build(project: Project) -> None:
         "area_crs": project.area_crs,
         "ci_threshold": ci_threshold,
         "summer_zero_months": ",".join(str(m) for m in _SUMMER_ZERO_MONTHS),
+        INTERMEDIATE_CONFIG_FINGERPRINT_ATTR: config_fp,
+        INTERMEDIATE_CODE_VERSION_ATTR: code_ver,
     }
 
     year_specs = iter_period_years(period[0], period[1])
@@ -193,6 +215,8 @@ def build(project: Project) -> None:
             intermediates_dir=intermediates_dir,
             nn_fill=nn_fill,
             nn_max_candidates=nn_max_candidates,
+            config_fingerprint=config_fp,
+            code_version=code_ver,
         )
 
     output_path = project.targets_dir() / sca_cfg["output_file"]
@@ -229,6 +253,27 @@ def build(project: Project) -> None:
         )
 
 
+def _warn_low_valid_coverage(year: int, frac_valid: float, ci_threshold: float) -> None:
+    """Emit the per-year low-valid-coverage WARNING if below the floor.
+
+    Called from both first-build (computed ``frac_valid``) and skip-re-run
+    (cached ``frac_valid_bound`` global attr) paths, so an operator
+    re-running against a healthy-fingerprint cache continues to see the
+    alert that fired on the original build (#213, closing PR #212 item I1).
+    """
+    if frac_valid < _LOW_VALID_WARN_FRACTION:
+        logger.warning(
+            "sca year %d: only %.4f%% of (HRU, day) cells produced a "
+            "valid CI-passing bound (threshold for warning: %.2f%%). "
+            "Either the aggregated mod10c1 NC is degenerate for this year "
+            "or ci_threshold=%.2f is too strict.",
+            year,
+            frac_valid * 100,
+            _LOW_VALID_WARN_FRACTION * 100,
+            ci_threshold,
+        )
+
+
 def _build_year(
     *,
     project: Project,
@@ -242,33 +287,43 @@ def _build_year(
     intermediates_dir: Path,
     nn_fill: bool,
     nn_max_candidates: int,
+    config_fingerprint: str,
+    code_version: str,
 ) -> None:
     """Build SCA bounds for one calendar year and write per-year NCs.
 
-    Idempotent: if both expected per-year NCs already exist
-    (``sca_targets_<year>.nc`` and, when ``nn_fill``,
-    ``sca_targets_<year>_nn_filled.nc``), the build is skipped — useful
-    when re-running after a partial OOM mid-period.
+    Idempotent: if both expected per-year NCs already exist AND their
+    fingerprint global attrs match the active config + code version,
+    the build is skipped. On a fingerprint mismatch the stale
+    intermediate(s) are deleted automatically and rebuilt — see
+    :func:`nhf_spatial_targets.targets._common.should_skip_year_build`.
+
+    On a healthy skip, the cached ``frac_valid_bound`` global attr is
+    read and the low-valid-coverage WARNING is re-emitted if the
+    cached fraction is below threshold, so an operator re-running
+    against a valid cache continues to see the alert.
     """
     year_unfilled = intermediates_dir / f"sca_targets_{year}.nc"
     year_nn = intermediates_dir / f"sca_targets_{year}_nn_filled.nc"
-    if year_unfilled.exists() and ((not nn_fill) or year_nn.exists()):
-        # Intermediates are path-keyed only — not fingerprinted by
-        # ci_threshold, sources list, code version, or any other config.
-        # Log the active threshold so an operator re-reading the run
-        # output can cross-check it against the file's global attrs
-        # (see module docstring warning). Tracked for an automatic
-        # cross-target fix in #213.
+    expected_paths = [year_unfilled] + ([year_nn] if nn_fill else [])
+    skip, cached_attrs = should_skip_year_build(
+        expected_paths,
+        active_config_fingerprint=config_fingerprint,
+        active_code_version=code_version,
+        target_label="sca",
+        year=year,
+        logger=logger,
+    )
+    if skip:
         logger.info(
-            "Year %d intermediates exist; skipping. Active ci_threshold=%.2f. "
-            "Any change to sca config or to the builder module since the "
-            "intermediates were written invalidates them — "
-            "rm %s/sca_targets_%d*.nc and re-run if so.",
+            "Year %d intermediates valid (config=%s code=%s); skipping.",
             year,
-            ci_threshold,
-            intermediates_dir,
-            year,
+            config_fingerprint,
+            code_version,
         )
+        cached_frac = (cached_attrs or {}).get(_FRAC_VALID_BOUND_ATTR)
+        if cached_frac is not None:
+            _warn_low_valid_coverage(year, float(cached_frac), ci_threshold)
         return
 
     year_master_idx = pd.date_range(year_period[0], year_period[1], freq="D")
@@ -331,20 +386,10 @@ def _build_year(
 
     # Operator-visible warning when an upstream regression or
     # genuinely fully-cloudy season produces near-zero coverage for
-    # the year. Cheap single-scalar reduction; mirrors the per-year
-    # warning shape in aggregate/mod10c1.py:_log_low_valid_coverage.
+    # the year. Persisted to global attrs so the skip branch can re-emit
+    # it on a cached re-run (#213).
     frac_valid = float(valid_bound.mean().compute())
-    if frac_valid < _LOW_VALID_WARN_FRACTION:
-        logger.warning(
-            "sca year %d: only %.4f%% of (HRU, day) cells produced a "
-            "valid CI-passing bound (threshold for warning: %.2f%%). "
-            "Either the aggregated mod10c1 NC is degenerate for this year "
-            "or ci_threshold=%.2f is too strict.",
-            year,
-            frac_valid * 100,
-            _LOW_VALID_WARN_FRACTION * 100,
-            ci_threshold,
-        )
+    _warn_low_valid_coverage(year, frac_valid, ci_threshold)
 
     write_bounds_target(
         project=project,
@@ -360,7 +405,11 @@ def _build_year(
         output_path=year_unfilled,
         title=f"NHM SCA calibration target year {year} (intermediate)",
         nn_title=(f"NHM SCA calibration target year {year} (NN-filled intermediate)"),
-        extra_global_attrs={**extra_attrs, "year_chunk": year},
+        extra_global_attrs={
+            **extra_attrs,
+            "year_chunk": year,
+            _FRAC_VALID_BOUND_ATTR: frac_valid,
+        },
         hru_meta=hru_meta,
         nn_fill=nn_fill,
         nn_max_candidates=nn_max_candidates,

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -45,11 +45,12 @@ nearest finite HRU's value at the same day (cKDTree donor walk in
 attrs (``config_fingerprint``, ``code_version``) that the skip branch
 compares against the active values. A mismatch — caused by a config
 edit (``sources``, ``period``, ``nn_max_candidates``), a fabric swap,
-or a code version bump — logs a WARNING, deletes the stale
+or a ``__version__`` bump — logs a WARNING, deletes the stale
 intermediate, and rebuilds the year. Operators do not need to manually
-``rm`` after config or release-version changes; mid-version edits to
-this module (typical only during development) still require a manual
-``rm`` since the ``code_version`` tag only changes on release bumps.
+``rm`` after config or version-bump changes; any commit that modifies
+builder logic WITHOUT a ``__version__`` bump still requires a manual
+``rm`` because the ``code_version`` tag is tied to the package
+version string.
 """
 
 from __future__ import annotations
@@ -327,10 +328,7 @@ def build(project: Project) -> None:
     id_col = project.id_col
     fabric_hru_ids = hru_meta.index.values
 
-    # 2. Cache-invalidation fingerprints (#213). Compute once and pass
-    # through ``extra_attrs`` so they land on every per-year intermediate
-    # AND the stitched output. The skip predicate compares the cached
-    # values against these to detect a stale cache.
+    # 2. Cache fingerprints — see should_skip_year_build (#213).
     config_fp = target_config_fingerprint(project, "snow_water_equivalent")
     code_ver = code_version_fingerprint()
 

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -39,6 +39,17 @@ If ``snow_water_equivalent.nn_fill`` is True (default), a second file
 ``<output>_nn_filled.nc`` is written with bound NaNs filled by the
 nearest finite HRU's value at the same day (cKDTree donor walk in
 ``project.area_crs``).
+
+**Cache invalidation.** Per-year intermediates under
+``<project>/targets/.swe_intermediates/`` carry two fingerprint global
+attrs (``config_fingerprint``, ``code_version``) that the skip branch
+compares against the active values. A mismatch — caused by a config
+edit (``sources``, ``period``, ``nn_max_candidates``), a fabric swap,
+or a code version bump — logs a WARNING, deletes the stale
+intermediate, and rebuilds the year. Operators do not need to manually
+``rm`` after config or release-version changes; mid-version edits to
+this module (typical only during development) still require a manual
+``rm`` since the ``code_version`` tag only changes on release bumps.
 """
 
 from __future__ import annotations
@@ -52,8 +63,11 @@ import xarray as xr
 
 from nhf_spatial_targets import catalog
 from nhf_spatial_targets.targets._common import (
+    INTERMEDIATE_CODE_VERSION_ATTR,
+    INTERMEDIATE_CONFIG_FINGERPRINT_ATTR,
     SourceShim,
     check_hru_coords,
+    code_version_fingerprint,
     compute_hru_centroids,
     iter_period_years,
     multi_source_nanminmax,
@@ -61,7 +75,9 @@ from nhf_spatial_targets.targets._common import (
     read_aggregated_source,
     reindex_to_day_start,
     shims_by_config_label,
+    should_skip_year_build,
     stitch_year_chunks_to_target,
+    target_config_fingerprint,
     validate_source_units,
     write_bounds_target,
 )
@@ -311,7 +327,14 @@ def build(project: Project) -> None:
     id_col = project.id_col
     fabric_hru_ids = hru_meta.index.values
 
-    # 2. Common global attrs (same on per-year intermediates and the
+    # 2. Cache-invalidation fingerprints (#213). Compute once and pass
+    # through ``extra_attrs`` so they land on every per-year intermediate
+    # AND the stitched output. The skip predicate compares the cached
+    # values against these to detect a stale cache.
+    config_fp = target_config_fingerprint(project, "snow_water_equivalent")
+    code_ver = code_version_fingerprint()
+
+    # 3. Common global attrs (same on per-year intermediates and the
     # stitched final NC).
     extra_attrs = {
         "source": "; ".join(shims[s].description for s in sources),
@@ -323,6 +346,8 @@ def build(project: Project) -> None:
         "fabric_token": fabric_token or "",
         "period": swe_cfg["period"],
         "area_crs": project.area_crs,
+        INTERMEDIATE_CONFIG_FINGERPRINT_ATTR: config_fp,
+        INTERMEDIATE_CODE_VERSION_ATTR: code_ver,
     }
 
     # 3. Year-chunked build. SWE is the only daily-cadence multi-source
@@ -364,6 +389,8 @@ def build(project: Project) -> None:
             intermediates_dir=intermediates_dir,
             nn_fill=nn_fill,
             nn_max_candidates=nn_max_candidates,
+            config_fingerprint=config_fp,
+            code_version=code_ver,
         )
 
     # 4. Stitch per-year intermediates into the canonical single-file
@@ -414,6 +441,8 @@ def _build_year(
     intermediates_dir: Path,
     nn_fill: bool,
     nn_max_candidates: int,
+    config_fingerprint: str,
+    code_version: str,
 ) -> None:
     """Build SWE bounds for one calendar year and write per-year NCs.
 
@@ -424,15 +453,30 @@ def _build_year(
     filter, e.g., ``ds.where(ds.n_sources >= 2)`` to require 2-source
     agreement, or ``>= 3`` to require SNODAS-era completeness.
 
-    Idempotent: if both expected per-year NCs already exist
-    (``swe_targets_<year>.nc`` and, when ``nn_fill``,
-    ``swe_targets_<year>_nn_filled.nc``), the build is skipped — useful
-    when re-running after a partial OOM mid-period.
+    Idempotent: if both expected per-year NCs already exist AND their
+    fingerprint global attrs match the active config + code version,
+    the build is skipped. On a fingerprint mismatch the stale
+    intermediate(s) are deleted automatically and rebuilt — see
+    :func:`nhf_spatial_targets.targets._common.should_skip_year_build`.
     """
     year_unfilled = intermediates_dir / f"swe_targets_{year}.nc"
     year_nn = intermediates_dir / f"swe_targets_{year}_nn_filled.nc"
-    if year_unfilled.exists() and ((not nn_fill) or year_nn.exists()):
-        logger.info("Year %d intermediates exist; skipping", year)
+    expected_paths = [year_unfilled] + ([year_nn] if nn_fill else [])
+    skip, _cached_attrs = should_skip_year_build(
+        expected_paths,
+        active_config_fingerprint=config_fingerprint,
+        active_code_version=code_version,
+        target_label="swe",
+        year=year,
+        logger=logger,
+    )
+    if skip:
+        logger.info(
+            "Year %d intermediates valid (config=%s code=%s); skipping.",
+            year,
+            config_fingerprint,
+            code_version,
+        )
         return
 
     year_master_idx = pd.date_range(year_period[0], year_period[1], freq="D")

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -1872,3 +1872,72 @@ def test_should_skip_year_build_handles_partial_intermediate_set(tmp_path: Path)
     assert attrs is None
     # Primary preserved — the caller's rebuild path will overwrite it.
     assert primary.exists()
+
+
+def test_should_skip_year_build_recovers_from_corrupt_cache(tmp_path: Path, caplog):
+    """A corrupt/truncated cached intermediate must be detected, deleted,
+    and rebuilt rather than crashing the multi-year build.
+
+    The recovery path uses ``except (OSError, RuntimeError, ValueError)``
+    to cover the three exception classes the netCDF4 backend can raise on
+    a malformed file. Regression guard: narrowing the catch to a single
+    class (or just FileNotFoundError) would let a truncated file from a
+    SIGKILL during the previous run abort the whole build.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    # 16 bytes of garbage — not a valid HDF5/NetCDF header.
+    nc_path.write_bytes(b"\x00\x01\x02\x03" * 4)
+    assert nc_path.exists()
+
+    with caplog.at_level(logging.WARNING):
+        skip, attrs = should_skip_year_build(
+            [nc_path],
+            active_config_fingerprint="abc123",
+            active_code_version="0.1.0",
+            target_label="sca",
+            year=2005,
+            logger=logging.getLogger("test"),
+        )
+    assert skip is False
+    # Corrupt-file branch returns the {} sentinel (no readable attrs).
+    assert attrs == {}
+    # File was unlinked so the caller can rebuild without conflict.
+    assert not nc_path.exists()
+    # Operator-visible WARNING names the recovery action.
+    assert "could not be opened" in caplog.text
+    assert "rebuilding" in caplog.text
+
+
+def test_should_skip_year_build_empty_string_fingerprint_treated_as_missing(
+    tmp_path: Path, caplog
+):
+    """A cached file with empty-string fingerprint attrs (malformed
+    upstream writer) must be treated as missing-fingerprint, not as
+    "equal to active if active is also empty."
+    """
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    # Empty-string fingerprint attrs — pathological but possible.
+    _write_fingerprinted_nc(nc_path, config_fp="", code_ver="")
+
+    with caplog.at_level(logging.WARNING):
+        skip, _attrs = should_skip_year_build(
+            [nc_path],
+            active_config_fingerprint="abc123",
+            active_code_version="0.1.0",
+            target_label="sca",
+            year=2005,
+            logger=logging.getLogger("test"),
+        )
+    assert skip is False
+    assert not nc_path.exists()
+    # The missing-attrs branch ("predates") fires, not the mismatch branch
+    # ("fingerprint mismatch") — empty string is treated as missing.
+    assert "predates" in caplog.text or "missing" in caplog.text

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -1589,3 +1589,286 @@ def test_read_aggregated_source_masks_netcdf_default_fill_cells(tmp_path: Path):
     assert np.all(vals[:, 0] == 25.0)
     assert np.all(np.isnan(vals[:, 1]))  # the masked HRU
     assert np.all(vals[:, 2] == 25.0)
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation for year-chunked intermediates (#213)
+# ---------------------------------------------------------------------------
+
+
+def _project_with_target(tmp_path: Path, target_block: dict, fabric_sha: str = ""):
+    """Build a minimal project skeleton that carries a target config block.
+
+    ``parents=True`` so callers can pass a sub-path of ``tmp_path`` for
+    multi-project tests where two distinct configs need separate workdirs
+    under one ``tmp_path`` fixture.
+    """
+    workdir = tmp_path / "proj"
+    workdir.mkdir(parents=True)
+    fabric_path = tmp_path / "f.gpkg"
+    cfg = {
+        "datastore": str(tmp_path / "store"),
+        "fabric": {"path": str(fabric_path), "id_col": "nhm_id"},
+        "targets": {"snow_covered_area": target_block},
+    }
+    (workdir / "config.yml").write_text(yaml.safe_dump(cfg))
+    fabric_json = {"id_col": "nhm_id"}
+    if fabric_sha:
+        fabric_json["sha256"] = fabric_sha
+    (workdir / "fabric.json").write_text(json.dumps(fabric_json))
+    return load(workdir)
+
+
+def test_target_config_fingerprint_is_stable(tmp_path: Path):
+    """Same project → same fingerprint across calls."""
+    from nhf_spatial_targets.targets._common import target_config_fingerprint
+
+    block = {"period": "2005/2010", "ci_threshold": 0.7, "nn_fill": True}
+    project = _project_with_target(tmp_path, block)
+    fp1 = target_config_fingerprint(project, "snow_covered_area")
+    fp2 = target_config_fingerprint(project, "snow_covered_area")
+    assert fp1 == fp2
+    # 12-char hex truncation per the helper contract.
+    assert len(fp1) == 12
+    assert all(c in "0123456789abcdef" for c in fp1)
+
+
+def test_target_config_fingerprint_changes_on_target_edit(tmp_path: Path):
+    """Editing any knob in the target block produces a different fingerprint."""
+    from nhf_spatial_targets.targets._common import target_config_fingerprint
+
+    block_a = {"period": "2005/2010", "ci_threshold": 0.70}
+    block_b = {"period": "2005/2010", "ci_threshold": 0.80}  # threshold bump
+    fp_a = target_config_fingerprint(
+        _project_with_target(tmp_path / "a", block_a), "snow_covered_area"
+    )
+    fp_b = target_config_fingerprint(
+        _project_with_target(tmp_path / "b", block_b), "snow_covered_area"
+    )
+    assert fp_a != fp_b
+
+
+def test_target_config_fingerprint_changes_on_fabric_swap(tmp_path: Path):
+    """Different fabric.sha256 → different fingerprint (catches fabric swap)."""
+    from nhf_spatial_targets.targets._common import target_config_fingerprint
+
+    block = {"period": "2005/2010", "ci_threshold": 0.70}
+    fp_a = target_config_fingerprint(
+        _project_with_target(tmp_path / "a", block, fabric_sha="deadbeef"),
+        "snow_covered_area",
+    )
+    fp_b = target_config_fingerprint(
+        _project_with_target(tmp_path / "b", block, fabric_sha="cafef00d"),
+        "snow_covered_area",
+    )
+    assert fp_a != fp_b
+
+
+def test_code_version_fingerprint_returns_package_version():
+    from nhf_spatial_targets import __version__
+    from nhf_spatial_targets.targets._common import code_version_fingerprint
+
+    assert code_version_fingerprint() == __version__
+
+
+def _write_fingerprinted_nc(path: Path, *, config_fp: str, code_ver: str) -> None:
+    """Helper for should_skip_year_build tests: write a 1-var NC with fingerprint attrs."""
+    from nhf_spatial_targets.targets._common import (
+        INTERMEDIATE_CODE_VERSION_ATTR,
+        INTERMEDIATE_CONFIG_FINGERPRINT_ATTR,
+    )
+
+    ds = xr.Dataset(
+        {"x": (("time",), np.array([1.0, 2.0], dtype=np.float32))},
+        coords={"time": pd.date_range("2005-01-01", periods=2, freq="D")},
+        attrs={
+            INTERMEDIATE_CONFIG_FINGERPRINT_ATTR: config_fp,
+            INTERMEDIATE_CODE_VERSION_ATTR: code_ver,
+        },
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def test_should_skip_year_build_returns_false_when_path_missing(tmp_path: Path):
+    """No cached intermediate → (False, None); caller proceeds to build."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    logger = logging.getLogger("test")
+    skip, attrs = should_skip_year_build(
+        [tmp_path / "missing.nc"],
+        active_config_fingerprint="abc",
+        active_code_version="0.1.0",
+        target_label="sca",
+        year=2005,
+        logger=logger,
+    )
+    assert skip is False
+    assert attrs is None
+
+
+def test_should_skip_year_build_returns_true_when_fingerprints_match(tmp_path: Path):
+    """Cached fingerprints match → (True, attrs); caller may skip rebuild."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    _write_fingerprinted_nc(nc_path, config_fp="abc123", code_ver="0.1.0")
+    skip, attrs = should_skip_year_build(
+        [nc_path],
+        active_config_fingerprint="abc123",
+        active_code_version="0.1.0",
+        target_label="sca",
+        year=2005,
+        logger=logging.getLogger("test"),
+    )
+    assert skip is True
+    assert attrs is not None
+    assert attrs["config_fingerprint"] == "abc123"
+    # File preserved (skip path does not unlink).
+    assert nc_path.exists()
+
+
+def test_should_skip_year_build_rebuilds_on_config_mismatch(tmp_path: Path, caplog):
+    """Cached config_fingerprint differs → WARN + unlink + (False, attrs)."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    _write_fingerprinted_nc(nc_path, config_fp="OLDcfg", code_ver="0.1.0")
+    with caplog.at_level(logging.WARNING):
+        skip, attrs = should_skip_year_build(
+            [nc_path],
+            active_config_fingerprint="NEWcfg",
+            active_code_version="0.1.0",
+            target_label="sca",
+            year=2005,
+            logger=logging.getLogger("test"),
+        )
+    assert skip is False
+    assert attrs is not None
+    assert attrs["config_fingerprint"] == "OLDcfg"
+    # Stale file unlinked.
+    assert not nc_path.exists()
+    # Operator-visible WARNING names both fingerprints so the operator
+    # can correlate the rebuild to a config change.
+    assert "mismatch" in caplog.text
+    assert "OLDcfg" in caplog.text
+    assert "NEWcfg" in caplog.text
+
+
+def test_should_skip_year_build_rebuilds_on_code_version_mismatch(
+    tmp_path: Path, caplog
+):
+    """Cached code_version differs → WARN + unlink + (False, attrs)."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    _write_fingerprinted_nc(nc_path, config_fp="abc123", code_ver="0.0.9")
+    with caplog.at_level(logging.WARNING):
+        skip, attrs = should_skip_year_build(
+            [nc_path],
+            active_config_fingerprint="abc123",
+            active_code_version="0.1.0",
+            target_label="sca",
+            year=2005,
+            logger=logging.getLogger("test"),
+        )
+    assert skip is False
+    assert not nc_path.exists()
+    assert "0.0.9" in caplog.text
+    assert "0.1.0" in caplog.text
+
+
+def test_should_skip_year_build_rebuilds_on_missing_fingerprint_attrs(
+    tmp_path: Path, caplog
+):
+    """Pre-#213 intermediate (no fingerprint attrs) → WARN + unlink + rebuild.
+
+    Required for the upgrade transition: operators with on-disk
+    intermediates from before #213 must get them automatically
+    invalidated without needing a manual rm step.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    nc_path = tmp_path / "y2005.nc"
+    # NC with no fingerprint attrs (mimics pre-#213 write).
+    ds = xr.Dataset(
+        {"x": (("time",), np.array([1.0], dtype=np.float32))},
+        coords={"time": pd.date_range("2005-01-01", periods=1, freq="D")},
+    )
+    nc_path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(nc_path)
+
+    with caplog.at_level(logging.WARNING):
+        skip, attrs = should_skip_year_build(
+            [nc_path],
+            active_config_fingerprint="abc123",
+            active_code_version="0.1.0",
+            target_label="sca",
+            year=2005,
+            logger=logging.getLogger("test"),
+        )
+    assert skip is False
+    assert not nc_path.exists()
+    assert "predates" in caplog.text or "missing" in caplog.text
+
+
+def test_should_skip_year_build_unlinks_companion_paths(tmp_path: Path):
+    """Mismatch deletes ALL expected paths (e.g. nn_filled companion), not just the primary."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    primary = tmp_path / "y2005.nc"
+    companion = tmp_path / "y2005_nn_filled.nc"
+    _write_fingerprinted_nc(primary, config_fp="OLD", code_ver="0.1.0")
+    _write_fingerprinted_nc(companion, config_fp="OLD", code_ver="0.1.0")
+
+    skip, _attrs = should_skip_year_build(
+        [primary, companion],
+        active_config_fingerprint="NEW",
+        active_code_version="0.1.0",
+        target_label="sca",
+        year=2005,
+        logger=logging.getLogger("test"),
+    )
+    assert skip is False
+    assert not primary.exists()
+    assert not companion.exists()
+
+
+def test_should_skip_year_build_handles_partial_intermediate_set(tmp_path: Path):
+    """If a required companion is missing, return (False, None) — caller rebuilds.
+
+    Treats this as a fresh build, not a mismatch — the primary may
+    exist but the operator deleted the companion intentionally to
+    force a rebuild.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets._common import should_skip_year_build
+
+    primary = tmp_path / "y2005.nc"
+    _write_fingerprinted_nc(primary, config_fp="abc123", code_ver="0.1.0")
+    # Companion does NOT exist.
+    skip, attrs = should_skip_year_build(
+        [primary, tmp_path / "y2005_nn_filled.nc"],
+        active_config_fingerprint="abc123",
+        active_code_version="0.1.0",
+        target_label="sca",
+        year=2005,
+        logger=logging.getLogger("test"),
+    )
+    assert skip is False
+    assert attrs is None
+    # Primary preserved — the caller's rebuild path will overwrite it.
+    assert primary.exists()

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -439,13 +439,15 @@ def test_idempotent_skip_existing_year(tmp_path: Path, caplog):
     workdir = _make_sca_project(tmp_path, period="2005-03-01/2005-03-31")
     project = load(workdir)
     build(project)
-    # Second build: intermediates exist; should log "skipping" AND
-    # name the active ci_threshold so a re-running operator can
-    # cross-check against the cached value (#213 follow-up).
+    # Second build: intermediates valid (matching fingerprints) → skip.
+    # New (#213) log line names the active config + code fingerprints
+    # so operators can cross-check against the cached values without
+    # opening the file by hand.
     with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     assert "skipping" in caplog.text
-    assert "ci_threshold=0.70" in caplog.text
+    assert "config=" in caplog.text
+    assert "code=" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -714,12 +716,14 @@ def test_idempotent_skip_with_nn_fill(tmp_path: Path, caplog):
     project = load(workdir)
     build(project)
     # Second build with both intermediates present → skip, naming the
-    # active ci_threshold so a re-running operator can cross-check.
+    # active fingerprints so a re-running operator can cross-check
+    # (#213).
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     assert "skipping" in caplog.text
-    assert "ci_threshold=0.70" in caplog.text
+    assert "config=" in caplog.text
+    assert "code=" in caplog.text
     # Delete only the nn intermediate; the predicate must fall through
     # and re-do the year (which regenerates the nn file).
     nn_intermediate = (
@@ -868,3 +872,150 @@ def test_low_valid_coverage_partial_pass_no_warning(tmp_path: Path, caplog):
     assert not any("valid CI-passing bound" in r.message for r in caplog.records), (
         "1/3 coverage should clear the 1% threshold without warning"
     )
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation by fingerprint (#213)
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_mismatch_rebuilds_year(tmp_path: Path, caplog):
+    """Edit ci_threshold between two builds → the cached intermediate is
+    automatically rebuilt with the new threshold, no manual ``rm`` needed.
+
+    Regression guard for #213's core promise: a config change invalidates
+    the cache without operator intervention.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # First build: ci_threshold=0.70 (default). 60/90 input → lower=0.54.
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-15/2005-03-15",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    project = load(workdir)
+    build(project)
+    # Sanity: first build wrote bound 0.54.
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        np.testing.assert_allclose(ds["lower_bound"].values, 0.54, rtol=1e-5)
+        first_fp = ds.attrs["config_fingerprint"]
+
+    # Mutate ci_threshold to 0.95 (now strictly above the synthetic CI=0.90).
+    cfg_path = workdir / "config.yml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["targets"]["snow_covered_area"]["ci_threshold"] = 0.95
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    # Also delete the stitched output so we can confirm the rebuild
+    # writes a fresh one consistent with the new threshold.
+    (project.targets_dir() / "sca_targets.nc").unlink()
+
+    project = load(workdir)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+
+    # The fingerprint mismatch surfaced as a WARNING from the shared
+    # skip predicate (logged under the _common logger).
+    assert any("mismatch" in r.message for r in caplog.records), (
+        "fingerprint mismatch on cached intermediate must log a WARNING"
+    )
+    # Rebuild applied the new threshold: ci=0.90 < 0.95 → NaN bound.
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert np.isnan(ds["lower_bound"].values).all(), (
+            "rebuilt year must reflect the new ci_threshold (0.95)"
+        )
+        second_fp = ds.attrs["config_fingerprint"]
+    assert first_fp != second_fp
+
+
+def test_pre_213_intermediate_triggers_rebuild(tmp_path: Path, caplog):
+    """An on-disk intermediate without fingerprint attrs (legacy file
+    from before #213) must be detected, deleted, and rebuilt rather
+    than silently reused.
+
+    Required for the upgrade transition.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-01/2005-03-15",
+        snow_native=60.0,
+        ci_native=90.0,
+    )
+    # Pre-populate intermediates_dir with a fake legacy file (no fingerprint).
+    intermediates_dir = workdir / "targets" / ".sca_intermediates"
+    intermediates_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = intermediates_dir / "sca_targets_2005.nc"
+    # Minimal valid NC with no fingerprint attrs.
+    legacy = xr.Dataset(
+        {"placeholder": (("time",), np.array([0.0], dtype=np.float32))},
+        coords={"time": pd.date_range("2005-01-01", periods=1, freq="D")},
+    )
+    legacy.to_netcdf(legacy_path)
+    project = load(workdir)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+    # WARN + rebuild: the legacy file was deleted and a fresh
+    # fingerprinted intermediate written in its place.
+    assert any(
+        ("predates" in r.message or "missing" in r.message) for r in caplog.records
+    )
+    rebuilt = xr.open_dataset(legacy_path)
+    try:
+        assert "config_fingerprint" in rebuilt.attrs
+        assert "lower_bound" in rebuilt.data_vars
+    finally:
+        rebuilt.close()
+
+
+def test_low_coverage_warning_reemits_on_cached_skip(tmp_path: Path, caplog):
+    """The low-coverage WARNING must fire on EVERY build, including
+    cached-skip re-runs (#213 closes PR #212 item I1).
+
+    First build writes a low-coverage year; second build skips the
+    rebuild (fingerprints match) but reads ``frac_valid_bound`` from
+    cached attrs and re-emits the warning so the operator sees the
+    alert on every run, not just the first.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(
+        tmp_path,
+        period="2005-03-01/2005-03-31",
+        snow_native=60.0,
+        ci_native=10.0,  # fully below threshold → low coverage warning
+    )
+    project = load(workdir)
+    # First build: warning fires from the live computation.
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    assert any("valid CI-passing bound" in r.message for r in caplog.records)
+    first_warning_count = sum(
+        1 for r in caplog.records if "valid CI-passing bound" in r.message
+    )
+    # Second build: intermediates skip-eligible. Warning must STILL fire
+    # from the cached frac_valid_bound attr.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+        build(project)
+    second_warning_count = sum(
+        1 for r in caplog.records if "valid CI-passing bound" in r.message
+    )
+    assert second_warning_count >= 1, (
+        "low-coverage WARNING must re-emit on cached-skip path"
+    )
+    # The two should be the same magnitude (1 warning per year both times).
+    assert first_warning_count == second_warning_count

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -980,12 +980,17 @@ def test_pre_213_intermediate_triggers_rebuild(tmp_path: Path, caplog):
 
 def test_low_coverage_warning_reemits_on_cached_skip(tmp_path: Path, caplog):
     """The low-coverage WARNING must fire on EVERY build, including
-    cached-skip re-runs (#213 closes PR #212 item I1).
+    cached-skip re-runs (#213).
 
     First build writes a low-coverage year; second build skips the
     rebuild (fingerprints match) but reads ``frac_valid_bound`` from
     cached attrs and re-emits the warning so the operator sees the
     alert on every run, not just the first.
+
+    Explicitly asserts the second build took the SKIP path (via the
+    "intermediates valid" INFO log) so a regression that accidentally
+    re-runs the year and emits the WARNING from the live computation
+    would fail this test instead of silently passing.
     """
     import logging
 
@@ -1007,15 +1012,56 @@ def test_low_coverage_warning_reemits_on_cached_skip(tmp_path: Path, caplog):
         1 for r in caplog.records if "valid CI-passing bound" in r.message
     )
     # Second build: intermediates skip-eligible. Warning must STILL fire
-    # from the cached frac_valid_bound attr.
+    # from the cached frac_valid_bound attr. Capture INFO too so we can
+    # assert the skip path was actually taken (not a silent rebuild).
     caplog.clear()
-    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
+    with caplog.at_level(logging.INFO, logger="nhf_spatial_targets.targets.sca"):
         build(project)
     second_warning_count = sum(
-        1 for r in caplog.records if "valid CI-passing bound" in r.message
+        1
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "valid CI-passing bound" in r.message
     )
     assert second_warning_count >= 1, (
         "low-coverage WARNING must re-emit on cached-skip path"
     )
     # The two should be the same magnitude (1 warning per year both times).
     assert first_warning_count == second_warning_count
+    # Regression guard: the second build must have hit the skip branch,
+    # not silently re-run the year. The skip log line includes
+    # "intermediates valid" + "skipping"; the rebuild path does not.
+    assert any(
+        "intermediates valid" in r.message and "skipping" in r.message
+        for r in caplog.records
+    ), "second build must take the cached-skip path, not silently rebuild"
+
+
+def test_frac_valid_bound_not_in_stitched_output(tmp_path: Path):
+    """The per-year ``frac_valid_bound`` attr must NOT appear on the
+    stitched ``sca_targets.nc``.
+
+    ``combine_attrs="override"`` in stitch picks the first per-year
+    file's attrs by default, which would leak a single-year coverage
+    fraction onto the multi-year stitched output as if it were a
+    multi-year statistic. ``stitch_year_chunks_to_target`` strips it
+    alongside ``year_chunk`` so an operator inspecting the stitched
+    NC's attrs cannot accidentally trust a misleading single-year
+    number.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # Two-year period so the stitch actually runs.
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2006-12-31")
+    project = load(workdir)
+    build(project)
+    # Per-year intermediate carries the attr (forensic value).
+    per_year = project.targets_dir() / ".sca_intermediates" / "sca_targets_2005.nc"
+    with xr.open_dataset(per_year) as ds:
+        assert "frac_valid_bound" in ds.attrs
+    # Stitched output must NOT carry the per-year attr.
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        assert "frac_valid_bound" not in ds.attrs
+        # Sanity: stitched output still carries the active fingerprints.
+        assert "config_fingerprint" in ds.attrs
+        assert "code_version" in ds.attrs

--- a/tests/test_targets_swe.py
+++ b/tests/test_targets_swe.py
@@ -715,3 +715,107 @@ def test_build_nn_fill_actually_fills_nan_cells(tmp_path: Path):
         assert (filled["nn_filled"].values[:, 1] == 1).all()
         assert (filled["nn_filled"].values[:, 0] == 0).all()
         assert (filled["nn_filled"].values[:, 2] == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation by fingerprint (#213)
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_mismatch_rebuilds_year(tmp_path: Path, caplog):
+    """Edit the SWE sources list between two builds → the cached
+    intermediate is automatically rebuilt with the new source set,
+    no manual ``rm`` needed.
+
+    Regression guard for #213's core promise: a config change invalidates
+    the cache without operator intervention.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.swe import build
+    from nhf_spatial_targets.workspace import load
+
+    # First build: all 4 OR sources (period 2003-10 → SNODAS-era 2003+
+    # so all four contribute). _make_swe_project default values produce
+    # well-ordered bounds.
+    workdir = _make_swe_project(
+        tmp_path,
+        period="2003-12-15/2003-12-15",
+        fabric_token="or",
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    with xr.open_dataset(project.targets_dir() / "swe_targets.nc") as ds:
+        first_fp = ds.attrs["config_fingerprint"]
+        # All 4 sources → n_sources=4 by construction in the test fixture.
+        assert (ds["n_sources"].values == 4).all()
+
+    # Mutate sources list: drop margulis_wus_sr. The fingerprint must
+    # change, the year intermediate must be deleted, the rebuild must
+    # produce n_sources=3.
+    cfg_path = workdir / "config.yml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["targets"]["snow_water_equivalent"]["sources"] = [
+        "daymet",
+        "snodas",
+        "era5_land",
+    ]
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    # Delete stitched output so we can confirm the rebuild wrote a fresh one.
+    (project.targets_dir() / "swe_targets.nc").unlink()
+
+    project = load(workdir)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+    # Skip predicate logged a fingerprint-mismatch warning under the
+    # shared _common logger.
+    assert any("mismatch" in r.message for r in caplog.records), (
+        "fingerprint mismatch on cached intermediate must log a WARNING"
+    )
+    with xr.open_dataset(project.targets_dir() / "swe_targets.nc") as ds:
+        second_fp = ds.attrs["config_fingerprint"]
+        # Rebuild reflects the trimmed sources list.
+        assert (ds["n_sources"].values == 3).all()
+        assert "Margulis" not in ds.attrs["source"]
+    assert first_fp != second_fp
+
+
+def test_pre_213_intermediate_triggers_rebuild(tmp_path: Path, caplog):
+    """A legacy intermediate without fingerprint attrs (from before
+    #213) must be detected, deleted, and rebuilt rather than silently
+    reused. Required for the upgrade transition."""
+    import logging
+
+    from nhf_spatial_targets.targets.swe import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_swe_project(
+        tmp_path,
+        period="2003-12-15/2003-12-15",
+        fabric_token="or",
+        nn_fill=False,
+    )
+    # Pre-populate intermediates_dir with a fake legacy file (no fingerprint).
+    intermediates_dir = workdir / "targets" / ".swe_intermediates"
+    intermediates_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = intermediates_dir / "swe_targets_2003.nc"
+    legacy = xr.Dataset(
+        {"placeholder": (("time",), np.array([0.0], dtype=np.float32))},
+        coords={"time": pd.date_range("2003-12-15", periods=1, freq="D")},
+    )
+    legacy.to_netcdf(legacy_path)
+    project = load(workdir)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+    assert any(
+        ("predates" in r.message or "missing" in r.message) for r in caplog.records
+    )
+    rebuilt = xr.open_dataset(legacy_path)
+    try:
+        assert "config_fingerprint" in rebuilt.attrs
+        assert "lower_bound" in rebuilt.data_vars
+    finally:
+        rebuilt.close()


### PR DESCRIPTION
Closes #213. Closes PR #212 silent-failure items I1 (warnings silenced by cache) and I2 (skip-log compares apples to oranges).

## Summary

Adds automatic cache invalidation to both year-chunked target builders (sca + swe). A config edit, fabric swap, or release version bump no longer leaves stale intermediates on disk — the skip predicate detects the mismatch via fingerprint global attrs, deletes the stale file(s), and rebuilds.

## What landed

### Shared helpers in [`src/nhf_spatial_targets/targets/_common.py`](src/nhf_spatial_targets/targets/_common.py)

- **`target_config_fingerprint(project, target_name)`** — sha256[:12] of the target's config block + fabric.path + fabric_sha256. Catches every knob change AND fabric swaps in one hash.
- **`code_version_fingerprint()`** — package `__version__`. Catches builder changes across releases. Mid-version dev edits still need manual `rm` (documented).
- **`should_skip_year_build(paths, ...)`** — predicate that compares cached `config_fingerprint` / `code_version` global attrs against active values; on mismatch (or pre-#213 missing-attrs / corrupt-file), logs a WARNING naming both fingerprints, deletes ALL paths (primary + nn_filled companion), and falls through. Returns `cached_attrs` even on skip so the caller can re-emit per-year diagnostics.

### SCA migration ([`targets/sca.py`](src/nhf_spatial_targets/targets/sca.py))

- `build()` computes fingerprints once, adds them to `extra_attrs` so they land on every per-year intermediate AND the stitched output.
- `_build_year()` replaces the path-existence skip predicate with `should_skip_year_build(...)`.
- On skip, reads cached `frac_valid_bound` attr and re-emits the low-coverage WARNING — **closes PR #212 item I1** (warnings no longer silenced by cache).
- Persists `frac_valid` to the per-year NC global attrs so it's readable on subsequent runs.
- Extracts the low-coverage warning into a `_warn_low_valid_coverage()` helper callable from both first-build and skip-rerun paths.

### SWE migration ([`targets/swe.py`](src/nhf_spatial_targets/targets/swe.py))

- Mirrors the SCA migration shape: `build()` computes fingerprints, `_build_year()` uses the shared skip predicate. No per-year diagnostic to re-emit (SWE has no low-coverage warning today).

### Docstring updates

Both module docstrings replace their `.warning::` blocks from \"manual rm\" to \"automatic invalidation; mid-version edits still need rm.\"

## Test plan

`pixi run -e dev pytest tests/test_targets_common.py tests/test_targets_sca.py tests/test_targets_swe.py` — **151 tests pass in 22 s** locally on caldera.

- [x] **9 new unit tests** for the shared helpers ([`test_targets_common.py`](tests/test_targets_common.py)): fingerprint stability, target-edit invalidation, fabric-swap invalidation, version passthrough, skip-true-on-match, skip-false-on-config-mismatch (+ unlink), skip-false-on-version-mismatch (+ unlink), skip-false-on-pre-#213-missing-attrs (+ unlink), partial intermediate set treated as fresh build, companion-path unlink.
- [x] **3 end-to-end SCA tests** ([`test_targets_sca.py`](tests/test_targets_sca.py)): fingerprint-mismatch rebuilds with new threshold; pre-#213 legacy intermediate triggers rebuild; low-coverage warning re-emits on cached-skip path.
- [x] **2 end-to-end SWE tests** ([`test_targets_swe.py`](tests/test_targets_swe.py)): fingerprint-mismatch rebuilds with new sources list; pre-#213 legacy intermediate triggers rebuild.
- [x] Updated two pre-existing SCA skip-log assertions to the new \"config=\" + \"code=\" format (replaces \"ci_threshold=0.70\" which is no longer in the log).
- [x] No new dependencies; `pixi run -e dev fmt` + `lint` green.

## Operator-visible behavior changes

- A config edit followed by re-run **no longer requires manual rm** of intermediates. WARNING logged, stale file deleted, year rebuilds automatically.
- SCA low-coverage WARNING fires on **every** subsequent cached-skip run, not just the first build — operators see the alert consistently.
- Skip-log message changed from `\"Year %d intermediates exist; skipping\"` (SWE) / `\"...Active ci_threshold=0.70...\"` (SCA) to `\"Year %d intermediates valid (config=<hash> code=<ver>); skipping.\"` (both targets).
- Mid-version dev edits to `targets/sca.py` or `targets/swe.py` **still need manual rm** (the `code_version` tag only changes on release bumps); both module docstrings document this limitation.

## Cross-references

- Memory note `feedback_swe_intermediate_cache_fix_blocker.md` updated to reflect that case 1 (per-year code change) is now automatic; case 2 (period shrink, #211) still requires manual rm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)