### PR TITLE
feature(release): PR-A catalog + config foundations

### DIFF
--- a/catalog/release_defaults.yml
+++ b/catalog/release_defaults.yml
@@ -1,0 +1,33 @@
+# ============================================================================
+# release_defaults.yml — repo-level FGDC + ScienceBase release defaults
+# ============================================================================
+#
+# Per-project release config (authors, IPDS number, DOI) lives in each
+# project's config.yml under the `release:` block. Repo-level boilerplate
+# (publisher, distribution contact, liability text, keyword thesauri,
+# abstract templates, versioning policy) lives here and is read by the
+# upcoming `release/` module via the catalog interface.
+#
+# This file is intentionally scaffolded with empty blocks at PR-A time and
+# is populated incrementally as PRs in the #241 series land:
+#
+#   PR-A (this PR): empty scaffold so downstream PRs have a stable file to
+#                   write into and the loader has a well-known path.
+#   PR-D:           abstract templates, keyword thesauri, source_abstract_suffix,
+#                   spatial_reference block.
+#   PR-E:           contacts.distributor, contacts.point_of_contact,
+#                   distribution.* (liability, fees, use_constraints).
+#   PR-G:           operator-facing setup notes that don't fit in docs/.
+#
+# See docs/data_release/fgdc-field-map.md for the field-by-field mapping
+# from these defaults into FGDC CSDGM 2.0 + ISO 19139 metadata.
+# ============================================================================
+
+metadata: {}
+contacts: {}
+distribution: {}
+keywords: {}
+umbrella: {}
+source: {}
+fabric: {}
+spatial_reference: {}

--- a/catalog/release_defaults.yml
+++ b/catalog/release_defaults.yml
@@ -1,27 +1,11 @@
-# ============================================================================
-# release_defaults.yml — repo-level FGDC + ScienceBase release defaults
-# ============================================================================
+# Repo-level FGDC + ScienceBase release defaults consumed by the
+# release/ module via the catalog interface. Per-project bits (authors,
+# IPDS number, DOI) live in each project's config.yml under `release:`.
+# See docs/data_release/fgdc-field-map.md for the field-by-field map
+# from these defaults into FGDC CSDGM 2.0 + ISO 19139 output.
 #
-# Per-project release config (authors, IPDS number, DOI) lives in each
-# project's config.yml under the `release:` block. Repo-level boilerplate
-# (publisher, distribution contact, liability text, keyword thesauri,
-# abstract templates, versioning policy) lives here and is read by the
-# upcoming `release/` module via the catalog interface.
-#
-# This file is intentionally scaffolded with empty blocks at PR-A time and
-# is populated incrementally as PRs in the #241 series land:
-#
-#   PR-A (this PR): empty scaffold so downstream PRs have a stable file to
-#                   write into and the loader has a well-known path.
-#   PR-D:           abstract templates, keyword thesauri, source_abstract_suffix,
-#                   spatial_reference block.
-#   PR-E:           contacts.distributor, contacts.point_of_contact,
-#                   distribution.* (liability, fees, use_constraints).
-#   PR-G:           operator-facing setup notes that don't fit in docs/.
-#
-# See docs/data_release/fgdc-field-map.md for the field-by-field mapping
-# from these defaults into FGDC CSDGM 2.0 + ISO 19139 metadata.
-# ============================================================================
+# Scaffold only at PR-A time; blocks are populated by later PRs in the
+# #241 series.
 
 metadata: {}
 contacts: {}

--- a/catalog/release_registry.yml
+++ b/catalog/release_registry.yml
@@ -1,0 +1,44 @@
+# ============================================================================
+# release_registry.yml — running state of the ScienceBase data release
+# ============================================================================
+#
+# Source of truth for what has been published to ScienceBase under the
+# nhf-spatial-targets umbrella release. Populated by `nhf-targets release
+# publish` (PR-E) as items are created or updated. flock-protected on
+# write so concurrent publishes against different scopes don't clobber
+# each other.
+#
+# Schema (post-PR-E):
+#
+#   umbrella:
+#     sb_id:          <ScienceBase item ID>
+#     doi:            <full DOI URL once minted post-IPDS>
+#     version:        <release version, e.g. "1.0">
+#     published_utc:  <ISO 8601 timestamp of first publish>
+#     title:          <canonical title used for find_items lookups>
+#
+#   consolidated_sources:
+#     <source_key>:
+#       sb_id:                       <ScienceBase item ID>
+#       uploaded_utc:                <ISO 8601 timestamp of last upload>
+#       file_count:                  <int>
+#       total_bytes:                 <int>
+#       checksums_sha256_of_manifest: <hex digest of staged checksums.csv>
+#
+#   fabrics:
+#     <fabric_label>:
+#       sb_id:                       <ScienceBase item ID>
+#       uploaded_utc:                <ISO 8601 timestamp of last upload>
+#       file_count:                  <int>
+#       total_bytes:                 <int>
+#       checksums_sha256_of_manifest: <hex digest of staged checksums.csv>
+#       project_path_hint:           <last-known project dir, free-text>
+#
+# Initial state below. After every successful publish the registry is
+# updated and the operator is reminded to commit it (so the repo carries
+# the authoritative record of what's been released).
+# ============================================================================
+
+umbrella: null
+consolidated_sources: {}
+fabrics: {}

--- a/catalog/release_registry.yml
+++ b/catalog/release_registry.yml
@@ -1,43 +1,13 @@
-# ============================================================================
-# release_registry.yml — running state of the ScienceBase data release
-# ============================================================================
+# Running publish-state for the ScienceBase data release. Updated by
+# `nhf-targets release publish` (post-PR-E) as items are created or
+# refreshed; flock-protected on write so concurrent publishes don't
+# clobber each other.
 #
-# Source of truth for what has been published to ScienceBase under the
-# nhf-spatial-targets umbrella release. Populated by `nhf-targets release
-# publish` (PR-E) as items are created or updated. flock-protected on
-# write so concurrent publishes against different scopes don't clobber
-# each other.
-#
-# Schema (post-PR-E):
-#
-#   umbrella:
-#     sb_id:          <ScienceBase item ID>
-#     doi:            <full DOI URL once minted post-IPDS>
-#     version:        <release version, e.g. "1.0">
-#     published_utc:  <ISO 8601 timestamp of first publish>
-#     title:          <canonical title used for find_items lookups>
-#
-#   consolidated_sources:
-#     <source_key>:
-#       sb_id:                       <ScienceBase item ID>
-#       uploaded_utc:                <ISO 8601 timestamp of last upload>
-#       file_count:                  <int>
-#       total_bytes:                 <int>
-#       checksums_sha256_of_manifest: <hex digest of staged checksums.csv>
-#
-#   fabrics:
-#     <fabric_label>:
-#       sb_id:                       <ScienceBase item ID>
-#       uploaded_utc:                <ISO 8601 timestamp of last upload>
-#       file_count:                  <int>
-#       total_bytes:                 <int>
-#       checksums_sha256_of_manifest: <hex digest of staged checksums.csv>
-#       project_path_hint:           <last-known project dir, free-text>
-#
-# Initial state below. After every successful publish the registry is
-# updated and the operator is reminded to commit it (so the repo carries
-# the authoritative record of what's been released).
-# ============================================================================
+# Initial state below: `umbrella: null` signals "no first-publish yet";
+# loaders must handle that case explicitly rather than indexing into a
+# missing dict. Once published, the umbrella block carries sb_id, doi,
+# version, published_utc, and title — see docs/data_release/fgdc-field-map.md
+# for the post-PR-E schema and PR-E's writer for the authoritative shape.
 
 umbrella: null
 consolidated_sources: {}

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -383,6 +383,17 @@ sources:
     units: kg m-2 s-1
     license: CC BY-NC 4.0
     status: current
+    release:
+      # CC BY-NC 4.0 redistribution by a US federal agency is legally
+      # ambiguous (USGS itself is non-commercial but downstream users may
+      # not be). Excluded from the ScienceBase release until OSQI clears
+      # it or WaterGAP 2.2e (expected open-access) supersedes 2.2d. The
+      # aggregated recharge bound that depends on this source is still
+      # produced from the remaining sources at target build time.
+      publishable: false
+      notes: >
+        CC BY-NC 4.0 license; pending OSQI review or WaterGAP 2.2e
+        substitution before inclusion in a USGS data release.
 
   # ---------------------------------------------------------------------------
   # SOIL MOISTURE
@@ -740,6 +751,18 @@ sources:
     units: "kg m-2 (swe, prcp); degC (tmax, tmin); W m-2 (srad); Pa (vp)"
     license: public domain (NASA / ORNL DAAC)
     status: current
+    release:
+      # Daymet source data is ~4.6 TB of zarr stores hosted by ORNL DAAC;
+      # we do not redistribute it. The consolidated-source child in the
+      # ScienceBase release carries README + FGDC + an upstream pointer
+      # only. The fabric children still include the HRU-aggregated Daymet
+      # NCs, which ARE redistributable as a USGS-derivative product.
+      publishable: true
+      distribution_kind: metadata_only
+      notes: >
+        Source data lives on ORNL DAAC as multi-TB zarr stores; the
+        consolidated-source child carries metadata + an upstream pointer
+        rather than file payload.
 
   snodas:
     name: SNODAS Snow Data Assimilation System Data Products (NSIDC G02158)
@@ -865,6 +888,16 @@ sources:
     units: m water equivalent
     license: public domain (NASA NSIDC)
     status: current
+    release:
+      # `fabric_scope` restricts AGGREGATION consumption to the Oregon
+      # fabric, but the consolidated NSIDC source NCs themselves are
+      # public-domain redistributable. The consolidated-source child in
+      # the ScienceBase release carries the data.
+      publishable: true
+      notes: >
+        Fabric-scoped to "or" for aggregation/consumption; the
+        consolidated source data is public-domain and redistributable as
+        part of the umbrella release for any consumer.
 
   ua_swe:
     name: University of Arizona Daily 4-km Gridded SWE and Snow Depth (NSIDC-0719)

--- a/config/pipeline.yml
+++ b/config/pipeline.yml
@@ -168,3 +168,24 @@ targets:
 #   soil_moisture: *rep_pts
 #   snow_covered_area: *rep_pts
 #   swe: *rep_pts
+
+# ---------------------------------------------------------------------------
+# ScienceBase data release (optional)
+# ---------------------------------------------------------------------------
+# Per-project metadata for the `nhf-targets release` workflow. Most
+# defaults live in catalog/release_defaults.yml (committed repo-wide).
+# This block carries the per-project bits: authors, IPDS number, DOI
+# (filled after ScienceBase staff mints it post-IPDS approval), and an
+# optional fabric-label override. Leave commented until ready to publish.
+# See docs/data_release/ for the full workflow.
+#
+# release:
+#   authors:
+#     - given: Jane
+#       family: Doe
+#       orcid: 0000-0000-0000-0000
+#       affiliation: U.S. Geological Survey
+#   ipds_number: IP-XXXXXX
+#   doi: null               # populated after SB staff mints DOI
+#   abstract_notes: null    # optional paragraph appended to fabric abstract
+#   fabric_label: null      # human-readable name; defaults to Path(fabric.path).stem

--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -309,18 +309,24 @@ def publishable_sources() -> dict:
 
     A source is eligible iff:
 
-    - its ``status`` is not ``"superseded"`` — superseded sources never
-      ship (`mod16a2`, `mod10c1` v006 variants, `merra_land`,
-      `watergap22a`, etc. are catalog-archive entries only); AND
+    - it carries no ``superseded_by`` field — superseded sources never
+      ship as catalog-archive entries only (this is the same marker
+      :func:`test_every_current_source_has_status_field` uses, robust
+      against status-string variants like ``"superseded_registration_required"``); AND
     - its ``release.publishable`` is True (the default).
 
     The returned dict mirrors :func:`sources` but excludes filtered keys.
     Order is preserved from the underlying YAML to keep deterministic
     output across release builds.
+
+    Note: this function is informational on PR-A. Downstream enforcement
+    (refusing to build a release for a non-publishable source) lands with
+    PR-D/PR-E. Callers that need a hard gate should not assume this
+    function's return value is acted on yet.
     """
     out: dict = {}
     for key, src in sources().items():
-        if src.get("status") == "superseded":
+        if src.get("superseded_by") is not None:
             continue
         rb = release_block(key)
         if rb["publishable"]:

--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -153,6 +153,25 @@ def source_var_cell_methods(source_key: str, var_name: str) -> str | None:
 # enforcement in the target builders.
 FABRIC_SCOPE_TOKENS: frozenset[str] = frozenset({"or"})
 
+# Allowed `release.distribution_kind` tokens.
+#
+# - "data": the consolidated-source child item carries the source's
+#   consolidated NetCDF files (the default; most sources).
+# - "metadata_only": the child item carries README + FGDC + an upstream
+#   pointer but no data payload. Used for sources whose primary
+#   distribution is elsewhere (e.g. daymet, hosted on ORNL DAAC as
+#   multi-TB zarr stores that we do not redistribute).
+DISTRIBUTION_KIND_TOKENS: frozenset[str] = frozenset({"data", "metadata_only"})
+
+# Release-block default values applied when a source omits one or more keys
+# from its optional ``release:`` block. Kept in one place so the FGDC
+# builder and the publishability filter agree on defaults.
+_RELEASE_DEFAULTS: dict = {
+    "publishable": True,
+    "distribution_kind": "data",
+    "notes": None,
+}
+
 
 def validate_fabric_scope(source_key: str, scope: dict | None) -> None:
     """Raise ValueError if a source's ``fabric_scope`` block is malformed.
@@ -200,3 +219,110 @@ def validate_fabric_scope(source_key: str, scope: dict | None) -> None:
             f"{sorted(FABRIC_SCOPE_TOKENS)}. If you intended to add a "
             f"new fabric, extend FABRIC_SCOPE_TOKENS in catalog.py."
         )
+
+
+def validate_release_block(source_key: str, release: dict | None) -> None:
+    """Raise ValueError if a source's ``release`` block is malformed.
+
+    The check is intentionally narrow:
+
+    - ``release`` may be ``None`` (no block, defaults apply).
+    - When present, ``release`` must be a mapping. Recognized keys are
+      ``publishable`` (bool), ``distribution_kind`` (member of
+      :data:`DISTRIBUTION_KIND_TOKENS`), and ``notes`` (string).
+    - Unknown keys raise — catches typos like ``publishible`` that would
+      otherwise silently fall through to the default.
+
+    Parameters
+    ----------
+    source_key : str
+        Catalog source key (for error messages).
+    release : dict or None
+        The value of ``sources[source_key].release``.
+
+    Raises
+    ------
+    ValueError
+        ``release`` is not a mapping; ``publishable`` is not a bool;
+        ``distribution_kind`` is not in :data:`DISTRIBUTION_KIND_TOKENS`;
+        ``notes`` is not a string; or there are unknown keys.
+    """
+    if release is None:
+        return
+    if not isinstance(release, dict):
+        raise ValueError(
+            f"sources[{source_key!r}].release must be a mapping; "
+            f"got {type(release).__name__}."
+        )
+    unknown = set(release) - set(_RELEASE_DEFAULTS)
+    if unknown:
+        raise ValueError(
+            f"sources[{source_key!r}].release contains unknown key(s) "
+            f"{sorted(unknown)}. Allowed: {sorted(_RELEASE_DEFAULTS)}."
+        )
+    pub = release.get("publishable")
+    if pub is not None and not isinstance(pub, bool):
+        raise ValueError(
+            f"sources[{source_key!r}].release.publishable must be a bool; "
+            f"got {type(pub).__name__}."
+        )
+    kind = release.get("distribution_kind")
+    if kind is not None and kind not in DISTRIBUTION_KIND_TOKENS:
+        raise ValueError(
+            f"sources[{source_key!r}].release.distribution_kind must be one of "
+            f"{sorted(DISTRIBUTION_KIND_TOKENS)}; got {kind!r}."
+        )
+    notes = release.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        raise ValueError(
+            f"sources[{source_key!r}].release.notes must be a string; "
+            f"got {type(notes).__name__}."
+        )
+
+
+def release_block(source_key: str) -> dict:
+    """Return the ``release`` block for ``source_key`` with defaults applied.
+
+    Returns a fresh dict with the four canonical keys (``publishable``,
+    ``distribution_kind``, ``notes``) populated from the source's
+    optional ``release:`` block plus :data:`_RELEASE_DEFAULTS` fallbacks.
+    Validates the on-disk block on every call — catches typos at the same
+    boundary the FGDC builder reads from.
+
+    Raises
+    ------
+    ValueError
+        The source declares a malformed ``release`` block (see
+        :func:`validate_release_block`).
+    """
+    src = source(source_key)
+    raw = src.get("release")
+    validate_release_block(source_key, raw)
+    out = dict(_RELEASE_DEFAULTS)
+    if isinstance(raw, dict):
+        out.update({k: v for k, v in raw.items() if v is not None})
+    return out
+
+
+def publishable_sources() -> dict:
+    """Return the subset of sources eligible for the ScienceBase release.
+
+    A source is eligible iff:
+
+    - its ``status`` is not ``"superseded"`` — superseded sources never
+      ship (`mod16a2`, `mod10c1` v006 variants, `merra_land`,
+      `watergap22a`, etc. are catalog-archive entries only); AND
+    - its ``release.publishable`` is True (the default).
+
+    The returned dict mirrors :func:`sources` but excludes filtered keys.
+    Order is preserved from the underlying YAML to keep deterministic
+    output across release builds.
+    """
+    out: dict = {}
+    for key, src in sources().items():
+        if src.get("status") == "superseded":
+            continue
+        rb = release_block(key)
+        if rb["publishable"]:
+            out[key] = src
+    return out

--- a/src/nhf_spatial_targets/defaults.py
+++ b/src/nhf_spatial_targets/defaults.py
@@ -133,6 +133,20 @@ DEFAULTS: dict = {
             "nn_max_candidates": 10,
         },
     },
+    # ScienceBase data-release metadata. Optional — all leaves carry safe
+    # defaults so existing projects continue to validate. Populated by the
+    # operator before running `nhf-targets release publish`; see
+    # docs/data_release/. authors is the only field the release CLI will
+    # treat as required when actually publishing (validated at that point,
+    # not at config-load time). doi is filled by the operator after the
+    # ScienceBase staff mints it post-IPDS approval.
+    "release": {
+        "authors": [],
+        "ipds_number": None,
+        "doi": None,
+        "abstract_notes": None,
+        "fabric_label": None,
+    },
 }
 
 

--- a/src/nhf_spatial_targets/init_run.py
+++ b/src/nhf_spatial_targets/init_run.py
@@ -168,6 +168,27 @@ targets:
 #   soil_moisture: *rep_pts
 #   snow_covered_area: *rep_pts
 #   swe: *rep_pts
+
+# ---------------------------------------------------------------------------
+# ScienceBase data release (optional)
+# ---------------------------------------------------------------------------
+# Per-project metadata for the `nhf-targets release` workflow. Most
+# defaults live in catalog/release_defaults.yml (committed repo-wide).
+# This block carries the per-project bits: authors, IPDS number, DOI
+# (filled after ScienceBase staff mints it post-IPDS approval), and an
+# optional fabric-label override. Leave commented until ready to publish.
+# See docs/data_release/ for the full workflow.
+#
+# release:
+#   authors:
+#     - given: Jane
+#       family: Doe
+#       orcid: 0000-0000-0000-0000
+#       affiliation: U.S. Geological Survey
+#   ipds_number: IP-XXXXXX
+#   doi: null               # populated after SB staff mints DOI
+#   abstract_notes: null    # optional paragraph appended to fabric abstract
+#   fabric_label: null      # human-readable name; defaults to Path(fabric.path).stem
 """
 
 _CREDENTIALS_TEMPLATE = {

--- a/src/nhf_spatial_targets/upgrade_config.py
+++ b/src/nhf_spatial_targets/upgrade_config.py
@@ -110,6 +110,32 @@ OPTIONAL_CONFIG_FEATURES: list[OptionalConfigFeature] = [
         added="2026-05-23 (#193)",
         why="per-target REPRESENTATIVE_POINTS for inspect_* notebooks (#192)",
     ),
+    OptionalConfigFeature(
+        name="release",
+        # Top-level `release:` key (no other `release:` in the schema).
+        detect=r"(?m)^\s*#?\s*release\s*:",
+        block=(
+            "# Per-project metadata for the `nhf-targets release` workflow. Most\n"
+            "# defaults live in catalog/release_defaults.yml (committed repo-wide).\n"
+            "# This block carries the per-project bits: authors, IPDS number, DOI\n"
+            "# (filled after ScienceBase staff mints it post-IPDS approval), and an\n"
+            "# optional fabric-label override. Leave commented until ready to publish.\n"
+            "# See docs/data_release/ for the full workflow.\n"
+            "#\n"
+            "# release:\n"
+            "#   authors:\n"
+            "#     - given: Jane\n"
+            "#       family: Doe\n"
+            "#       orcid: 0000-0000-0000-0000\n"
+            "#       affiliation: U.S. Geological Survey\n"
+            "#   ipds_number: IP-XXXXXX\n"
+            "#   doi: null               # populated after SB staff mints DOI\n"
+            "#   abstract_notes: null    # optional paragraph appended to fabric abstract\n"
+            "#   fabric_label: null      # human-readable name; defaults to Path(fabric.path).stem\n"
+        ),
+        added="2026-05-26 (#243)",
+        why="ScienceBase data-release metadata for `nhf-targets release` (#241)",
+    ),
 ]
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -384,3 +384,142 @@ def test_source_var_cell_methods_raises_on_unknown_variable():
 
     with pytest.raises(KeyError, match="not found"):
         source_var_cell_methods("era5_land", "no_such_var")
+
+
+# ---------------------------------------------------------------------------
+# release block (PR-A foundation for the ScienceBase release workflow, #241/#243)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_release_block_none_is_ok():
+    """No block on a source means defaults apply; not an error."""
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    validate_release_block("test_src", None)
+
+
+def test_validate_release_block_accepts_bare_publishable_false():
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    validate_release_block("test_src", {"publishable": False})
+
+
+def test_validate_release_block_rejects_non_mapping():
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        validate_release_block("test_src", "publishable: true")
+
+
+def test_validate_release_block_rejects_unknown_key():
+    """Typo guard — `publishible` must not silently fall through to default."""
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    with pytest.raises(ValueError, match="unknown key"):
+        validate_release_block("test_src", {"publishible": True})
+
+
+def test_validate_release_block_rejects_non_bool_publishable():
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    with pytest.raises(ValueError, match="must be a bool"):
+        validate_release_block("test_src", {"publishable": "yes"})
+
+
+def test_validate_release_block_rejects_unknown_distribution_kind():
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    with pytest.raises(ValueError, match="distribution_kind"):
+        validate_release_block("test_src", {"distribution_kind": "metadata"})
+
+
+def test_validate_release_block_rejects_non_string_notes():
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    with pytest.raises(ValueError, match="notes"):
+        validate_release_block("test_src", {"notes": ["a", "b"]})
+
+
+def test_distribution_kind_tokens():
+    from nhf_spatial_targets.catalog import DISTRIBUTION_KIND_TOKENS
+
+    assert DISTRIBUTION_KIND_TOKENS == frozenset({"data", "metadata_only"})
+
+
+def test_release_block_defaults_apply_when_unset():
+    """A source with no `release:` block reports the defaults."""
+    from nhf_spatial_targets.catalog import release_block
+
+    # era5_land carries no release block on PR-A; it should default to
+    # publishable=True, distribution_kind="data", notes=None.
+    rb = release_block("era5_land")
+    assert rb == {"publishable": True, "distribution_kind": "data", "notes": None}
+
+
+def test_release_block_watergap22d_is_not_publishable():
+    """watergap22d is CC BY-NC; held back from the release per PR-A."""
+    from nhf_spatial_targets.catalog import release_block
+
+    rb = release_block("watergap22d")
+    assert rb["publishable"] is False
+    assert "CC BY-NC" in rb["notes"]
+
+
+def test_release_block_daymet_is_metadata_only():
+    """Daymet ships metadata only (4.6 TB zarr lives on ORNL DAAC)."""
+    from nhf_spatial_targets.catalog import release_block
+
+    rb = release_block("daymet")
+    assert rb["publishable"] is True
+    assert rb["distribution_kind"] == "metadata_only"
+    assert "ORNL" in rb["notes"]
+
+
+def test_release_block_margulis_publishable_despite_fabric_scope():
+    """Margulis WUS-SR is fabric-scoped for consumption, not for publication."""
+    from nhf_spatial_targets.catalog import release_block
+
+    rb = release_block("margulis_wus_sr")
+    assert rb["publishable"] is True
+    assert rb["distribution_kind"] == "data"
+
+
+def test_every_release_block_validates():
+    """Every declared `release:` block in catalog/sources.yml passes the validator."""
+    from nhf_spatial_targets.catalog import validate_release_block
+
+    for key, src in sources().items():
+        validate_release_block(key, src.get("release"))
+
+
+def test_publishable_sources_excludes_superseded():
+    """Sources with `status: superseded` are skipped regardless of `release.publishable`."""
+    from nhf_spatial_targets.catalog import publishable_sources
+
+    pub = publishable_sources()
+    # merra_land is superseded → out.
+    assert "merra_land" not in pub
+    # mwbm (the original MWBM, before mwbm_climgrid) is superseded → out.
+    superseded_keys = {
+        k for k, s in sources().items() if s.get("status") == "superseded"
+    }
+    assert pub.keys().isdisjoint(superseded_keys)
+
+
+def test_publishable_sources_excludes_watergap22d():
+    """watergap22d is `release.publishable: false` → excluded."""
+    from nhf_spatial_targets.catalog import publishable_sources
+
+    assert "watergap22d" not in publishable_sources()
+
+
+def test_publishable_sources_includes_daymet_and_margulis():
+    """Metadata-only and fabric-scoped sources still publish."""
+    from nhf_spatial_targets.catalog import publishable_sources
+
+    pub = publishable_sources()
+    assert "daymet" in pub
+    assert "margulis_wus_sr" in pub
+    # And the default-true sources are in too.
+    assert "era5_land" in pub
+    assert "snodas" in pub

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -484,6 +484,35 @@ def test_release_block_margulis_publishable_despite_fabric_scope():
     assert rb["distribution_kind"] == "data"
 
 
+def test_release_block_watergap22d_preserves_distribution_kind_default():
+    """Partial-override: setting `publishable` alone must leave the
+    `distribution_kind` default in place. Locks the per-key merge contract
+    against a future refactor that does wholesale replacement instead.
+    """
+    from nhf_spatial_targets.catalog import release_block
+
+    rb = release_block("watergap22d")
+    # watergap22d sets publishable + notes, but NOT distribution_kind.
+    # The default must propagate through.
+    assert rb["distribution_kind"] == "data"
+
+
+def test_release_block_explicit_null_falls_back_to_default(monkeypatch):
+    """Locks current behavior: an explicit `null` on a release-block field
+    is filtered out and the default applies. If we ever want explicit-null to
+    mean something different (e.g. "force unset"), update this test.
+    """
+    from nhf_spatial_targets import catalog
+
+    monkeypatch.setattr(
+        catalog,
+        "source",
+        lambda key: {"release": {"publishable": None, "distribution_kind": None}},
+    )
+    rb = catalog.release_block("synthetic")
+    assert rb == {"publishable": True, "distribution_kind": "data", "notes": None}
+
+
 def test_every_release_block_validates():
     """Every declared `release:` block in catalog/sources.yml passes the validator."""
     from nhf_spatial_targets.catalog import validate_release_block
@@ -493,17 +522,36 @@ def test_every_release_block_validates():
 
 
 def test_publishable_sources_excludes_superseded():
-    """Sources with `status: superseded` are skipped regardless of `release.publishable`."""
+    """Sources with `superseded_by` set are skipped regardless of `release.publishable`.
+
+    Pinned to a hard-coded expected set so the test stays independent of the
+    predicate the code under test uses — catches the kind of bug that would
+    leak `watergap22a` (status `"superseded_registration_required"`) through
+    a string-equality filter.
+    """
     from nhf_spatial_targets.catalog import publishable_sources
 
     pub = publishable_sources()
-    # merra_land is superseded → out.
-    assert "merra_land" not in pub
-    # mwbm (the original MWBM, before mwbm_climgrid) is superseded → out.
-    superseded_keys = {
-        k for k, s in sources().items() if s.get("status") == "superseded"
-    }
-    assert pub.keys().isdisjoint(superseded_keys)
+    # Every source whose `superseded_by` field is populated must be excluded.
+    # As of #243 this set is: mod16a2 (v006), mod10c1 (v006), merra_land, watergap22a.
+    expected_excluded = {"mod16a2", "mod10c1", "merra_land", "watergap22a"}
+    for key in expected_excluded:
+        assert key not in pub, (
+            f"superseded source {key!r} leaked into publishable_sources()"
+        )
+
+
+def test_publishable_sources_excludes_watergap22a():
+    """Regression: watergap22a's `status: superseded_registration_required` must
+    not slip through. Pre-fix, the filter used `status == "superseded"` which
+    silently included watergap22a (#244 review)."""
+    from nhf_spatial_targets.catalog import publishable_sources, source
+
+    src = source("watergap22a")
+    # Sanity-check the catalog state the regression depends on.
+    assert src.get("superseded_by") == "watergap22d"
+    assert "superseded" in src.get("status", "")
+    assert "watergap22a" not in publishable_sources()
 
 
 def test_publishable_sources_excludes_watergap22d():
@@ -523,3 +571,46 @@ def test_publishable_sources_includes_daymet_and_margulis():
     # And the default-true sources are in too.
     assert "era5_land" in pub
     assert "snodas" in pub
+
+
+def test_release_defaults_yml_loads_as_valid_yaml():
+    """Scaffold for repo-level FGDC defaults. Populated by PR-D/PR-E; we
+    just verify YAML parses cleanly so an accidental corruption is caught
+    before downstream code starts reading it.
+    """
+    import yaml
+    from pathlib import Path
+
+    catalog_dir = Path(__file__).resolve().parent.parent / "catalog"
+    data = yaml.safe_load((catalog_dir / "release_defaults.yml").read_text())
+    assert isinstance(data, dict)
+    # Every top-level block is a dict (empty on scaffold, populated later).
+    for key in (
+        "metadata",
+        "contacts",
+        "distribution",
+        "keywords",
+        "umbrella",
+        "source",
+        "fabric",
+        "spatial_reference",
+    ):
+        assert key in data
+        assert isinstance(data[key], dict)
+
+
+def test_release_registry_yml_loads_as_valid_yaml():
+    """Scaffold for the running publish-state registry. Populated by PR-E
+    as items are created on ScienceBase; we verify YAML parses cleanly and
+    the initial-state shape is what PR-E will expect.
+    """
+    import yaml
+    from pathlib import Path
+
+    catalog_dir = Path(__file__).resolve().parent.parent / "catalog"
+    data = yaml.safe_load((catalog_dir / "release_registry.yml").read_text())
+    assert isinstance(data, dict)
+    # Initial state: no umbrella published yet; empty per-source/per-fabric maps.
+    assert data["umbrella"] is None
+    assert data["consolidated_sources"] == {}
+    assert data["fabrics"] == {}

--- a/tests/test_init_run.py
+++ b/tests/test_init_run.py
@@ -106,3 +106,19 @@ def test_init_config_template_carries_representative_points_stub(tmp_path):
         "swe",
     ):
         assert tgt in text
+
+
+def test_init_config_template_carries_release_stub(tmp_path):
+    """The release: stub teaches operators about the ScienceBase data-release
+    workflow before they need it (#241/#243)."""
+    workdir = tmp_path / "ws"
+    init_project(workdir)
+    text = (workdir / "config.yml").read_text()
+    assert "# release:" in text
+    # Nested keys live under `#   ipds_number:` / `#   doi:` with extra
+    # indentation. Check by-key with re-style anchoring.
+    assert "ipds_number" in text
+    assert "docs/data_release/" in text
+    # Commented-out by default (operator opts in by uncommenting).
+    cfg = yaml.safe_load(text)
+    assert "release" not in cfg

--- a/tests/test_upgrade_config.py
+++ b/tests/test_upgrade_config.py
@@ -32,8 +32,8 @@ def test_check_drift_reports_all_features_when_none_present(tmp_path):
     _write_minimal_config(tmp_path)
     missing = check_drift(tmp_path)
     names = {f.name for f in missing}
-    # Both shipped features (PR #193) should be reported on a bare config.
-    assert {"fabric.token", "representative_points"} <= names
+    # All shipped features should be reported on a bare config.
+    assert {"fabric.token", "representative_points", "release"} <= names
 
 
 def test_check_drift_clean_when_live_value_present(tmp_path):
@@ -74,6 +74,27 @@ def test_check_drift_raises_when_config_missing(tmp_path):
         check_drift(tmp_path / "does-not-exist")
 
 
+def test_check_drift_release_detects_commented_stub(tmp_path):
+    """The release: stub (commented or live) counts as in-sync."""
+    _write_minimal_config(tmp_path, body="# release:\n#   ipds_number: IP-XXXXXX\n")
+    assert "release" not in {f.name for f in check_drift(tmp_path)}
+
+
+def test_check_drift_release_detects_live_block(tmp_path):
+    """An uncommented `release:` block also counts as in-sync."""
+    _write_minimal_config(
+        tmp_path,
+        body=(
+            "release:\n"
+            "  authors:\n"
+            "    - given: Jane\n"
+            "      family: Doe\n"
+            "  ipds_number: IP-XXXXXX\n"
+        ),
+    )
+    assert "release" not in {f.name for f in check_drift(tmp_path)}
+
+
 # --- registry shape ---------------------------------------------------------
 
 
@@ -111,7 +132,7 @@ def test_cli_exits_one_on_drift(tmp_path, capsys):
 def test_cli_exits_zero_when_in_sync(tmp_path, capsys):
     from nhf_spatial_targets.cli import app
 
-    # Operator pasted both commented stubs from the latest template.
+    # Operator pasted all commented stubs from the latest template.
     (tmp_path / "config.yml").write_text(
         "fabric:\n"
         "  path: /x.gpkg\n"
@@ -119,6 +140,7 @@ def test_cli_exits_zero_when_in_sync(tmp_path, capsys):
         "  # token: or\n"
         "datastore: /x\n"
         "# representative_points:\n"
+        "# release:\n"
     )
     # Cyclopts wraps even successful returns in SystemExit(0).
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

First implementation phase of the ScienceBase data-release feature (#241). Schema + scaffolds only — no behavior change to the existing pipeline. Unblocks PR-B (lineage capture) onward.

## What lands

- **`catalog/sources.yml`** — new optional `release: { publishable, distribution_kind, notes }` block on per-source entries. Concrete values applied:
  - `watergap22d.release.publishable: false` — CC BY-NC 4.0; pending OSQI review or WaterGAP 2.2e substitution
  - `daymet.release.distribution_kind: metadata_only` — 4.6 TB zarr on ORNL DAAC, we publish a pointer not the data
  - `margulis_wus_sr.release.publishable: true` with a note clarifying that `fabric_scope` is a consumption rule, not a publication rule
- **`catalog/release_defaults.yml`** — new scaffold file (empty blocks; populated by PR-D/PR-E)
- **`catalog/release_registry.yml`** — new scaffold file (umbrella: null, empty consolidated_sources/fabrics; populated by `publish` from PR-E)
- **`catalog.py`** — `DISTRIBUTION_KIND_TOKENS`, `validate_release_block()` (mirrors `validate_fabric_scope`), `release_block()` defaults-aware getter, `publishable_sources()` filter
- **`defaults.py` / `init_run.py` / `config/pipeline.yml` / `upgrade_config.py`** — new optional per-project `release:` config block (authors, ipds_number, doi, abstract_notes, fabric_label) shipped as a commented stub. Mirrored across all five Config Schema Additions surfaces per the CLAUDE.md checklist.
- **Tests** — `tests/test_catalog.py` (~140 lines): validator coverage, defaults application, per-source values, publishable filter excluding superseded + opt-out. `tests/test_init_run.py`: stub renders in the init template. `tests/test_upgrade_config.py`: drift detection for the new feature.

## Non-goals (later PRs in #241)

- No new Python modules under `src/nhf_spatial_targets/release/` yet — PR-C onward
- No `manifest.json.steps[]` lineage instrumentation — PR-B
- No FGDC / MCF / ISO generation — PR-D
- No ScienceBase API calls — PR-E

## Test plan

- [x] `pixi run -e dev fmt && pixi run -e dev lint` clean (and pre-commit hooks confirm)
- [x] Smoke: `catalog.publishable_sources()` returns 15 keys; excludes `watergap22d`, `merra_land`; includes `daymet`, `margulis_wus_sr`, `era5_land`
- [x] Smoke: `apply_defaults({})` carries the new `release:` block with safe defaults
- [x] Smoke: `OPTIONAL_CONFIG_FEATURES` includes `release`; detect regex matches both commented stub and live block
- [ ] CI runs the full pytest suite (skipping local pytest per HPC convention)

Closes part of #241. The umbrella tracking issue is #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)