### PR TITLE
docs: add ScienceBase data-release reference notes

### DIFF
--- a/docs/data_release/README.md
+++ b/docs/data_release/README.md
@@ -1,0 +1,49 @@
+# `docs/data_release/` — ScienceBase data release reference
+
+Reference notes for the planned `nhf-targets release` feature (publishing this
+pipeline's outputs as a USGS data release on
+[ScienceBase](https://www.sciencebase.gov/)). These are background reading
+captured at design time — they are **not** the spec for the feature itself.
+The spec lives in the issue and PRs as the work lands.
+
+## When to read these files
+
+- **Designing or reviewing PRs in the `release/` track** — see the field map
+  and sciencebasepy notes for what the code must do.
+- **Onboarding to USGS data-release process** — start with `usgs-process.md`
+  for the lifecycle.
+- **Debugging an FGDC validation failure** — see `fgdc-field-map.md` for where
+  each FGDC element comes from in the pipeline's data.
+
+## Files
+
+- [usgs-process.md](usgs-process.md) — USGS data release lifecycle (IPDS →
+  ScienceBase → DOI), FGDC CSDGM 2.0 requirements, file/data requirements,
+  parent/child item structure, and how new fabric children get added
+  incrementally to an existing release.
+- [sciencebasepy-notes.md](sciencebasepy-notes.md) — capability matrix for the
+  [`sciencebasepy`](https://github.com/DOI-USGS/sciencebasepy) Python client.
+  What it makes easy, what it cannot do (no DOI minting; no FGDC XML
+  generation), and the sharp edges we'll hit.
+- [fgdc-field-map.md](fgdc-field-map.md) — concrete mapping from
+  `catalog/sources.yml` + `catalog/variables.yml` + `manifest.json` +
+  `<project>/config.yml` to FGDC CSDGM 2.0 elements, via a pygeometa-shaped
+  MCF intermediate representation. The implementation-side reference for
+  `release/mcf.py` and the Jinja2 FGDC templates.
+
+## External pointers
+
+- USGS data release process: <https://www.usgs.gov/sciencebase-instructions-and-documentation/data-release-process>
+- ScienceBase data release checklist: <https://www.usgs.gov/sciencebase-instructions-and-documentation/sciencebase-data-release-checklist>
+- ScienceBase metadata instructions: <https://www.usgs.gov/sciencebase-instructions-and-documentation/metadata-instructions>
+- `sciencebasepy` source: <https://github.com/DOI-USGS/sciencebasepy>
+- `pygeometa` (MCF + ISO 19139 emitter): <https://geopython.github.io/pygeometa/>
+- USGS Metadata Parser (FGDC validator): <https://geology.usgs.gov/tools/metadata/tools/doc/mp.html>
+- MetadataWizard (USGS-blessed GUI; not used here): <https://doi-usgs.github.io/fort-pymdwizard/>
+
+## Status of these notes
+
+Captured 2026-05-26 during the design conversation that produced the
+implementation plan. Treat them as the snapshot of external-world facts at
+that date; if you find something out of date, fix it in place — they exist
+to save the next person from re-doing the research.

--- a/docs/data_release/fgdc-field-map.md
+++ b/docs/data_release/fgdc-field-map.md
@@ -1,0 +1,212 @@
+# FGDC field map
+
+How each FGDC CSDGM 2.0 element gets populated from this pipeline's data
+sources, organized by item type (umbrella / consolidated-source child /
+fabric child). The implementation reference for `release/mcf.py` and the
+Jinja2 FGDC templates under `release/templates/fgdc/`.
+
+## Intermediate representation: MCF dict
+
+Rather than build FGDC XML directly from catalog + manifest, we build a
+[`pygeometa` Metadata Control File (MCF)](https://geopython.github.io/pygeometa/reference/mcf/)
+shaped dict as the intermediate representation, then render it twice:
+
+- **FGDC XML** via Jinja2 templates (pygeometa has no FGDC output schema —
+  see `sciencebasepy-notes.md`).
+- **ISO 19139 XML** via `pygeometa.schemas.iso19139.ISO19139OutputSchema`,
+  shipped as a supplemental file alongside the FGDC.
+
+Why MCF as the IR? Three reasons:
+
+1. **Two output formats from one source of truth.** No risk of FGDC and ISO
+   drifting against each other.
+2. **Forward-compatible with pygeometa.** If pygeometa ever adds an FGDC
+   schema, we replace the Jinja templates without touching the upstream
+   builders.
+3. **MCF is well-documented.** Engineers can read it without spelunking
+   USGS-internal conventions.
+
+## Common MCF fields (all item types)
+
+| MCF path | Source |
+|---|---|
+| `mcf.version` | Hard-coded `"1.0"` |
+| `metadata.identifier` | `release_registry.<scope>.<key>.sb_id` (post-publish) or a generated UUID4 (pre-publish) |
+| `metadata.language` | `release_defaults.metadata.language` (default `"en"`) |
+| `metadata.charset` | `"utf8"` |
+| `metadata.datestamp` | UTC `now()` at build time |
+| `metadata.hierarchylevel` | `"dataset"` for source + fabric children; `"series"` for umbrella |
+| `contact.distributor` | `release_defaults.contacts.distributor` (USGS ScienceBase block) |
+| `contact.pointOfContact` | `release_defaults.contacts.point_of_contact` (overridable per project) |
+| `identification.charset` | `"utf8"` |
+| `identification.language` | `"en"` |
+| `identification.fees` | `release_defaults.distribution.fees` (default `"None"`) |
+| `identification.accessconstraints` | `release_defaults.distribution.access_constraints` |
+
+## Umbrella item
+
+| MCF path | Source | FGDC element |
+|---|---|---|
+| `identification.title` | `release_defaults.umbrella.title_template` formatted with `release_registry.umbrella.version` | `<title>` |
+| `identification.abstract` | `release_defaults.umbrella.abstract_template`, Jinja-rendered over list of published children pulled from `release_registry` | `<abstract>` |
+| `identification.purpose` | `release_defaults.umbrella.purpose` | `<purpose>` |
+| `identification.dates.publication` | `release_registry.umbrella.published_utc` | `<pubdate>` |
+| `identification.dates.revision` | `max(child.uploaded_utc)` across all children in registry | `<revdate>` |
+| `identification.keywords.theme` | `release_defaults.keywords.umbrella.theme` (e.g. "Hydrologic Cycle", "Calibration", "National Hydrologic Model") | `<themekey>` |
+| `identification.keywords.place` | Union of all children's spatial extents (CONUS + sub-regions) | `<placekey>` |
+| `identification.extents.spatial.bbox` | Union of all published children's bboxes | `<bounding>` |
+| `identification.extents.temporal.begin/end` | Union of all children's `<period>` ranges | `<timeperd>` |
+| `identification.useconstraints` | `release_defaults.distribution.use_constraints` + USGS standard + per-source notes from each child | `<useconst>` |
+| `identification.doi` | `release_registry.umbrella.doi` (full URL form: `https://doi.org/10.5066/...`) | `<onlink>` in `<citeinfo>` |
+| `identification.citation.authors` | `<project>/config.yml.release.authors` (each `{given, family, orcid, affiliation}` becomes a CSDGM `<cntinfo>` block) | `<origin>` |
+| `dataquality.lineage.statement` | `release_defaults.umbrella.lineage_statement` | `<lineage>` |
+
+## Consolidated-source child item
+
+(One per source from `catalog/sources.yml`. Sources with `status: superseded`
+or `release.publishable: false` are skipped.)
+
+| MCF path | Source | FGDC element |
+|---|---|---|
+| `identification.title` | `catalog/sources.yml[<key>].name` + " (consolidated for NHF)" | `<title>` |
+| `identification.abstract` | `catalog/sources.yml[<key>].description` + `release_defaults.source_abstract_suffix` (Jinja-rendered with source-specific context) | `<abstract>` |
+| `identification.purpose` | `release_defaults.source.purpose_template` | `<purpose>` |
+| `identification.keywords.theme` | `release_defaults.keywords.source.theme` + per-variable CF `standard_name` for each var in `catalog/sources.yml[<key>].variables` | `<themekey>` |
+| `identification.keywords.place` | `catalog/sources.yml[<key>].spatial_extent` (parsed/normalized) | `<placekey>` |
+| `identification.extents.spatial.bbox` | `catalog/sources.yml[<key>].access.bbox_nwse` if present, else union of bboxes from staged consolidated NCs | `<bounding>` |
+| `identification.extents.temporal.begin/end` | `catalog/sources.yml[<key>].period` (parsed `"YYYY/YYYY"` → begin + end) | `<timeperd>` |
+| `identification.citation.authors` | `catalog/sources.yml[<key>].citations[]` (parsed into structured form where possible; raw string otherwise) | `<origin>` |
+| `identification.citation.doi` | `catalog/sources.yml[<key>].doi` or `.access.doi` | `<onlink>` |
+| `identification.useconstraints` | `catalog/sources.yml[<key>].license` + `release_defaults.distribution.use_constraints` + `catalog/sources.yml[<key>].release.notes` | `<useconst>` |
+| `dataquality.lineage.statement` | `catalog/sources.yml[<key>].notes` + `catalog/sources.yml[<key>].access.notes` | `<lineage>` |
+| `dataquality.lineage.processstep[]` | `<project>/manifest.json.steps[]` filtered to `source_key == <key>` | `<procstep>` (one per record) |
+| `distribution.online[*]` | One entry per consolidated NC: `name=<filename>`, `description="Consolidated NetCDF, <period>"`, `protocol="WWW:DOWNLOAD-1.0-http--download"` | `<digtinfo>` + `<netaddr>` |
+| Per-variable `identification.entityandattribute` | Each entry in `catalog/sources.yml[<key>].variables`: `name`, `long_name`, `cf_units`, `cell_methods` | `<eainfo>` |
+
+Special case for `release.distribution_kind: metadata_only` (Daymet):
+`distribution.online[*]` carries a single entry pointing to the upstream
+source (ORNL DAAC for Daymet) instead of a list of staged NCs.
+
+## Fabric child item
+
+(One per fabric. The "fabric" is identified by the operator's
+`<project>/config.yml.fabric.path` + an optional `release.fabric_label`
+override.)
+
+| MCF path | Source | FGDC element |
+|---|---|---|
+| `identification.title` | `release_defaults.fabric.title_template` formatted with fabric label (from `release.fabric_label` or `Path(fabric.path).stem`) | `<title>` |
+| `identification.abstract` | `release_defaults.fabric.abstract_template`, Jinja-rendered over: fabric_label, `<project>/fabric.json.hru_count`, list of targets from `<project>/config.yml.targets`, source list from `<project>/manifest.json.sources`, and `<project>/config.yml.release.abstract_notes` | `<abstract>` |
+| `identification.purpose` | `release_defaults.fabric.purpose_template` | `<purpose>` |
+| `identification.keywords.theme` | `release_defaults.keywords.fabric.theme` + one keyword per enabled target name + `"National Hydrologic Model"` | `<themekey>` |
+| `identification.keywords.place` | Derived from `<project>/fabric.json.bbox` + fabric_label | `<placekey>` |
+| `identification.extents.spatial.bbox` | `<project>/fabric.json.bbox` | `<bounding>` |
+| `identification.extents.temporal.begin/end` | Union of enabled-target periods in `<project>/config.yml.targets[*].period` | `<timeperd>` |
+| `identification.citation.authors` | `<project>/config.yml.release.authors` | `<origin>` |
+| `identification.citation.doi` | `release_registry.umbrella.doi` (children share the umbrella DOI per SB convention) | `<onlink>` |
+| `identification.useconstraints` | Union of participating source `license` strings + `<project>/config.yml.release.use_constraints_addition` (optional) | `<useconst>` |
+| `dataquality.lineage.statement` | `release_defaults.fabric.lineage_statement_template`, Jinja-rendered with source + target list | `<lineage>` |
+| `dataquality.lineage.processstep[]` | All entries in `<project>/manifest.json.steps[]` | `<procstep>` (one per record) |
+| `distribution.online[*]` | One entry per staged file: `fabric.gpkg`, every aggregated NC, every target NC (and `_nn_filled.nc`), `manifest.json`, `README.md`, `checksums.csv`, `SHA256SUMS` | `<digtinfo>` |
+| Per-target `identification.entityandattribute` | Each enabled target from `catalog/variables.yml`: `description`, `units`, `range_method`, `range_notes`, plus per-source variable mapping | `<eainfo>` |
+
+## Lineage record → CSDGM `<procstep>`
+
+The pipeline accumulates lineage records in `<project>/manifest.json.steps[]`
+(PR-B instruments the call sites). Each record has the shape:
+
+```json
+{
+  "kind": "fetch|consolidate|aggregate|target|nn_fill|validate",
+  "source_key": "era5_land",
+  "timestamp_utc": "2026-05-26T12:34:56+00:00",
+  "software_version": "0.7.0",
+  "tool": "nhf-targets",
+  "command": "agg era5-land",
+  "inputs":  [{"path": "...", "size_bytes": ..., "mtime_utc": "..."}],
+  "outputs": [{"path": "...", "sha256": "...", "size_bytes": ..., "mtime_utc": "..."}],
+  "params":  {"batch_size": 10000, ...}
+}
+```
+
+In FGDC, each step renders to:
+
+```xml
+<procstep>
+  <procdesc>{kind} via {tool} {software_version}, command: {command}; params: {params (formatted)}</procdesc>
+  <procdate>{YYYYMMDD from timestamp_utc}</procdate>
+  <proctime>{HHMMSS from timestamp_utc}</proctime>
+  <srcused>{inputs[*].path joined}</srcused>
+  <srcprod>{outputs[*].path joined}</srcprod>
+</procstep>
+```
+
+Filtering rule:
+
+- For a **consolidated-source child** with key `<key>`, include only steps
+  where `source_key == <key>` (this captures the fetch + consolidate steps
+  for that source).
+- For a **fabric child**, include all steps in `manifest.json.steps[]`
+  (fetch + consolidate + aggregate + target + nn_fill + validate). The
+  union describes how this fabric's outputs were produced.
+- For the **umbrella**, no per-step lineage in the FGDC — the umbrella's
+  `<lineage>` statement is a high-level prose summary; per-step detail
+  lives on the children.
+
+## CRS metadata
+
+All NetCDFs in the release carry the CF-1.6 `grid_mapping` variable already
+(see [`docs/architecture/nc-encoding-policy.md`](../architecture/nc-encoding-policy.md)).
+FGDC additionally requires CRS info in the spatial reference block:
+
+```xml
+<spref>
+  <horizsys>
+    <geograph>
+      <latres>0.001</latres>
+      <longres>0.001</longres>
+      <geogunit>Decimal degrees</geogunit>
+    </geograph>
+    <geodetic>
+      <horizdn>WGS_1984</horizdn>
+      <ellips>WGS_1984</ellips>
+      <semiaxis>6378137.0</semiaxis>
+      <denflat>298.257223563</denflat>
+    </geodetic>
+  </horizsys>
+</spref>
+```
+
+This is constant across all our items (everything is on WGS84 HRU
+centroids) and lives in `release_defaults.yml.spatial_reference` as a block
+that's spliced verbatim into the FGDC template.
+
+## Validation
+
+After FGDC XML is rendered, `release/validate_xml.py` shells out to the
+[USGS Metadata Parser (`mp`)](https://geology.usgs.gov/tools/metadata/tools/doc/mp.html)
+if it's on PATH. Three-state result:
+
+| State | Behavior |
+|---|---|
+| `mp` not found | Warn-only; FGDC unvalidated; build proceeds |
+| `mp` returns warnings | Surfaced in `release dry-run` Rich table; build proceeds |
+| `mp` returns errors | Fatal by default; `--skip-mp` flag overrides |
+
+Optional fallback: `xmlschema` Python library validates against the CSDGM
+2.0 schema (`fgdc-std-001-1998.dtd`) without requiring `mp`. We may add this
+later if operator feedback says `mp` is painful to install.
+
+## Reading order for implementation
+
+When you implement PR-D (MCF + FGDC + ISO), read in this order:
+
+1. The "Common MCF fields" table — what's shared.
+2. The three per-item tables — what's different per scope.
+3. The lineage section — where the `<procstep>` blocks come from.
+4. The validation section — what to wire up at the tail of the build.
+
+Then look at `release/mcf.py` (build the dict) and the Jinja templates
+under `release/templates/fgdc/` (render to XML). The MCF dict shape is
+identical for FGDC and ISO output, so `release/iso.py` consumes the same
+dict and calls `pygeometa.schemas.iso19139`.

--- a/docs/data_release/fgdc-field-map.md
+++ b/docs/data_release/fgdc-field-map.md
@@ -5,6 +5,24 @@ sources, organized by item type (umbrella / consolidated-source child /
 fabric child). The implementation reference for `release/mcf.py` and the
 Jinja2 FGDC templates under `release/templates/fgdc/`.
 
+> **Forward references in this document.** Several sources referenced below
+> are landed by upcoming PRs in the #241 phasing and do not exist on `main`
+> yet:
+>
+> - The `release:` block on each entry in `catalog/sources.yml`
+>   (`release.publishable`, `release.distribution_kind`, `release.notes`) —
+>   added by PR-A.
+> - `catalog/release_defaults.yml` and `catalog/release_registry.yml` —
+>   added by PR-A.
+> - The `release:` block in `<project>/config.yml`
+>   (`release.authors`, `release.fabric_label`, `release.abstract_notes`) —
+>   added by PR-A.
+> - The `<project>/manifest.json.steps[]` content — instrumented by PR-B.
+> - The `release/` Python module — built across PR-C through PR-F.
+>
+> Field paths below describe the post-PR-A/PR-B shape. Cross-check against
+> the catalog when implementing each downstream PR.
+
 ## Intermediate representation: MCF dict
 
 Rather than build FGDC XML directly from catalog + manifest, we build a
@@ -134,12 +152,16 @@ In FGDC, each step renders to:
 ```xml
 <procstep>
   <procdesc>{kind} via {tool} {software_version}, command: {command}; params: {params (formatted)}</procdesc>
+  <srcused>{srcabbr-for-inputs[i]}</srcused>
+  <!-- one <srcused> per input; element is repeatable -->
   <procdate>{YYYYMMDD from timestamp_utc}</procdate>
   <proctime>{HHMMSS from timestamp_utc}</proctime>
-  <srcused>{inputs[*].path joined}</srcused>
-  <srcprod>{outputs[*].path joined}</srcprod>
+  <srcprod>{srcabbr-for-outputs[i]}</srcprod>
+  <!-- one <srcprod> per output; element is repeatable -->
 </procstep>
 ```
+
+**CSDGM 2.0 element order is fixed** as `procdesc → srcused → procdate → proctime → srcprod`; `mp` rejects out-of-order steps. Both `<srcused>` and `<srcprod>` carry a **Source Citation Abbreviation** (a short token resolving to a separate `<srcinfo>` block elsewhere in the document), not a raw file path. They are repeatable, so a step with N inputs renders N `<srcused>` elements, not one comma-joined element. `release/mcf.py` is responsible for emitting the corresponding `<srcinfo>` entries — design that mapping when implementing PR-D.
 
 Filtering rule:
 

--- a/docs/data_release/sciencebasepy-notes.md
+++ b/docs/data_release/sciencebasepy-notes.md
@@ -1,0 +1,170 @@
+# `sciencebasepy` capability notes
+
+What the [`sciencebasepy`](https://github.com/DOI-USGS/sciencebasepy) Python
+client makes easy, what it can't do, and the sharp edges we'll hit when
+implementing `release/sb_client.py`. Captured 2026-05-26.
+
+## TL;DR
+
+**Easy:** Token/password auth, item CRUD with `parentId`, file upload
+(single, multi, and via S3), file download, search by title/query, ACL
+management.
+
+**You build yourself:**
+
+- **DOI minting** — not in the library; manual SB-staff step after IPDS
+  approval.
+- **FGDC XML generation** — not in the library; bring your own XML and
+  attach as a file. The library can *scrape* FGDC from S3 via GraphQL but
+  cannot emit it.
+- **Find-by-title idempotency** — no dedicated `upsert_by_title` method; you
+  use `find_items(q='...')` and adopt the matched ID into your registry.
+- **Resumable upload** — single-file uploads are not resumable. Network
+  drops mid-multi-GB-file mean full retry. Multipart S3 upload exists
+  internally for cloud paths but is not exposed.
+- **Version history** — re-uploading a file with the same name silently
+  overwrites; no version history is retained. Track checksums in
+  `catalog/release_registry.yml` to detect drift across builds.
+
+## Authentication
+
+| Method | Method signature | Use when |
+|---|---|---|
+| Token | `sb.add_token(token_json)` or `sb.get_token()` (browser flow) | Default — short-lived, scoped to user |
+| Username + password | `sb.login(username, password)` or `sb.loginc(username)` (interactive) | Service accounts only; password auth is gated on USGS service-account roles |
+| Status | `sb.is_logged_in()`, `sb.logout()` | Sanity checks |
+
+For this pipeline: store the token under `.credentials.yml.sciencebase.token`,
+materialize to whatever pickup location `SbSession` expects (likely
+`~/.sb_token.json` — confirm against current `sciencebasepy` docs at PR-G
+time) via an extended `materialize-credentials` command.
+
+`get_token()` (browser flow) has had issues on Windows 11 launching the
+default browser; document the manual token-paste fallback in the runbook.
+
+## Item CRUD
+
+| Method | Notes |
+|---|---|
+| `create_item(item_json)` | Requires `title` and `parentId`. Returns full item JSON including generated `id`. |
+| `get_item(itemid, params={'fields': '...'})` | Field filtering supported via the `fields` param. |
+| `update_item(item_json)` | Pass dict with `id` + modified fields. Returns updated item. |
+| `delete_item(item_json)` | Returns boolean. |
+| `move_item(item, new_parent_id)` | Re-parent an item. |
+| `create_items()` / `update_items()` / `delete_items()` | Batch variants for efficiency. |
+
+Item body is a free-form dict; SB doesn't validate FGDC at this layer.
+Citation, time period, bounding box are populated by setting the right
+top-level keys in the item JSON — there are no typed setters for them.
+
+## File upload
+
+| Method | Notes |
+|---|---|
+| `upload_file_to_item(item, filename, scrape_file=True)` | Single file. `scrape_file=True` attempts metadata extraction (variable results). |
+| `upload_files_and_upsert_item(item_json, files=[...])` | Upserts the item and uploads files in one call. Matches existing item by `id`. |
+| `upload_cloud_file_to_item(item, s3_url)` | S3 path; multipart upload happens internally. |
+| `replace_file()` | In-place replace; updates checksum + dateUploaded + uploadedBy fields. |
+| `publish_array_to_public_bucket(items, urls)` | Batch S3 publish. |
+
+Sharp edges:
+
+- **No exposed multipart**. The cloud upload path uses multipart internally,
+  but the standard `upload_file_to_item` does not. Multi-GB files have
+  occasionally been reported as failing on flaky connections (no GitHub
+  issue numbers documented at capture time; verify before relying).
+- **No size limit documented**. SB itself has practical limits ~10 GB per
+  file, ~100 GB per item.
+- **`scrape_file=True` for `.xml`** can create duplicate extension entries
+  (sciencebasepy issue #17). Recommended: upload FGDC XML with
+  `scrape_file=False` and rely on our own metadata population.
+
+## Idempotency and lookup
+
+The library has one upsert helper:
+
+```python
+sb.upload_files_and_upsert_item(item_json, files=[...])
+```
+
+This matches the existing item by `id` (must already be in `item_json`).
+There is no `upsert_by_title()`. To implement that ourselves:
+
+```python
+results = sb.find_items(params={"q": canonical_title, "parentId": umbrella_id})
+matches = [i for i in results["items"] if i["title"] == canonical_title]
+if len(matches) == 1:
+    item_id = matches[0]["id"]
+    mode = "update"
+elif len(matches) == 0:
+    mode = "create"
+else:
+    raise SbMultipleMatches(...)
+```
+
+`find_items()` returns paginated results; iterate `["nextlink"]` for large
+result sets. This is what `release/publish.py` will do on the
+registry-says-missing path (see the idempotency strategy in the design plan).
+
+## DOI
+
+Not supported by the library at all. DOI minting is a ScienceBase-staff
+operation. After mint, the DOI appears in `item["identifiers"][0]["key"]`
+(format: `doi:10.5066/<id>`).
+
+The pipeline workflow:
+
+1. Operator runs `nhf-targets release publish --scope umbrella --confirm` —
+   creates the parent item without DOI.
+2. IPDS approval happens externally.
+3. Operator emails `sciencebase@usgs.gov` requesting DOI mint.
+4. After mint, operator copies the DOI into
+   `catalog/release_registry.yml.umbrella.doi` and reruns the umbrella
+   publish — this re-emits FGDC + ISO XMLs with the DOI populated and patches
+   the item body.
+
+## Versioning
+
+Re-uploading a file with the same `name` to an existing item overwrites the
+previous file. SB does not keep a version history; the only metadata that
+changes is `dateUploaded`, `uploadedBy`, and `checksum`.
+
+To detect drift between builds, our `release/registry.py` records
+`checksums_sha256_of_manifest` (SHA256 of the staged `checksums.csv`) per
+child. A build whose manifest checksum doesn't match the previous build is
+flagged in `release status` and triggers full re-upload.
+
+## Bulk operations and rate limiting
+
+- `create_items()`, `update_items()`, `delete_items()` for batch CRUD.
+- `download_cloud_files(urls, tokens)` for multi-file download via tokenized
+  S3 links.
+- `generate_S3_download_links()` to create download tokens.
+- `publish_array_to_public_bucket()` for bulk S3 publish.
+
+Rate limiting is not explicitly documented in the README or recent issues.
+Our `sb_client.upload_file` wrapper retries 429 + 5xx with exponential
+backoff (3 tries; 2s / 4s / 8s) to be defensive.
+
+## Known sharp edges (from sciencebasepy GitHub issues at capture time)
+
+| Issue | Behavior |
+|---|---|
+| #52 | `get_token()` may fail to open the browser on Windows 11; manual paste fallback needed. |
+| #51 | SSL errors on S3 cloud uploads; sometimes mitigated by retry. |
+| #17 | Uploading metadata XML with `scrape_file=True` creates duplicate extension entries. |
+| #9 | Web-link items (no file payload, just a URL) aren't well-supported. |
+
+If new issues surface during PR-E (SB client) implementation, link them
+here. This file is the running log of "things to watch out for."
+
+## Library facts worth memorizing
+
+- **DOI minting**: not in the library. Manual SB-staff step.
+- **FGDC XML generation**: not in the library. Bring your own XML.
+- **Find by title**: roll your own with `find_items(q=...)`.
+- **Resumable upload**: no.
+- **Version history**: no — overwrite is silent. Track checksums.
+
+These are also captured as a project memory under
+`project_sciencebase_release_facts` so they don't get re-discovered.

--- a/docs/data_release/sciencebasepy-notes.md
+++ b/docs/data_release/sciencebasepy-notes.md
@@ -50,7 +50,7 @@ default browser; document the manual token-paste fallback in the runbook.
 | `get_item(itemid, params={'fields': '...'})` | Field filtering supported via the `fields` param. |
 | `update_item(item_json)` | Pass dict with `id` + modified fields. Returns updated item. |
 | `delete_item(item_json)` | Returns boolean. |
-| `move_item(item, new_parent_id)` | Re-parent an item. |
+| `move_item(itemid, parentid)` | Re-parent an item (both args are ID strings). |
 | `create_items()` / `update_items()` / `delete_items()` | Batch variants for efficiency. |
 
 Item body is a free-form dict; SB doesn't validate FGDC at this layer.
@@ -63,9 +63,9 @@ top-level keys in the item JSON — there are no typed setters for them.
 |---|---|
 | `upload_file_to_item(item, filename, scrape_file=True)` | Single file. `scrape_file=True` attempts metadata extraction (variable results). |
 | `upload_files_and_upsert_item(item_json, files=[...])` | Upserts the item and uploads files in one call. Matches existing item by `id`. |
-| `upload_cloud_file_to_item(item, s3_url)` | S3 path; multipart upload happens internally. |
+| `upload_cloud_file_to_item(itemid, filename)` | `filename` is a local path; cloud-side multipart happens internally. |
 | `replace_file()` | In-place replace; updates checksum + dateUploaded + uploadedBy fields. |
-| `publish_array_to_public_bucket(items, urls)` | Batch S3 publish. |
+| `publish_array_to_public_bucket(item_id, filenames)` | Batch S3 publish. |
 
 Sharp edges:
 
@@ -108,20 +108,10 @@ registry-says-missing path (see the idempotency strategy in the design plan).
 
 ## DOI
 
-Not supported by the library at all. DOI minting is a ScienceBase-staff
-operation. After mint, the DOI appears in `item["identifiers"][0]["key"]`
-(format: `doi:10.5066/<id>`).
-
-The pipeline workflow:
-
-1. Operator runs `nhf-targets release publish --scope umbrella --confirm` —
-   creates the parent item without DOI.
-2. IPDS approval happens externally.
-3. Operator emails `sciencebase@usgs.gov` requesting DOI mint.
-4. After mint, operator copies the DOI into
-   `catalog/release_registry.yml.umbrella.doi` and reruns the umbrella
-   publish — this re-emits FGDC + ISO XMLs with the DOI populated and patches
-   the item body.
+Not supported by the library at all. After mint, the DOI appears in
+`item["identifiers"][0]["key"]` (format: `doi:10.5066/<id>`). The full
+out-of-band mint workflow lives in
+[usgs-process.md](usgs-process.md#doi-workflow).
 
 ## Versioning
 
@@ -137,8 +127,8 @@ flagged in `release status` and triggers full re-upload.
 ## Bulk operations and rate limiting
 
 - `create_items()`, `update_items()`, `delete_items()` for batch CRUD.
-- `download_cloud_files(urls, tokens)` for multi-file download via tokenized
-  S3 links.
+- `download_cloud_files(filenames, download_links, destination='.')` for
+  multi-file download via tokenized S3 links.
 - `generate_S3_download_links()` to create download tokens.
 - `publish_array_to_public_bucket()` for bulk S3 publish.
 
@@ -146,25 +136,20 @@ Rate limiting is not explicitly documented in the README or recent issues.
 Our `sb_client.upload_file` wrapper retries 429 + 5xx with exponential
 backoff (3 tries; 2s / 4s / 8s) to be defensive.
 
-## Known sharp edges (from sciencebasepy GitHub issues at capture time)
+## Known sharp edges
+
+Issue numbers below were all open against [`DOI-USGS/sciencebasepy`](https://github.com/DOI-USGS/sciencebasepy/issues) as of 2026-05-26. Click through to check current state before relying on the symptom description.
 
 | Issue | Behavior |
 |---|---|
-| #52 | `get_token()` may fail to open the browser on Windows 11; manual paste fallback needed. |
-| #51 | SSL errors on S3 cloud uploads; sometimes mitigated by retry. |
-| #17 | Uploading metadata XML with `scrape_file=True` creates duplicate extension entries. |
-| #9 | Web-link items (no file payload, just a URL) aren't well-supported. |
+| [#52](https://github.com/DOI-USGS/sciencebasepy/issues/52) | `get_token()` may fail to open the browser on Windows 11; manual paste fallback needed. |
+| [#51](https://github.com/DOI-USGS/sciencebasepy/issues/51) | SSL errors on S3 cloud uploads; sometimes mitigated by retry. |
+| [#17](https://github.com/DOI-USGS/sciencebasepy/issues/17) | Uploading metadata XML with `scrape_file=True` creates duplicate extension entries. |
+| [#9](https://github.com/DOI-USGS/sciencebasepy/issues/9) | Web-link items (no file payload, just a URL) aren't well-supported. |
 
 If new issues surface during PR-E (SB client) implementation, link them
 here. This file is the running log of "things to watch out for."
 
-## Library facts worth memorizing
-
-- **DOI minting**: not in the library. Manual SB-staff step.
-- **FGDC XML generation**: not in the library. Bring your own XML.
-- **Find by title**: roll your own with `find_items(q=...)`.
-- **Resumable upload**: no.
-- **Version history**: no — overwrite is silent. Track checksums.
-
-These are also captured as a project memory under
-`project_sciencebase_release_facts` so they don't get re-discovered.
+The TL;DR at the top of this file is the canonical "what to memorize" list;
+it is also captured as a project memory under
+`project_sciencebase_release_facts` so it doesn't get re-discovered.

--- a/docs/data_release/usgs-process.md
+++ b/docs/data_release/usgs-process.md
@@ -1,0 +1,199 @@
+# USGS data release process
+
+Summary of the USGS data release lifecycle as it applies to publishing
+`nhf-spatial-targets` outputs on ScienceBase. Source: the USGS data-release
+process pages (linked in [README.md](README.md)), captured 2026-05-26.
+
+## TL;DR
+
+1. **Prepare data and metadata** in open formats (NetCDF, CSV) + FGDC CSDGM 2.0 XML.
+2. **Create an IPDS record** (Information Product Data System) — USGS internal approval workflow. **IPDS approval is required before the DOI is minted.**
+3. **Create a ScienceBase landing-page item** as the data-release container.
+4. **Finalize metadata** — title self-explanatory outside USGS, DOI as full URL in the citation, distribution contact + liability statement attached.
+5. **Decide organization** — single item, multiple files on one item, or parent-child (the pattern this repo uses).
+6. **Upload files** — data + FGDC XML to ScienceBase.
+7. **Format citation** — author names, publication date, DOI URL.
+8. **Submit for final review** — ScienceBase team verifies the [checklist](https://www.usgs.gov/sciencebase-instructions-and-documentation/sciencebase-data-release-checklist) (up to 2 business days).
+
+After publication the parent item is **locked** in the sense that the DOI is
+permanent, but child items can still be added or replaced. The DOI landing
+page's metadata, however, is generated from a snapshot taken at IPDS time and
+**does not auto-refresh** when children are added later.
+
+## Roles and approval gates
+
+| Gate | Who | What it verifies |
+|---|---|---|
+| **IPDS Review** | USGS bureau approving official + science center | Fundamental Science Practices (FSP): data accuracy, methodology, peer review |
+| **ScienceBase Review** | ScienceBase staff | Checklist conformance: FGDC validates, files are open formats, citation is well-formed, DOI URL present, distribution liability statement present |
+| **DOI Mint** | ScienceBase staff (post-IPDS) | Manual; registers DOI with DataCite as `10.5066/<id>`; not exposed via API |
+
+`sciencebasepy` automates only the ScienceBase upload steps. IPDS submissions
+and DOI mint requests are manual.
+
+## ScienceBase item anatomy
+
+ScienceBase is a "certified USGS Trusted Digital Repository" supporting
+hierarchical items. For this pipeline:
+
+- **Parent item** — landing page. Carries the DOI, top-level FGDC metadata,
+  citation, and (optionally) a README + manifest describing the whole
+  collection. No data files at the parent level in our design.
+- **Child items** — sub-items linked via `parentId`. Each has its own FGDC
+  metadata. Each child may carry data files. Children inherit citation +
+  contact info from the parent by convention but maintain their own metadata
+  records.
+
+Required parent-item fields at upload time:
+
+| Field | Constraint |
+|---|---|
+| Title | Meaningful outside USGS context (appears in [USGS Science Data Catalog](https://data.usgs.gov/datacatalog/)) |
+| Citation block | Authors + publication date + title + DOI URL in the `<onlink>` element of the citation section |
+| Distribution info | Contact organization "U.S. Geological Survey - ScienceBase", contact address/phone/email, liability statement, digital format name, online resource link (the DOI URL), fees (typically "None") |
+| Abstract | Describes purpose, scope, and relevance |
+
+## FGDC CSDGM required elements
+
+[FGDC CSDGM 2.0](https://www.fgdc.gov/standards/projects/FGDC-standards-projects/metadata/base-metadata)
+is the mandated federal standard for USGS data releases. ISO 19115 is an
+acceptable alternative on paper but ScienceBase staff strongly prefer CSDGM.
+At minimum:
+
+| FGDC element | Source in this pipeline |
+|---|---|
+| Title | Generated from `catalog/release_defaults.yml` umbrella template + `release_registry.yml.umbrella.version` |
+| Abstract | Per-item template in `release_defaults.yml`, Jinja-rendered with item-specific context |
+| Purpose | Per-item template |
+| Bounding coordinates | Umbrella: union of children. Source child: `catalog/sources.yml[<key>].access.bbox_nwse`. Fabric child: `<project>/fabric.json.bbox` |
+| Time period | Umbrella: union of children. Source child: `catalog/sources.yml[<key>].period`. Fabric child: union of enabled-target periods |
+| Lineage / Process steps | `<project>/manifest.json.steps[]` (currently empty — PR-B instruments this) |
+| Entity / Attribute | Per-NC variable: from `catalog/sources.yml[<key>].variables[].{name,long_name,cf_units,cell_methods}`; per-target: from `catalog/variables.yml[<target>]` |
+| Keywords (theme) | `release_defaults.yml.keywords.{umbrella,source,fabric}` + per-target CF standard_names |
+| Point of contact | `release_defaults.yml.contacts.point_of_contact` (overridable per project) |
+| Distribution liability | `release_defaults.yml.distribution.liability_statement` (USGS standard text) |
+| Use constraints | `catalog/sources.yml[<key>].license` + `release_defaults.yml.distribution.use_constraints` + per-source notes |
+| Citation Format | `<project>/config.yml.release.authors` + DOI URL from `release_registry.yml.umbrella.doi` |
+
+Validate FGDC XML with the [USGS Metadata Parser](https://geology.usgs.gov/tools/metadata/tools/doc/mp.html)
+before upload. Our `release/validate_xml.py` shells out to `mp` if it's on
+PATH and reports warn-only if not.
+
+## File and data requirements
+
+- **Open formats**: NetCDF, CSV, ASCII. Our pipeline writes CF-1.6 NetCDF and
+  GeoPackage; both are acceptable.
+- **NetCDF and OGC services**: ScienceBase does *not* auto-generate OGC web
+  services from NetCDF uploads (only from GeoTIFF / shapefile / raster). NCs
+  are uploaded as files only. Document the variable schema in FGDC + README.
+- **Checksums**: Not strictly mandated by the SB checklist but strongly
+  recommended for preservation. Our pipeline ships per-item `checksums.csv`
+  (path, sha256, size, mtime) + GNU `SHA256SUMS` (for `sha256sum -c`).
+- **CRS metadata**: EPSG code in FGDC + CF `grid_mapping` variable in each
+  NetCDF. Already enforced by [`io_nc.atomic_to_netcdf`](../../src/nhf_spatial_targets/io_nc.py).
+- **Variable docs**: CF standard names where they exist, plus `long_name`,
+  `units`, `cell_methods`. Already enforced by
+  [`fetch/consolidate.py::apply_cf_metadata`](../../src/nhf_spatial_targets/fetch/consolidate.py).
+- **README**: Not mandated but expected. Auto-generated per child in our
+  pipeline (`release/readme.py` + Jinja templates).
+- **File size**: Per-file practical limit is ~10 GB on ScienceBase; per-item
+  practical limit ~100 GB. We're comfortably under both. The largest single
+  file we'll publish is `mwbm_climgrid` (~7.5 GB).
+
+## DOI workflow
+
+1. ScienceBase parent item is created (no DOI yet).
+2. Operator emails the [USGS Science Quality and Integrity](https://www.usgs.gov/about/organization/science-support/office-science-quality-and-integrity)
+   contact (or the bureau approving official) with the IPDS record and SB item
+   link.
+3. After IPDS approval, the operator (or ScienceBase staff) requests DOI mint
+   via the SB web UI or by emailing `sciencebase@usgs.gov`.
+4. DOI is registered with DataCite as `10.5066/<id>` and shows up in the item
+   JSON within minutes.
+5. Operator pulls the new DOI into `catalog/release_registry.yml.umbrella.doi`
+   and re-runs `nhf-targets release publish --scope umbrella --confirm` to
+   re-emit FGDC + ISO XMLs with the DOI populated and update the SB item body.
+
+There is **no** `mint_doi()` API on `sciencebasepy`. The whole DOI step is
+out-of-band.
+
+## Incremental child additions (the multi-fabric story)
+
+The release model in this repo is one umbrella + many children, with new
+fabric children added over time. ScienceBase supports this:
+
+- New child items can be created under a DOI-minted parent at any time. The
+  parent's DOI doesn't change.
+- The new child gets its own FGDC metadata but no separate DOI (children
+  inherit the umbrella DOI for citation).
+- The umbrella's FGDC abstract is intentionally written to describe the
+  series as a whole, not enumerate children, so it stays valid as children
+  are added.
+- The **DOI landing page** metadata is snapshotted at IPDS time and won't
+  auto-refresh. If you add a major new fabric and want the landing page to
+  reflect it, you must email ScienceBase staff to update the landing-page
+  metadata. There is no automated path.
+
+For minor additions (one new fabric child, no change to umbrella abstract)
+the DOI landing page can be left stale — it still resolves correctly to the
+parent item, which displays the up-to-date child list.
+
+For substantial additions (new source class, major version bump) prefer
+minting a new DOI via a new umbrella version. The `release_registry.yml`
+schema supports `umbrella.version` for exactly this.
+
+## Version policy (for this pipeline)
+
+| Change kind | Action |
+|---|---|
+| New fabric (e.g. add `oregon`) | Append child under existing umbrella; no DOI bump |
+| Add a new source (e.g. add a new reanalysis) | Append a consolidated-source child + republish fabric children that use it; no DOI bump |
+| Refresh source data (e.g. SNODAS adds 2026) | Re-upload affected child files; no DOI bump |
+| Methodology change to a target | New umbrella version + new DOI; the old release stays online |
+| Catalog correction that changes target values | New umbrella version + new DOI |
+
+The `release_defaults.yml.umbrella.versioning_policy` field records the
+canonical policy text for the FGDC abstract.
+
+## Licensing and redistribution
+
+USGS data releases are public-domain by default, but **derived products may
+inherit restrictions from upstream sources**. The catalog flags this per
+source:
+
+```yaml
+# catalog/sources.yml (excerpt)
+era5_land:
+  license: "Copernicus license (free, attribution)"
+  release: { publishable: true, notes: "Acknowledge Copernicus in FGDC useconst" }
+
+watergap22d:
+  license: "CC BY-NC 4.0"
+  release:
+    publishable: false
+    notes: "CC BY-NC 4.0 is incompatible with USGS-federal redistribution policy; pending OSQI review or WaterGAP 2.2e substitution"
+
+daymet:
+  release:
+    publishable: true
+    distribution_kind: "metadata_only"
+    notes: "Source is 4.6 TB of zarr stores; publish a metadata-only child pointing to ORNL DAAC"
+```
+
+The `release.publishable` flag is the authoritative gate. The
+`release.distribution_kind` flag distinguishes "data + metadata" children
+(default) from "metadata-only" children (Daymet). Sources with
+`status: superseded` are auto-skipped regardless of `release.publishable`.
+
+Open license questions to resolve with OSQI before any publish:
+
+- **WaterGAP 2.2d** — CC BY-NC redistribution by a federal agency is legally
+  ambiguous. Default position: exclude until OSQI clears or 2.2e supersedes.
+- **Copernicus ERA5-Land** — free with attribution. Add explicit
+  acknowledgment text to FGDC `useconst` and README.
+- **NASA Earthdata sources** (MODIS, MERRA-2, NLDAS, GLDAS) — public-domain
+  but Earthdata acknowledgment text recommended.
+- **NSIDC sources** (SNODAS, Margulis WUS-SR) — public-domain. No constraint.
+- **USGS sources** (Reitz 2017, MWBM ClimGrid) — already public releases.
+  Cite original DOI; we publish the HRU-aggregated derivative, not the raw
+  data.

--- a/docs/data_release/usgs-process.md
+++ b/docs/data_release/usgs-process.md
@@ -159,10 +159,14 @@ canonical policy text for the FGDC abstract.
 
 USGS data releases are public-domain by default, but **derived products may
 inherit restrictions from upstream sources**. The catalog flags this per
-source:
+source.
+
+> **Forward reference.** The `release:` block on `catalog/sources.yml`
+> entries does not exist on `main` yet — it is added by PR-A in the #241
+> phasing. The excerpt below shows the post-PR-A shape.
 
 ```yaml
-# catalog/sources.yml (excerpt)
+# catalog/sources.yml (excerpt, post-PR-A)
 era5_land:
   license: "Copernicus license (free, attribution)"
   release: { publishable: true, notes: "Acknowledge Copernicus in FGDC useconst" }


### PR DESCRIPTION
## Summary

- Adds `docs/data_release/` with four reference files capturing what we learned at design time about the USGS data-release process, the `sciencebasepy` Python client, and the FGDC CSDGM 2.0 field-map for the planned `nhf-targets release` feature.
- No code changes; pure documentation. Pre-work for the 7-PR phasing tracked in #241.

### Files

- `docs/data_release/README.md` — index + how to use these references.
- `docs/data_release/usgs-process.md` — USGS data-release lifecycle (IPDS → ScienceBase → DOI), FGDC CSDGM 2.0 requirements, file/data requirements, parent/child item structure, incremental child additions, licensing per source.
- `docs/data_release/sciencebasepy-notes.md` — capability matrix for the `sciencebasepy` Python client: what it makes easy (auth, item CRUD, file upload), what it doesn't (DOI minting, FGDC XML generation, find-by-title idempotency, resumable upload), known sharp edges.
- `docs/data_release/fgdc-field-map.md` — concrete mapping from `catalog/sources.yml` + `catalog/variables.yml` + `manifest.json` + `<project>/config.yml` → MCF intermediate → FGDC CSDGM 2.0 elements, per item type (umbrella / consolidated-source child / fabric child), plus the lineage-record-to-`<procstep>` shape.

### Why now

Capturing these notes before the first code PR (PR-A: catalog + config foundations) so the team has shared context. The full implementation plan lives in the design conversation but the external-world facts about the USGS workflow, the Python client, and the FGDC schema should live in the repo so they don't have to be re-discovered.

## Test plan

- [ ] Skim each file end-to-end; check internal links resolve (README.md links to the three siblings; cross-links to docs/architecture/ and src/).
- [ ] No CI changes expected; ruff and pytest jobs are unaffected by docs-only changes.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)