### PR TITLE
refactor(targets): promote _build_single_shot to public build_single_shot (#231)

### DIFF
--- a/src/nhf_spatial_targets/targets/_driver.py
+++ b/src/nhf_spatial_targets/targets/_driver.py
@@ -140,7 +140,7 @@ def _adapter_logger(adapter: TargetAdapter) -> logging.Logger:
 def build(adapter: TargetAdapter, project: Project) -> None:
     """Build a target's canonical NC according to the adapter.
 
-    Dispatches to :func:`_build_single_shot` for unchunked targets and
+    Dispatches to :func:`build_single_shot` for unchunked targets and
     :func:`_build_year_chunked` otherwise.
     """
     target_cfg = project.target(adapter.config_key)
@@ -164,7 +164,7 @@ def build(adapter: TargetAdapter, project: Project) -> None:
             id_col=id_col,
         )
     else:
-        _build_single_shot(
+        build_single_shot(
             adapter=adapter,
             project=project,
             target_cfg=target_cfg,
@@ -175,7 +175,7 @@ def build(adapter: TargetAdapter, project: Project) -> None:
         )
 
 
-def _build_single_shot(
+def build_single_shot(
     *,
     adapter: TargetAdapter,
     project: Project,
@@ -185,7 +185,19 @@ def _build_single_shot(
     hru_meta,
     id_col: str,
 ) -> None:
-    """Single-shot path: load the period, combine, write."""
+    """Single-shot driver path: load the period, combine, write one NC.
+
+    Public seam for **multi-variant targets** — targets that emit more than
+    one NC under a single ``config_key`` and therefore can't be driven by
+    :func:`build` (whose contract is one adapter, one output file). Such
+    targets declare one :class:`TargetAdapter` per variant and call this
+    function directly in a loop, overriding ``target_cfg["output_file"]``
+    per variant. See :func:`nhf_spatial_targets.targets.som.build` for the
+    canonical example (monthly + annual soil-moisture targets).
+
+    Single-variant targets should call :func:`build` instead and let it
+    dispatch here on the adapter's ``year_chunked`` flag.
+    """
     fabric_hru_ids = hru_meta.index.values
 
     result = adapter.source_loader(

--- a/src/nhf_spatial_targets/targets/som.py
+++ b/src/nhf_spatial_targets/targets/som.py
@@ -324,7 +324,7 @@ def build(project: Project) -> None:
     of scope for the driver — declaring two adapters keeps the driver's
     "one adapter, one file" contract intact.
     """
-    from nhf_spatial_targets.targets._driver import _build_single_shot
+    from nhf_spatial_targets.targets._driver import build_single_shot
     from nhf_spatial_targets.targets._io import (
         compute_hru_centroids,
         parse_period as _parse,
@@ -345,7 +345,7 @@ def build(project: Project) -> None:
     ):
         variant_cfg = dict(som_cfg)
         variant_cfg["output_file"] = _derive_variant_path(base_output, variant).name
-        _build_single_shot(
+        build_single_shot(
             adapter=adapter,
             project=project,
             target_cfg=variant_cfg,


### PR DESCRIPTION
Closes #231.

## Summary

- Rename `_build_single_shot` → `build_single_shot` in [`targets/_driver.py`](src/nhf_spatial_targets/targets/_driver.py).
- Update SOM's import + call site in [`targets/som.py`](src/nhf_spatial_targets/targets/som.py) so it no longer reaches across a `_`-prefixed API boundary.
- Expand the docstring to document the multi-variant use case (point at `som.build()` as the canonical example; redirect single-variant targets to `build()`).

## Why Option A (rename) over Option B (wrap in `build_with_output_override`)

The function already does what SOM needs — load the period, combine, write one NC, with the output path resolved from `target_cfg["output_file"]`. The only thing wrong was the leading underscore signaling "internal." A wrapper layer with the same signature would add ceremony without behavioral difference; promoting in place keeps the call-graph honest.

## Scope

- `_build_single_shot` had 1 definition + 1 internal call + 1 docstring reference in `_driver.py`, and 1 import + 1 call site in `som.py`. No test code referenced it. After this PR `grep -rn _build_single_shot src/ tests/ docs/` returns no matches.
- Behavior unchanged. Tests should pass without modification.

## Docs

`pixi run -e docs docs-build --strict` is clean. The new public symbol now renders under [`api/targets-driver`](docs/api/targets-driver.md) (mkdocstrings picks it up automatically because it no longer has a leading underscore).

## Test plan

- [ ] CI: ruff + pytest pass on a clean Linux runner.
- [ ] mkdocs strict build passes (verified locally; CI re-runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)