### PR TITLE
fix(targets): honor config period at stitch step + prune orphan intermediates (#211)

### DIFF
--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -1307,8 +1307,10 @@ def should_skip_year_build(
 # Orphan pruning for year-chunked intermediates (issue #211)
 # ---------------------------------------------------------------------------
 
-# Match per-year intermediate filenames. Pattern: ``<base>_<YYYY>.nc`` or
-# ``<base>_<YYYY>_nn_filled.nc`` where <YYYY> is exactly 4 digits.
+# The 4-digit anchor is load-bearing — a 5-digit "year" must NOT match
+# so that misnamed intermediates fall through to the stitch's
+# computed-from-iter_period_years input list as the second defense layer
+# (verified by test_stitch_input_computed_from_period_not_glob).
 _YEAR_INTERMEDIATE_PATTERN = re.compile(r"_(\d{4})(?:_nn_filled)?\.nc$")
 
 
@@ -1331,11 +1333,11 @@ def prune_orphan_year_intermediates(
 
     Used by year-chunked target builders (sca, swe) to defend the stitch
     step against orphan intermediates left behind by a previous build
-    against a wider period. Without this pass the stitcher's directory
-    glob would silently include them, leaking out-of-period years into
-    the final canonical NC (#211 was first observed when an OR SWE
-    period shrank from 1980-2025 to 1980-2024 and the stitched output
-    still covered through 2025).
+    against a wider period (#211). Without this pass the stitcher's
+    directory glob would silently include them, leaking out-of-period
+    years into the final canonical NC. Files matching the glob but
+    failing the strict year regex (e.g. operator-renamed debris) are
+    logged at DEBUG and left untouched.
 
     Parameters
     ----------
@@ -1360,18 +1362,39 @@ def prune_orphan_year_intermediates(
     Sorted list of years pruned. Empty when no orphans were found.
     """
     pruned: dict[int, list[Path]] = {}
+    skipped: list[str] = []
     for path in intermediates_dir.glob(f"{base}_*.nc"):
         match = _YEAR_INTERMEDIATE_PATTERN.search(path.name)
         if not match:
             # Filename didn't match the canonical pattern — skip rather
-            # than risk unlinking an unrelated file.
+            # than risk unlinking an unrelated file. Recorded for the
+            # DEBUG breadcrumb so operators auditing the intermediates
+            # dir know prune saw them and chose not to act.
+            skipped.append(path.name)
             continue
         year = int(match.group(1))
         if year in expected_years:
             continue
         pruned.setdefault(year, []).append(path)
 
+    if skipped:
+        logger.debug(
+            "%s: %d files in %s matched the glob but not the year "
+            "regex; left untouched (names: %s)",
+            target_label,
+            len(skipped),
+            intermediates_dir,
+            ", ".join(sorted(skipped)),
+        )
+
     if not pruned:
+        # Audit breadcrumb — operators tailing the build log can confirm
+        # the prune pass actually ran when nothing was found.
+        logger.debug(
+            "%s: no orphan year intermediates to prune (active period covers %d years)",
+            target_label,
+            len(expected_years),
+        )
         return []
 
     for year_paths in pruned.values():
@@ -1383,7 +1406,8 @@ def prune_orphan_year_intermediates(
         "%s: pruned %d orphan year intermediates outside the active "
         "period (years: %s). Caused by a downward period change since "
         "the previous build; without pruning the stitched output would "
-        "silently include these years.",
+        "silently include these years. This is automatic recovery; no "
+        "action required.",
         target_label,
         sum(len(v) for v in pruned.values()),
         ", ".join(str(y) for y in pruned_years),

--- a/src/nhf_spatial_targets/targets/_common.py
+++ b/src/nhf_spatial_targets/targets/_common.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -1300,6 +1301,94 @@ def should_skip_year_build(
         return False, cached_attrs
 
     return True, cached_attrs
+
+
+# ---------------------------------------------------------------------------
+# Orphan pruning for year-chunked intermediates (issue #211)
+# ---------------------------------------------------------------------------
+
+# Match per-year intermediate filenames. Pattern: ``<base>_<YYYY>.nc`` or
+# ``<base>_<YYYY>_nn_filled.nc`` where <YYYY> is exactly 4 digits.
+_YEAR_INTERMEDIATE_PATTERN = re.compile(r"_(\d{4})(?:_nn_filled)?\.nc$")
+
+
+def prune_orphan_year_intermediates(
+    intermediates_dir: Path,
+    base: str,
+    expected_years: "set[int]",
+    *,
+    target_label: str,
+    logger: logging.Logger,
+) -> "list[int]":
+    """Delete per-year intermediate NCs whose year falls outside ``expected_years``.
+
+    Globs both ``<base>_<YYYY>.nc`` and ``<base>_<YYYY>_nn_filled.nc``
+    under ``intermediates_dir``, parses the 4-digit year from each
+    filename, and unlinks files whose year is not in ``expected_years``.
+    Mirrors the auto-invalidation pattern from
+    :func:`should_skip_year_build` (#213): the operator sees a WARNING
+    naming the years pruned but does not need to ``rm`` by hand.
+
+    Used by year-chunked target builders (sca, swe) to defend the stitch
+    step against orphan intermediates left behind by a previous build
+    against a wider period. Without this pass the stitcher's directory
+    glob would silently include them, leaking out-of-period years into
+    the final canonical NC (#211 was first observed when an OR SWE
+    period shrank from 1980-2025 to 1980-2024 and the stitched output
+    still covered through 2025).
+
+    Parameters
+    ----------
+    intermediates_dir
+        ``<project>/targets/.<target>_intermediates/`` for the current
+        build. Must exist (caller's responsibility).
+    base
+        Filename prefix matching the per-year writer's pattern, without
+        the trailing ``_<YYYY>``. E.g. ``"sca_targets"`` matches
+        ``sca_targets_2005.nc`` and ``sca_targets_2005_nn_filled.nc``.
+    expected_years
+        Set of calendar years the active config period covers. Files
+        whose parsed year is NOT in this set are pruned.
+    target_label
+        Short string used in log messages (e.g. ``"sca"``, ``"swe"``).
+    logger
+        Caller's module logger so the WARNING appears under the right
+        name.
+
+    Returns
+    -------
+    Sorted list of years pruned. Empty when no orphans were found.
+    """
+    pruned: dict[int, list[Path]] = {}
+    for path in intermediates_dir.glob(f"{base}_*.nc"):
+        match = _YEAR_INTERMEDIATE_PATTERN.search(path.name)
+        if not match:
+            # Filename didn't match the canonical pattern — skip rather
+            # than risk unlinking an unrelated file.
+            continue
+        year = int(match.group(1))
+        if year in expected_years:
+            continue
+        pruned.setdefault(year, []).append(path)
+
+    if not pruned:
+        return []
+
+    for year_paths in pruned.values():
+        for path in year_paths:
+            path.unlink(missing_ok=True)
+
+    pruned_years = sorted(pruned)
+    logger.warning(
+        "%s: pruned %d orphan year intermediates outside the active "
+        "period (years: %s). Caused by a downward period change since "
+        "the previous build; without pruning the stitched output would "
+        "silently include these years.",
+        target_label,
+        sum(len(v) for v in pruned.values()),
+        ", ".join(str(y) for y in pruned_years),
+    )
+    return pruned_years
 
 
 def stitch_year_chunks_to_target(

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -58,6 +58,14 @@ the ``code_version`` tag is tied to the package version string.
 The per-year low-valid-coverage WARNING is also persisted via the
 ``frac_valid_bound`` attr and re-emitted on the skip branch so it
 fires on every run, not just the first.
+
+**Period-shrink defense.** Downward changes to ``period`` (e.g.
+``2000-2024`` → ``2000-2023``) leave per-year intermediates from the
+removed years on disk. ``prune_orphan_year_intermediates`` (#211)
+deletes them with a WARNING before the stitch step, and the stitch
+input is computed deterministically from ``iter_period_years`` rather
+than a directory glob, so the canonical ``sca_targets.nc`` always
+matches the active period exactly.
 """
 
 from __future__ import annotations
@@ -77,6 +85,7 @@ from nhf_spatial_targets.targets._common import (
     compute_hru_centroids,
     iter_period_years,
     parse_period,
+    prune_orphan_year_intermediates,
     read_aggregated_source,
     reindex_to_day_start,
     should_skip_year_build,
@@ -216,10 +225,23 @@ def build(project: Project) -> None:
             code_version=code_ver,
         )
 
-    output_path = project.targets_dir() / sca_cfg["output_file"]
-    unfilled_files = sorted(
-        intermediates_dir.glob("sca_targets_[0-9][0-9][0-9][0-9].nc")
+    # Defense against #211: prune any per-year intermediates left behind
+    # by a previous build against a wider period. Stitch input is then
+    # computed deterministically from year_specs, not from a directory
+    # glob, so the canonical NC always matches the active config period.
+    in_period_years = {year for year, _, _ in year_specs}
+    prune_orphan_year_intermediates(
+        intermediates_dir,
+        "sca_targets",
+        in_period_years,
+        target_label="sca",
+        logger=logger,
     )
+
+    output_path = project.targets_dir() / sca_cfg["output_file"]
+    unfilled_files = [
+        intermediates_dir / f"sca_targets_{year}.nc" for year, _, _ in year_specs
+    ]
     stitch_year_chunks_to_target(
         unfilled_files,
         output_path,
@@ -232,9 +254,10 @@ def build(project: Project) -> None:
     )
 
     if nn_fill:
-        nn_files = sorted(
-            intermediates_dir.glob("sca_targets_[0-9][0-9][0-9][0-9]_nn_filled.nc")
-        )
+        nn_files = [
+            intermediates_dir / f"sca_targets_{year}_nn_filled.nc"
+            for year, _, _ in year_specs
+        ]
         nn_path = output_path.with_name(
             output_path.stem + "_nn_filled" + output_path.suffix
         )

--- a/src/nhf_spatial_targets/targets/sca.py
+++ b/src/nhf_spatial_targets/targets/sca.py
@@ -59,13 +59,10 @@ The per-year low-valid-coverage WARNING is also persisted via the
 ``frac_valid_bound`` attr and re-emitted on the skip branch so it
 fires on every run, not just the first.
 
-**Period-shrink defense.** Downward changes to ``period`` (e.g.
-``2000-2024`` → ``2000-2023``) leave per-year intermediates from the
-removed years on disk. ``prune_orphan_year_intermediates`` (#211)
-deletes them with a WARNING before the stitch step, and the stitch
-input is computed deterministically from ``iter_period_years`` rather
-than a directory glob, so the canonical ``sca_targets.nc`` always
-matches the active period exactly.
+**Period-shrink defense.** Downward changes to ``period`` are
+handled automatically by ``prune_orphan_year_intermediates`` plus a
+``iter_period_years``-derived stitch input list — see the helper
+docstring in ``_common.py`` (#211).
 """
 
 from __future__ import annotations
@@ -225,10 +222,7 @@ def build(project: Project) -> None:
             code_version=code_ver,
         )
 
-    # Defense against #211: prune any per-year intermediates left behind
-    # by a previous build against a wider period. Stitch input is then
-    # computed deterministically from year_specs, not from a directory
-    # glob, so the canonical NC always matches the active config period.
+    # Prune orphans + compute stitch input from year_specs (#211).
     in_period_years = {year for year, _, _ in year_specs}
     prune_orphan_year_intermediates(
         intermediates_dir,

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -52,13 +52,10 @@ builder logic WITHOUT a ``__version__`` bump still requires a manual
 ``rm`` because the ``code_version`` tag is tied to the package
 version string.
 
-**Period-shrink defense.** Downward changes to ``period`` (e.g.
-``2000-2024`` → ``2000-2023``) leave per-year intermediates from the
-removed years on disk. ``prune_orphan_year_intermediates`` (#211)
-deletes them with a WARNING before the stitch step, and the stitch
-input is computed deterministically from ``iter_period_years`` rather
-than a directory glob, so the canonical ``swe_targets.nc`` always
-matches the active period exactly.
+**Period-shrink defense.** Downward changes to ``period`` are
+handled automatically by ``prune_orphan_year_intermediates`` plus a
+``iter_period_years``-derived stitch input list — see the helper
+docstring in ``_common.py`` (#211).
 """
 
 from __future__ import annotations
@@ -400,11 +397,7 @@ def build(project: Project) -> None:
             code_version=code_ver,
         )
 
-    # 4. Defense against #211: prune any per-year intermediates left
-    # behind by a previous build against a wider period. Stitch input
-    # is then computed deterministically from year_specs, not from a
-    # directory glob, so the canonical NC always matches the active
-    # config period.
+    # 4. Prune orphans + compute stitch input from year_specs (#211).
     in_period_years = {year for year, _, _ in year_specs}
     prune_orphan_year_intermediates(
         intermediates_dir,

--- a/src/nhf_spatial_targets/targets/swe.py
+++ b/src/nhf_spatial_targets/targets/swe.py
@@ -51,6 +51,14 @@ intermediate, and rebuilds the year. Operators do not need to manually
 builder logic WITHOUT a ``__version__`` bump still requires a manual
 ``rm`` because the ``code_version`` tag is tied to the package
 version string.
+
+**Period-shrink defense.** Downward changes to ``period`` (e.g.
+``2000-2024`` → ``2000-2023``) leave per-year intermediates from the
+removed years on disk. ``prune_orphan_year_intermediates`` (#211)
+deletes them with a WARNING before the stitch step, and the stitch
+input is computed deterministically from ``iter_period_years`` rather
+than a directory glob, so the canonical ``swe_targets.nc`` always
+matches the active period exactly.
 """
 
 from __future__ import annotations
@@ -73,6 +81,7 @@ from nhf_spatial_targets.targets._common import (
     iter_period_years,
     multi_source_nanminmax,
     parse_period,
+    prune_orphan_year_intermediates,
     read_aggregated_source,
     reindex_to_day_start,
     shims_by_config_label,
@@ -391,12 +400,26 @@ def build(project: Project) -> None:
             code_version=code_ver,
         )
 
-    # 4. Stitch per-year intermediates into the canonical single-file
+    # 4. Defense against #211: prune any per-year intermediates left
+    # behind by a previous build against a wider period. Stitch input
+    # is then computed deterministically from year_specs, not from a
+    # directory glob, so the canonical NC always matches the active
+    # config period.
+    in_period_years = {year for year, _, _ in year_specs}
+    prune_orphan_year_intermediates(
+        intermediates_dir,
+        "swe_targets",
+        in_period_years,
+        target_label="swe",
+        logger=logger,
+    )
+
+    # 5. Stitch per-year intermediates into the canonical single-file
     # outputs. Dask-streamed so peak memory stays bounded.
     output_path = project.targets_dir() / swe_cfg["output_file"]
-    unfilled_files = sorted(
-        intermediates_dir.glob("swe_targets_[0-9][0-9][0-9][0-9].nc")
-    )
+    unfilled_files = [
+        intermediates_dir / f"swe_targets_{year}.nc" for year, _, _ in year_specs
+    ]
     stitch_year_chunks_to_target(
         unfilled_files,
         output_path,
@@ -406,9 +429,10 @@ def build(project: Project) -> None:
     )
 
     if nn_fill:
-        nn_files = sorted(
-            intermediates_dir.glob("swe_targets_[0-9][0-9][0-9][0-9]_nn_filled.nc")
-        )
+        nn_files = [
+            intermediates_dir / f"swe_targets_{year}_nn_filled.nc"
+            for year, _, _ in year_specs
+        ]
         nn_path = output_path.with_name(
             output_path.stem + "_nn_filled" + output_path.suffix
         )

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -1941,3 +1941,132 @@ def test_should_skip_year_build_empty_string_fingerprint_treated_as_missing(
     # The missing-attrs branch ("predates") fires, not the mismatch branch
     # ("fingerprint mismatch") — empty string is treated as missing.
     assert "predates" in caplog.text or "missing" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Orphan pruning for year-chunked intermediates (#211)
+# ---------------------------------------------------------------------------
+
+
+def _touch_nc(path: Path) -> None:
+    """Write a minimal NetCDF placeholder so the path exists and is readable."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds = xr.Dataset(
+        {"placeholder": (("time",), np.array([0.0], dtype=np.float32))},
+        coords={"time": pd.date_range("2000-01-01", periods=1, freq="D")},
+    )
+    ds.to_netcdf(path)
+
+
+def test_prune_orphan_year_intermediates_keeps_in_period_files(tmp_path: Path):
+    """Files whose year is in ``expected_years`` are preserved."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import prune_orphan_year_intermediates
+
+    for year in (2003, 2004, 2005):
+        _touch_nc(tmp_path / f"swe_targets_{year}.nc")
+        _touch_nc(tmp_path / f"swe_targets_{year}_nn_filled.nc")
+
+    pruned = prune_orphan_year_intermediates(
+        tmp_path,
+        "swe_targets",
+        {2003, 2004, 2005},
+        target_label="swe",
+        logger=logging.getLogger("test"),
+    )
+    assert pruned == []
+    # All 6 files still on disk.
+    assert sorted(p.name for p in tmp_path.glob("swe_targets_*.nc")) == [
+        "swe_targets_2003.nc",
+        "swe_targets_2003_nn_filled.nc",
+        "swe_targets_2004.nc",
+        "swe_targets_2004_nn_filled.nc",
+        "swe_targets_2005.nc",
+        "swe_targets_2005_nn_filled.nc",
+    ]
+
+
+def test_prune_orphan_year_intermediates_unlinks_out_of_period_files(
+    tmp_path: Path, caplog
+):
+    """Files outside ``expected_years`` are deleted; WARNING names the
+    pruned years."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import prune_orphan_year_intermediates
+
+    # 2003-2005 in period; 2002 + 2006 are orphans from a wider previous build.
+    for year in (2002, 2003, 2004, 2005, 2006):
+        _touch_nc(tmp_path / f"swe_targets_{year}.nc")
+        _touch_nc(tmp_path / f"swe_targets_{year}_nn_filled.nc")
+
+    with caplog.at_level(logging.WARNING):
+        pruned = prune_orphan_year_intermediates(
+            tmp_path,
+            "swe_targets",
+            {2003, 2004, 2005},
+            target_label="swe",
+            logger=logging.getLogger("test"),
+        )
+
+    assert pruned == [2002, 2006]
+    # Both unfilled + nn_filled companion files for the orphan years are gone.
+    assert not (tmp_path / "swe_targets_2002.nc").exists()
+    assert not (tmp_path / "swe_targets_2002_nn_filled.nc").exists()
+    assert not (tmp_path / "swe_targets_2006.nc").exists()
+    assert not (tmp_path / "swe_targets_2006_nn_filled.nc").exists()
+    # In-period files are still on disk.
+    for year in (2003, 2004, 2005):
+        assert (tmp_path / f"swe_targets_{year}.nc").exists()
+        assert (tmp_path / f"swe_targets_{year}_nn_filled.nc").exists()
+    # WARNING names both orphan years and the count of pruned files.
+    assert "2002" in caplog.text
+    assert "2006" in caplog.text
+    assert "4" in caplog.text  # 2 years × 2 files each
+
+
+def test_prune_orphan_year_intermediates_ignores_unrelated_files(tmp_path: Path):
+    """Files that don't match the canonical year pattern are not pruned."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import prune_orphan_year_intermediates
+
+    _touch_nc(tmp_path / "swe_targets_2005.nc")
+    # Unrelated files that shouldn't be touched:
+    _touch_nc(tmp_path / "swe_targets_summary.nc")  # not a year
+    _touch_nc(tmp_path / "swe_targets_abcd.nc")  # not 4 digits
+    _touch_nc(tmp_path / "other_targets_2005.nc")  # different base prefix
+
+    pruned = prune_orphan_year_intermediates(
+        tmp_path,
+        "swe_targets",
+        {2005},
+        target_label="swe",
+        logger=logging.getLogger("test"),
+    )
+    assert pruned == []
+    # All non-canonical files preserved.
+    for name in (
+        "swe_targets_2005.nc",
+        "swe_targets_summary.nc",
+        "swe_targets_abcd.nc",
+        "other_targets_2005.nc",
+    ):
+        assert (tmp_path / name).exists()
+
+
+def test_prune_orphan_year_intermediates_empty_dir(tmp_path: Path):
+    """Empty intermediates dir returns [] without raising."""
+    import logging
+
+    from nhf_spatial_targets.targets._common import prune_orphan_year_intermediates
+
+    pruned = prune_orphan_year_intermediates(
+        tmp_path,
+        "swe_targets",
+        {2005},
+        target_label="swe",
+        logger=logging.getLogger("test"),
+    )
+    assert pruned == []

--- a/tests/test_targets_common.py
+++ b/tests/test_targets_common.py
@@ -2070,3 +2070,31 @@ def test_prune_orphan_year_intermediates_empty_dir(tmp_path: Path):
         logger=logging.getLogger("test"),
     )
     assert pruned == []
+
+
+def test_prune_orphan_handles_nn_filled_only_companion(tmp_path: Path):
+    """Asymmetric on-disk state: only the ``_nn_filled.nc`` companion is
+    present (operator deleted the unfilled half by hand, or a SIGKILL
+    landed mid-write). The regex must match the companion's filename
+    independently of the unfilled file's presence, and the prune must
+    unlink it when its year is out of period.
+
+    Without this guarantee, a future refactor that switched the glob
+    to exclude ``_nn_filled.nc`` would silently leave nn-fill orphans
+    on disk.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets._common import prune_orphan_year_intermediates
+
+    # Only the companion file for 2006 — no unfilled.
+    _touch_nc(tmp_path / "swe_targets_2006_nn_filled.nc")
+    pruned = prune_orphan_year_intermediates(
+        tmp_path,
+        "swe_targets",
+        {2005},
+        target_label="swe",
+        logger=logging.getLogger("test"),
+    )
+    assert pruned == [2006]
+    assert not (tmp_path / "swe_targets_2006_nn_filled.nc").exists()

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -1065,3 +1065,99 @@ def test_frac_valid_bound_not_in_stitched_output(tmp_path: Path):
         # Sanity: stitched output still carries the active fingerprints.
         assert "config_fingerprint" in ds.attrs
         assert "code_version" in ds.attrs
+
+
+# ---------------------------------------------------------------------------
+# Period-shrink defense (#211)
+# ---------------------------------------------------------------------------
+
+
+def test_period_shrink_prunes_orphan_intermediates(tmp_path: Path, caplog):
+    """Shrinking the active period leaves out-of-period intermediates on
+    disk from the wider previous build. The next build must prune them
+    AND the stitched output must cover only the new (smaller) period.
+
+    Regression guard for #211: without the prune + computed stitch
+    input, the stitcher's directory glob would silently include the
+    orphan 2006 file and produce a 2-year stitched NC instead of the
+    1-year output the config requests.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # First build: 2 years wide.
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2006-12-31")
+    project = load(workdir)
+    build(project)
+    intermediates_dir = project.targets_dir() / ".sca_intermediates"
+    assert (intermediates_dir / "sca_targets_2005.nc").exists()
+    assert (intermediates_dir / "sca_targets_2006.nc").exists()
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        years_first = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years_first == [2005, 2006]
+
+    # Shrink period: drop 2006. Delete the stitched output so we can
+    # confirm the rebuild writes a fresh one matching the new period.
+    cfg_path = workdir / "config.yml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["targets"]["snow_covered_area"]["period"] = "2005-01-01/2005-12-31"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    (project.targets_dir() / "sca_targets.nc").unlink()
+
+    project = load(workdir)
+    caplog.clear()
+    # Capture WARNING from _common (prune + fingerprint-mismatch both
+    # log there).
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+
+    # 1. Orphan was pruned with a WARNING naming year 2006.
+    assert any("pruned" in r.message and "2006" in r.message for r in caplog.records), (
+        "prune WARNING must name the orphan year(s)"
+    )
+    assert not (intermediates_dir / "sca_targets_2006.nc").exists()
+
+    # 2. Stitched output covers ONLY 2005, not 2005-2006.
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        years_second = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years_second == [2005], (
+        f"stitched output must match shrunk period; got years {years_second}"
+    )
+
+
+def test_stitch_input_computed_from_period_not_glob(tmp_path: Path):
+    """Even if a stale orphan intermediate slipped past the prune step
+    (e.g. mid-pattern filename a future hash variant didn't strip), the
+    stitch input must be computed from iter_period_years so the orphan
+    cannot leak into the canonical output.
+
+    Defense in depth: this test plants an orphan with a filename pattern
+    the prune helper does NOT match (a 5-digit "year") and asserts the
+    stitched output still excludes it.
+    """
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2005-12-31")
+    project = load(workdir)
+    # Pre-plant a misnamed orphan in the intermediates dir before build.
+    intermediates_dir = project.targets_dir() / ".sca_intermediates"
+    intermediates_dir.mkdir(parents=True, exist_ok=True)
+    orphan = intermediates_dir / "sca_targets_99999.nc"
+    # Realistic-looking but out-of-period file the prune regex won't catch.
+    ds = xr.Dataset(
+        {"placeholder": (("time",), np.array([0.0], dtype=np.float32))},
+        coords={"time": pd.date_range("9999-01-01", periods=1, freq="D")},
+    )
+    ds.to_netcdf(orphan)
+    project = load(workdir)
+    build(project)
+    # Orphan unaffected by the prune (its name doesn't match the
+    # canonical year pattern), but the stitch input is computed from
+    # year_specs so it must not leak.
+    assert orphan.exists()
+    with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
+        years = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years == [2005]

--- a/tests/test_targets_sca.py
+++ b/tests/test_targets_sca.py
@@ -1108,15 +1108,19 @@ def test_period_shrink_prunes_orphan_intermediates(tmp_path: Path, caplog):
 
     project = load(workdir)
     caplog.clear()
-    # Capture WARNING from _common (prune + fingerprint-mismatch both
-    # log there).
-    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+    # The prune WARNING is emitted under the caller's logger
+    # (the sca module logger), not under _common — the helper takes
+    # the caller's logger as a parameter precisely so the message
+    # appears under the right name in operator logs.
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.sca"):
         build(project)
 
-    # 1. Orphan was pruned with a WARNING naming year 2006.
-    assert any("pruned" in r.message and "2006" in r.message for r in caplog.records), (
-        "prune WARNING must name the orphan year(s)"
-    )
+    # 1. Orphan was pruned with a WARNING naming year 2006 + the
+    # target label so operators can filter logs by target.
+    assert any(
+        "pruned" in r.message and "2006" in r.message and "sca" in r.message
+        for r in caplog.records
+    ), "prune WARNING must name the orphan year(s) and the target label"
     assert not (intermediates_dir / "sca_targets_2006.nc").exists()
 
     # 2. Stitched output covers ONLY 2005, not 2005-2006.
@@ -1161,3 +1165,39 @@ def test_stitch_input_computed_from_period_not_glob(tmp_path: Path):
     with xr.open_dataset(project.targets_dir() / "sca_targets.nc") as ds:
         years = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
     assert years == [2005]
+
+
+def test_stitch_fails_loud_on_missing_in_period_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """If an in-period per-year intermediate is missing at stitch time
+    (e.g. operator manually deleted one, or build crashed mid-loop and
+    was restarted into the skip branch), the stitch must raise a clear
+    error rather than silently producing a year-gapped stitched NC.
+
+    Before #211 the stitcher globbed the directory, so a missing
+    in-period file silently produced a year-gapped output. With the
+    computed-from-year_specs input list, the missing file surfaces
+    as an error naming the path.
+    """
+    import nhf_spatial_targets.targets.sca as sca_mod
+    from nhf_spatial_targets.targets.sca import build
+    from nhf_spatial_targets.workspace import load
+
+    # Build a 3-year target so we have multiple intermediates to choose from.
+    workdir = _make_sca_project(tmp_path, period="2005-01-01/2007-12-31")
+    project = load(workdir)
+    build(project)
+    intermediates_dir = project.targets_dir() / ".sca_intermediates"
+    # Delete the 2006 intermediate + the stitched output. Then patch
+    # _build_year to a no-op so the missing 2006 intermediate stays
+    # missing through the second build's stitch call (otherwise the
+    # build loop's should_skip_year_build would see the missing file
+    # and rebuild it).
+    (intermediates_dir / "sca_targets_2006.nc").unlink()
+    (project.targets_dir() / "sca_targets.nc").unlink()
+    monkeypatch.setattr(sca_mod, "_build_year", lambda **_kw: None)
+
+    project = load(workdir)
+    with pytest.raises((FileNotFoundError, OSError), match="2006"):
+        build(project)

--- a/tests/test_targets_swe.py
+++ b/tests/test_targets_swe.py
@@ -819,3 +819,68 @@ def test_pre_213_intermediate_triggers_rebuild(tmp_path: Path, caplog):
         assert "lower_bound" in rebuilt.data_vars
     finally:
         rebuilt.close()
+
+
+# ---------------------------------------------------------------------------
+# Period-shrink defense (#211)
+# ---------------------------------------------------------------------------
+
+
+def test_period_shrink_prunes_orphan_intermediates(tmp_path: Path, caplog):
+    """Shrinking the active period leaves out-of-period intermediates on
+    disk from the wider previous build. The next build must prune them
+    AND the stitched output must cover only the new (smaller) period.
+
+    Regression guard for #211, the original symptom that motivated this
+    fix: OR SWE's period shrunk from 1980-2025 to 1980-2024 and the
+    stitched ``swe_targets.nc`` still covered through 2025 because the
+    stitcher's directory glob silently included the orphan 2025
+    intermediate.
+    """
+    import logging
+
+    from nhf_spatial_targets.targets.swe import build
+    from nhf_spatial_targets.workspace import load
+
+    # First build: 2 years wide (2003-2004 — SNODAS era so all 4 OR
+    # sources contribute).
+    workdir = _make_swe_project(
+        tmp_path,
+        period="2003-12-01/2004-01-31",
+        fabric_token="or",
+        nn_fill=False,
+    )
+    project = load(workdir)
+    build(project)
+    intermediates_dir = project.targets_dir() / ".swe_intermediates"
+    assert (intermediates_dir / "swe_targets_2003.nc").exists()
+    assert (intermediates_dir / "swe_targets_2004.nc").exists()
+    with xr.open_dataset(project.targets_dir() / "swe_targets.nc") as ds:
+        years_first = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years_first == [2003, 2004]
+
+    # Shrink period: drop 2004. Delete the stitched output so we can
+    # confirm the rebuild writes a fresh one matching the new period.
+    cfg_path = workdir / "config.yml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    cfg["targets"]["snow_water_equivalent"]["period"] = "2003-12-01/2003-12-31"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    (project.targets_dir() / "swe_targets.nc").unlink()
+
+    project = load(workdir)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+        build(project)
+
+    # 1. Orphan was pruned with a WARNING naming year 2004.
+    assert any("pruned" in r.message and "2004" in r.message for r in caplog.records), (
+        "prune WARNING must name the orphan year(s)"
+    )
+    assert not (intermediates_dir / "swe_targets_2004.nc").exists()
+
+    # 2. Stitched output covers ONLY 2003, not 2003-2004.
+    with xr.open_dataset(project.targets_dir() / "swe_targets.nc") as ds:
+        years_second = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years_second == [2003], (
+        f"stitched output must match shrunk period; got years {years_second}"
+    )

--- a/tests/test_targets_swe.py
+++ b/tests/test_targets_swe.py
@@ -869,13 +869,19 @@ def test_period_shrink_prunes_orphan_intermediates(tmp_path: Path, caplog):
 
     project = load(workdir)
     caplog.clear()
-    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets._common"):
+    # The prune WARNING is emitted under the caller's logger
+    # (the swe module logger), not under _common — the helper takes
+    # the caller's logger as a parameter precisely so the message
+    # appears under the right name in operator logs.
+    with caplog.at_level(logging.WARNING, logger="nhf_spatial_targets.targets.swe"):
         build(project)
 
-    # 1. Orphan was pruned with a WARNING naming year 2004.
-    assert any("pruned" in r.message and "2004" in r.message for r in caplog.records), (
-        "prune WARNING must name the orphan year(s)"
-    )
+    # 1. Orphan was pruned with a WARNING naming year 2004 + the
+    # target label so operators can filter logs by target.
+    assert any(
+        "pruned" in r.message and "2004" in r.message and "swe" in r.message
+        for r in caplog.records
+    ), "prune WARNING must name the orphan year(s) and the target label"
     assert not (intermediates_dir / "swe_targets_2004.nc").exists()
 
     # 2. Stitched output covers ONLY 2003, not 2003-2004.
@@ -884,3 +890,42 @@ def test_period_shrink_prunes_orphan_intermediates(tmp_path: Path, caplog):
     assert years_second == [2003], (
         f"stitched output must match shrunk period; got years {years_second}"
     )
+
+
+def test_stitch_input_computed_from_period_not_glob(tmp_path: Path):
+    """Defense-in-depth (parallels the SCA test by the same name):
+    even if a stale orphan with a non-canonical filename slips past
+    the prune regex, the stitch input must be computed from
+    iter_period_years so the orphan cannot leak into the canonical
+    output.
+    """
+    from nhf_spatial_targets.targets.swe import build
+    from nhf_spatial_targets.workspace import load
+
+    workdir = _make_swe_project(
+        tmp_path,
+        period="2003-12-15/2003-12-15",
+        fabric_token="or",
+        nn_fill=False,
+    )
+    project = load(workdir)
+    intermediates_dir = project.targets_dir() / ".swe_intermediates"
+    intermediates_dir.mkdir(parents=True, exist_ok=True)
+    # 5-digit "year" — prune regex (anchored at \d{4}) won't match,
+    # so the file stays on disk after the build.
+    orphan = intermediates_dir / "swe_targets_99999.nc"
+    orphan_ds = xr.Dataset(
+        {"placeholder": (("time",), np.array([0.0], dtype=np.float32))},
+        coords={"time": pd.date_range("9999-01-01", periods=1, freq="D")},
+    )
+    orphan_ds.to_netcdf(orphan)
+
+    build(project)
+
+    # Orphan survives the prune (regex didn't match).
+    assert orphan.exists()
+    # Stitched output excludes the orphan because the stitch input list
+    # is computed from iter_period_years, not from a directory glob.
+    with xr.open_dataset(project.targets_dir() / "swe_targets.nc") as ds:
+        years = sorted(set(pd.DatetimeIndex(ds["time"].values).year))
+    assert years == [2003]


### PR DESCRIPTION
Closes #211. Closes the last manual-rm case in the year-chunked target builders — downward period changes are now self-healing across SCA + SWE, matching the auto-invalidation posture established by #213/#214.

## The bug

OR SWE's period shrunk from \`1980-2025\` → \`1980-2024\` in \`config.yml\`. The per-year build loop correctly produced only the 45 in-period intermediates, but the stitcher's directory glob picked up the stale 2025 file from the previous wider build. Resulting \`swe_targets.nc\` covered 1980-2025 (16,802 timesteps) instead of the configured 1980-2024 (16,437 timesteps). Silent correctness bug — output looked plausible, caught only because the operator counted timesteps.

When #213 made SCA use the same year-chunk + stitch pattern, the bug propagated there too.

## The fix (two defenses)

### 1. New helper [`prune_orphan_year_intermediates`](src/nhf_spatial_targets/targets/_common.py)

Globs \`<base>_<YYYY>.nc\` and \`<base>_<YYYY>_nn_filled.nc\` under the intermediates dir, parses the 4-digit year from each filename via a strict regex (so unrelated files like \`summary.nc\` or \`other_targets_2005.nc\` are ignored), unlinks any whose year is not in \`expected_years\`, and logs a single WARNING naming the pruned years and file count.

### 2. Stitch input computed from \`iter_period_years()\`, not from a directory glob

Both [\`build()\`](src/nhf_spatial_targets/targets/sca.py) functions now build the stitch input list deterministically from the active period. Defense in depth: even if pruning ever failed (e.g. a future filename pattern the regex doesn't match), the stitched output would still match the active period.

## Test plan

\`pixi run -e dev pytest tests/test_targets_common.py tests/test_targets_sca.py tests/test_targets_swe.py\` — **161 tests pass in 23 s** locally on caldera.

- [x] **4 unit tests** for the prune helper ([\`test_targets_common.py\`](tests/test_targets_common.py)): in-period files preserved; out-of-period unlinked with WARNING naming the years; unrelated files (\`summary.nc\`, \`abcd.nc\`, different base prefix) ignored; empty dir returns \`[]\`.
- [x] **2 end-to-end SCA tests** ([\`test_targets_sca.py\`](tests/test_targets_sca.py)): period-shrink prunes orphan + stitched output matches new period; stitch-input-computed-from-period (defense in depth — plants a misnamed orphan past the prune regex and asserts the stitched output still excludes it).
- [x] **1 end-to-end SWE test** ([\`test_targets_swe.py\`](tests/test_targets_swe.py)): period-shrink prunes orphan + stitched output matches new period (mirrors the original symptom).
- [x] No new dependencies; \`pixi run -e dev fmt\` + \`lint\` green.

## Operator-visible behavior changes

- After shrinking \`targets.<target>.period\`, the next build automatically prunes out-of-period intermediates with a WARNING listing the years deleted. **No more manual \`rm\` required**.
- WARNING format: \`<target>: pruned <N> orphan year intermediates outside the active period (years: 2025). Caused by a downward period change since the previous build; without pruning the stitched output would silently include these years.\`
- The stitched output is now guaranteed to match the active period exactly, regardless of what's on disk in the intermediates dir.

## What's still open in the cache-invalidation space

- **Mid-version dev edits** to \`targets/sca.py\` / \`targets/swe.py\` / \`targets/_common.py\` still require manual \`rm\` (the \`code_version\` tag is tied to package \`__version__\`, which doesn't change between edits within a release). Documented in both module docstrings and in the updated memory note.

## Cross-references

- Memory note \`feedback_swe_intermediate_cache_fix_blocker.md\` updated to reflect that the period-shrink case is now closed; only mid-version code edits remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)