### PR TITLE
docs(sources): expand docs/sources/ from 4 to 14 — one per fetched source

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,14 @@ nhf-spatial-targets/
 ├── docs/
 │   ├── architecture/        # transformation-pipeline, nc-encoding, python-patterns
 │   ├── references/          # TM 6-B10 crib sheet, lessons-learned, known-gaps-resolved
-│   ├── sources/             # per-source operator notes (manual-staging caveats etc.)
+│   ├── sources/             # per-source operator notes (one per catalog source)
+│   │                        #   runoff: era5_land.md, gldas.md
+│   │                        #   AET: ssebop.md, mod16a2_v061.md
+│   │                        #   recharge: reitz2017.md, watergap22d.md
+│   │                        #   soil moisture: merra2.md, ncep_ncar.md, nldas_mosaic.md, nldas_noah.md
+│   │                        #   snow-covered area: mod10c1_v061.md
+│   │                        #   SWE: daymet.md, snodas.md, margulis_wus_sr.md
+│   │                        #   integrated water balance: mwbm_climgrid.md
 │   └── figures/             # rendered inspection panels (gitignored except small samples)
 ├── notebooks/
 │   ├── consolidated/        # gridded source sanity checks (pre-aggregation)

--- a/docs/sources/era5_land.md
+++ b/docs/sources/era5_land.md
@@ -9,7 +9,7 @@ resolution:
 | Variable | Long name | Native units | cell_methods | Target |
 | -------- | --------- | ------------ | ------------ | ------ |
 | `ro` | total runoff | m | `time: sum` (accumulated) | runoff |
-| `sro` | surface runoff | m | `time: sum` (accumulated) | reserve |
+| `sro` | surface runoff | m | `time: sum` (accumulated) | reserved (future) |
 | `ssro` | sub-surface runoff | m | `time: sum` (accumulated) | recharge (proxy) |
 | `sd` | snow depth water equivalent | m | `time: point` (instantaneous) | SWE |
 
@@ -64,7 +64,7 @@ each variable's `cell_methods` from `catalog/sources.yml`:
   is credited to the prior day, then (d) sums hourly increments per
   calendar day. The daily→monthly step is a `.sum()`.
 - **Instantaneous** (`sd`): values are point-in-time snowpack water
-  equivalent. Hourly→daily is a `.mean()`; monthly→daily is also a
+  equivalent. Hourly→daily is a `.mean()`; daily→monthly is also a
   `.mean()`. Applying the accumulated reducer here would yield
   physically meaningless values.
 

--- a/docs/sources/era5_land.md
+++ b/docs/sources/era5_land.md
@@ -1,0 +1,142 @@
+# ERA5-Land (Copernicus CDS)
+
+ECMWF [ERA5-Land](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land)
+hourly reanalysis (Muñoz-Sabater et al., 2021;
+doi:10.5194/essd-13-4349-2021). The pipeline downloads four variables
+across CONUS + contributing watersheds (Canada/Mexico) at 0.1° native
+resolution:
+
+| Variable | Long name | Native units | cell_methods | Target |
+| -------- | --------- | ------------ | ------------ | ------ |
+| `ro` | total runoff | m | `time: sum` (accumulated) | runoff |
+| `sro` | surface runoff | m | `time: sum` (accumulated) | reserve |
+| `ssro` | sub-surface runoff | m | `time: sum` (accumulated) | recharge (proxy) |
+| `sd` | snow depth water equivalent | m | `time: point` (instantaneous) | SWE |
+
+ERA5-Land is the largest fetch by far in the catalog: hourly fields
+across ~12 GB/variable-year (CONUS+ bbox) and a 1979/present publisher
+window. The pipeline writes both a daily and a monthly consolidated
+NetCDF per year to the datastore (`<datastore>/era5_land/{daily,monthly}/era5_land_{daily,monthly}_<year>.nc`).
+
+## Access path — Copernicus CDS API
+
+Authenticated via `cdsapi.Client()`. Operators must:
+
+1. Create a free Copernicus CDS account at
+   <https://cds.climate.copernicus.eu/>.
+2. Accept the **ERA5-Land licence** at
+   <https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=download#manage-licences>
+   — the API will fail with a licence-not-accepted error otherwise, and
+   CDS does not surface this clearly in the failure message.
+3. Place credentials (`url`, `key`) in `.credentials.yml` under the
+   `cdsapi:` key, then run
+   `nhf-targets materialize-credentials --project-dir <project>` to
+   render `~/.cdsapirc`.
+
+## Monthly-chunked CDS requests
+
+Each year of each variable is split into **12 monthly CDS requests**
+because a single annual all-hours-all-days request exceeds the CDS
+per-request cost limit. The per-month chunks land alongside the year
+file as
+`<datastore>/era5_land/hourly/era5_land_<var>_<year>_<MM>.nc` and are
+**preserved on disk** so re-runs are idempotent at the chunk level.
+
+The monthly chunk validator (`_validate_chunk_time_coord` in
+[`fetch/era5_land.py`](../../src/nhf_spatial_targets/fetch/era5_land.py))
+guards against an observed-in-production rare CDS quirk: a chunk file
+on disk whose `time` coord covers a different month than the chunk
+filename implies. When detected, the bad chunk is deleted and
+re-fetched. Without this guard, `open_mfdataset(combine="by_coords")`
+silently inflates the year's time range and corrupts every downstream
+daily/monthly NC.
+
+## Hourly → daily → monthly aggregation
+
+Two distinct reducers are dispatched by `_VARIABLE_KIND`, which reads
+each variable's `cell_methods` from `catalog/sources.yml`:
+
+- **Accumulated** (`ro`, `sro`, `ssro`): hourly values are
+  midnight-resetting accumulations since 00 UTC. The hourly→daily step
+  in `hourly_to_daily` (a) diffs the accumulation, (b) substitutes the
+  raw accumulated value at the midnight reset where the diff is
+  negative, (c) shifts timestamps back 1 hour so the 23→00 increment
+  is credited to the prior day, then (d) sums hourly increments per
+  calendar day. The daily→monthly step is a `.sum()`.
+- **Instantaneous** (`sd`): values are point-in-time snowpack water
+  equivalent. Hourly→daily is a `.mean()`; monthly→daily is also a
+  `.mean()`. Applying the accumulated reducer here would yield
+  physically meaningless values.
+
+If you add a new ERA5-Land variable, set its catalog `cell_methods` to
+either `time: sum` (accumulated) or `time: point` (instantaneous);
+anything else makes `_derive_variable_kind` raise so the dispatch
+table doesn't silently misclassify.
+
+## Procedure
+
+```bash
+nhf-targets fetch era5-land \
+    --project-dir <project> \
+    --period 1979/2025 \
+    [--worker-index 0 --n-workers 4]
+```
+
+Or via the sharded SLURM array (default 4 workers, respects CDS
+per-user throttling):
+
+```bash
+sbatch slurm/shared/fetch_era5_land.slurm
+```
+
+Each worker takes a round-robin slice of `all_years`; the slice is
+computed independently of sibling progress (the manifest fast-path that
+caused gap-bugs in earlier versions was rewritten in #126).
+
+## Manifest fast-path
+
+A year is considered "complete" only when its manifest entry carries
+both `daily_path` and `monthly_path` *and* both files exist on disk.
+This means rerunning `fetch era5-land` after a hand-deletion of one of
+the consolidated NCs picks the year back up, and rerunning after a new
+worker pool size change picks up any years no previous slice covered.
+
+## HPC memory/time notes
+
+- CDS throttles each user to a few concurrent requests; the
+  `slurm/shared/fetch_era5_land.slurm` script uses 4 parallel workers
+  by default, which has converged on Hovenweep without
+  rate-limit retries.
+- A full 1979/2025 pipeline run takes many hours, sometimes days, with
+  the CDS queue being the dominant cost.
+- Memory is modest (~8-16 GB); the per-month chunks bound peak RSS even
+  when concatenating into a year file.
+
+## Aggregator wiring
+
+`aggregate/era5_land.py` exposes **two adapters** for the one source:
+
+- `ADAPTER` reads `<datastore>/era5_land/monthly/era5_land_monthly_*.nc`
+  and emits the runoff variables (`ro`, `sro`, `ssro`). Output at
+  `<project>/data/aggregated/era5_land/era5_land_<year>_agg.nc`.
+- `ADAPTER_SD` reads `<datastore>/era5_land/daily/era5_land_daily_*.nc`
+  and emits the snow depth water equivalent (`sd`). Output at
+  `<project>/data/aggregated/era5_land_sd/era5_land_sd_<year>_agg.nc`.
+  The synthetic source key `era5_land_sd` keeps the SWE adapter's
+  weight cache, manifest entry, and aggregated subdir distinct from
+  the monthly runoff adapter without duplicating catalog metadata.
+
+Both adapters use `stat_method="mean"` (no per-pixel masking is done
+upstream; CDS-delivered NaN pixels propagate honestly to NaN HRUs).
+
+## Troubleshooting
+
+- `Required licence not yet accepted` from `cdsapi.Client.retrieve` —
+  see step 2 above; accept the ERA5-Land licence in the CDS web UI.
+- A year repeatedly fails consolidation while individual monthly
+  chunks are present — almost always a hand-corrupted chunk. Inspect
+  `era5_land_<var>_<year>_<MM>.nc` files for non-NetCDF magic bytes,
+  delete the offender, and re-run.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `era5_land:` block for variable units, the bbox (53°/-125° → 24.7°/-66°),
+  and CF metadata that flows through `apply_cf_metadata`.

--- a/docs/sources/gldas.md
+++ b/docs/sources/gldas.md
@@ -1,0 +1,99 @@
+# GLDAS-2.1 NOAH Monthly Runoff
+
+NASA's Global Land Data Assimilation System version 2.1, NOAH land
+surface model, monthly product
+([GLDAS_NOAH025_M](https://disc.gsfc.nasa.gov/datasets/GLDAS_NOAH025_M_2.1/summary);
+Rodell et al., 2004). Used as the second source for the runoff
+calibration target (alongside ERA5-Land). The catalog key is
+`gldas_noah_v21_monthly` — `GLDAS` alone is ambiguous between NOAH /
+CLSM / VIC and between 2.0 / 2.1 / monthly / 3-hourly variants.
+
+The pipeline downloads two variables and writes a derived third at
+consolidation:
+
+| Variable | Long name | Native units | cell_methods |
+| -------- | --------- | ------------ | ------------ |
+| `Qs_acc` | storm surface runoff | kg m-2 | `time: sum` |
+| `Qsb_acc` | baseflow-groundwater runoff | kg m-2 | `time: sum` |
+| `runoff_total` (derived) | `Qs_acc + Qsb_acc` | kg m-2 | `time: sum` |
+
+The catalog `notes` field captures the GLDAS-2.1 `_acc` convention
+gotcha: variables ending in `_acc` are stored as the **mean of
+3-hourly accumulations across the month**, not as a monthly sum,
+despite the misleading `cell_methods: time: sum`. To recover monthly
+mm, multiply by `8 × days_in_month`. The runoff target builder
+(`targets/run.py`) applies this conversion in `gldas_to_mm_per_month`;
+do not apply it at fetch or aggregate time, where the native units are
+preserved (see CLAUDE.md Aggregation Transformation Policy: linear
+conversions live in `targets/`).
+
+## Access path — NASA earthaccess
+
+Authenticated via `earthaccess.login(strategy="netrc")` from
+[`fetch/_auth.py`](../../src/nhf_spatial_targets/fetch/_auth.py). Requires
+a NASA Earthdata Login account with the GES DISC application linked
+(see <https://disc.gsfc.nasa.gov/earthdata-login>). Credentials are
+materialized into `~/.netrc` by
+`nhf-targets materialize-credentials --project-dir <project>`.
+
+Granules are **global** monthly NetCDF-4 files (~few MB each). The
+download happens full-globe; spatial clipping to the
+CONUS+contributing-watersheds bbox (53°/-125° → 24.7°/-66°) happens at
+consolidate time via `clip_to_bbox`, which handles both ascending and
+descending latitude ordering and converts 0-360 longitude to -180-180
+if needed.
+
+## On-disk layout
+
+```
+<datastore>/gldas_noah_v21_monthly/
+  raw/                                    # per-month granules from earthaccess
+    GLDAS_NOAH025_M.A<YYYYMM>.021.nc4
+    ...
+  gldas_noah_v21_monthly.nc               # consolidated, clipped, CF-1.6
+```
+
+The consolidator runs `derive_runoff_total → clip_to_bbox →
+apply_cf_metadata` and writes atomically via a `.nc.tmp` rename.
+
+## Procedure
+
+```bash
+nhf-targets fetch gldas --project-dir <project> --period 2000/2025
+```
+
+Or via the general SLURM fetch array, index 1
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+The function fails fast (raises `ValueError`) if `earthaccess.search_data`
+returns no granules, and raises `RuntimeError` on partial downloads —
+the consolidated NC is regenerated from scratch on every call rather
+than re-merging.
+
+## HPC memory/time notes
+
+- The general 128 GB / 24 h fetch SLURM allocation is overkill for
+  GLDAS; runs typically finish in under an hour with peak RSS under a
+  few GB. No source-specific tuning needed.
+
+## Aggregator wiring
+
+`aggregate/gldas.py` is a thin `SourceAdapter` (`monthly` cadence,
+`stat_method="mean"` default). The pre-aggregate hook redundantly
+re-derives `runoff_total` to defend against datastores that pre-date
+the fetch-time derivation, but the consolidated NC already carries it.
+Output at `<project>/data/aggregated/gldas_noah_v21_monthly/gldas_<year>_agg.nc`,
+one per year.
+
+## Troubleshooting
+
+- `ValueError: No GLDAS granules found ...` — check Earthdata
+  credentials and that GES DISC is linked to your EDL account.
+- `ValueError: Clipping produced an empty dataset` — the bbox
+  convention (lon/lat) and dataset longitude convention (-180/180 vs
+  0/360) mismatch. The clipper converts 0/360→-180/180 automatically;
+  if this raises anyway, file an issue with the offending file's
+  lon/lat range from the error message.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `gldas_noah_v21_monthly:` block for the `_acc` convention note and
+  the runoff target's mm-conversion factor.

--- a/docs/sources/gldas.md
+++ b/docs/sources/gldas.md
@@ -53,8 +53,10 @@ if needed.
   gldas_noah_v21_monthly.nc               # consolidated, clipped, CF-1.6
 ```
 
-The consolidator runs `derive_runoff_total → clip_to_bbox →
-apply_cf_metadata` and writes atomically via a `.nc.tmp` rename.
+The consolidator (in [`fetch/gldas.py`](../../src/nhf_spatial_targets/fetch/gldas.py))
+runs `derive_runoff_total → clip_to_bbox → apply_cf_metadata` (the
+shared CF helper from `fetch/consolidate.py`) and writes atomically
+via a `.nc.tmp` rename.
 
 ## Procedure
 

--- a/docs/sources/merra2.md
+++ b/docs/sources/merra2.md
@@ -42,7 +42,8 @@ Granules are global monthly NetCDF-4 files
 the project's `fabric.bbox_buffered`, but **earthaccess returns the
 full global granule regardless** — bounding_box is a server-side
 *overlap* test, not a subset operation. Spatial subsetting happens at
-target-build time, not at fetch time.
+aggregation time (gdptools reads only the pixels overlapping fabric
+HRUs), not at fetch time.
 
 ## On-disk layout
 

--- a/docs/sources/merra2.md
+++ b/docs/sources/merra2.md
@@ -1,0 +1,99 @@
+# MERRA-2 Soil Moisture (M2TMNXLND)
+
+NASA's [Modern-Era Retrospective analysis for Research and
+Applications, Version 2](https://disc.gsfc.nasa.gov/datasets/M2TMNXLND_5.12.4/summary)
+monthly land surface diagnostics (Gelaro et al., 2017;
+Reichle et al., 2017). Used as one of four sources for the soil
+moisture (`som`) calibration target range. The catalog short_name is
+`M2TMNXLND`, version `5.12.4`, served by NASA GES DISC.
+
+This is the **current replacement for MERRA-Land** (which was
+discontinued 2016-02-29). All new runs use MERRA-2; the `merra_land`
+catalog entry is preserved with `status: superseded` for documentary
+provenance only.
+
+The pipeline downloads three dimensionless soil-wetness variables:
+
+| Variable | Long name | Layer depth | Units |
+| -------- | --------- | ----------- | ----- |
+| `GWETTOP` | surface_soil_wetness | 0.00-0.05 m (surface) | `1` (fraction of saturation, 0-1) |
+| `GWETROOT` | root_zone_soil_wetness | 0.00-1.00 m (root zone) | `1` |
+| `GWETPROF` | ave_prof_soil_moisture | spatially varying (surface to bedrock) | `1` |
+
+`GWETTOP` is the **preferred variable** (marked `preferred: true` in
+the catalog) for comparison with PRMS `soil_rechr`. All three are
+already dimensionless (fraction of saturation 0-1) so no unit
+conversion is needed before normalization. Note that magnitudes are
+not expected to match across sources at different layer depths;
+TM 6-B10 normalization makes this irrelevant for calibration. Layer
+thickness fields (`dzsf`, `dzrz`, `dzpr`) live in the `M2CONXLND`
+collection and are documented in the catalog `layer_depth_notes`
+block.
+
+## Access path — NASA earthaccess
+
+Authenticated via `earthaccess.login(strategy="netrc")`. Requires a
+NASA Earthdata Login account with **GES DISC linked** (a separate
+opt-in from the base EDL account). Materialize credentials with
+`nhf-targets materialize-credentials --project-dir <project>`.
+
+Granules are global monthly NetCDF-4 files
+(`MERRA2_<stream>.tavgM_2d_lnd_Nx.<YYYYMM>.nc4`). The CMR search uses
+the project's `fabric.bbox_buffered`, but **earthaccess returns the
+full global granule regardless** — bounding_box is a server-side
+*overlap* test, not a subset operation. Spatial subsetting happens at
+target-build time, not at fetch time.
+
+## On-disk layout
+
+```
+<datastore>/merra2/
+  MERRA2_*.tavgM_2d_lnd_Nx.<YYYYMM>.nc4    # one per year-month
+  merra2_consolidated.nc                    # combined CF-1.6 NC (consolidate_merra2)
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch merra2 --project-dir <project> --period 1980/2025
+```
+
+Or via the general SLURM fetch array, index 2
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+Fully **incremental**: months already recorded in `manifest.json` are
+skipped at search-result filter time, so a re-run after adding new
+years downloads only the new months and re-runs `consolidate_merra2`
+against the union of files on disk. The manifest is read-merge-write
+to preserve sibling-source provenance (issue #97).
+
+## HPC memory/time notes
+
+- 1980-2025 ≈ 540 monthly granules at ~10 MB each (~5-8 GB total raw,
+  see [README.md](../../README.md) §Datastore Storage Estimates).
+- The general 128 GB / 24 h fetch SLURM allocation is comfortable;
+  most runs finish within a few hours, dominated by network throughput
+  to GES DISC.
+
+## Aggregator wiring
+
+`aggregate/merra2.py` is a thin `SourceAdapter` (`monthly` cadence,
+`stat_method="mean"`). All three variables flow through area-weighted
+aggregation onto the HRU fabric and out to
+`<project>/data/aggregated/merra2/merra2_<year>_agg.nc`, one per year,
+in native units (dimensionless 0-1). The `som` target consumes
+`GWETTOP` by default; the other two are kept for diagnostic
+cross-checks.
+
+## Troubleshooting
+
+- `ValueError: No granules found for M2TMNXLND ...` — Earthdata
+  credentials missing or GES DISC application not linked. Visit
+  <https://urs.earthdata.nasa.gov/profile> → Applications → Authorized
+  Apps to confirm.
+- `Partial download: got N of M granules` warning — earthaccess saw
+  fewer files arrive than CMR listed. The consolidate step proceeds
+  with the files on disk; re-run to fill the gap.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `merra2:` block for variable definitions, the `layer_depth_notes`
+  block on layer thicknesses, and the GES DISC links.

--- a/docs/sources/mod10c1_v061.md
+++ b/docs/sources/mod10c1_v061.md
@@ -1,0 +1,143 @@
+# MOD10C1 v061 (MODIS Daily Snow Cover, NSIDC)
+
+NASA's [MOD10C1 v061](https://nsidc.org/data/mod10c1/versions/61)
+Daily Snow Cover L3 Global 0.05° CMG product (Hall & Riggs;
+doi:10.5067/MODIS/MOD10C1.006 for v006, v061 is the current
+replacement). Distributed by NSIDC and accessed via NASA Earthdata via
+CMR. Used as the single source for the snow-covered area (`sca`)
+calibration target via the TM 6-B10 CI-bounded recipe.
+
+This replaces v006, preserved in the catalog with `status: superseded`
+for documentary provenance only. The variable renamed in v061:
+`Day_CMG_Clear_Index` (v061) was `Day_CMG_Confidence_Index` (v006).
+
+The pipeline downloads four variables but only the first two are used
+for `sca`:
+
+| Variable | Long name | Native units | Notes |
+| -------- | --------- | ------------ | ----- |
+| `Day_CMG_Snow_Cover` | daily snow-covered area | percent (0-100) | Primary signal |
+| `Day_CMG_Clear_Index` | daily clear-sky % of cell | percent (0-100) | TM 6-B10 "confidence interval" (CI) |
+| `Day_CMG_Cloud_Obscured` | daily cloud-obscured % | percent (0-100) | QA cross-check (kept) |
+| `Snow_Spatial_QA` | categorical QA flag | `1` (0=best ... 4=other) | **Not a percent** — see notes |
+
+## Flag values to mask
+
+> Source HDF carries flag values that must be masked before any
+> quantitative use:
+>
+> - `107` = lake ice
+> - `111` = night
+> - `237` = inland water
+> - `239` = ocean
+> - `250` = cloud-obscured water
+> - `253` = data not mapped
+> - `255` = fill
+>
+> **Mask values > 100 to NaN** before plotting or aggregation. The
+> aggregator's `pre_aggregate_hook` (`build_masked_source`) does this
+> for `Day_CMG_Snow_Cover` and `Day_CMG_Clear_Index`. The pipeline
+> never plots / aggregates raw HDF reads.
+
+## The Snow_Spatial_QA mislabel
+
+> Source HDF labels `Snow_Spatial_QA` with `units: percent` but it is
+> **not** a percent — it is a categorical QA flag with `valid_range
+> 0-4` (0=best, 1=good, 2=ok, 3=poor, 4=other) plus flag values
+> 237/239/250/252/253/254/255 for water/Antarctica/no-retrieval.
+>
+> **Do NOT divide by 100** to obtain a "fraction"; the result is
+> meaningless. TM 6-B10 uses `Day_CMG_Clear_Index` for the CI filter,
+> not `Snow_Spatial_QA`. The catalog declares
+> `cf_units: "1"` (dimensionless) to override the misleading on-disk
+> attribute.
+
+## Access path — NASA earthaccess + NSIDC
+
+Authenticated via `earthaccess.login(strategy="netrc")`. Requires a
+NASA Earthdata Login account with **NSIDC** application linked.
+Materialize credentials with
+`nhf-targets materialize-credentials --project-dir <project>`.
+
+MOD10C1 granules are **global daily HDF4-EOS files** (not tiled like
+MOD16A2). For each year, the fetcher searches CMR by bounding box
+(which still returns global granules — bounding_box is a server-side
+overlap test), downloads each HDF, **subsets to CONUS** in-process by
+opening with the rasterio engine and slicing
+`lat=slice(maxy, miny), lon=slice(minx, maxx)`, and saves the result
+as `*.conus.nc` (deleting the global HDF afterward to save disk).
+
+Each year's `*.conus.nc` files are then concatenated by
+`consolidate_mod10c1` into a per-year consolidated NetCDF.
+
+## On-disk layout
+
+```
+<datastore>/mod10c1_v061/
+  MOD10C1.A<YYYYDDD>.061.<production>.conus.nc   # one per day, CONUS-subset
+  mod10c1_v061_<year>_consolidated.nc              # per-year CF-1.6 NC
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch mod10c1 --project-dir <project> --period 2000/2025
+# force re-fetch a year (e.g. after a consolidation bug fix):
+nhf-targets fetch mod10c1 --project-dir <project> --period 2000/2025 --force
+```
+
+Or via the general SLURM fetch array, index 9
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+Per-year incremental: years recorded in `manifest.json` are skipped
+unless `--force` is set. Zero-byte downloads from EDL truncations are
+discarded immediately (logged); the next run picks up the missing
+granules.
+
+## HPC memory/time notes
+
+- **Memory-heavy** but less than MOD16A2 (no per-timestep tile
+  mosaicking — global daily files arrive whole, then subset).
+- 2000-2025 ≈ ~9500 daily granules; full-period fetch can take 8-12
+  hours bottlenecked by EDL throughput. Per-year consolidation runs
+  in minutes.
+- The general 128 GB / 24 h fetch SLURM allocation has held without
+  OOMs.
+
+## Aggregator wiring — pre-aggregate CI gate, `masked_mean`
+
+`aggregate/mod10c1.py` applies a **per-pixel quality gate** in
+`pre_aggregate_hook`: pixels are kept only when their own CI > 70
+(strict `>`, not `>=`). Per-pixel gating is methodologically
+different from gating the area-weighted-mean CI after aggregation,
+and matches TM 6-B10's recipe (PR #210/#212; promotion from stub to
+CI-bounded implementation).
+
+Because the pre-aggregate hook constructs NaN-emitting masks, the
+adapter uses `stat_method="masked_mean"`. HRUs whose contributing
+pixels are all flag-coded or fail the CI gate come out NaN — the
+honest "no MOD10C1 here" signal. The diagnostic
+`valid_area_fraction` variable records the area-weighted fraction of
+the HRU that passed the CI gate; low values (<10%) emit a warning.
+
+Output at
+`<project>/data/aggregated/mod10c1_v061/mod10c1_<year>_agg.nc`, one
+per year, in **native 0-100 integer scale** (the `÷ 100` rescale is a
+linear conversion downstream in `targets/sca.py` /
+`normalize/methods.py`).
+
+## Troubleshooting
+
+- `Found 0 granules ...` — Earthdata credentials missing or NSIDC
+  application not linked at <https://urs.earthdata.nasa.gov/profile>
+  → Applications.
+- `Failed to subset <name>` warnings followed by a partial-year on
+  disk — one HDF was corrupt and was removed; re-run picks it up.
+- Aggregated NC has unexpectedly many NaN HRUs — increase the CI
+  threshold sensitivity by reading `valid_area_fraction` from the
+  aggregated NC, or relax the CI gate via the catalog
+  `ci_threshold:` (default 70). Avoid relaxing without revalidating
+  against `notebooks/aggregated/inspect_aggregated_sca.ipynb`.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `mod10c1_v061:` block for the flag values and the
+  `Snow_Spatial_QA` mislabel notes.

--- a/docs/sources/mod10c1_v061.md
+++ b/docs/sources/mod10c1_v061.md
@@ -1,11 +1,14 @@
 # MOD10C1 v061 (MODIS Daily Snow Cover, NSIDC)
 
 NASA's [MOD10C1 v061](https://nsidc.org/data/mod10c1/versions/61)
-Daily Snow Cover L3 Global 0.05° CMG product (Hall & Riggs;
-doi:10.5067/MODIS/MOD10C1.006 for v006, v061 is the current
-replacement). Distributed by NSIDC and accessed via NASA Earthdata via
-CMR. Used as the single source for the snow-covered area (`sca`)
-calibration target via the TM 6-B10 CI-bounded recipe.
+Daily Snow Cover L3 Global 0.05° CMG product (Hall & Riggs).
+Distributed by NSIDC and accessed via NASA Earthdata via CMR. Used as
+the single source for the snow-covered area (`sca`) calibration
+target via the TM 6-B10 CI-bounded recipe.
+
+> The v061 product replaces v006 (doi:10.5067/MODIS/MOD10C1.006 — v006
+> only). NSIDC has not minted a separate v061 DOI; cite the v061
+> landing page above for the active product.
 
 This replaces v006, preserved in the catalog with `status: superseded`
 for documentary provenance only. The variable renamed in v061:
@@ -21,10 +24,12 @@ for `sca`:
 | `Day_CMG_Cloud_Obscured` | daily cloud-obscured % | percent (0-100) | QA cross-check (kept) |
 | `Snow_Spatial_QA` | categorical QA flag | `1` (0=best ... 4=other) | **Not a percent** — see notes |
 
-## Flag values to mask
+## Flag values to mask (`Day_CMG_Snow_Cover` + `Day_CMG_Clear_Index`)
 
-> Source HDF carries flag values that must be masked before any
-> quantitative use:
+> The two quantitative variables carry flag values that must be
+> masked before any quantitative use. (`Snow_Spatial_QA` is a
+> categorical variable with a different flag scheme — see the
+> mislabel callout below.)
 >
 > - `107` = lake ice
 > - `111` = night
@@ -118,7 +123,9 @@ adapter uses `stat_method="masked_mean"`. HRUs whose contributing
 pixels are all flag-coded or fail the CI gate come out NaN — the
 honest "no MOD10C1 here" signal. The diagnostic
 `valid_area_fraction` variable records the area-weighted fraction of
-the HRU that passed the CI gate; low values (<10%) emit a warning.
+the HRU that passed the CI gate. The aggregator warns when more than
+10% of HRU/time cells have zero valid area after the CI filter
+(`_LOW_COVERAGE_WARN_THRESHOLD` in `aggregate/mod10c1.py`).
 
 Output at
 `<project>/data/aggregated/mod10c1_v061/mod10c1_<year>_agg.nc`, one
@@ -133,11 +140,14 @@ linear conversion downstream in `targets/sca.py` /
   → Applications.
 - `Failed to subset <name>` warnings followed by a partial-year on
   disk — one HDF was corrupt and was removed; re-run picks it up.
-- Aggregated NC has unexpectedly many NaN HRUs — increase the CI
-  threshold sensitivity by reading `valid_area_fraction` from the
-  aggregated NC, or relax the CI gate via the catalog
-  `ci_threshold:` (default 70). Avoid relaxing without revalidating
-  against `notebooks/aggregated/inspect_aggregated_sca.ipynb`.
+- Aggregated NC has unexpectedly many NaN HRUs — inspect
+  `valid_area_fraction` in the aggregated NC to see where HRUs lost
+  pixels to the CI gate. The aggregator's CI threshold is **hardcoded**
+  as `_CI_THRESHOLD_NATIVE = 70` in [`aggregate/mod10c1.py`](../../src/nhf_spatial_targets/aggregate/mod10c1.py)
+  and is **not** read from the catalog — relaxing it requires a code
+  change. The `ci_threshold:` keys in `catalog/variables.yml` and the
+  project config (default `0.70`) affect only the **target-stage**
+  filter in `targets/sca.py`, not the aggregator's pre-aggregate gate.
 - Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
   `mod10c1_v061:` block for the flag values and the
   `Snow_Spatial_QA` mislabel notes.

--- a/docs/sources/mod16a2_v061.md
+++ b/docs/sources/mod16a2_v061.md
@@ -1,0 +1,141 @@
+# MOD16A2 v061 (MODIS AET, LP DAAC)
+
+NASA's [MOD16A2 v061](https://lpdaac.usgs.gov/products/mod16a2v061/)
+Global Terrestrial Evapotranspiration 8-Day L4 500 m product (Running,
+Mu, Zhao; LP DAAC). The catalog short_name is `MOD16A2GF` (the
+gap-filled v061 variant), distributed at LP DAAC and accessed via NASA
+Earthdata via CMR. Used as one of three sources for the AET (`aet`)
+calibration target.
+
+This replaces v006, which is preserved with `status: superseded` in
+the catalog for documentary provenance only. The original TM 6-B10
+calibration used v006, but v006 has been decommissioned.
+
+The pipeline downloads two variables:
+
+| Variable | Long name | Native units | cell_methods |
+| -------- | --------- | ------------ | ------------ |
+| `ET_500m` | actual evapotranspiration | kg m-2 (per 8-day period) | `time: sum` |
+| `ET_QC_500m` | ET quality control | `1` (categorical) | — |
+
+## The PR #88 fill-value contamination story
+
+> Earlier consolidated NCs showed a **flat seasonal cycle**
+> (CONUS-mean Jul/Jan ratio ≈ 1.12, vs the published ~5×). This was
+> an artefact of fill-value contamination at the consolidate-time
+> sinusoidal → 4 km reprojection: `rioxarray`'s `masked=True` only
+> maps the declared `_FillValue` to NaN, leaving the other special
+> codes as ordinary numeric pixels that `Resampling.average` then
+> blended with valid neighbours:
+>
+> - `32761` = water
+> - `32762` = barren
+> - `32763` = snow/ice
+> - `32764` = cloudy
+> - `32766` = no-data
+>
+> Fixed in PR #88 by masking `ET_500m` fills **before** reprojection
+> in `fetch/consolidate.py:_mosaic_and_reproject_timestep`.
+> **Consolidated NCs produced before PR #88 are invalid** —
+> re-fetch + re-aggregate to recover realistic seasonality. See
+> [`docs/references/lessons-learned.md`](../references/lessons-learned.md)
+> § MOD16A2 v061 flat-on-CONUS+.
+
+## Access path — NASA earthaccess + LP DAAC
+
+Authenticated via `earthaccess.login(strategy="netrc")`. Requires a
+NASA Earthdata Login account with **LP DAAC** application linked.
+Materialize credentials with
+`nhf-targets materialize-credentials --project-dir <project>`.
+
+For each year, the fetcher searches CMR for granules overlapping
+`fabric.bbox_buffered`, filters by bounding box (CMR can return
+extras), groups by `AYYYYDDD` timestep (each 8-day period spans
+multiple sinusoidal tiles), and downloads each timestep's tiles in
+parallel via a `ThreadPoolExecutor` with `_PREFETCH_AHEAD = 2`
+(download is I/O-bound, consolidation is CPU-bound; overlapping them
+hides download latency).
+
+Each downloaded tile is mosaiced and reprojected from sinusoidal to
+WGS84 (EPSG:4326) by
+`consolidate_mod16a2_timestep` and `consolidate_mod16a2_finalize`,
+which together write one consolidated NC per year. **The raw HDF
+tiles are deleted after consolidation** to save disk space; re-fetch
+needs to re-download from LP DAAC.
+
+## On-disk layout
+
+```
+<datastore>/mod16a2_v061/
+  mod16a2_v061_<year>_consolidated.nc   # per-year CF-1.6 NC at 500 m WGS84 (CONUS+ bbox)
+```
+
+(Per-timestep temp NCs `_tmp_*_*.nc` are cleaned up between runs.)
+
+## Procedure
+
+```bash
+nhf-targets fetch mod16a2 --project-dir <project> --period 2000/2025
+# force re-fetch a year (e.g. after a consolidation bug fix):
+nhf-targets fetch mod16a2 --project-dir <project> --period 2000/2025 --force
+```
+
+Or via the general SLURM fetch array, index 8
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+Per-year incremental: years recorded in `manifest.json` are skipped
+unless `--force` is set. `--force` re-fetches all years in `period`
+and overwrites the manifest entry at the end; use after a pipeline
+change has invalidated existing consolidated NCs (e.g. PR #88's
+fill-mask change).
+
+## HPC memory/time notes
+
+- **Memory-heavy.** Each timestep mosaics multiple sinusoidal tiles
+  to a CONUS-bbox 4 km WGS84 grid; peak RSS scales with the number
+  of tiles per timestep. The general 128 GB / 24 h fetch SLURM
+  allocation has held without OOMs.
+- 2000-2025 ≈ 26 years × 46 8-day periods ≈ 1200 timesteps × ~10 sinusoidal tiles each. Full-period fetch can take 10-20 hours bottlenecked by EDL throughput and CPU reprojection cost.
+- Per-timestep memory logging via `log_memory(...)` from
+  `fetch.consolidate` lets operators tune `--mem` if a SLURM run
+  starts to OOM at a specific timestep count.
+
+## Aggregator wiring — `stat_method="masked_mean"`
+
+`aggregate/mod16a2.py` declares `source_crs="EPSG:4326"` (the
+consolidated NC has been reprojected; using the original sinusoidal
+CRS would cause gdptools to slice the WGS84 coord with metric
+sinusoidal bounds and produce empty subsets).
+
+Crucially, the adapter uses **`stat_method="masked_mean"`**: the
+per-pixel fill mask runs in `pre_aggregate_hook` (`_mask_et_fill`,
+keeping `ET_500m <= 3270.0`) AND inside consolidate before
+reprojection (PR #88). With the default `stat_method="mean"`, those
+NaN pixels would propagate to the HRU, marking every HRU touching a
+coastline / water body / snow boundary as NaN. `masked_mean` lets
+HRUs reflect the area-weighted mean of surviving pixels; HRUs whose
+contributing pixels are *all* fills still come out NaN, which is the
+honest "no MOD16A2 here" signal. See
+[`docs/architecture/transformation-pipeline.md`](../architecture/transformation-pipeline.md)
+for the policy.
+
+Output at
+`<project>/data/aggregated/mod16a2_v061/mod16a2_<year>_agg.nc`, one
+per year, in native `kg m-2` per 8-day period. The `aet` target
+builder applies the linear conversion to inches/day downstream.
+
+## Troubleshooting
+
+- `Found 0 granules ...` for years that should have data — likely
+  CMR is mid-outage; retry. If persistent, verify Earthdata
+  application has LP DAAC linked.
+- Flat seasonal cycle in the consolidated/aggregated NC (Jul/Jan
+  CONUS-mean ratio < 2) — almost certainly a pre-PR-#88
+  consolidation. Re-fetch with `--force`.
+- A timestep stalls indefinitely — the prefetch thread pool can
+  occasionally hang on a corrupt EDL stream. The fix is to delete the
+  timestep's `_tmp_*` NC (the file inventory glob), kill the run,
+  and re-submit; the manifest fast-path resumes from the last
+  finalized year.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `mod16a2_v061:` block for the PR #88 notes and LP DAAC link.

--- a/docs/sources/ncep_ncar.md
+++ b/docs/sources/ncep_ncar.md
@@ -1,0 +1,117 @@
+# NCEP/NCAR Reanalysis Soil Moisture
+
+NOAA's [NCEP/NCAR Reanalysis 1](https://psl.noaa.gov/data/gridded/data.ncep.reanalysis.html)
+soil moisture (Kalnay et al., 1996). Used as one of four sources for
+the soil moisture (`som`) calibration target range. The publisher (NOAA
+PSL) distributes per-year daily files; the pipeline resamples to
+monthly means on the fly during the fetch.
+
+The pipeline downloads two layers:
+
+| Variable | Long name | Layer depth | Units (effective) |
+| -------- | --------- | ----------- | ----------------- |
+| `soilw_0_10cm` | volumetric soil moisture 0-10 cm | 0.00-0.10 m | `m3 m-3` (VWC) |
+| `soilw_10_200cm` | volumetric soil moisture 10-200 cm | 0.10-2.00 m | `m3 m-3` (VWC) |
+
+## The NCEP R1 `units: kg/m2` mislabel
+
+> The upstream NetCDFs from NOAA PSL carry `units: kg/m2` on the
+> `soilw.*.gauss` variables, but the long_name, var_desc, and
+> valid_range `[0.0, 1.0]` (with observed actual_range ≈ `[0.10, 0.43]`)
+> all confirm the values are **volumetric water content (m³/m³)**, not
+> mass per area. This is a known mislabel in the NCEP R1 GRIB
+> metadata.
+>
+> **Do NOT divide by `(layer_depth × ρ_water)` to convert to VWC; the
+> data already is VWC.** The catalog `units:` field overrides the
+> on-disk attribute, and `apply_cf_metadata` writes the corrected
+> `units` into the consolidated NC.
+
+The catalog `notes` field documents this explicitly. Always read units
+from `catalog/sources.yml` not from the on-disk file (also a general
+project convention; see CLAUDE.md → "Read source units from the
+catalog, not from on-disk NetCDF attrs").
+
+## Access path — direct HTTP (NOAA PSL)
+
+No authentication required. The fetch module
+[`fetch/ncep_ncar.py`](../../src/nhf_spatial_targets/fetch/ncep_ncar.py)
+constructs annual URLs from the catalog `file_pattern`:
+
+```
+https://downloads.psl.noaa.gov/Datasets/ncep.reanalysis.dailyavgs/surface_gauss/<file_variable>.{year}.nc
+```
+
+Each annual daily file is downloaded with `urllib.request.urlretrieve`,
+opened with xarray, resampled to monthly means via `.resample(time="1ME").mean()`,
+renamed to the catalog variable name (`soilw` → `soilw_0_10cm` or
+`soilw_10_200cm`), and written as a monthly file alongside the daily
+file. The daily file is then **deleted** — the source archive
+preserves it for re-download if needed.
+
+The fetch loop covers `(year, var)` pairs in a single `tqdm` progress
+bar so partial-run resumption is per-(year, var), not per-year.
+
+## On-disk layout
+
+```
+<datastore>/ncep_ncar/
+  soilw.0-10cm.gauss.<year>.monthly.nc       # one per year-variable pair
+  soilw.10-200cm.gauss.<year>.monthly.nc
+  ncep_ncar_consolidated.nc                    # combined CF-1.6 NC
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch ncep-ncar --project-dir <project> --period 1979/2025
+```
+
+Or via the general SLURM fetch array, index 5
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+**Incremental**: years already recorded in `manifest.json` are skipped
+before any HTTP work. Manifest writes are read-merge-write.
+
+## Grid resolution and choropleth quirk
+
+NCEP/NCAR R1 uses a **T62 Gaussian grid** at ~1.875° (~210 km). At
+HRU sizes typical of NHM, many HRUs land inside the same source cell,
+which produces visibly "blocky" aggregated choropleths — large
+contiguous regions of HRUs with the same value because they share an
+upstream cell. This is the visual evidence for the gfv2 fabric's
+exclusion of `ncep_ncar` from `som` (see
+[`docs/references/known-gaps-resolved.md`](../references/known-gaps-resolved.md)
+if applicable, or the project memo
+`project_coarse_source_blockiness`). It is not a pipeline bug.
+
+## HPC memory/time notes
+
+- 1979-2025 ≈ 47 years × 2 variables = ~94 annual daily downloads,
+  each resampled to monthly in-memory. Peak RSS stays well under 8 GB.
+- The general 128 GB / 24 h fetch SLURM allocation is overkill;
+  full-period runs finish in ~1 hour, bottlenecked by the
+  per-(year, var) sequential HTTP downloads.
+
+## Aggregator wiring
+
+`aggregate/ncep_ncar.py` is a thin `SourceAdapter` (monthly cadence,
+`stat_method="mean"`). Output at
+`<project>/data/aggregated/ncep_ncar/ncep_ncar_<year>_agg.nc`, one
+per year, in native VWC `m3 m-3` (with the catalog's
+units-correction in the variable attrs).
+
+## Troubleshooting
+
+- `RuntimeError: Failed to download <url>: HTTP 404` — NOAA PSL may
+  have moved or renamed the dataset path. Inspect
+  <https://psl.noaa.gov/data/gridded/data.ncep.reanalysis.html> and
+  update `file_pattern` in `catalog/sources.yml` if so.
+- The on-disk NetCDF `cf_units` attribute reads as something
+  inconsistent with the catalog — trust the catalog
+  (`catalog.source("ncep_ncar")["variables"][i]["units"]`); on-disk
+  attrs drift after corrections. The aggregated NC is written by
+  `apply_cf_metadata` and should agree with the catalog after the
+  next aggregator run.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `ncep_ncar:` block for the `kg/m2`-mislabel notes block.

--- a/docs/sources/nldas_mosaic.md
+++ b/docs/sources/nldas_mosaic.md
@@ -1,0 +1,83 @@
+# NLDAS-2 MOSAIC Soil Moisture
+
+NASA's [North American Land Data Assimilation System phase 2](https://disc.gsfc.nasa.gov/datasets/NLDAS_MOS0125_M_2.0/summary),
+**MOSAIC** land surface model, monthly output (Xia et al., 2012). Used
+as one of four sources for the soil moisture (`som`) calibration target
+range. Distributed by NASA GES DISC as `NLDAS_MOS0125_M` v2.0 on a
+0.125° CONUS grid.
+
+The pipeline downloads three soil moisture layers:
+
+| Variable | Long name | Layer depth |
+| -------- | --------- | ----------- |
+| `SoilM_0_10cm` | soil moisture 0-10 cm | 0.00-0.10 m |
+| `SoilM_10_40cm` | soil moisture 10-40 cm | 0.10-0.40 m |
+| `SoilM_40_200cm` | soil moisture 40-200 cm | 0.40-2.00 m |
+
+All in native `kg m-2`; the `som` target normalizes to a dimensionless
+[0, 1] range, so units differences across the four `som` sources
+(MERRA-2 / NCEP-NCAR / NLDAS-MOSAIC / NLDAS-NOAH) wash out by design
+(TM 6-B10). Note MOSAIC's third layer is **40-200 cm** — different
+from NLDAS-2 NOAH, which subdivides the same range into 40-100 and
+100-200 cm; see [`nldas_noah.md`](nldas_noah.md).
+
+## Access path — NASA earthaccess
+
+Authenticated via `earthaccess.login(strategy="netrc")`. Requires a
+NASA Earthdata Login account with **GES DISC linked**. Materialize
+credentials with
+`nhf-targets materialize-credentials --project-dir <project>`. CMR
+search is bbox-filtered via `fabric.bbox_buffered`; granules are
+already CONUS-clipped at the source, so unlike GLDAS/MERRA-2 the
+downloaded files do not require post-hoc spatial subsetting.
+
+Granule filenames embed `AYYYYMM` (e.g.
+`NLDAS_MOS0125_M.A200101.020.grb.SUB.nc4`). The shared NLDAS fetch
+module ([`fetch/nldas.py`](../../src/nhf_spatial_targets/fetch/nldas.py))
+handles both MOSAIC and NOAH variants behind the per-source key.
+
+## On-disk layout
+
+```
+<datastore>/nldas_mosaic/
+  NLDAS_MOS0125_M.A<YYYYMM>.020.grb.SUB.nc4   # per-month granules
+  nldas_mosaic_consolidated.nc                  # combined CF-1.6 NC
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch nldas-mosaic --project-dir <project> --period 1979/2025
+```
+
+Or via the general SLURM fetch array, index 3
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+**Incremental**: months already recorded in `manifest.json` are skipped
+at search-result filter time, so re-running after adding a new period
+fetches only the new months. Manifest writes are read-merge-write.
+
+## HPC memory/time notes
+
+- 1979-2025 ≈ 564 monthly CONUS granules, ~2-4 GB raw total (see
+  [README.md](../../README.md) §Datastore Storage Estimates).
+- The general 128 GB / 24 h fetch SLURM allocation is far more than
+  needed; full-period runs finish in 1-2 hours on a warm network.
+
+## Aggregator wiring
+
+`aggregate/nldas_mosaic.py` is a thin `SourceAdapter` (monthly cadence,
+`stat_method="mean"`, default `mean` policy because no per-pixel
+masking happens upstream). Output at
+`<project>/data/aggregated/nldas_mosaic/nldas_mosaic_<year>_agg.nc`,
+one per year, in native `kg m-2`.
+
+## Troubleshooting
+
+- `ValueError: No granules found for NLDAS_MOS0125_M ...` — Earthdata
+  credentials missing or GES DISC application not linked at
+  <https://urs.earthdata.nasa.gov/profile> → Applications.
+- Same `Partial download` warning as MERRA-2; re-run picks up missing
+  months by filename.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `nldas_mosaic:` block for variable definitions and GES DISC links.

--- a/docs/sources/nldas_noah.md
+++ b/docs/sources/nldas_noah.md
@@ -1,0 +1,86 @@
+# NLDAS-2 NOAH Soil Moisture
+
+NASA's [North American Land Data Assimilation System phase 2](https://disc.gsfc.nasa.gov/datasets/NLDAS_NOAH0125_M_2.0/summary),
+**NOAH** land surface model, monthly output (Xia et al., 2012). Used
+as one of four sources for the soil moisture (`som`) calibration target
+range. Distributed by NASA GES DISC as `NLDAS_NOAH0125_M` v2.0 on the
+same 0.125° CONUS grid as the MOSAIC variant.
+
+The pipeline downloads four soil moisture layers:
+
+| Variable | Long name | Layer depth |
+| -------- | --------- | ----------- |
+| `SoilM_0_10cm` | soil moisture 0-10 cm | 0.00-0.10 m |
+| `SoilM_10_40cm` | soil moisture 10-40 cm | 0.10-0.40 m |
+| `SoilM_40_100cm` | soil moisture 40-100 cm | 0.40-1.00 m |
+| `SoilM_100_200cm` | soil moisture 100-200 cm | 1.00-2.00 m |
+
+All in native `kg m-2`. NOAH subdivides 40-200 cm into two layers
+(40-100 and 100-200) while MOSAIC keeps it as a single 40-200 layer —
+choose deliberately when constructing a `som` target stack and do not
+sum NOAH's bottom two layers and compare to MOSAIC's bottom layer
+without verifying the integration is meaningful.
+
+## Access path — NASA earthaccess
+
+Authenticated via `earthaccess.login(strategy="netrc")`. Requires a
+NASA Earthdata Login account with **GES DISC linked**. Materialize
+credentials with
+`nhf-targets materialize-credentials --project-dir <project>`. CMR
+search is bbox-filtered via `fabric.bbox_buffered`; granules are
+already CONUS-clipped so no further spatial subsetting is needed.
+
+Granule filenames embed `AYYYYMM` (e.g.
+`NLDAS_NOAH0125_M.A200101.020.grb.SUB.nc4`). The shared NLDAS fetch
+module ([`fetch/nldas.py`](../../src/nhf_spatial_targets/fetch/nldas.py))
+handles both NOAH and MOSAIC variants behind the per-source key.
+
+## On-disk layout
+
+```
+<datastore>/nldas_noah/
+  NLDAS_NOAH0125_M.A<YYYYMM>.020.grb.SUB.nc4   # per-month granules
+  nldas_noah_consolidated.nc                     # combined CF-1.6 NC
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch nldas-noah --project-dir <project> --period 1979/2025
+```
+
+Or via the general SLURM fetch array, index 4
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+**Incremental**: months already recorded in `manifest.json` are
+skipped at search-result filter time. Manifest writes are
+read-merge-write.
+
+## HPC memory/time notes
+
+- 1979-2025 ≈ 564 monthly CONUS granules, ~2-4 GB raw total (see
+  [README.md](../../README.md) §Datastore Storage Estimates).
+- The general 128 GB / 24 h fetch SLURM allocation is far more than
+  needed; full-period runs finish in 1-2 hours.
+
+## Aggregator wiring
+
+`aggregate/nldas_noah.py` is a thin `SourceAdapter` (monthly cadence,
+`stat_method="mean"`). All four layers are aggregated; the `som`
+target builder selects layers per the project's target config.
+Output at
+`<project>/data/aggregated/nldas_noah/nldas_noah_<year>_agg.nc`, one
+per year, in native `kg m-2`.
+
+## Troubleshooting
+
+- `ValueError: No granules found for NLDAS_NOAH0125_M ...` — Earthdata
+  credentials missing or GES DISC application not linked at
+  <https://urs.earthdata.nasa.gov/profile> → Applications.
+- For MOSAIC vs NOAH ambiguity: the `som` target builder reads the
+  catalog `variables:` block by source key, so each
+  `aggregate/nldas_*.py` adapter writes a separate aggregated NC and
+  the multi-source min/max combination in `targets/som.py` keeps them
+  distinct.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `nldas_noah:` block for variable definitions and GES DISC links.

--- a/docs/sources/reitz2017.md
+++ b/docs/sources/reitz2017.md
@@ -1,0 +1,127 @@
+# Reitz 2017 Empirical Recharge (USGS ScienceBase)
+
+[Reitz et al. (2017)](https://www.sciencebase.gov/catalog/item/56c49126e4b0946c65219231)
+annual empirical regression-based estimates of groundwater recharge for
+CONUS (doi:10.5066/F7PN93P0; the publication also covers runoff and
+ET, but only **total recharge** and **effective recharge** are used
+here). Used as one of two sources for the recharge (`rch`) calibration
+target range alongside [WaterGAP 2.2d](watergap22d.md).
+
+The pipeline downloads two variables, one annual GeoTIFF per
+year-variable, for 2000-2013:
+
+| Variable | File variable | Long name | Units (after correction) |
+| -------- | ------------- | --------- | ----------------------- |
+| `total_recharge` | `TotalRecharge` | total groundwater recharge | `m yr-1` |
+| `eff_recharge` | `EffRecharge` | effective groundwater recharge (base flow) | `m yr-1` |
+
+## The "no embedded units" gotcha
+
+> The ScienceBase release of these GeoTIFFs has **no embedded units
+> metadata** — no `Band.GetUnitType`, no file/band metadata, no PAM
+> `.aux.xml` sidecar. The ScienceBase landing page documents the
+> values as **m/year**, and CONUS-wide mean (~122 mm/yr) plus
+> spot-checks at known-high-recharge locations are consistent with
+> that interpretation.
+>
+> Earlier catalog versions declared inches/year, which produced values
+> ~8× too low. Corrected to `m yr-1` (see PR #68 review). The
+> catalog `units:` field is authoritative.
+
+This is a worked example of "validate magnitudes against published
+means before trusting catalog metadata" (see the
+`feedback_validate_magnitudes` memo). A CONUS-mean >30% off published
+value is a smoking gun for a missed conversion factor.
+
+## Access path — sciencebasepy
+
+No NASA/CDS credentials needed. The fetch module
+[`fetch/reitz2017.py`](../../src/nhf_spatial_targets/fetch/reitz2017.py)
+uses [`sciencebasepy`](https://github.com/DOI-USGS/sciencebasepy) to:
+
+1. Connect to ScienceBase item
+   [`55d383a9e4b0518e35468e58`](https://www.sciencebase.gov/catalog/item/55d383a9e4b0518e35468e58)
+   (the child item of the catalog `item_id` parent that holds the
+   actual files).
+2. Build a filename → file-info lookup from `sb.get_item_file_info(item)`.
+3. For each year in `period`, download two zipped GeoTIFFs:
+   `TotalRecharge_<year>.zip` and `EffRecharge_<year>.zip`.
+4. Extract the single `.tif` from each (renaming `RC_<year>.tif` /
+   `RC_eff_<year>.tif` to match the
+   `TotalRecharge_<year>.tif` / `EffRecharge_<year>.tif` convention).
+5. Delete the zip after extraction; keep the GeoTIFF on disk.
+
+After all year-variable GeoTIFFs are present, `_consolidate` stacks
+them along a `time` dimension (mid-year July 1 timestamps) and writes
+a single CF-1.6 consolidated NetCDF.
+
+## On-disk layout
+
+```
+<datastore>/reitz2017/
+  TotalRecharge_<year>.tif       # one per year in 2000-2013
+  EffRecharge_<year>.tif
+  reitz2017_consolidated.nc       # combined CF-1.6 NC (consumed by aggregator)
+```
+
+## Period gating
+
+The fetch hard-rejects years outside 2000-2013 with a clear error
+because the publisher's archive ends at 2013. `nhf-targets fetch reitz2017
+--period 1979/2025` will fail loudly before any HTTP work.
+
+## Procedure
+
+```bash
+nhf-targets fetch reitz2017 --project-dir <project> --period 2000/2013
+```
+
+Or via the general SLURM fetch array, index 7
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+The fetcher is **incremental at the year-variable pair level**:
+existing GeoTIFFs on disk are skipped. The consolidator regenerates the
+combined NetCDF from whatever's on disk, so removing a year's tif and
+re-running rebuilds without that year.
+
+## CRS gotcha — Reitz GeoTIFFs declare NAD83 (EPSG:4269)
+
+`aggregate/reitz2017.py` overrides the default `EPSG:4326` with
+`source_crs="EPSG:4269"` (NAD83 geographic). The CRS is preserved
+through `_consolidate → apply_cf_metadata` and read from the on-disk
+GeoTIFF's WKT (`rio.crs.to_wkt()`) — this is the only catalog source
+that uses NAD83 rather than WGS84 natively.
+
+## HPC memory/time notes
+
+- 14 years × 2 variables = 28 small GeoTIFFs at ~tens of MB each.
+  Total raw ~2-4 GB (see [README.md](../../README.md) §Datastore
+  Storage Estimates).
+- The general 128 GB / 24 h fetch SLURM allocation is overkill;
+  full-period runs finish in 5-10 minutes.
+
+## Aggregator wiring
+
+`aggregate/reitz2017.py` is a thin `SourceAdapter` (annual cadence,
+`stat_method="mean"`). Per-year aggregated NCs land at
+`<project>/data/aggregated/reitz2017/reitz2017_<year>_agg.nc`, in
+native `m yr-1`. The `rch` target builder normalizes to [0, 1] and
+combines with WaterGAP 2.2d.
+
+## Troubleshooting
+
+- `RuntimeError: File '<zip>' not found in ScienceBase item ...` —
+  the child item's file listing has changed. Browse to
+  <https://www.sciencebase.gov/catalog/item/55d383a9e4b0518e35468e58>
+  and verify the expected `TotalRecharge_YYYY.zip` /
+  `EffRecharge_YYYY.zip` files exist; update `file_patterns` in
+  the catalog if renamed.
+- `ValueError: Year YYYY is outside the Reitz 2017 data range
+  (2000-2013)` — adjust `--period` to fit the publisher window.
+- A CONUS-mean recharge plot that looks like 1/8 of expected
+  magnitude — the `units` field in the catalog drifted from `m yr-1`
+  back to `in/yr` or similar. Re-confirm against `catalog.source("reitz2017")`
+  and re-fetch + re-aggregate.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `reitz2017:` block for the units-correction notes and ScienceBase
+  links.

--- a/docs/sources/ssebop.md
+++ b/docs/sources/ssebop.md
@@ -1,0 +1,121 @@
+# SSEBop AET (USGS NHGF STAC, aggregator-only)
+
+USGS [Operational Simplified Surface Energy Balance (SSEBop)](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-data-citation)
+monthly actual evapotranspiration (Senay et al., 2013;
+doi:10.5066/P9L2YMV). Used as one of three sources for the AET (`aet`)
+calibration target range.
+
+**This source has no fetch step.** SSEBop is read on the fly from the
+USGS NHGF STAC Zarr store via [gdptools](https://github.com/usgs-makerspace/gdptools)
+during aggregation. There is no consolidated NC in the datastore;
+`<datastore>/ssebop/` does not exist as a directory in this pipeline.
+The aggregator opens the remote Zarr per batch per year and writes
+per-year aggregated NCs directly.
+
+## Access path — USGS NHGF STAC catalog
+
+| Field | Value |
+| ----- | ----- |
+| Collection ID | `ssebopeta_monthly` |
+| STAC endpoint | <https://usgs.osn.mghpcc.org/> |
+| Zarr store | `s3://mdmf/gdp/ssebopeta_monthly.zarr/` |
+| Period | 2000-2023 (monthly) |
+| Spatial extent | CONUS, ~1 km |
+| Source variable | `et` (kg m-2 ≡ mm water-equivalent per month) |
+
+No authentication. The STAC collection is resolved at aggregator
+start via `gdptools.helpers.get_stac_collection("ssebopeta_monthly")`,
+which fails fast with an explanatory note if the NHGF STAC endpoint
+is unreachable.
+
+The source-level `units: mm/month` (preserved in the catalog for
+backwards readability) is recovered by combining `cf_units: mm` with
+the time-axis aggregation declared in `cell_methods: time: sum`. The
+`aet` target builder applies the linear conversion to inches/day
+downstream (CLAUDE.md: linear conversions live in `targets/`).
+
+## On-disk layout — no fetch artefact
+
+```
+<project>/data/aggregated/ssebop/
+  ssebop_<year>_agg.nc          # one per year in --period
+<project>/weights/
+  ssebop_batch<i>.csv           # per-batch weight cache
+  ssebop_batch<i>.csv.meta      # fingerprint sidecar
+  ssebop_batch<i>.csv.fp        # fingerprint canonical-form
+```
+
+No `<datastore>/ssebop/` directory; the source is remote.
+
+## Procedure — aggregation only, `--period` required
+
+```bash
+pixi run nhf-targets agg ssebop \
+    --project-dir <project> \
+    --period 2000/2023
+```
+
+`--period` is **required** (unlike file-based sources, where the
+aggregator infers years from the consolidated NC). Months outside the
+publisher window (2000-2023) raise on STAC read.
+
+Or via the dedicated SLURM script
+([`slurm/shared/agg_ssebop.slurm`](../../slurm/shared/agg_ssebop.slurm),
+not slotted into the `agg_all_<fabric>.slurm` array because the array
+doesn't forward periods):
+
+```bash
+export PROJECT_DIR=/path/to/project
+sbatch slurm/shared/agg_ssebop.slurm
+```
+
+## Aggregator wiring — custom STAC path
+
+`aggregate/ssebop.py` is **not** a thin `SourceAdapter`. It re-uses
+the driver's helpers (`_atomic_write_netcdf`, `_batch_fingerprint`,
+`compute_or_load_weights`, `load_and_batch_fabric`, `update_manifest`,
+`_verify_year_coverage`) but reads the remote Zarr directly via
+`NHGFStacZarrData → WeightGen / AggGen`. Highlights:
+
+- **Weight cache uses STAC collection ID as the source-identity arm.**
+  The fingerprint is keyed on `f"stac:{collection_id}"` rather than a
+  source CRS, so a future SSEBop migration to a different
+  collection invalidates the cache.
+- **Per-year idempotent.** Existing per-year NCs are skipped; zero-byte
+  stubs (left by a non-atomic write or SIGKILL) are unlinked and
+  re-aggregated.
+- **SLURM-array sharding.** `--worker-index` / `--n-workers` select a
+  round-robin slice of years (issue #156). The contiguous-year check
+  in `_verify_year_coverage` is skipped when `n_workers > 1` so
+  sibling workers don't false-positive each other's gaps; the manifest
+  update merges file lists across workers via flock-protected
+  `update_manifest`.
+- **`stat_method="mean"`.** No per-pixel masking happens upstream; the
+  remote Zarr already has flagged pixels as NaN, so the default
+  NaN-propagating mean is correct (HRUs at the CONUS edge come out
+  honestly NaN).
+
+## HPC memory/time notes
+
+- Weight gen on a typical CONUS fabric runs ~15-30 s per batch on the
+  first year, with the per-batch cache reused across all subsequent
+  years. The cache is keyed on (HRU fingerprint, STAC collection); a
+  fabric swap or batch-size change invalidates it.
+- Aggregation itself is fast (per-year STAC read is on the order of a
+  minute for CONUS at 1 km monthly). Wall time is dominated by weight
+  generation on first year.
+- Single-job 128 GB / 24 h SLURM allocation is comfortable.
+
+## Troubleshooting
+
+- `Failed to resolve STAC collection 'ssebopeta_monthly'` — the
+  NHGF STAC endpoint is unreachable. Verify
+  <https://usgs.osn.mghpcc.org/> resolves and reachability via
+  `curl -I https://usgs.osn.mghpcc.org/` then retry.
+- `ssebop: --period must be 'YYYY/YYYY'` — pass `--period` explicitly;
+  unlike file-based sources, ssebop cannot infer years from disk.
+- Weight cache "stale batch fingerprint" warning followed by a
+  recompute — fabric or batch size changed since the cache was
+  written. This is normal; the recomputed cache is then re-used.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `ssebop:` block for the STAC collection ID and DOI.

--- a/docs/sources/ssebop.md
+++ b/docs/sources/ssebop.md
@@ -21,7 +21,7 @@ per-year aggregated NCs directly.
 | Zarr store | `s3://mdmf/gdp/ssebopeta_monthly.zarr/` |
 | Period | 2000-2023 (monthly) |
 | Spatial extent | CONUS, ~1 km |
-| Source variable | `et` (kg m-2 ≡ mm water-equivalent per month) |
+| Source variable | `et` (catalog `cf_units: mm` with `cell_methods: time: sum`) |
 
 No authentication. The STAC collection is resolved at aggregator
 start via `gdptools.helpers.get_stac_collection("ssebopeta_monthly")`,

--- a/docs/sources/watergap22d.md
+++ b/docs/sources/watergap22d.md
@@ -1,0 +1,113 @@
+# WaterGAP 2.2d Diffuse Groundwater Recharge (PANGAEA)
+
+WaterGAP 2.2d global hydrological model output (Müller Schmied et al.,
+2021; doi:10.5194/gmd-14-1037-2021), distributed via PANGAEA
+(doi:10.1594/PANGAEA.918447). Used as the second source for the
+recharge (`rch`) calibration target range alongside
+[Reitz 2017](reitz2017.md); the `rch` target is a `normalized_minmax`
+two-source target, so absolute magnitudes wash out.
+
+This is the **open-access successor to WaterGAP 2.2a**, which was
+registration-gated at the time of TM 6-B10. The 2.2a entry is
+preserved in the catalog with `status: superseded_registration_required`
+for provenance only.
+
+The pipeline downloads one variable from one file:
+
+| Variable | File variable | Long name | Native units |
+| -------- | ------------- | --------- | ------------ |
+| `groundwater_recharge` | `qrdif` | diffuse groundwater recharge | `kg m-2 s-1` |
+
+The publisher's NC4 (`watergap_22d_WFDEI-GPCC_histsoc_qrdif_monthly_1901_2016.nc4`)
+is **a single ~few-hundred-MB global monthly file covering 1901-2016**;
+spatial subsetting happens at aggregation time, not at fetch.
+
+## Access path — pangaeapy
+
+No NASA/CDS credentials needed. The fetch module
+[`fetch/pangaea.py`](../../src/nhf_spatial_targets/fetch/pangaea.py)
+uses [pangaeapy](https://github.com/pangaea-data-publisher/pangaeapy)
+to download the file by row index in the PanDataSet table (catalog
+`file_index: 30`). The download is sanity-checked against the
+expected filename stem before being moved into the datastore — a
+publisher reorganisation would surface as a clear `RuntimeError`
+rather than silently substituting a different file.
+
+## CF compliance fix-up
+
+PANGAEA's NC4 ships with **CF-non-conformant metadata** for this
+pipeline's purposes — most notably a `time` axis encoded as
+`months since 1901-01-01` (integer offsets, not CF-conformant
+calendar units). The fetch module reconstructs the time coord as
+`datetime64`, then runs `apply_cf_metadata` to add the WGS84 grid
+mapping, coordinate axis attrs, and `Conventions=CF-1.6` global, and
+writes the corrected file as
+`<datastore>/watergap22d/watergap22d_qrdif_cf.nc`. The raw NC4 is
+preserved on disk for forensic reference.
+
+## On-disk layout
+
+```
+<datastore>/watergap22d/
+  watergap_22d_WFDEI-GPCC_histsoc_qrdif_monthly_1901_2016.nc4   # raw
+  watergap22d_qrdif_cf.nc                                          # CF-corrected (consumed by aggregator)
+  .pangaea_cache/                                                  # pangaeapy cache (ok to delete)
+```
+
+## Procedure
+
+```bash
+nhf-targets fetch watergap22d --project-dir <project> --period 1979/2016
+```
+
+Or via the general SLURM fetch array, index 6
+([`slurm/shared/fetch_all.slurm`](../../slurm/shared/fetch_all.slurm)).
+
+Note the **publisher dataset ends 2016**; `period` end-years past
+2016 are silently truncated at aggregation time (the file simply has
+no data past 2016-12). Multi-source recharge runs targeting 2017+ will
+need WaterGAP 2.2e or a different second source.
+
+The `period` argument is **provenance-only** for this fetcher — the
+file itself covers the full 1901-2016 range and is not subsettable at
+download time. The aggregator's `--period` is what actually clips
+output.
+
+## HPC memory/time notes
+
+- The file is ~ few hundred MB; the fetch is fast (single connection
+  to PANGAEA, no chunking). The general 128 GB / 24 h fetch SLURM
+  allocation is overkill — the operation runs in minutes.
+- Re-runs are idempotent: if `watergap22d_qrdif_cf.nc` already exists,
+  the fetcher skips re-download and re-fix-up.
+
+## Aggregator wiring
+
+`aggregate/watergap22d.py` is a thin `SourceAdapter` (monthly cadence,
+`stat_method="mean"`, `files_glob="*_cf.nc"` so the raw NC4 is not
+accidentally re-aggregated). The aggregator's per-year emission walks
+the monthly time axis and writes
+`<project>/data/aggregated/watergap22d/watergap22d_<year>_agg.nc`,
+one per year, in native `kg m-2 s-1`. The `rch` target builder
+applies the linear conversion to mm/yr downstream.
+
+## Grid resolution and choropleth quirk
+
+WaterGAP 2.2d is on a **0.5° global grid** (~55 km). On
+intermountain-west fabrics with many small HRUs per source cell, the
+aggregated choropleth looks visibly blocky (see
+`project_coarse_source_blockiness` memo). This is the visual
+evidence for the gfv2 fabric excluding WaterGAP from the `rch` target;
+per-fabric decision, not a pipeline bug.
+
+## Troubleshooting
+
+- `RuntimeError: PANGAEA file index 30 contains '<name>', expected '<stem>'`
+  — PANGAEA reorganised the dataset listing. Inspect
+  `pan_ds.data` from a Python session and update `file_index` in
+  `catalog/sources.yml`.
+- `RuntimeError: Failed to connect to PANGAEA dataset 918447` — check
+  <https://doi.pangaea.de/10.1594/PANGAEA.918447> in a browser; the
+  server is occasionally offline.
+- Catalog reference: see [`catalog/sources.yml`](../../catalog/sources.yml)
+  `watergap22d:` block for the file index and DOI.


### PR DESCRIPTION
## Summary

Closes #220. Expands `docs/sources/` from 4 to 14 — one operator-facing
doc per active catalog entry in `catalog/sources.yml`. Each new doc
follows the shape of `docs/sources/snodas.md`:

- title + intro pointing at the upstream provider's landing page
- access pathway (CDS / earthaccess / HTTP / pangaeapy / sciencebasepy / STAC) + auth quirks
- on-disk layout under `<datastore>/<source_key>/`
- per-variable units and unit-conversion gotchas
- known archive gaps / data-quality issues (PR# cross-references)
- HPC memory/time notes where non-default
- aggregator wiring summary (stat_method + masked_mean rationale)
- catalog cross-reference

New docs (10):

- `era5_land.md` — Copernicus CDS, monthly-chunked, accumulated vs instantaneous reducers
- `gldas.md` — earthaccess + GLDAS-2.1 `_acc` mm convention
- `merra2.md` — earthaccess + 3-variable wetness, preferred GWETTOP
- `nldas_mosaic.md` / `nldas_noah.md` — layer differences (40-200 vs 40-100/100-200)
- `ncep_ncar.md` — `kg/m2` → m³/m³ mislabel, T62 grid blockiness
- `watergap22d.md` — PANGAEA file_index, CF time fix-up
- `reitz2017.md` — no embedded units, m/year correction (PR #68)
- `mod16a2_v061.md` — PR #88 fill contamination, masked_mean
- `mod10c1_v061.md` — flag values, Snow_Spatial_QA mislabel, CI > 70 gate
- `ssebop.md` — STAC-only (no fetch), custom aggregator wiring

README.md §Repository Structure now enumerates the per-target groupings.

## Test plan

- [ ] Spot-check 2-3 docs for technical accuracy against the corresponding `fetch/` and `aggregate/` modules
- [ ] Verify all 14 source keys in `catalog/sources.yml` are now documented
- [ ] Verify README.md links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)