### PR TITLE
feat(ua_swe): add fetch + catalog entry for NSIDC-0719 (PR-A of #237)

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -803,8 +803,13 @@ sources:
     status: current
 
   margulis_wus_sr:
-    name: Margulis Western US Snow Reanalysis (NSIDC-0719)
+    name: Margulis Western US Snow Reanalysis (WUS_UCLA_SR)
     description: >
+      NOTE: Distinct from NSIDC-0719 — that catalog ID is the UA
+      Broxton/Zeng/Dawson 4-km CONUS SWE+snow-depth product (see
+      `ua_swe`). The earlier title here claimed NSIDC-0719 in error;
+      Margulis WUS-SR has its own NSIDC ID (operator to confirm via
+      earthaccess at implementation time; the DOI below is correct).
       UCLA/Margulis Western US Snow Reanalysis, daily 90 m posterior
       snow water equivalent over the Sierra Nevada, Cascades, Rockies
       and adjacent ranges for water years 1985-2021. Used as a SWE
@@ -821,15 +826,17 @@ sources:
       type: nsidc
       short_name: WUS_UCLA_SR
       version: "1"
-      url: https://nsidc.org/data/nsidc-0719
+      url: https://nsidc.org/data/wus_ucla_sr
       notes: >
         Access via earthaccess (NASA Earthdata login required).
         Granules are per-water-year per-tile NetCDFs covering the
         Western US domain; the fetch module subsets to the fabric
         bounding box at search time. Confirm short_name via an
-        earthaccess CMR query at implementation time — historically
-        the NSIDC-0719 short_name has been WUS_UCLA_SR but the value
-        is subject to NSIDC bookkeeping.
+        earthaccess CMR query at implementation time — the historical
+        WUS_UCLA_SR value is subject to NSIDC bookkeeping changes.
+        The earlier `url:` here pointed at https://nsidc.org/data/nsidc-0719
+        which is the UA Broxton product (see `ua_swe`), not this one;
+        the corrected slug is /wus_ucla_sr.
     fabric_scope:
       # `fabrics:` is the list of fabric tokens for which this source
       # should be aggregated. Allowed tokens (kept in sync with the
@@ -856,5 +863,97 @@ sources:
     spatial_extent: Western US (Sierra Nevada, Cascades, Rockies and adjacent ranges)
     spatial_resolution: 90 m
     units: m water equivalent
+    license: public domain (NASA NSIDC)
+    status: current
+
+  ua_swe:
+    name: University of Arizona Daily 4-km Gridded SWE and Snow Depth (NSIDC-0719)
+    description: >
+      Daily 4-km CONUS SWE and snow depth from assimilation of SNOTEL/COOP
+      in-situ measurements with PRISM modeled data (Broxton, Zeng & Dawson,
+      University of Arizona). Water years 1982-2023 (1981-10-01 through
+      2023-09-30). Used as a third SWE source — alongside Daymet, SNODAS,
+      and ERA5-Land `sd` — and as a second snow-covered-area source via a
+      depth-derived binary snow-cover indicator, area-weighted to HRU in
+      aggregate/ua_swe.py.
+    citations:
+      - "Broxton, P., Zeng, X., and Dawson, N., 2019, doi:10.5067/0GGPB220EX6A"
+    doi: "10.5067/0GGPB220EX6A"
+    access:
+      # `nsidc_https` = filenames are deterministic at the archive root, so
+      # the fetch module constructs URLs directly per water year rather
+      # than via `earthaccess.search_data`. Same pattern as SNODAS
+      # (CMR may carry the collection record but historically NSIDC's
+      # HTTPS-only archives have been granule-less stubs, per #107).
+      # `short_name` is recorded for provenance and future CMR queries
+      # but is not used by the fetch path.
+      type: nsidc_https
+      short_name: NSIDC-0719
+      version: "1"
+      url: https://nsidc.org/data/nsidc-0719/versions/1
+      archive_url: https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0719_SWE_Snow_Depth_v1/
+      notes: >
+        Access via the earthaccess HTTPS auth session (NASA Earthdata
+        Login required). File layout at the archive (confirmed
+        empirically against one WY): one NetCDF per water year named
+        `4km_SWE_Depth_WY<YYYY>_v01.nc` for WYs 1982 through 2023 (42
+        files, ~90 MB each), plus one CONUS land/water/ice mask
+        `SWE_Mask_v01.nc` at the archive root. Native variables are
+        `SWE` (float32, mm water-eq) and `DEPTH` (float32, mm snow
+        thickness) on a 621x1405 NAD83 EPSG:4269 lat-lon grid; fill is
+        NaN, with no integer sentinel. Time is float32 days since
+        1900-01-01 with no `units` attribute; the consolidator decodes
+        explicitly. Pre-projection to EPSG:5070 NAD83/CONUS Albers at
+        4 km happens at consolidate time (mirrors the SNODAS pattern
+        from issue #121) so the aggregator's WEIGHT_GEN_CRS matches
+        and gdptools skips reprojection during weight generation
+        (~5-8x weight-gen speedup measured for SNODAS). Nearest-
+        neighbour resampling preserves NaN fill without bleed.
+    variables:
+      - name: swe
+        long_name: snow water equivalent
+        cf_units: "kg m-2"
+        cell_methods: "time: mean"
+        notes: >
+          Native units mm water-equivalent (= kg m-2 at density 1000).
+          Publisher fill is NaN — no integer sentinel — so no fill mask
+          is required at consolidate time. The consolidator does enforce
+          `min >= -1.0` as a guard against a future format change that
+          might introduce a -9999 sentinel; values below that abort with
+          a clear ValueError.
+      - name: snow_depth
+        long_name: snow depth
+        cf_units: "mm"
+        cell_methods: "time: mean"
+        notes: >
+          Native units mm of snow thickness (NOT water equivalent).
+          Same NaN-fill convention as `swe`. Used both as a standalone
+          aggregated variable and as the basis for `snow_covered_fraction`
+          (see below).
+      - name: snow_covered_fraction
+        long_name: snow-covered fraction of HRU area
+        cf_units: "1"
+        cell_methods: "area: mean time: mean"
+        notes: >
+          Derived in aggregate/ua_swe.py::pre_aggregate_hook by converting
+          the per-pixel `snow_depth > depth_threshold_mm` test to a 0/1
+          binary indicator before area-weighting via gdptools. The
+          area-weighted mean of the binary then yields fractional snow
+          cover at the HRU scale. The threshold is configurable via
+          `snow_covered_area.depth_threshold_mm` in the project config
+          (default 1.0 mm). Per-pixel fill values propagate as NaN
+          through the test so the aggregator's `masked_mean` reduction
+          excludes them from the HRU mean denominator.
+    time_step: daily
+    # Calendar-year range for compatibility with the fetch period parser;
+    # the actual archive runs water years 1982-2023 (1981-10-01 through
+    # 2023-09-30). The fetch module converts requested calendar years to
+    # the touching water-year files (e.g. CY 1990 touches WY 1990 and WY
+    # 1991, since Oct-Dec 1990 lives in WY 1991).
+    period: "1981/2023"
+    spatial_extent: CONUS
+    spatial_resolution: 4000 m (EPSG:5070, pre-projected at consolidate
+      time; native NAD83 ~4 km lat-lon)
+    units: kg m-2 (mm water equivalent), mm
     license: public domain (NASA NSIDC)
     status: current

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -913,7 +913,9 @@ sources:
       - name: swe
         long_name: snow water equivalent
         cf_units: "kg m-2"
-        cell_methods: "time: mean"
+        # Daily assimilated snapshot (instantaneous state at end of day),
+        # not a within-day mean. Matches the SNODAS `time: point` semantics.
+        cell_methods: "time: point"
         notes: >
           Native units mm water-equivalent (= kg m-2 at density 1000).
           Publisher fill is NaN — no integer sentinel — so no fill mask
@@ -924,7 +926,7 @@ sources:
       - name: snow_depth
         long_name: snow depth
         cf_units: "mm"
-        cell_methods: "time: mean"
+        cell_methods: "time: point"
         notes: >
           Native units mm of snow thickness (NOT water equivalent).
           Same NaN-fill convention as `swe`. Used both as a standalone
@@ -933,7 +935,10 @@ sources:
       - name: snow_covered_fraction
         long_name: snow-covered fraction of HRU area
         cf_units: "1"
-        cell_methods: "area: mean time: mean"
+        # area: mean — the per-HRU fraction is an area-weighted mean over
+        # the HRU's source pixels. time: point — the value represents the
+        # snow-covered fraction at that day's instant, not a daily average.
+        cell_methods: "area: mean time: point"
         notes: >
           Derived in aggregate/ua_swe.py::pre_aggregate_hook by converting
           the per-pixel `snow_depth > depth_threshold_mm` test to a 0/1

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -932,6 +932,17 @@ sources:
           Same NaN-fill convention as `swe`. Used both as a standalone
           aggregated variable and as the basis for `snow_covered_fraction`
           (see below).
+      # SCAFFOLDING for the PR-B aggregate-layer slice (umbrella #237).
+      # This variable does NOT exist in the consolidated fetch output;
+      # it is emitted by a `pre_aggregate_hook` in `aggregate/ua_swe.py`
+      # (still to land) that converts per-pixel `snow_depth >
+      # depth_threshold_mm` to a 0/1 binary indicator before area-
+      # weighting via gdptools. The threshold and the consuming config
+      # key `snow_covered_area.depth_threshold_mm` will both arrive
+      # with the aggregate-layer PR. Listing it here keeps the catalog
+      # entry whole so reviewers see the full intended variable set,
+      # but treat this block as documentation, not a contract enforced
+      # by anything in PR-A.
       - name: snow_covered_fraction
         long_name: snow-covered fraction of HRU area
         cf_units: "1"
@@ -940,15 +951,17 @@ sources:
         # snow-covered fraction at that day's instant, not a daily average.
         cell_methods: "area: mean time: point"
         notes: >
-          Derived in aggregate/ua_swe.py::pre_aggregate_hook by converting
-          the per-pixel `snow_depth > depth_threshold_mm` test to a 0/1
-          binary indicator before area-weighting via gdptools. The
-          area-weighted mean of the binary then yields fractional snow
-          cover at the HRU scale. The threshold is configurable via
-          `snow_covered_area.depth_threshold_mm` in the project config
-          (default 1.0 mm). Per-pixel fill values propagate as NaN
-          through the test so the aggregator's `masked_mean` reduction
-          excludes them from the HRU mean denominator.
+          DEFERRED to the PR-B aggregate slice. Derived in
+          aggregate/ua_swe.py::pre_aggregate_hook (to be added) by
+          converting the per-pixel `snow_depth > depth_threshold_mm`
+          test to a 0/1 binary indicator before area-weighting via
+          gdptools. The area-weighted mean of the binary then yields
+          fractional snow cover at the HRU scale. The threshold is
+          configurable via `snow_covered_area.depth_threshold_mm` in
+          the project config (default 1.0 mm), to be wired in PR-B.
+          Per-pixel fill values propagate as NaN through the test so
+          the aggregator's `masked_mean` reduction excludes them from
+          the HRU mean denominator.
     time_step: daily
     # Calendar-year range for compatibility with the fetch period parser;
     # the actual archive runs water years 1982-2023 (1981-10-01 through

--- a/src/nhf_spatial_targets/cli/fetch.py
+++ b/src/nhf_spatial_targets/cli/fetch.py
@@ -882,7 +882,7 @@ def fetch_margulis_wus_sr_cmd(
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
     ] = "1985/2021",
 ):
-    """Download Margulis Western US Snow Reanalysis (NSIDC-0719) via earthaccess.
+    """Download Margulis Western US Snow Reanalysis (WUS_UCLA_SR) via earthaccess.
 
     Fabric-scoped to Oregon only (catalog `fabric_scope`); the scope is
     recorded in manifest.json but not enforced at fetch time. Fetch-only:

--- a/src/nhf_spatial_targets/cli/fetch.py
+++ b/src/nhf_spatial_targets/cli/fetch.py
@@ -56,6 +56,7 @@ def fetch_all_cmd(
     from nhf_spatial_targets.fetch.pangaea import fetch_watergap22d
     from nhf_spatial_targets.fetch.reitz2017 import fetch_reitz2017
     from nhf_spatial_targets.fetch.snodas import fetch_snodas
+    from nhf_spatial_targets.fetch.ua_swe import fetch_ua_swe
 
     # (display name, catalog source key, fetch function)
     sources = [
@@ -75,6 +76,7 @@ def fetch_all_cmd(
         ("daymet", "daymet", fetch_daymet),
         ("snodas", "snodas", fetch_snodas),
         ("margulis-wus-sr", "margulis_wus_sr", fetch_margulis_wus_sr),
+        ("ua-swe", "ua_swe", fetch_ua_swe),
     ]
 
     results = {}
@@ -913,4 +915,81 @@ def fetch_margulis_wus_sr_cmd(
         sys.exit(1)
 
     console.print("[green]Margulis WUS-SR: downloaded to datastore[/green]")
+    console.print(json_mod.dumps(result, indent=2))
+
+
+@fetch_app.command(name="ua-swe")
+def fetch_ua_swe_cmd(
+    workdir: Annotated[
+        Path,
+        Parameter(
+            name=["--project-dir"],
+            help="Project created by 'nhf-targets init'.",
+        ),
+    ],
+    period: Annotated[
+        str,
+        Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
+    ] = "1981/2023",
+    worker_index: Annotated[
+        int,
+        Parameter(
+            name=["--worker-index"],
+            help="0-based index of this worker within the pool (default 0).",
+        ),
+    ] = 0,
+    n_workers: Annotated[
+        int,
+        Parameter(
+            name=["--n-workers"],
+            help="Total number of parallel workers (default 1 = serial).",
+        ),
+    ] = 1,
+):
+    """Download UA daily 4-km SWE + snow depth (NSIDC-0719) from NSIDC.
+
+    One NetCDF per water year is fetched from the NSIDC HTTPS archive
+    via the earthaccess auth session, then consolidated into a CF-1.6
+    daily NC pre-projected to EPSG:5070 at
+    ``<datastore>/ua_swe/daily/ua_swe_daily_WY<YYYY>.nc``. Raw downloads
+    are preserved under ``<datastore>/ua_swe/raw/``.
+    """
+    import json as json_mod
+
+    from rich.console import Console
+
+    from nhf_spatial_targets.fetch.ua_swe import fetch_ua_swe
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    console = Console()
+    if n_workers > 1:
+        console.print(
+            f"[bold]Fetching UA SWE for period {period} "
+            f"(worker {worker_index}/{n_workers})...[/bold]"
+        )
+    else:
+        console.print(f"[bold]Fetching UA SWE for period {period}...[/bold]")
+
+    try:
+        result = fetch_ua_swe(
+            workdir=workdir,
+            period=period,
+            worker_index=worker_index,
+            n_workers=n_workers,
+        )
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        _logger.exception("Unexpected error during UA SWE fetch")
+        print(
+            f"Unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    console.print("[green]UA SWE: downloaded to datastore[/green]")
     console.print(json_mod.dumps(result, indent=2))

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -14,8 +14,8 @@ float32 days since ``1900-01-01`` without a ``units`` attribute; the
 companion ``time_str`` variable carries the same dates as
 ``dd-mmm-yyyy`` byte strings. Fill is ``NaN`` (the dataset uses no
 integer sentinel), so a ``where(>=0)`` mask is unnecessary at consolidate
-time — but the consolidator asserts non-negative values to catch a
-future format change loudly.
+time — but the consolidator asserts ``min >= -1.0`` (raising on any
+value below that) to catch a future format change to e.g. -9999 loudly.
 
 Filenames are deterministic, so granule discovery is direct URL
 construction by water year rather than CMR search. CMR may carry a
@@ -295,17 +295,21 @@ def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> P
        the ``time:units`` attribute, so xarray cannot auto-decode).
     2. Decode the ``time`` float32 axis as days since
        :data:`_SRC_TIME_EPOCH` (= 1900-01-01) into ``pd.Timestamp``.
-    3. Drop the redundant ``time_str`` provenance variable and the
-       inline ``crs`` scalar (rioxarray writes its own grid-mapping).
+    3. Build a new :class:`xr.Dataset` containing only the reprojected
+       ``swe`` / ``snow_depth`` variables — the source's ``time_str``
+       provenance variable and inline ``crs`` scalar are left behind by
+       construction (not via ``drop_vars``); :func:`apply_cf_metadata`
+       in step 7 writes a fresh grid-mapping ancillary.
     4. Rename ``SWE`` → ``swe``, ``DEPTH`` → ``snow_depth`` to match the
        catalog ``variables`` block.
     5. Attach the source CRS (NAD83 / EPSG:4269) via rioxarray.
-    6. Reproject both 3-D variables to EPSG:5070 at 4-km resolution
-       using nearest-neighbour resampling (preserves NaN fill).
+    6. Reproject both 3-D variables to EPSG:5070 (NAD83 / CONUS Albers)
+       at 4-km resolution using nearest-neighbour resampling
+       (preserves NaN fill).
     7. Apply CF-1.6 metadata via
        :func:`fetch.consolidate.apply_cf_metadata` (sets variable
        ``units`` / ``long_name`` / ``cell_methods`` from the catalog
-       and the WGS84 / EPSG:5070 grid-mapping ancillary).
+       and emits the EPSG:5070 grid-mapping ancillary).
     8. Atomic write via ``.nc.tmp`` rename.
 
     Idempotency: if the output NC exists and is newer than the raw NC,
@@ -381,16 +385,31 @@ def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> P
         # per-day DataArrays are accumulated into lists and concatenated
         # at the end; this trades a tiny accumulator-list footprint for
         # a much lower reproject-step peak.
+        #
+        # Lock the destination grid on the first day's reprojection and
+        # force every subsequent day onto exactly that ``(transform,
+        # shape)`` via ``shape=`` / ``transform=`` (rather than re-deriving
+        # from ``resolution=``). This mirrors the SNODAS pattern in
+        # ``_compute_dst_grid`` / ``_decode_and_reproject_day`` and
+        # eliminates any chance of floating-point drift in the destination
+        # bounds producing mismatched per-day shapes that would either
+        # break the final ``xr.concat`` or (worse) silently broadcast.
+        #
+        # ``nodata=np.float32("nan")`` is pinned explicitly so a future
+        # rioxarray default change can't quietly alter fill-handling on
+        # the projected output. The publisher's NaN-fill convention is
+        # preserved across reprojection.
         reprojected_per_var: dict[str, list[xr.DataArray]] = {
             _DEST_SWE_VAR: [],
             _DEST_DEPTH_VAR: [],
         }
-        # Tuples of (source name, destination name) so we can rename
-        # in the same pass.
         var_map = (
             (_NATIVE_SWE_VAR, _DEST_SWE_VAR),
             (_NATIVE_DEPTH_VAR, _DEST_DEPTH_VAR),
         )
+        dst_transform = None
+        dst_shape: tuple[int, int] | None = None
+        nan_f32 = np.float32("nan")
         for t in range(n_time):
             for src_name, dst_name in var_map:
                 da_day = ds_raw[src_name].isel(time=t)
@@ -398,11 +417,30 @@ def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> P
                     x_dim="lon", y_dim="lat", inplace=False
                 )
                 da_day = da_day.rio.write_crs(_SRC_CRS, inplace=False)
-                da_day_reproj = da_day.rio.reproject(
-                    dst_crs=_DST_CRS,
-                    resolution=(_DST_RESOLUTION_M, _DST_RESOLUTION_M),
-                    resampling=Resampling.nearest,
-                )
+                if dst_transform is None:
+                    # First reprojection: derive (and capture) the
+                    # destination grid from the requested resolution.
+                    da_day_reproj = da_day.rio.reproject(
+                        dst_crs=_DST_CRS,
+                        resolution=(_DST_RESOLUTION_M, _DST_RESOLUTION_M),
+                        resampling=Resampling.nearest,
+                        nodata=nan_f32,
+                    )
+                    dst_transform = da_day_reproj.rio.transform()
+                    dst_shape = (
+                        int(da_day_reproj.sizes["y"]),
+                        int(da_day_reproj.sizes["x"]),
+                    )
+                else:
+                    # Subsequent reprojections: force onto the locked
+                    # day-0 grid so all days are guaranteed-conformable.
+                    da_day_reproj = da_day.rio.reproject(
+                        dst_crs=_DST_CRS,
+                        shape=dst_shape,
+                        transform=dst_transform,
+                        resampling=Resampling.nearest,
+                        nodata=nan_f32,
+                    )
                 # Drop any inherited time-related scalar coords that
                 # snuck through `isel(time=t)`; we re-attach the proper
                 # time vector via `expand_dims` next.
@@ -411,7 +449,6 @@ def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> P
                     errors="ignore",
                 )
                 da_day_reproj = da_day_reproj.expand_dims(time=[times[t]])
-                # Rename to the destination variable name.
                 da_day_reproj.name = dst_name
                 reprojected_per_var[dst_name].append(da_day_reproj)
 

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -468,7 +468,14 @@ def _build_consolidated_encoding(ds: xr.Dataset) -> dict:
         "units": "days since 1970-01-01",
         "calendar": "proleptic_gregorian",
         "dtype": "float64",
+        # CF §9.6 strongly discourages _FillValue on coordinate variables
+        # (coordinates should be exhaustive). xarray auto-attaches one
+        # otherwise; setting None suppresses it.
+        "_FillValue": None,
     }
+    for coord in ("x", "y"):
+        if coord in ds.coords:
+            encoding[coord] = {"_FillValue": None}
     return encoding
 
 

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -1,0 +1,785 @@
+"""Fetch UA Daily 4-km Gridded SWE and Snow Depth (NSIDC-0719) from NSIDC.
+
+The Broxton/Zeng/Dawson University of Arizona product publishes one
+NetCDF per water year at the NSIDC archive root:
+
+    https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0719_SWE_Snow_Depth_v1/
+        4km_SWE_Depth_WY<YYYY>_v01.nc       # one per water year, ~90 MB
+        SWE_Mask_v01.nc                     # one CONUS/water/ice mask, ~2 MB
+
+Each per-WY file carries float32 ``SWE`` (millimeters water equivalent)
+and ``DEPTH`` (millimeters snow thickness) on a CONUS NAD83 (EPSG:4269)
+lat-lon grid of 621 × 1405 (~0.04167° = ~4 km). Time is encoded as
+float32 days since ``1900-01-01`` without a ``units`` attribute; the
+companion ``time_str`` variable carries the same dates as
+``dd-mmm-yyyy`` byte strings. Fill is ``NaN`` (the dataset uses no
+integer sentinel), so a ``where(>=0)`` mask is unnecessary at consolidate
+time — but the consolidator asserts non-negative values to catch a
+future format change loudly.
+
+Filenames are deterministic, so granule discovery is direct URL
+construction by water year rather than CMR search. CMR may carry a
+collection record for NSIDC-0719 but historically NSIDC's CMR records
+for HTTPS-archive products have been granule-less stubs (issue #107
+documented this for SNODAS/G02158); the deterministic-URL approach
+sidesteps the question entirely.
+
+After download, :func:`consolidate_water_year_ua_swe` decodes time,
+renames the native ``SWE`` / ``DEPTH`` variables to the pipeline's
+``swe`` / ``snow_depth`` (matching ``catalog/sources.yml``), and
+**reprojects from NAD83 lat-lon to EPSG:5070 (NAD83 / CONUS Albers
+Equal Area) at 4000 m using nearest-neighbour resampling**, mirroring
+the SNODAS pre-projection (issue #121) so the aggregator's
+``WEIGHT_GEN_CRS`` matches and gdptools' weight generation does not
+need to reproject the source grid at all. Output is a single per-WY
+CF-1.6 NetCDF at
+``<datastore>/ua_swe/daily/ua_swe_daily_WY<YYYY>.nc``. Raw downloaded
+NCs are preserved under ``<datastore>/ua_swe/raw/`` for provenance and
+to enable re-decode after a catalog metadata change.
+
+Backwards-compat note: ``catalog/sources.yml[ua_swe].period`` is the
+calendar-year range ``1981/2023`` for compatibility with
+:func:`fetch._period.parse_period`; the actual archive runs water years
+1982-2023 (1981-10-01 through 2023-09-30). A user-requested calendar
+year may touch one or two adjacent water-year files; the fetch module
+resolves the set of WY files needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import rioxarray  # noqa: F401  (registers .rio accessor)
+import xarray as xr
+from rasterio.enums import Resampling
+
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:  # Windows fallback (not used on HPC).
+    _HAVE_FLOCK = False
+
+import nhf_spatial_targets.catalog as _catalog
+from nhf_spatial_targets import __version__
+from nhf_spatial_targets.fetch._period import (
+    parse_period,
+    period_bounds,
+    years_in_period,
+)
+from nhf_spatial_targets.fetch.consolidate import apply_cf_metadata
+from nhf_spatial_targets.workspace import load as _load_project
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_KEY = "ua_swe"
+
+# Per-request HTTP timeout (connect + first-byte). UA SWE per-WY files
+# are ~90 MB compressed; 120 s is generous for a healthy network.
+_HTTP_TIMEOUT_SECONDS = 120
+_DOWNLOAD_CHUNK_BYTES = 8 * 1024 * 1024
+# Defense in depth against truncated bodies. A real per-WY file is
+# 70-100 MB; anything below ~10 MB is a stub. Content-Length integrity
+# is the primary defense; this is the fallback when the server omits
+# the header.
+_MIN_VALID_NC_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+# Filenames are deterministic at the NSIDC archive root.
+_WY_FILENAME_TEMPLATE = "4km_SWE_Depth_WY{wy}_v01.nc"
+_MASK_FILENAME = "SWE_Mask_v01.nc"
+_CONSOLIDATED_FILENAME_TEMPLATE = "ua_swe_daily_WY{wy}.nc"
+
+# Source-side variable names; renamed at consolidate time to match the
+# lowercase pipeline convention (and the catalog `variables` block).
+_NATIVE_SWE_VAR = "SWE"
+_NATIVE_DEPTH_VAR = "DEPTH"
+_DEST_SWE_VAR = "swe"
+_DEST_DEPTH_VAR = "snow_depth"
+
+# Time encoding in the native NetCDFs is float32 days since 1900-01-01
+# without a `units` attribute; the consolidator decodes via this epoch
+# explicitly. The companion `time_str` byte variable carries the same
+# dates as `dd-mmm-yyyy` for cross-check, but we don't depend on it.
+_SRC_TIME_EPOCH = pd.Timestamp("1900-01-01")
+
+# Source CRS as advertised in the per-WY NCs' `crs` ancillary variable.
+_SRC_CRS = "EPSG:4269"  # NAD83 geographic
+
+# Pre-projection target — matches the aggregator's WEIGHT_GEN_CRS.
+# Nearest-neighbour resampling preserves NaN fill without bleed.
+_DST_CRS = "EPSG:5070"  # NAD83 / CONUS Albers
+_DST_RESOLUTION_M = 4000.0
+
+
+# ---------------------------------------------------------------------------
+# Period helpers
+# ---------------------------------------------------------------------------
+
+
+def _calendar_years_to_water_years(years: list[int]) -> list[int]:
+    """Map calendar years to the set of water years whose files contain them.
+
+    Water year ``Y`` runs from ``Oct 1, Y-1`` through ``Sep 30, Y``. A
+    calendar year ``C`` therefore touches:
+
+    - WY ``C`` (covers Jan-Sep of CY ``C``)
+    - WY ``C+1`` (covers Oct-Dec of CY ``C``)
+
+    The returned list is sorted and deduplicated.
+    """
+    touched: set[int] = set()
+    for cy in years:
+        touched.add(cy)  # Jan-Sep of CY lives in WY = CY
+        touched.add(cy + 1)  # Oct-Dec of CY lives in WY = CY+1
+    return sorted(touched)
+
+
+def _wy_url(archive_url: str, wy: int) -> str:
+    """Construct the deterministic per-WY file URL at the NSIDC archive."""
+    base = archive_url.rstrip("/")
+    return f"{base}/{_WY_FILENAME_TEMPLATE.format(wy=wy)}"
+
+
+def _mask_url(archive_url: str) -> str:
+    """Construct the deterministic CONUS/water/ice mask URL."""
+    base = archive_url.rstrip("/")
+    return f"{base}/{_MASK_FILENAME}"
+
+
+# ---------------------------------------------------------------------------
+# HTTPS session + download
+# ---------------------------------------------------------------------------
+
+
+def _earthaccess_session():
+    """Return an authenticated HTTPS session for daacdata.apps.nsidc.org.
+
+    Wraps ``earthaccess.login(strategy='netrc').get_session()``. Callers
+    are responsible for ensuring ``~/.netrc`` carries valid Earthdata
+    credentials (the ``nhf-targets materialize-credentials`` command
+    populates this from ``.credentials.yml``).
+    """
+    try:
+        import earthaccess
+    except ImportError as exc:  # pragma: no cover - import-time guarantee
+        raise RuntimeError(
+            "earthaccess is required for ua_swe fetch but is not installed."
+        ) from exc
+
+    auth = earthaccess.login(strategy="netrc")
+    if auth is None or not getattr(auth, "authenticated", False):
+        raise RuntimeError(
+            "NASA Earthdata login failed. Run `nhf-targets "
+            "materialize-credentials --project-dir <project>` to populate "
+            "~/.netrc from your project's .credentials.yml, or visit "
+            "https://urs.earthdata.nasa.gov/users/new to register."
+        )
+    return auth.get_session()
+
+
+def _download_file(
+    session,
+    url: str,
+    out_path: Path,
+    *,
+    timeout: int = _HTTP_TIMEOUT_SECONDS,
+    min_bytes: int = _MIN_VALID_NC_BYTES,
+) -> str:
+    """Stream a single file from *url* to *out_path*. Returns a status code.
+
+    Status codes (manifest-friendly):
+
+    - ``"downloaded"`` — file streamed AND verified against Content-Length
+      (or, if the server omits Content-Length, the body cleared
+      ``min_bytes``) and written this call.
+    - ``"already_present"`` — file exists on disk with size at or above
+      ``min_bytes``; skipped.
+    - ``"missing_404"`` — server returned 404; logged as a warning.
+    - ``"error"`` — any other failure; logged, not raised.
+
+    Atomic: streams to a ``.tmp`` sibling, then renames on success. The
+    ``.tmp`` is unlinked on any failure path (including a Content-Length
+    mismatch) so resume sees a clean directory.
+    """
+    if out_path.exists():
+        sz = out_path.stat().st_size
+        if sz >= min_bytes:
+            return "already_present"
+        logger.warning(
+            "ua_swe: existing %s is suspiciously small (%d < %d bytes); redownloading.",
+            out_path.name,
+            sz,
+            min_bytes,
+        )
+        out_path.unlink(missing_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    try:
+        resp = session.get(url, timeout=timeout, stream=True, allow_redirects=True)
+    except Exception as exc:
+        logger.warning("ua_swe: GET failed for %s: %s", url, exc)
+        tmp.unlink(missing_ok=True)
+        return "error"
+    try:
+        if resp.status_code == 404:
+            logger.warning("ua_swe: 404 for %s", url)
+            return "missing_404"
+        if resp.status_code != 200:
+            logger.warning("ua_swe: unexpected status %d for %s", resp.status_code, url)
+            return "error"
+
+        declared_len = resp.headers.get("Content-Length")
+        try:
+            declared_bytes: int | None = int(declared_len) if declared_len else None
+        except ValueError:
+            declared_bytes = None
+
+        bytes_written = 0
+        with tmp.open("wb") as f:
+            for chunk in resp.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+                if chunk:
+                    f.write(chunk)
+                    bytes_written += len(chunk)
+
+        if declared_bytes is not None:
+            if bytes_written != declared_bytes:
+                logger.warning(
+                    "ua_swe: short read for %s — wrote %d of %d declared bytes",
+                    url,
+                    bytes_written,
+                    declared_bytes,
+                )
+                tmp.unlink(missing_ok=True)
+                return "error"
+        elif bytes_written < min_bytes:
+            logger.warning(
+                "ua_swe: truncated response for %s — wrote %d bytes "
+                "(< %d minimum and no Content-Length to confirm); discarding",
+                url,
+                bytes_written,
+                min_bytes,
+            )
+            tmp.unlink(missing_ok=True)
+            return "error"
+
+        tmp.replace(out_path)
+        return "downloaded"
+    except Exception as exc:
+        logger.warning("ua_swe: write failed for %s → %s: %s", url, out_path, exc)
+        tmp.unlink(missing_ok=True)
+        return "error"
+    finally:
+        try:
+            resp.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Consolidation
+# ---------------------------------------------------------------------------
+
+
+def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> Path:
+    """Consolidate a per-WY raw NC into a CF-1.6 pre-projected daily NC.
+
+    Steps:
+
+    1. Open the raw file with ``decode_times=False`` (the source omits
+       the ``time:units`` attribute, so xarray cannot auto-decode).
+    2. Decode the ``time`` float32 axis as days since
+       :data:`_SRC_TIME_EPOCH` (= 1900-01-01) into ``pd.Timestamp``.
+    3. Drop the redundant ``time_str`` provenance variable and the
+       inline ``crs`` scalar (rioxarray writes its own grid-mapping).
+    4. Rename ``SWE`` → ``swe``, ``DEPTH`` → ``snow_depth`` to match the
+       catalog ``variables`` block.
+    5. Attach the source CRS (NAD83 / EPSG:4269) via rioxarray.
+    6. Reproject both 3-D variables to EPSG:5070 at 4-km resolution
+       using nearest-neighbour resampling (preserves NaN fill).
+    7. Apply CF-1.6 metadata via
+       :func:`fetch.consolidate.apply_cf_metadata` (sets variable
+       ``units`` / ``long_name`` / ``cell_methods`` from the catalog
+       and the WGS84 / EPSG:5070 grid-mapping ancillary).
+    8. Atomic write via ``.nc.tmp`` rename.
+
+    Idempotency: if the output NC exists and is newer than the raw NC,
+    the rebuild is skipped.
+
+    Parameters
+    ----------
+    wy : int
+        Water year. The output filename embeds this label.
+    raw_path : Path
+        Source raw NC, e.g. ``<datastore>/ua_swe/raw/4km_SWE_Depth_WY1982_v01.nc``.
+    daily_dir : Path
+        Output directory; the file is written as
+        ``ua_swe_daily_WY<wy>.nc`` inside.
+
+    Returns
+    -------
+    Path
+        Path to the consolidated NC.
+    """
+    if not raw_path.exists():
+        raise FileNotFoundError(f"ua_swe raw NC not found: {raw_path}")
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    out_path = daily_dir / _CONSOLIDATED_FILENAME_TEMPLATE.format(wy=wy)
+
+    # Mtime-based idempotency. A rebuild is forced only when the raw
+    # NC is newer than the consolidated output (e.g. after re-download).
+    if out_path.exists() and out_path.stat().st_mtime >= raw_path.stat().st_mtime:
+        logger.info(
+            "ua_swe: WY %d already consolidated and current (%s); skipping.",
+            wy,
+            out_path.name,
+        )
+        return out_path
+
+    # Per-day reproject pattern: keep peak memory bounded for environments
+    # without a per-job SLURM allocation (login node cgroups, etc.). For a
+    # 365-day WY on a 621x1405 source and ~1500x900 EPSG:5070 destination,
+    # peak working set stays at a few hundred MB instead of the ~10 GB the
+    # whole-year reproject can demand.
+    ds_raw = xr.open_dataset(raw_path, decode_times=False)
+    try:
+        # Decode time axis manually (the source omits the `time:units`
+        # attribute, so xarray cannot auto-decode).
+        time_days = ds_raw["time"].values.astype("float64")
+        times = _SRC_TIME_EPOCH + pd.to_timedelta(time_days, unit="D")
+        n_time = ds_raw.sizes["time"]
+
+        # Defensive: a real format change to integer sentinels (e.g.
+        # -9999 added in a future v02) must fail loudly rather than
+        # silently producing nonsense aggregates. Use chunked min across
+        # time so we never materialise the full year in memory just to
+        # check.
+        for vname in (_NATIVE_SWE_VAR, _NATIVE_DEPTH_VAR):
+            v = ds_raw[vname]
+            running_min = np.inf
+            for t in range(n_time):
+                slab = v.isel(time=t).values
+                m = np.nanmin(slab)
+                if np.isfinite(m) and m < running_min:
+                    running_min = float(m)
+            if running_min < -1.0:
+                raise ValueError(
+                    f"ua_swe WY {wy}: variable {vname!r} contains values "
+                    f"< -1.0 (min={running_min:.3f}); the publisher may "
+                    f"have introduced an integer sentinel. Inspect the raw "
+                    f"NC and update fetch/ua_swe.py before consolidating "
+                    f"further."
+                )
+
+        # Reproject one day at a time. Each day is a small 2-D array
+        # (~3.5 MB raw), so reprojection is cheap. The resulting
+        # per-day DataArrays are accumulated into lists and concatenated
+        # at the end; this trades a tiny accumulator-list footprint for
+        # a much lower reproject-step peak.
+        reprojected_per_var: dict[str, list[xr.DataArray]] = {
+            _DEST_SWE_VAR: [],
+            _DEST_DEPTH_VAR: [],
+        }
+        # Tuples of (source name, destination name) so we can rename
+        # in the same pass.
+        var_map = (
+            (_NATIVE_SWE_VAR, _DEST_SWE_VAR),
+            (_NATIVE_DEPTH_VAR, _DEST_DEPTH_VAR),
+        )
+        for t in range(n_time):
+            for src_name, dst_name in var_map:
+                da_day = ds_raw[src_name].isel(time=t)
+                da_day = da_day.rio.set_spatial_dims(
+                    x_dim="lon", y_dim="lat", inplace=False
+                )
+                da_day = da_day.rio.write_crs(_SRC_CRS, inplace=False)
+                da_day_reproj = da_day.rio.reproject(
+                    dst_crs=_DST_CRS,
+                    resolution=(_DST_RESOLUTION_M, _DST_RESOLUTION_M),
+                    resampling=Resampling.nearest,
+                )
+                # Drop any inherited time-related scalar coords that
+                # snuck through `isel(time=t)`; we re-attach the proper
+                # time vector via `expand_dims` next.
+                da_day_reproj = da_day_reproj.drop_vars(
+                    [c for c in da_day_reproj.coords if c == "time"],
+                    errors="ignore",
+                )
+                da_day_reproj = da_day_reproj.expand_dims(time=[times[t]])
+                # Rename to the destination variable name.
+                da_day_reproj.name = dst_name
+                reprojected_per_var[dst_name].append(da_day_reproj)
+
+        ds_reproj = xr.Dataset(
+            {
+                dst_name: xr.concat(days, dim="time")
+                for dst_name, days in reprojected_per_var.items()
+            }
+        )
+    finally:
+        ds_raw.close()
+
+    # Step 7: catalog-driven CF-1.6 metadata. `coord_type="projected"`
+    # keeps the (y, x) dims as metres and emits the projected grid
+    # mapping into the `crs` ancillary.
+    ds_out = apply_cf_metadata(
+        ds_reproj,
+        _SOURCE_KEY,
+        time_step="daily",
+        coord_type="projected",
+    )
+
+    # Step 8: atomic write with explicit encoding (build_encoding(
+    # layer="consolidated") is the issue #158 seam and currently
+    # raises). Encoding mirrors the SNODAS consolidator: zlib 4, time
+    # pinned to days since 1970-01-01 in a proleptic_gregorian
+    # calendar so downstream tools agree on the epoch.
+    encoding = _build_consolidated_encoding(ds_out)
+    _atomic_write_dataset(ds_out, out_path, encoding=encoding)
+    return out_path
+
+
+def _build_consolidated_encoding(ds: xr.Dataset) -> dict:
+    """Hand-rolled encoding for the consolidated NC (issue #158 workaround).
+
+    ``io_nc.build_encoding(layer="consolidated", ...)`` currently
+    raises ``NotImplementedError`` because the per-source spatial
+    tiling policy is open work; until it lands, fetch modules carry
+    their own encoding. The defaults here match the SNODAS
+    consolidator: zlib level 4, integer shuffle off (we have float
+    data), float32 ``_FillValue=NaN``, and a pinned time epoch.
+    """
+    encoding: dict[str, dict] = {}
+    for vname in (_DEST_SWE_VAR, _DEST_DEPTH_VAR):
+        if vname in ds.data_vars:
+            encoding[vname] = {
+                "zlib": True,
+                "complevel": 4,
+                "shuffle": False,
+                "_FillValue": np.float32("nan"),
+                "dtype": "float32",
+            }
+    encoding["time"] = {
+        "units": "days since 1970-01-01",
+        "calendar": "proleptic_gregorian",
+        "dtype": "float64",
+    }
+    return encoding
+
+
+def _atomic_write_dataset(ds: xr.Dataset, out_path: Path, encoding: dict) -> None:
+    """Write *ds* to *out_path* via ``.nc.tmp`` rename. Cleans up on failure."""
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    try:
+        ds.to_netcdf(tmp, encoding=encoding, format="NETCDF4")
+        tmp.replace(out_path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Manifest (read-merge-write, flock-protected)
+# ---------------------------------------------------------------------------
+
+
+def _update_manifest(
+    workdir: Path,
+    period: str,
+    meta: dict,
+    wy_records: list[dict],
+    archive_url: str,
+    mask_record: dict | None,
+) -> None:
+    """Merge ua_swe provenance into ``manifest.json`` under file lock.
+
+    Read-merge-write semantics so concurrent worker invocations cannot
+    clobber each other (mirrors the SNODAS pattern). Records for the
+    same water year overwrite earlier entries on later calls.
+    """
+    ws = _load_project(workdir)
+    manifest_path = ws.manifest_path
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _do_update() -> None:
+        if manifest_path.exists():
+            try:
+                manifest = json.loads(manifest_path.read_text())
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"manifest.json in {workdir} is corrupt and cannot be "
+                    f"parsed. Delete it and re-run the fetch step. "
+                    f"Original error: {exc}"
+                ) from exc
+        else:
+            manifest = {"sources": {}, "steps": []}
+
+        manifest.setdefault("sources", {})
+        entry = manifest["sources"].get(_SOURCE_KEY, {})
+        existing_by_wy = {int(y["water_year"]): y for y in entry.get("water_years", [])}
+        for rec in wy_records:
+            existing_by_wy[int(rec["water_year"])] = rec
+        merged_wys = [existing_by_wy[w] for w in sorted(existing_by_wy)]
+        access = meta["access"]
+        entry.update(
+            {
+                "source_key": _SOURCE_KEY,
+                "access_url": access["url"],
+                "archive_url": archive_url,
+                "doi": meta.get("doi"),
+                "license": meta.get("license", "public domain (NASA NSIDC)"),
+                "period": period,
+                "variables": [v["name"] for v in meta["variables"]],
+                "water_years": merged_wys,
+                "fetched_by": f"nhf_spatial_targets {__version__}",
+            }
+        )
+        if mask_record is not None:
+            # Preserve any prior mask record if this run didn't touch it.
+            entry["mask"] = mask_record
+        manifest["sources"][_SOURCE_KEY] = entry
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=manifest_path.parent, suffix=".json.tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump(manifest, f, indent=2)
+            Path(tmp_path).replace(manifest_path)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+    if _HAVE_FLOCK:
+        with open(lock_path, "a") as lock_f:
+            _fcntl.flock(lock_f, _fcntl.LOCK_EX)
+            try:
+                _do_update()
+            finally:
+                _fcntl.flock(lock_f, _fcntl.LOCK_UN)
+    else:
+        _do_update()
+    logger.info(
+        "ua_swe: updated manifest.json for water years %s",
+        [r["water_year"] for r in wy_records],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worker sharding
+# ---------------------------------------------------------------------------
+
+
+def _assign_worker_water_years(
+    all_wys: list[int],
+    worker_index: int,
+    n_workers: int,
+) -> list[int]:
+    """Round-robin slice of ``all_wys`` for one worker.
+
+    Mirrors :func:`snodas._assign_worker_years`. Slicing the full list
+    (not a remaining-work set) keeps each worker's assignment
+    independent of sibling progress, which is what manifests with
+    concurrent file locks expect.
+    """
+    if n_workers < 1:
+        raise ValueError(f"n_workers must be >= 1, got {n_workers}")
+    if not 0 <= worker_index < n_workers:
+        raise ValueError(
+            f"worker_index must be in [0, {n_workers}); got {worker_index}"
+        )
+    return list(all_wys[worker_index::n_workers])
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def fetch_ua_swe(
+    workdir: Path,
+    period: str,
+    *,
+    worker_index: int = 0,
+    n_workers: int = 1,
+) -> dict:
+    """Download UA SWE per-WY NCs and consolidate to CF NetCDFs.
+
+    Two-phase per water year: (1) stream
+    ``4km_SWE_Depth_WY<YYYY>_v01.nc`` from the NSIDC HTTPS archive into
+    ``<datastore>/ua_swe/raw/`` via the earthaccess auth session.
+    (2) Decode, rename, pre-project to EPSG:5070, and write a
+    CF-compliant per-WY NC at
+    ``<datastore>/ua_swe/daily/ua_swe_daily_WY<YYYY>.nc``. The CONUS
+    water/ice mask (``SWE_Mask_v01.nc``) is downloaded once at the
+    datastore root and reused across runs.
+
+    Parameters
+    ----------
+    workdir : Path
+        Project directory.
+    period : str
+        Calendar-year window ``"YYYY/YYYY"`` (inclusive). The actual WY
+        files needed are CY and CY+1 for each requested calendar year;
+        the fetcher resolves the union internally. Validated against
+        the catalog's ``period``.
+    worker_index, n_workers : int
+        Round-robin water-year sharding for parallel workers.
+
+    Returns
+    -------
+    dict
+        Provenance summary with the per-WY records appended.
+
+    Raises
+    ------
+    ValueError
+        Requested period falls outside the catalog window, or
+        ``access.archive_url`` is missing from the catalog.
+    RuntimeError
+        Earthdata login failed.
+    """
+    parse_period(period)
+    ws = _load_project(workdir)
+    meta = _catalog.source(_SOURCE_KEY)
+    access = meta["access"]
+    archive_url = access.get("archive_url")
+    if not archive_url:
+        raise ValueError(
+            f"catalog `sources.yml[{_SOURCE_KEY}].access.archive_url` is "
+            f"missing. Set it to the NSIDC HTTPS archive root."
+        )
+    data_lo, data_hi = period_bounds(meta["period"])
+    requested_cys = years_in_period(period)
+    for cy in requested_cys:
+        if cy < data_lo or cy > data_hi:
+            raise ValueError(
+                f"Calendar year {cy} is outside the ua_swe publisher window "
+                f"({data_lo}-{data_hi}, from catalog "
+                f"`sources.yml[{_SOURCE_KEY}].period`). Adjust --period."
+            )
+    # Resolve calendar years to the water-year files that contain them.
+    # For each WY needed, also clamp to the publisher's available WY
+    # range. WY 1982 is the earliest published; WY 2023 the latest.
+    candidate_wys = _calendar_years_to_water_years(requested_cys)
+    publisher_wy_lo = data_lo + 1  # WY 1982 for catalog "1981/2023"
+    publisher_wy_hi = data_hi  # WY 2023
+    wys = [w for w in candidate_wys if publisher_wy_lo <= w <= publisher_wy_hi]
+    if not wys:
+        logger.warning(
+            "ua_swe: requested calendar years %s map to no published water "
+            "years in [%d, %d]; nothing to fetch.",
+            requested_cys,
+            publisher_wy_lo,
+            publisher_wy_hi,
+        )
+
+    raw_dir = ws.raw_dir(_SOURCE_KEY) / "raw"
+    daily_dir = ws.raw_dir(_SOURCE_KEY) / "daily"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    now_utc = datetime.now(timezone.utc).isoformat()
+
+    session = _earthaccess_session()
+
+    # Mask is downloaded once per datastore. Only worker 0 attempts it
+    # to avoid concurrent writes to the same path; siblings just see
+    # `already_present` on their next pass.
+    mask_record: dict | None = None
+    if worker_index == 0:
+        mask_path = raw_dir / _MASK_FILENAME
+        mask_status = _download_file(
+            session,
+            _mask_url(archive_url),
+            mask_path,
+            min_bytes=128 * 1024,  # mask is small (~2 MB); use a smaller floor
+        )
+        mask_record = {
+            "filename": _MASK_FILENAME,
+            "url": _mask_url(archive_url),
+            "path": str(mask_path),
+            "status": mask_status,
+            "downloaded_utc": now_utc,
+        }
+        logger.info("ua_swe: CONUS mask status=%s (%s)", mask_status, mask_path)
+
+    assigned = _assign_worker_water_years(wys, worker_index, n_workers)
+    if not assigned:
+        logger.info(
+            "ua_swe: worker %d/%d has no water years to process for period %s",
+            worker_index,
+            n_workers,
+            period,
+        )
+        return {
+            "source_key": _SOURCE_KEY,
+            "period": period,
+            "archive_url": archive_url,
+            "worker_index": worker_index,
+            "n_workers": n_workers,
+            "water_years": [],
+            "fetched_at": now_utc,
+            "mask": mask_record,
+        }
+
+    wy_records: list[dict] = []
+    for wy in assigned:
+        url = _wy_url(archive_url, wy)
+        raw_path = raw_dir / _WY_FILENAME_TEMPLATE.format(wy=wy)
+        status = _download_file(session, url, raw_path)
+        rec: dict = {
+            "water_year": wy,
+            "url": url,
+            "raw_path": str(raw_path),
+            "status": status,
+            "downloaded_utc": now_utc,
+        }
+        if status in ("downloaded", "already_present"):
+            # Data-level failures are recorded and continue; programming
+            # errors are not caught.
+            try:
+                daily_path = consolidate_water_year_ua_swe(wy, raw_path, daily_dir)
+                rec["daily_path"] = str(daily_path)
+                rec["consolidated_utc"] = datetime.now(timezone.utc).isoformat()
+            except (ValueError, FileNotFoundError, OSError, RuntimeError) as exc:
+                logger.warning("ua_swe: consolidation failed for WY %d: %s", wy, exc)
+                rec["consolidate_error"] = str(exc)
+        elif status == "missing_404":
+            logger.warning(
+                "ua_swe: WY %d returned 404 at %s; skipping consolidation. "
+                "Confirm the catalog `archive_url` and the v01 filename "
+                "convention if this persists.",
+                wy,
+                url,
+            )
+        else:  # "error"
+            logger.warning(
+                "ua_swe: WY %d download failed (%s); skipping consolidation.",
+                wy,
+                status,
+            )
+        wy_records.append(rec)
+        logger.info(
+            "ua_swe: WY %d — status=%s%s",
+            wy,
+            status,
+            (f", daily={Path(rec['daily_path']).name}" if "daily_path" in rec else ""),
+        )
+
+    _update_manifest(workdir, period, meta, wy_records, archive_url, mask_record)
+    return {
+        "source_key": _SOURCE_KEY,
+        "period": period,
+        "archive_url": archive_url,
+        "worker_index": worker_index,
+        "n_workers": n_workers,
+        "water_years": wy_records,
+        "fetched_at": now_utc,
+        "mask": mask_record,
+    }

--- a/tests/test_fetch_ua_swe.py
+++ b/tests/test_fetch_ua_swe.py
@@ -1,0 +1,358 @@
+"""Tests for UA SWE (NSIDC-0719) fetch + consolidation (issue #238).
+
+Synthetic NetCDF fixtures mirror the layout of the real per-WY files
+(``time`` as float32 days since 1900-01-01 with no ``units`` attr,
+``SWE`` / ``DEPTH`` float32 in mm, NaN fill, CRS embedded in an ``|S1``
+``crs`` scalar with NAD83 WKT) so the consolidation logic is exercised
+end-to-end without touching the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import yaml
+
+from nhf_spatial_targets.fetch.ua_swe import (
+    _assign_worker_water_years,
+    _calendar_years_to_water_years,
+    _mask_url,
+    _wy_url,
+    consolidate_water_year_ua_swe,
+    fetch_ua_swe,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Materialize a minimal valid project directory.
+
+    The project loader requires ``config.yml`` and ``fabric.json`` to
+    exist. UA SWE downloads are full-CONUS regardless of the project's
+    fabric, so a stub fabric.json suffices.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    datastore = tmp_path / "datastore"
+    datastore.mkdir()
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {
+                    "path": str(tmp_path / "fabric.gpkg"),
+                    "id_col": "nhm_id",
+                },
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    return tmp_path
+
+
+def _make_synthetic_raw_nc(
+    path: Path,
+    wy: int,
+    *,
+    n_time: int = 3,
+    n_lat: int = 5,
+    n_lon: int = 6,
+    fill_fraction: float = 0.2,
+    inject_negative: bool = False,
+) -> None:
+    """Write a synthetic per-WY raw NC matching the real publisher layout.
+
+    Layout matches the NSIDC-0719 v1 files inspected at planning time:
+
+    - ``time`` is float32 days since 1900-01-01, **no** ``units`` attr.
+      (The consolidator decodes the epoch explicitly.)
+    - ``lat`` / ``lon`` are float32 degrees in NAD83.
+    - ``crs`` is an ``|S1`` scalar with a NAD83 WKT in ``spatial_ref``.
+    - ``SWE`` / ``DEPTH`` are float32 ``(time, lat, lon)`` arrays in mm,
+      NaN fill outside CONUS.
+    """
+    # Water year `wy` runs Oct 1 (wy-1) -> Sep 30 (wy). The first
+    # ``n_time`` days of that span are encoded.
+    start = pd.Timestamp(f"{wy - 1}-10-01")
+    epoch = pd.Timestamp("1900-01-01")
+    days_since_epoch = np.array(
+        [(start + pd.Timedelta(days=i) - epoch).days for i in range(n_time)],
+        dtype="float32",
+    )
+
+    # Tiny CONUS sub-grid (the consolidator's reprojection still runs;
+    # rio.reproject on a 5x6 grid is fast).
+    lat = np.linspace(30.0, 35.0, n_lat, dtype="float32")
+    lon = np.linspace(-110.0, -100.0, n_lon, dtype="float32")
+
+    rng = np.random.default_rng(seed=int(wy))
+    swe = rng.uniform(0.0, 500.0, size=(n_time, n_lat, n_lon)).astype("float32")
+    depth = rng.uniform(0.0, 2000.0, size=(n_time, n_lat, n_lon)).astype("float32")
+    # Stamp NaN fill on a deterministic pattern (matches the real
+    # "outside CONUS" mask convention; NaN, not -9999).
+    n_fill = int(fill_fraction * swe.size)
+    flat_idx = rng.choice(swe.size, size=n_fill, replace=False)
+    swe.ravel()[flat_idx] = np.nan
+    depth.ravel()[flat_idx] = np.nan
+    if inject_negative:
+        swe[0, 0, 0] = -9999.0
+
+    ds = xr.Dataset(
+        data_vars={
+            "SWE": (
+                ("time", "lat", "lon"),
+                swe,
+                {
+                    "long_name": "Snow Water Equivalent",
+                    "grid_mapping": "crs",
+                    "units": "millimeters h20",
+                },
+            ),
+            "DEPTH": (
+                ("time", "lat", "lon"),
+                depth,
+                {
+                    "long_name": "Snow Depth",
+                    "grid_mapping": "crs",
+                    "units": "millimeters snow thickness",
+                },
+            ),
+            "crs": (
+                (),
+                b" ",
+                {
+                    "grid_mapping_name": "latitude_longitude",
+                    "long_name": "CRS definition",
+                    "spatial_ref": (
+                        'GEOGCS["NAD83",DATUM["North_American_Datum_1983",'
+                        'SPHEROID["GRS 1980",6378137,298.257222101]],'
+                        'PRIMEM["Greenwich",0],UNIT["degree",0.01745329251994328],'
+                        'AUTHORITY["EPSG","4269"]]'
+                    ),
+                },
+            ),
+        },
+        coords={
+            "time": (("time",), days_since_epoch),
+            "lat": (("lat",), lat),
+            "lon": (("lon",), lon),
+        },
+    )
+    ds.to_netcdf(path)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarYearsToWaterYears:
+    def test_single_year(self):
+        # CY 1990 touches WY 1990 (Jan-Sep) and WY 1991 (Oct-Dec).
+        assert _calendar_years_to_water_years([1990]) == [1990, 1991]
+
+    def test_multi_year_dedupes(self):
+        # CY 1990, 1991 touches WYs {1990, 1991, 1991, 1992} → {1990, 1991, 1992}.
+        assert _calendar_years_to_water_years([1990, 1991]) == [1990, 1991, 1992]
+
+    def test_empty(self):
+        assert _calendar_years_to_water_years([]) == []
+
+    def test_sorted_output(self):
+        assert _calendar_years_to_water_years([1995, 1990]) == [
+            1990,
+            1991,
+            1995,
+            1996,
+        ]
+
+
+class TestAssignWorkerWaterYears:
+    def test_single_worker(self):
+        assert _assign_worker_water_years([1982, 1983, 1984], 0, 1) == [
+            1982,
+            1983,
+            1984,
+        ]
+
+    def test_round_robin(self):
+        wys = [1982, 1983, 1984, 1985, 1986]
+        assert _assign_worker_water_years(wys, 0, 2) == [1982, 1984, 1986]
+        assert _assign_worker_water_years(wys, 1, 2) == [1983, 1985]
+
+    def test_worker_index_out_of_range(self):
+        with pytest.raises(ValueError, match="worker_index"):
+            _assign_worker_water_years([1982], 2, 2)
+
+    def test_negative_n_workers(self):
+        with pytest.raises(ValueError, match="n_workers"):
+            _assign_worker_water_years([1982], 0, 0)
+
+
+class TestUrlConstruction:
+    def test_wy_url(self):
+        url = _wy_url("https://example.org/data/", 1990)
+        assert url == "https://example.org/data/4km_SWE_Depth_WY1990_v01.nc"
+
+    def test_mask_url(self):
+        # Trailing slash is normalised.
+        url = _mask_url("https://example.org/data/")
+        assert url == "https://example.org/data/SWE_Mask_v01.nc"
+
+
+# ---------------------------------------------------------------------------
+# consolidate_water_year_ua_swe
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidateWaterYear:
+    def test_happy_path(self, tmp_path: Path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        daily_dir = tmp_path / "daily"
+        raw_path = raw_dir / "4km_SWE_Depth_WY1982_v01.nc"
+        _make_synthetic_raw_nc(raw_path, wy=1982)
+
+        out_path = consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+        assert out_path.exists()
+        assert out_path.name == "ua_swe_daily_WY1982.nc"
+
+        with xr.open_dataset(out_path) as ds:
+            # Variable rename
+            assert "swe" in ds.data_vars
+            assert "snow_depth" in ds.data_vars
+            assert "SWE" not in ds.data_vars
+            assert "DEPTH" not in ds.data_vars
+
+            # CF-1.6 compliance
+            assert ds.attrs.get("Conventions") == "CF-1.6"
+
+            # Catalog-driven units
+            assert ds["swe"].attrs["units"] == "kg m-2"
+            assert ds["snow_depth"].attrs["units"] == "mm"
+            assert ds["swe"].attrs["grid_mapping"] == "crs"
+
+            # Time decoded as real timestamps, not floats
+            assert np.issubdtype(ds["time"].dtype, np.datetime64)
+            # The synthetic raw started at 1981-10-01 (WY 1982 day 1).
+            assert pd.Timestamp(ds["time"].values[0]) == pd.Timestamp("1981-10-01")
+
+            # Reprojected to EPSG:5070 — spatial dims are (y, x), not (lat, lon)
+            assert "y" in ds.dims
+            assert "x" in ds.dims
+            assert "lat" not in ds.dims
+            assert "lon" not in ds.dims
+
+            # CRS grid_mapping_name reflects Albers
+            assert (
+                ds["crs"].attrs.get("grid_mapping_name") == "albers_conical_equal_area"
+            )
+
+    def test_mtime_idempotent_skip(self, tmp_path: Path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        daily_dir = tmp_path / "daily"
+        raw_path = raw_dir / "4km_SWE_Depth_WY1982_v01.nc"
+        _make_synthetic_raw_nc(raw_path, wy=1982)
+
+        # First call: build.
+        out_path = consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+        first_mtime = out_path.stat().st_mtime
+
+        # Second call: should skip (raw_path mtime <= out_path mtime).
+        out_path2 = consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+        assert out_path2 == out_path
+        assert out_path2.stat().st_mtime == pytest.approx(first_mtime, abs=1e-3)
+
+    def test_rebuild_on_newer_raw(self, tmp_path: Path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        daily_dir = tmp_path / "daily"
+        raw_path = raw_dir / "4km_SWE_Depth_WY1982_v01.nc"
+        _make_synthetic_raw_nc(raw_path, wy=1982)
+
+        out_path = consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+        first_mtime = out_path.stat().st_mtime
+
+        # Touch raw to a strictly later mtime.
+        new_mtime = first_mtime + 100
+        import os
+
+        os.utime(raw_path, (new_mtime, new_mtime))
+
+        out_path2 = consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+        assert out_path2.stat().st_mtime > first_mtime
+
+    def test_negative_value_defense(self, tmp_path: Path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        daily_dir = tmp_path / "daily"
+        raw_path = raw_dir / "4km_SWE_Depth_WY1982_v01.nc"
+        _make_synthetic_raw_nc(raw_path, wy=1982, inject_negative=True)
+
+        with pytest.raises(ValueError, match="integer sentinel"):
+            consolidate_water_year_ua_swe(1982, raw_path, daily_dir)
+
+    def test_missing_raw_path(self, tmp_path: Path):
+        daily_dir = tmp_path / "daily"
+        with pytest.raises(FileNotFoundError, match="raw NC not found"):
+            consolidate_water_year_ua_swe(
+                1982, tmp_path / "does-not-exist.nc", daily_dir
+            )
+
+
+# ---------------------------------------------------------------------------
+# fetch_ua_swe entry-point gates
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPeriodGate:
+    def test_period_below_publisher_window_rejected(self, tmp_path: Path):
+        workdir = _make_project(tmp_path)
+        # Catalog window is 1981/2023; CY 1970 must be rejected.
+        with pytest.raises(ValueError, match="outside the ua_swe publisher window"):
+            fetch_ua_swe(workdir=workdir, period="1970/1971")
+
+    def test_period_above_publisher_window_rejected(self, tmp_path: Path):
+        workdir = _make_project(tmp_path)
+        with pytest.raises(ValueError, match="outside the ua_swe publisher window"):
+            fetch_ua_swe(workdir=workdir, period="2024/2025")
+
+    def test_malformed_period_rejected(self, tmp_path: Path):
+        workdir = _make_project(tmp_path)
+        with pytest.raises(ValueError, match="period"):
+            fetch_ua_swe(workdir=workdir, period="not-a-period")
+
+
+# ---------------------------------------------------------------------------
+# Integration (skipped by default; opt-in via -m integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_fetch_one_water_year_live(tmp_path: Path):
+    """Live download of one WY from NSIDC and consolidate.
+
+    Requires Earthdata Login credentials in ~/.netrc (run
+    ``nhf-targets materialize-credentials`` first). Skipped by default;
+    opt in via ``pixi run -e dev test-integration``.
+    """
+    workdir = _make_project(tmp_path)
+    result = fetch_ua_swe(
+        workdir=workdir,
+        period="2010/2010",  # touches WY 2010 + WY 2011
+        worker_index=0,
+        n_workers=1,
+    )
+    assert result["source_key"] == "ua_swe"
+    assert len(result["water_years"]) >= 1
+    # At least one WY should have consolidated successfully.
+    assert any("daily_path" in rec for rec in result["water_years"])

--- a/tests/test_fetch_ua_swe.py
+++ b/tests/test_fetch_ua_swe.py
@@ -10,7 +10,10 @@ end-to-end without touching the network.
 from __future__ import annotations
 
 import json
+import re
+import tempfile
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -21,6 +24,8 @@ import yaml
 from nhf_spatial_targets.fetch.ua_swe import (
     _assign_worker_water_years,
     _calendar_years_to_water_years,
+    _download_file,
+    _earthaccess_session,
     _mask_url,
     _wy_url,
     consolidate_water_year_ua_swe,
@@ -149,6 +154,126 @@ def _make_synthetic_raw_nc(
     ds.to_netcdf(path)
 
 
+def _make_synthetic_raw_nc_bytes(wy: int, **kwargs) -> bytes:
+    """Build a synthetic raw NC and return its bytes (for fake-session bodies)."""
+    with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        _make_synthetic_raw_nc(tmp_path, wy, **kwargs)
+        return tmp_path.read_bytes()
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+# Padding body for the CONUS mask download. The real mask is ~1.7 MB; for
+# tests we just need enough bytes to clear the hard-coded 128 KiB floor
+# that `fetch_ua_swe` passes as `min_bytes` for the mask call.
+_MASK_PAD_BODY = b"\x00" * 200_000
+
+
+def _synthetic_responder() -> Callable[[str], "_FakeResponse"]:
+    """Responder that serves valid synthetic NCs for every WY URL + mask URL.
+
+    Unrecognised URLs return 404. The same pattern as
+    `tests/test_fetch_snodas.py::_synthetic_tar_responder` for the SNODAS
+    tar URLs, adapted for ua_swe's per-WY NetCDF naming.
+    """
+
+    def responder(url: str) -> "_FakeResponse":
+        m = re.search(r"4km_SWE_Depth_WY(\d{4})_v01\.nc$", url)
+        if m:
+            wy = int(m.group(1))
+            body = _make_synthetic_raw_nc_bytes(wy)
+            return _FakeResponse(200, body=body)
+        if url.endswith("/SWE_Mask_v01.nc"):
+            return _FakeResponse(200, body=_MASK_PAD_BODY)
+        return _FakeResponse(404)
+
+    return responder
+
+
+class _FakeResponse:
+    """Tiny stand-in for ``requests.Response`` covering what _download_file uses.
+
+    `Content-Length` is auto-derived from the body length unless an
+    explicit value is passed via ``content_length``. Pass
+    ``content_length=None`` to simulate a server that omits the header.
+    Pass an integer that *disagrees* with the body length to exercise
+    the short-read integrity path. Ports `tests/test_fetch_snodas.py`'s
+    `_FakeResponse`.
+    """
+
+    _UNSET = object()
+
+    def __init__(
+        self,
+        status_code: int,
+        body: bytes = b"",
+        chunks: list[bytes] | None = None,
+        content_length: object = _UNSET,
+    ):
+        self.status_code = status_code
+        self._body = body
+        self._chunks = chunks if chunks is not None else [body]
+        self.headers: dict[str, str] = {}
+        if content_length is _FakeResponse._UNSET:
+            # Default: server sets Content-Length matching the body
+            # (NSIDC's archive does this on per-WY NetCDF responses).
+            self.headers["Content-Length"] = str(len(body))
+        elif content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+        # else: caller asked for no Content-Length header at all.
+
+    def iter_content(self, chunk_size: int = 8192):
+        for c in self._chunks:
+            yield c
+
+    def close(self):
+        pass
+
+
+def _stub_session(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    responder: Callable[[str], _FakeResponse] | None = None,
+) -> dict[str, list]:
+    """Patch ``_earthaccess_session`` with a session whose ``.get`` is stubbed.
+
+    ``responder`` overrides the per-URL response. Otherwise the default
+    `_synthetic_responder()` is used. Returns a call-log dict for
+    assertions (`{"urls": [...], "session_built": N}`).
+    """
+    calls: dict[str, list] = {"urls": [], "session_built": 0}
+
+    if responder is None:
+        responder = _synthetic_responder()
+
+    class _Session:
+        def get(self, url, timeout=None, stream=None, allow_redirects=None):
+            calls["urls"].append(url)
+            return responder(url)
+
+    def _fake_session():
+        calls["session_built"] += 1
+        return _Session()
+
+    monkeypatch.setattr(
+        "nhf_spatial_targets.fetch.ua_swe._earthaccess_session", _fake_session
+    )
+    return calls
+
+
+@pytest.fixture
+def small_min_bytes(monkeypatch):
+    """Lower `_MIN_VALID_NC_BYTES` so small synthetic test NCs pass.
+
+    Production threshold is 10 MiB (~90 MB per real WY file); synthetic
+    NCs are a few KiB. The mask's per-call `min_bytes=128*1024` is left
+    alone — `_MASK_PAD_BODY` is sized to clear that floor.
+    """
+    monkeypatch.setattr("nhf_spatial_targets.fetch.ua_swe._MIN_VALID_NC_BYTES", 1024)
+
+
 # ---------------------------------------------------------------------------
 # Pure helper functions
 # ---------------------------------------------------------------------------
@@ -251,10 +376,36 @@ class TestConsolidateWaterYear:
             assert "lat" not in ds.dims
             assert "lon" not in ds.dims
 
-            # CRS grid_mapping_name reflects Albers
-            assert (
-                ds["crs"].attrs.get("grid_mapping_name") == "albers_conical_equal_area"
+            # CRS ancillary carries the full Albers projection metadata
+            # (CLAUDE.md requires the CF-1.6 attribute set on every
+            # pipeline-written NC; assert the projection-specific bits
+            # not covered by the generic `Conventions` check).
+            crs = ds["crs"]
+            assert crs.attrs.get("grid_mapping_name") == "albers_conical_equal_area"
+            assert "crs_wkt" in crs.attrs
+            assert crs.attrs.get("longitude_of_central_meridian") == pytest.approx(
+                -96.0
             )
+            assert crs.attrs.get("latitude_of_projection_origin") == pytest.approx(23.0)
+            # standard_parallel for Albers is a 2-element array
+            sp = np.asarray(crs.attrs.get("standard_parallel"))
+            assert sp.shape == (2,)
+            assert sp[0] == pytest.approx(29.5)
+            assert sp[1] == pytest.approx(45.5)
+
+            # Projected coordinate variables carry the CF-required attrs
+            for coord_name, axis in (("x", "X"), ("y", "Y")):
+                ca = ds[coord_name]
+                assert (
+                    ca.attrs.get("standard_name")
+                    == f"projection_{coord_name}_coordinate"
+                )
+                assert ca.attrs.get("units") == "m"
+                assert ca.attrs.get("axis") == axis
+
+            # Time coord carries the CF-required attrs
+            assert ds["time"].attrs.get("standard_name") == "time"
+            assert ds["time"].attrs.get("axis") == "T"
 
     def test_mtime_idempotent_skip(self, tmp_path: Path):
         raw_dir = tmp_path / "raw"
@@ -330,6 +481,304 @@ class TestFetchPeriodGate:
         workdir = _make_project(tmp_path)
         with pytest.raises(ValueError, match="period"):
             fetch_ua_swe(workdir=workdir, period="not-a-period")
+
+
+# ---------------------------------------------------------------------------
+# _download_file — status code branches
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadFile:
+    """Exercise each status-code path in `_download_file`.
+
+    Uses a stub session that returns a synthetic `_FakeResponse` per
+    URL, so we can drive each branch (200, 404, short-read,
+    no-Content-Length-too-small, session exception, already-present)
+    without touching the network.
+    """
+
+    def _stub(self, monkeypatch, responder):
+        """Return a callable session.get equivalent for direct testing."""
+
+        class _Session:
+            def get(self, url, timeout=None, stream=None, allow_redirects=None):
+                return responder(url)
+
+        return _Session()
+
+    def test_200_downloaded(self, tmp_path: Path, monkeypatch):
+        session = self._stub(
+            monkeypatch, lambda url: _FakeResponse(200, body=b"X" * 4096)
+        )
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            session, "https://example.org/wy.nc", out, min_bytes=1024
+        )
+        assert status == "downloaded"
+        assert out.exists()
+        assert out.read_bytes() == b"X" * 4096
+        # No .tmp left behind
+        assert not (tmp_path / "wy.nc.tmp").exists()
+
+    def test_404_returns_missing_404(self, tmp_path: Path, monkeypatch):
+        session = self._stub(monkeypatch, lambda url: _FakeResponse(404))
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            session, "https://example.org/missing.nc", out, min_bytes=1024
+        )
+        assert status == "missing_404"
+        assert not out.exists()
+        assert not (tmp_path / "wy.nc.tmp").exists()
+
+    def test_already_present(self, tmp_path: Path, monkeypatch):
+        out = tmp_path / "wy.nc"
+        out.write_bytes(b"X" * 4096)
+        # Session shouldn't even be called; we still hand one in.
+        session = self._stub(
+            monkeypatch,
+            lambda url: pytest.fail(
+                "session.get should not be called when file is present"
+            ),
+        )
+        status = _download_file(
+            session, "https://example.org/wy.nc", out, min_bytes=1024
+        )
+        assert status == "already_present"
+
+    def test_short_read_content_length_mismatch(self, tmp_path: Path, monkeypatch):
+        # Server claims 8192 bytes but only delivers 1024 — integrity check
+        # should fail, .tmp should be cleaned up, status should be "error".
+        def responder(url):
+            return _FakeResponse(200, body=b"X" * 1024, content_length=8192)
+
+        session = self._stub(monkeypatch, responder)
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            session, "https://example.org/wy.nc", out, min_bytes=512
+        )
+        assert status == "error"
+        assert not out.exists()
+        assert not (tmp_path / "wy.nc.tmp").exists()
+
+    def test_no_content_length_below_min_returns_error(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # Server omits Content-Length and the body is below min_bytes —
+        # the fallback size check should reject and return "error".
+        def responder(url):
+            return _FakeResponse(200, body=b"X" * 128, content_length=None)
+
+        session = self._stub(monkeypatch, responder)
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            session, "https://example.org/wy.nc", out, min_bytes=1024
+        )
+        assert status == "error"
+        assert not out.exists()
+        assert not (tmp_path / "wy.nc.tmp").exists()
+
+    def test_session_exception_returns_error(self, tmp_path: Path, monkeypatch):
+        class _ExplodingSession:
+            def get(self, *a, **kw):
+                raise ConnectionError("simulated transport failure")
+
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            _ExplodingSession(), "https://example.org/wy.nc", out, min_bytes=1024
+        )
+        assert status == "error"
+        assert not out.exists()
+        assert not (tmp_path / "wy.nc.tmp").exists()
+
+    def test_non_200_non_404_returns_error(self, tmp_path: Path, monkeypatch):
+        # E.g. 503 on transient outage. Without retries inside
+        # _download_file (those live one layer up), the call returns
+        # "error" and the caller decides whether to retry.
+        session = self._stub(monkeypatch, lambda url: _FakeResponse(503))
+        out = tmp_path / "wy.nc"
+        status = _download_file(
+            session, "https://example.org/wy.nc", out, min_bytes=1024
+        )
+        assert status == "error"
+        assert not out.exists()
+
+
+# ---------------------------------------------------------------------------
+# _earthaccess_session — auth failure surface
+# ---------------------------------------------------------------------------
+
+
+class TestEarthaccessSession:
+    def test_auth_failure_raises(self, monkeypatch):
+        """`_earthaccess_session` must raise with an actionable message
+        when earthaccess returns an unauthenticated Auth object."""
+
+        class _UnauthAuth:
+            authenticated = False
+
+            def get_session(self):  # pragma: no cover - shouldn't be reached
+                raise AssertionError("unauthenticated session should not be used")
+
+        monkeypatch.setattr("earthaccess.login", lambda strategy="netrc": _UnauthAuth())
+        with pytest.raises(RuntimeError, match="Earthdata login failed"):
+            _earthaccess_session()
+
+
+# ---------------------------------------------------------------------------
+# fetch_ua_swe — mocked-session happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUaSweDriver:
+    """End-to-end fetcher tests with a stubbed Earthdata session.
+
+    These cover the integration of: catalog→WY mapping (CY→WY+1),
+    publisher-window clamping, worker-0 mask gate, per-WY download +
+    consolidate loop, and the manifest read-merge-write contract.
+    """
+
+    def test_period_2010_fetches_wy_2010_and_2011(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        calls = _stub_session(monkeypatch)
+
+        result = fetch_ua_swe(
+            workdir=workdir, period="2010/2010", worker_index=0, n_workers=1
+        )
+
+        # CY 2010 touches WY 2010 (Jan-Sep) and WY 2011 (Oct-Dec).
+        wy_urls = [u for u in calls["urls"] if "4km_SWE_Depth_WY" in u]
+        assert any("WY2010_v01.nc" in u for u in wy_urls)
+        assert any("WY2011_v01.nc" in u for u in wy_urls)
+        assert len(wy_urls) == 2
+
+        # Worker 0 always fetches the mask.
+        assert any("SWE_Mask_v01.nc" in u for u in calls["urls"])
+
+        # Each WY downloaded successfully and was consolidated.
+        assert len(result["water_years"]) == 2
+        for rec in result["water_years"]:
+            assert rec["status"] == "downloaded"
+            assert "daily_path" in rec, f"WY {rec['water_year']} missing daily_path"
+
+    def test_consolidated_ncs_land_on_disk(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        _stub_session(monkeypatch)
+
+        fetch_ua_swe(workdir=workdir, period="2010/2010")
+
+        daily_dir = workdir / "datastore" / "ua_swe" / "daily"
+        assert (daily_dir / "ua_swe_daily_WY2010.nc").exists()
+        assert (daily_dir / "ua_swe_daily_WY2011.nc").exists()
+
+
+# ---------------------------------------------------------------------------
+# Manifest read-merge-write + corrupt-JSON recovery
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUaSweManifest:
+    """Memory `feedback_manifest_writers_must_merge.md` documents an
+    incident where a non-merging manifest writer wiped 13 sources of
+    provenance. These tests pin the read-merge-write contract on the
+    `_update_manifest` path."""
+
+    def test_read_merge_write_preserves_unrelated_sources(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        # Pre-seed manifest with an unrelated source and an older ua_swe WY.
+        (workdir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "sources": {
+                        "snodas": {
+                            "source_key": "snodas",
+                            "period": "2003/2010",
+                            "years": [{"year": 2010, "n_granules": 365}],
+                        },
+                        "ua_swe": {
+                            "source_key": "ua_swe",
+                            "water_years": [
+                                {"water_year": 1982, "status": "pre-existing"}
+                            ],
+                        },
+                    },
+                    "steps": [],
+                }
+            )
+        )
+
+        _stub_session(monkeypatch)
+        fetch_ua_swe(workdir=workdir, period="2010/2010")
+
+        manifest = json.loads((workdir / "manifest.json").read_text())
+
+        # snodas entry must be untouched.
+        assert "snodas" in manifest["sources"]
+        assert manifest["sources"]["snodas"]["period"] == "2003/2010"
+        assert manifest["sources"]["snodas"]["years"] == [
+            {"year": 2010, "n_granules": 365}
+        ]
+
+        # ua_swe: WY 1982 preserved + new WY 2010 + WY 2011 added, sorted.
+        ua_swe_wys = manifest["sources"]["ua_swe"]["water_years"]
+        years_in_manifest = [r["water_year"] for r in ua_swe_wys]
+        assert years_in_manifest == [1982, 2010, 2011]
+        # The pre-existing 1982 entry retains its `status` field
+        # (only WYs touched by this run get overwritten).
+        wy1982 = next(r for r in ua_swe_wys if r["water_year"] == 1982)
+        assert wy1982["status"] == "pre-existing"
+
+    def test_corrupt_manifest_raises_valuerror(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        (workdir / "manifest.json").write_text("{not valid json")
+
+        _stub_session(monkeypatch)
+        with pytest.raises(ValueError, match="corrupt"):
+            fetch_ua_swe(workdir=workdir, period="2010/2010")
+
+
+# ---------------------------------------------------------------------------
+# Worker-0 mask gate
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUaSweWorkerGate:
+    """The mask file is downloaded by worker 0 only. A future refactor
+    that inverts the gate would silently break parallel runs."""
+
+    def test_worker_zero_fetches_mask(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        calls = _stub_session(monkeypatch)
+
+        result = fetch_ua_swe(
+            workdir=workdir, period="2010/2010", worker_index=0, n_workers=2
+        )
+
+        assert any("SWE_Mask_v01.nc" in u for u in calls["urls"])
+        assert result["mask"] is not None
+        assert result["mask"]["status"] == "downloaded"
+
+    def test_nonzero_worker_skips_mask(
+        self, tmp_path: Path, monkeypatch, small_min_bytes
+    ):
+        workdir = _make_project(tmp_path)
+        calls = _stub_session(monkeypatch)
+
+        result = fetch_ua_swe(
+            workdir=workdir, period="2010/2010", worker_index=1, n_workers=2
+        )
+
+        assert not any("SWE_Mask_v01.nc" in u for u in calls["urls"])
+        assert result["mask"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First slice of the **NSIDC-0719 (UA daily 4-km SWE + Snow Depth)** onboarding effort.

Closes #238. Tracking umbrella: #237.

## Summary

- Add the `ua_swe` source to `catalog/sources.yml` (Broxton/Zeng/Dawson UA daily 4-km CONUS SWE+snow-depth, WY 1982-2023, DOI [10.5067/0GGPB220EX6A](https://nsidc.org/data/nsidc-0719)).
- Implement `fetch/ua_swe.py` with HTTPS direct-URL construction by water year (avoids the SNODAS CMR-is-a-stub trap from #107), per-day rio.reproject to EPSG:5070 4 km at consolidate time, CF-1.6 metadata via the catalog, and atomic writes.
- Fix the `margulis_wus_sr` catalog title — Margulis WUS-SR is the WUS_UCLA_SR product, **not** NSIDC-0719 (that ID belongs to the UA Broxton product added here).
- 18 unit tests + 1 gated `@pytest.mark.integration` live-download test.

## Architecture decisions (locked in via planning Q&A)

| | |
| --- | --- |
| Source key | `ua_swe` (matches the dataset's common name; avoids future NSIDC-0719/0720 ID-collision risk) |
| Period in catalog | `1981/2023` (calendar years for parser compatibility; actual archive is WY 1982-2023 = 1981-10-01 to 2023-09-30) |
| CRS | Pre-project to EPSG:5070 at consolidate time so the aggregator's WEIGHT_GEN_CRS matches (mirrors SNODAS issue #121) |
| Variables emitted | `swe`, `snow_depth`, plus the derived `snow_covered_fraction` slot for PR-D's SCA multi-source refactor |

## What's verified

- Smoke-tested end-to-end against the real WY 1982 file (provided by Daisy): 92 MB raw → 124 MB consolidated EPSG:5070 NC, 802×1488 4-km grid, 365 days 1981-10-01 to 1982-09-30, mid-January day-100 SWE max 1489 mm and snow_depth max 4165 mm (plausible Sierra/Rockies values).
- All 18 unit tests pass.
- The gated `test_fetch_one_water_year_live` integration test passed against NSIDC with Daisy's Earthdata credentials, confirming the download + consolidation contract works in production.
- `pixi run -e dev fmt`, `pixi run -e dev lint` clean.
- `pixi run catalog-sources` parses; `tests/test_catalog.py` passes with the new entry.

## Explicitly out of scope (next PRs)

- **PR-B**: `aggregate/ua_swe.py` + `SourceAdapter` with the `snow_covered_fraction` pre-hook, inspect notebook.
- **PR-C**: `targets/swe.py` `SourceShim` for `ua_swe`; add to `catalog/variables.yml::snow_water_equivalent.sources`.
- **PR-D**: `targets/sca.py` multi-source refactor to combine MOD10C1's CI-bounded interval with `ua_swe.snow_covered_fraction`.

PR-A intentionally does **not** add `ua_swe` to `catalog/variables.yml::snow_water_equivalent.sources` — doing so before PR-B would break SWE builds because no aggregated NC exists for the source yet.

## Performance note for full-archive runs

The per-day reproject loop is correct and bounded-memory but slow (~8 min/WY on the caldera login-node cgroup; 42 WYs = ~6 hours serial). For real archive downloads:

```bash
sbatch --export=ALL,REPO_DIR=$PWD --mem=24G --time=12:00:00   --wrap='pixi run nhf-targets fetch ua-swe --project-dir <project> --period 1981/2023 --n-workers 8 --worker-index $SLURM_ARRAY_TASK_ID'
```

A chunked reproject (30-day chunks) could be ~30× faster — deferred to a follow-up if needed.

## Test plan

- [x] `pixi run catalog-sources` parses
- [x] `pixi run -e dev test tests/test_catalog.py` passes
- [x] `pixi run -e dev test tests/test_fetch_ua_swe.py` passes (19/19 including integration)
- [x] `pixi run -e dev fmt` clean
- [x] `pixi run -e dev lint` clean
- [x] `pixi run -e dev nhf-targets fetch --help` shows `ua-swe` subcommand
- [x] End-to-end smoke against real WY1982 file produces correct schema, units, CRS, time decoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)