### PR TITLE
feature(release): PR-B lineage capture (manifest.json.steps[])

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -152,20 +152,28 @@ def update_manifest(
         )
 
         # output_files is project-workdir-relative; resolve before stat.
+        # Workers only hash the slice they just wrote -- total hash cost
+        # scales with output size, not workspace size.
         output_entries: list[dict] = []
+        missing_outputs: list[str] = []
         for rel in output_files:
             abs_path = (project.workdir / rel).resolve()
             if abs_path.exists():
-                # output_file_entry computes sha256 -- per the plan,
-                # output integrity is what downstream FGDC consumers
-                # need; per-worker call sha256s only the slice this
-                # worker just wrote, so total cost is bounded.
                 output_entries.append(output_file_entry(abs_path))
+            else:
+                missing_outputs.append(rel)
+                logger.warning(
+                    "lineage: aggregate output %s listed in source-entry "
+                    "but not on disk; step record will omit its sha256",
+                    abs_path,
+                )
         step_params: dict = {"period": period, "fabric_sha256": fabric_sha}
         if batch_size is not None:
             step_params["batch_size"] = int(batch_size)
         if n_workers != 1:
             step_params["n_workers"] = int(n_workers)
+        if missing_outputs:
+            step_params["missing_outputs"] = missing_outputs
         manifest["steps"].append(
             build_step_record(
                 kind="aggregate",

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -138,6 +138,48 @@ def update_manifest(
         existing.update(entry)
         manifest["sources"][source_key] = existing
 
+        # Append a lineage step inside the SAME flock-protected critical
+        # section. This is the only place across the codebase where we
+        # update both ``sources[source_key]`` and ``steps`` in one write
+        # under one lock -- preserving the property that an interrupted
+        # SLURM array worker cannot leave the manifest with one but not
+        # the other. We import locally to keep release/lineage.py off the
+        # aggregate import path until it's needed (the release stack is
+        # PR-B-introduced; the aggregator predates it).
+        from nhf_spatial_targets.release.lineage import (
+            build_step_record,
+            output_file_entry,
+        )
+
+        # output_files is project-workdir-relative; resolve before stat.
+        output_entries: list[dict] = []
+        for rel in output_files:
+            abs_path = (project.workdir / rel).resolve()
+            if abs_path.exists():
+                # output_file_entry computes sha256 -- per the plan,
+                # output integrity is what downstream FGDC consumers
+                # need; per-worker call sha256s only the slice this
+                # worker just wrote, so total cost is bounded.
+                output_entries.append(output_file_entry(abs_path))
+        step_params: dict = {"period": period, "fabric_sha256": fabric_sha}
+        if batch_size is not None:
+            step_params["batch_size"] = int(batch_size)
+        if n_workers != 1:
+            step_params["n_workers"] = int(n_workers)
+        manifest["steps"].append(
+            build_step_record(
+                kind="aggregate",
+                source_key=source_key,
+                inputs=[],
+                outputs=output_entries,
+                params=step_params,
+                tool="nhf-targets",
+                command=f"agg {source_key.replace('_', '-')}",
+                software_version=None,
+                timestamp_utc=entry["timestamp"],
+            )
+        )
+
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=manifest_path.parent, suffix=".json.tmp"
         )

--- a/src/nhf_spatial_targets/fetch/daymet.py
+++ b/src/nhf_spatial_targets/fetch/daymet.py
@@ -463,6 +463,7 @@ def _update_manifest(
             manifest = {"sources": {}, "steps": []}
 
         manifest.setdefault("sources", {})
+        manifest.setdefault("steps", [])
         entry = manifest["sources"].get(_SOURCE_KEY, {})
         existing_regions = entry.get("regions", {}) or {}
         # Merge: keep regions we didn't touch this run, overwrite the ones we did.
@@ -481,6 +482,27 @@ def _update_manifest(
             }
         )
         manifest["sources"][_SOURCE_KEY] = entry
+
+        # Release PR-B: append a lineage step inside the same flock,
+        # so the region merge and the step record land atomically.
+        # Daymet is metadata-only (4.6 TB on ORNL DAAC, not republished),
+        # so ``outputs`` only carries the per-region zarr-fingerprint
+        # metadata that was already computed by the fetch step.
+        from nhf_spatial_targets.release.lineage import build_step_record
+
+        manifest["steps"].append(
+            build_step_record(
+                kind="consolidate",
+                source_key=_SOURCE_KEY,
+                outputs=[],  # zarr stores are not republished; see catalog
+                params={
+                    "period": period,
+                    "regions": sorted(region_records.keys()),
+                    "n_regions": len(region_records),
+                },
+                command=f"fetch {_SOURCE_KEY}",
+            )
+        )
 
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=manifest_path.parent, suffix=".json.tmp"

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -846,6 +846,7 @@ def _update_manifest(
             manifest = {"sources": {}, "steps": []}
 
         manifest.setdefault("sources", {})
+        manifest.setdefault("steps", [])
         entry = manifest["sources"].get(_SOURCE_KEY, {})
 
         # Merge files by year so incremental runs accumulate records.
@@ -894,6 +895,35 @@ def _update_manifest(
             }
         )
         manifest["sources"][_SOURCE_KEY] = entry
+
+        # Release PR-B: lineage step inside the same flock as the year
+        # merge. Only the daily NCs THIS worker just wrote contribute to
+        # ``outputs`` -- merged_files contains the union across workers
+        # and would over-attribute output_files to a single step.
+        from nhf_spatial_targets.release.lineage import (
+            build_step_record,
+            output_file_entry,
+        )
+
+        step_outputs: list[dict] = []
+        for f_rec in files:
+            for key in ("daily_path", "monthly_path", "path"):
+                nc = f_rec.get(key)
+                if nc and Path(nc).exists():
+                    step_outputs.append(output_file_entry(Path(nc)))
+        manifest["steps"].append(
+            build_step_record(
+                kind="consolidate",
+                source_key=_SOURCE_KEY,
+                outputs=step_outputs,
+                params={
+                    "period": effective_period,
+                    "bbox": bbox,
+                    "years": sorted({int(f["year"]) for f in files}),
+                },
+                command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+            )
+        )
 
         fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
         try:

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -823,7 +823,13 @@ def _update_manifest(
     """
     ws = _load_project(workdir)
     manifest_path = ws.manifest_path
-    lock_path = manifest_path.with_suffix(".lock")
+    # Lock filename must match every other call site (aggregate/_driver.py,
+    # release/lineage.py, snodas/margulis/ua_swe/daymet) so concurrent
+    # writers across modules serialize on the same lock. The pre-PR-B
+    # ``with_suffix(".lock")`` produced ``manifest.lock`` instead of
+    # ``manifest.json.lock`` and was a silent race with every other
+    # manifest writer.
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
 
     # Open the lock file in append mode (creates it if absent, never truncates).
     # Hold the exclusive lock for the entire read-modify-write so sibling

--- a/src/nhf_spatial_targets/fetch/gldas.py
+++ b/src/nhf_spatial_targets/fetch/gldas.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -230,27 +227,22 @@ def _update_manifest(
     meta: dict,
     file_info: dict,
 ) -> None:
-    """Merge GLDAS-2.1 provenance into manifest.json."""
+    """Merge GLDAS-2.1 provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard for this module (release PR-B).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupted and cannot be "
-                f"parsed. Inspect the file manually or restore from backup. "
-                f"Detail: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    entry.update(
-        {
+    consolidated = Path(file_info["path"])
+    outputs = [output_file_entry(consolidated)] if consolidated.exists() else []
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
             "license": meta.get("license", "public domain (NASA)"),
@@ -258,16 +250,15 @@ def _update_manifest(
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],
             "file": file_info,
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={
+            "period": period,
+            "bbox": bbox,
+            "n_granules": file_info.get("n_granules", 0),
+        },
+        command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        timestamp_utc=file_info.get("downloaded_utc"),
     )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    fd, tmp = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp).replace(manifest_path)
-    except BaseException:
-        Path(tmp).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with GLDAS-2.1 provenance")

--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -749,6 +749,7 @@ def _update_manifest(
             manifest = {"sources": {}, "steps": []}
 
         manifest.setdefault("sources", {})
+        manifest.setdefault("steps", [])
         entry = manifest["sources"].get(_SOURCE_KEY, {})
         existing_by_year = {int(y["year"]): y for y in entry.get("years", [])}
         for rec in year_records:
@@ -769,6 +770,36 @@ def _update_manifest(
             }
         )
         manifest["sources"][_SOURCE_KEY] = entry
+
+        # Release PR-B: lineage step inside the same flock as the year
+        # merge. Fabric scope is reflected in step params so PR-D's FGDC
+        # generator can flag the fabric-restricted consumption rule.
+        from nhf_spatial_targets.release.lineage import (
+            build_step_record,
+            output_file_entry,
+        )
+
+        step_outputs: list[dict] = []
+        for rec in year_records:
+            for key in ("consolidated_nc", "consolidated_path", "path"):
+                nc = rec.get(key)
+                if nc and Path(nc).exists():
+                    step_outputs.append(output_file_entry(Path(nc)))
+                    break
+        manifest["steps"].append(
+            build_step_record(
+                kind="consolidate",
+                source_key=_SOURCE_KEY,
+                outputs=step_outputs,
+                params={
+                    "period": period,
+                    "years": [int(rec["year"]) for rec in year_records],
+                    "search_bbox": list(search_bbox),
+                    "fabric_scope": fabric_scope,
+                },
+                command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+            )
+        )
 
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=manifest_path.parent, suffix=".json.tmp"

--- a/src/nhf_spatial_targets/fetch/merra2.py
+++ b/src/nhf_spatial_targets/fetch/merra2.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
-import tempfile
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -233,25 +231,25 @@ def _update_manifest(
     files: list[dict],
     consolidation: dict,
 ) -> None:
-    """Merge MERRA-2 provenance into manifest.json."""
+    """Merge MERRA-2 provenance into manifest.json and record a lineage step.
+
+    Delegates to :func:`release.lineage.merge_source_and_append_step` so
+    the read-merge-write happens under a single advisory ``flock`` and
+    the ``kind=consolidate`` lineage step is appended atomically with
+    the source-entry update (release PR-B; closes #180 for this module).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupted. Detail: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
-    merra2 = manifest["sources"].get(_SOURCE_KEY, {})
-    merra2.update(
-        {
+    consolidated_nc = Path(consolidation["consolidated_nc"])
+    outputs = [output_file_entry(consolidated_nc)] if consolidated_nc.exists() else []
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
             "license": resolve_license(meta, _SOURCE_KEY),
@@ -261,16 +259,15 @@ def _update_manifest(
             "files": files,
             "consolidated_nc": consolidation["consolidated_nc"],
             "last_consolidated_utc": consolidation["last_consolidated_utc"],
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={
+            "period": period,
+            "bbox": bbox,
+            "n_files": len(files),
+        },
+        command=f"fetch {_SOURCE_KEY}",
+        timestamp_utc=consolidation["last_consolidated_utc"],
     )
-    manifest["sources"][_SOURCE_KEY] = merra2
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with MERRA-2 provenance")

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import gc
 import json
 import logging
-import os
 import re
-import tempfile
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -319,27 +317,28 @@ def _update_manifest(
     files: list[dict],
     consolidated_ncs: dict[str, str],
 ) -> None:
-    """Merge MODIS provenance into ``manifest.json`` with atomic write."""
+    """Merge MODIS provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard (release PR-B). MODIS year-chunked
+    consolidation produces multiple per-year NCs; each one is fingerprinted
+    in ``outputs`` so FGDC consumers can verify integrity.
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupted and cannot be parsed. "
-                f"Inspect the file manually or restore from backup. Detail: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
     now_utc = datetime.now(timezone.utc).isoformat()
-    entry = manifest["sources"].get(source_key, {})
-    entry.update(
-        {
+    outputs: list[dict] = []
+    for nc_path in consolidated_ncs.values():
+        p = Path(nc_path)
+        if p.exists():
+            outputs.append(output_file_entry(p))
+    merge_source_and_append_step(
+        ws.manifest_path,
+        source_key,
+        source_updates={
             "source_key": source_key,
             "access_url": meta["access"]["url"],
             "license": resolve_license(meta, source_key),
@@ -349,18 +348,18 @@ def _update_manifest(
             "files": files,
             "consolidated_ncs": consolidated_ncs,
             "last_consolidated_utc": now_utc if consolidated_ncs else None,
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={
+            "period": period,
+            "bbox": bbox,
+            "n_files": len(files),
+            "n_year_chunks": len(consolidated_ncs),
+        },
+        command=f"fetch {source_key.replace('_', '-')}",
+        timestamp_utc=now_utc,
     )
-    manifest["sources"][source_key] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with %s provenance", source_key)
 
 

--- a/src/nhf_spatial_targets/fetch/mwbm_climgrid.py
+++ b/src/nhf_spatial_targets/fetch/mwbm_climgrid.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
-import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -311,26 +309,27 @@ def _update_manifest(
     license_str: str,
     file_record: dict,
 ) -> None:
-    """Merge mwbm_climgrid provenance into manifest.json."""
-    ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupt and cannot be "
-                f"parsed. Delete it and re-run the fetch step. "
-                f"Original error: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
+    """Merge mwbm_climgrid provenance + lineage step via the shared helper.
 
-    manifest.setdefault("sources", {})
+    Closes the #180 flock hazard (release PR-B). The catalog already
+    carries a sha256 in ``file_record`` so this reuses it rather than
+    re-hashing the (multi-GB) consolidated NC a second time.
+    """
+    from nhf_spatial_targets.release.lineage import merge_source_and_append_step
+
+    ws = _load_project(workdir)
     access = meta["access"]
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    entry.update(
-        {
+    output_entry = {
+        "path": file_record["path"],
+        "size_bytes": file_record["size_bytes"],
+        "mtime_utc": file_record.get("registered_utc"),
+    }
+    if "sha256" in file_record:
+        output_entry["sha256"] = file_record["sha256"]
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": access["url"],
             "doi": meta["doi"],
@@ -339,16 +338,14 @@ def _update_manifest(
             "spatial_extent": meta.get("spatial_extent", "CONUS"),
             "variables": [v["name"] for v in meta["variables"]],
             "file": file_record,
-        }
+        },
+        kind="consolidate",
+        outputs=[output_entry],
+        params={
+            "period": period,
+            "spatial_extent": meta.get("spatial_extent", "CONUS"),
+        },
+        command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        timestamp_utc=file_record.get("registered_utc"),
     )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with mwbm_climgrid provenance")

--- a/src/nhf_spatial_targets/fetch/ncep_ncar.py
+++ b/src/nhf_spatial_targets/fetch/ncep_ncar.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
 import urllib.error
 import urllib.request
 import warnings
@@ -233,25 +231,24 @@ def _update_manifest(
     files: list[dict],
     consolidation: dict,
 ) -> None:
-    """Merge NCEP/NCAR provenance into manifest.json."""
+    """Merge NCEP/NCAR provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard for this module (release PR-B).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupted. Detail: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    entry.update(
-        {
+    consolidated_nc = consolidation.get("consolidated_nc")
+    outputs: list[dict] = []
+    if consolidated_nc and Path(consolidated_nc).exists():
+        outputs = [output_file_entry(Path(consolidated_nc))]
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": meta["access"]["url"],
             "license": resolve_license(meta, _SOURCE_KEY),
@@ -259,18 +256,13 @@ def _update_manifest(
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],
             "files": files,
-            "consolidated_nc": consolidation.get("consolidated_nc"),
+            "consolidated_nc": consolidated_nc,
             "last_consolidated_utc": consolidation.get("last_consolidated_utc"),
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={"period": period, "bbox": bbox, "n_files": len(files)},
+        command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        timestamp_utc=consolidation.get("last_consolidated_utc"),
     )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with NCEP/NCAR provenance")

--- a/src/nhf_spatial_targets/fetch/nldas.py
+++ b/src/nhf_spatial_targets/fetch/nldas.py
@@ -282,25 +282,22 @@ def _update_manifest(
     files: list[dict],
     consolidation: dict,
 ) -> None:
-    """Merge NLDAS provenance into manifest.json."""
+    """Merge NLDAS provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard for this module (release PR-B).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupted. Detail: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
-    entry = manifest["sources"].get(source_key, {})
-    entry.update(
-        {
+    consolidated_nc = Path(consolidation["consolidated_nc"])
+    outputs = [output_file_entry(consolidated_nc)] if consolidated_nc.exists() else []
+    merge_source_and_append_step(
+        ws.manifest_path,
+        source_key,
+        source_updates={
             "source_key": source_key,
             "access_url": meta["access"]["url"],
             "license": resolve_license(meta, source_key),
@@ -310,20 +307,11 @@ def _update_manifest(
             "files": files,
             "consolidated_nc": consolidation["consolidated_nc"],
             "last_consolidated_utc": consolidation["last_consolidated_utc"],
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={"period": period, "bbox": bbox, "n_files": len(files)},
+        command=f"fetch {source_key.replace('_', '-')}",
+        timestamp_utc=consolidation["last_consolidated_utc"],
     )
-    manifest["sources"][source_key] = entry
-
-    import tempfile
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        import os
-
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with %s provenance", source_key)

--- a/src/nhf_spatial_targets/fetch/pangaea.py
+++ b/src/nhf_spatial_targets/fetch/pangaea.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 import shutil
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -216,28 +213,23 @@ def _update_manifest(
     license_str: str,
     file_info: dict,
 ) -> None:
-    """Merge WaterGAP 2.2d provenance into manifest.json."""
+    """Merge WaterGAP 2.2d provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard for this module (release PR-B).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupt and cannot be "
-                f"parsed. You may need to delete it and re-run the fetch "
-                f"step. Original error: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
     access = meta["access"]
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    entry.update(
-        {
+    nc_path = Path(file_info["path"])
+    outputs = [output_file_entry(nc_path)] if nc_path.exists() else []
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": access["url"],
             "doi": access["doi"],
@@ -246,16 +238,11 @@ def _update_manifest(
             "bbox": bbox,
             "variables": [v["name"] for v in meta["variables"]],
             "file": file_info,
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={"period": period, "bbox": bbox},
+        command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        timestamp_utc=file_info.get("downloaded_utc"),
     )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with WaterGAP 2.2d provenance")

--- a/src/nhf_spatial_targets/fetch/reitz2017.py
+++ b/src/nhf_spatial_targets/fetch/reitz2017.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -369,28 +366,23 @@ def _update_manifest(
     license_str: str,
     file_info: dict,
 ) -> None:
-    """Merge Reitz 2017 provenance into manifest.json."""
+    """Merge Reitz 2017 provenance + lineage step via the shared helper.
+
+    Closes the #180 flock hazard for this module (release PR-B).
+    """
+    from nhf_spatial_targets.release.lineage import (
+        merge_source_and_append_step,
+        output_file_entry,
+    )
+
     ws = _load_project(workdir)
-    manifest_path = ws.manifest_path
-    if manifest_path.exists():
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"manifest.json in {workdir} is corrupt and cannot be "
-                f"parsed. You may need to delete it and re-run the fetch "
-                f"step. Original error: {exc}"
-            ) from exc
-    else:
-        manifest = {"sources": {}, "steps": []}
-
-    if "sources" not in manifest:
-        manifest["sources"] = {}
-
     access = meta["access"]
-    entry = manifest["sources"].get(_SOURCE_KEY, {})
-    entry.update(
-        {
+    nc_path = Path(file_info["path"])
+    outputs = [output_file_entry(nc_path)] if nc_path.exists() else []
+    merge_source_and_append_step(
+        ws.manifest_path,
+        _SOURCE_KEY,
+        source_updates={
             "source_key": _SOURCE_KEY,
             "access_url": access["url"],
             "doi": access["doi"],
@@ -399,16 +391,15 @@ def _update_manifest(
             "spatial_extent": "CONUS",
             "variables": [v["name"] for v in meta["variables"]],
             "file": file_info,
-        }
+        },
+        kind="consolidate",
+        outputs=outputs,
+        params={
+            "period": period,
+            "years": file_info.get("years", []),
+            "spatial_extent": "CONUS",
+        },
+        command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        timestamp_utc=file_info.get("downloaded_utc"),
     )
-    manifest["sources"][_SOURCE_KEY] = entry
-
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
-    try:
-        with os.fdopen(tmp_fd, "w") as f:
-            json.dump(manifest, f, indent=2)
-        Path(tmp_path).replace(manifest_path)
-    except BaseException:
-        Path(tmp_path).unlink(missing_ok=True)
-        raise
     logger.info("Updated manifest.json with Reitz 2017 provenance")

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1246,6 +1246,7 @@ def _update_manifest(
             manifest = {"sources": {}, "steps": []}
 
         manifest.setdefault("sources", {})
+        manifest.setdefault("steps", [])
         entry = manifest["sources"].get(_SOURCE_KEY, {})
         existing_by_year = {int(y["year"]): y for y in entry.get("years", [])}
         for rec in year_records:
@@ -1265,6 +1266,36 @@ def _update_manifest(
             }
         )
         manifest["sources"][_SOURCE_KEY] = entry
+
+        # Release PR-B: lineage step inside the same flock as the year-
+        # records merge. Each year's consolidated NC path comes from the
+        # year_records this call just produced; fingerprint each so PR-D's
+        # FGDC consumer can verify integrity per-year.
+        from nhf_spatial_targets.release.lineage import (
+            build_step_record,
+            output_file_entry,
+        )
+
+        step_outputs: list[dict] = []
+        for rec in year_records:
+            for key in ("consolidated_nc", "consolidated_path"):
+                nc = rec.get(key)
+                if nc and Path(nc).exists():
+                    step_outputs.append(output_file_entry(Path(nc)))
+                    break
+        manifest["steps"].append(
+            build_step_record(
+                kind="consolidate",
+                source_key=_SOURCE_KEY,
+                outputs=step_outputs,
+                params={
+                    "period": period,
+                    "years": [int(rec["year"]) for rec in year_records],
+                    "archive_url": archive_url,
+                },
+                command=f"fetch {_SOURCE_KEY}",
+            )
+        )
 
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=manifest_path.parent, suffix=".json.tmp"

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -565,6 +565,7 @@ def _update_manifest(
             manifest = {"sources": {}, "steps": []}
 
         manifest.setdefault("sources", {})
+        manifest.setdefault("steps", [])
         entry = manifest["sources"].get(_SOURCE_KEY, {})
         existing_by_wy = {int(y["water_year"]): y for y in entry.get("water_years", [])}
         for rec in wy_records:
@@ -588,6 +589,33 @@ def _update_manifest(
             # Preserve any prior mask record if this run didn't touch it.
             entry["mask"] = mask_record
         manifest["sources"][_SOURCE_KEY] = entry
+
+        # Release PR-B: lineage step inside the same flock.
+        from nhf_spatial_targets.release.lineage import (
+            build_step_record,
+            output_file_entry,
+        )
+
+        step_outputs: list[dict] = []
+        for rec in wy_records:
+            for key in ("consolidated_nc", "consolidated_path", "path"):
+                nc = rec.get(key)
+                if nc and Path(nc).exists():
+                    step_outputs.append(output_file_entry(Path(nc)))
+                    break
+        manifest["steps"].append(
+            build_step_record(
+                kind="consolidate",
+                source_key=_SOURCE_KEY,
+                outputs=step_outputs,
+                params={
+                    "period": period,
+                    "water_years": [int(rec["water_year"]) for rec in wy_records],
+                    "archive_url": archive_url,
+                },
+                command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+            )
+        )
 
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=manifest_path.parent, suffix=".json.tmp"

--- a/src/nhf_spatial_targets/release/__init__.py
+++ b/src/nhf_spatial_targets/release/__init__.py
@@ -1,0 +1,28 @@
+"""Release tooling for the ScienceBase data-release feature.
+
+Public surface is added incrementally per the PR phasing in
+``~/.claude/plans/a-requirement-is-pushlishing-vast-crayon.md``. PR-B
+introduces :mod:`nhf_spatial_targets.release.lineage`; later PRs add
+``payload``, ``checksums``, ``mcf``, ``fgdc``, ``iso``, ``readme``,
+``sb_client``, ``registry``, ``build``, ``publish``, and ``cli``.
+"""
+
+from __future__ import annotations
+
+from nhf_spatial_targets.release.lineage import (
+    append_step,
+    build_step_record,
+    input_file_entry,
+    merge_source_and_append_step,
+    output_file_entry,
+    sha256_file,
+)
+
+__all__ = [
+    "append_step",
+    "build_step_record",
+    "input_file_entry",
+    "merge_source_and_append_step",
+    "output_file_entry",
+    "sha256_file",
+]

--- a/src/nhf_spatial_targets/release/lineage.py
+++ b/src/nhf_spatial_targets/release/lineage.py
@@ -1,0 +1,393 @@
+"""Lineage capture for ``manifest.json.steps[]``.
+
+Every pipeline write-site (validate, consolidate, aggregate, target,
+nn_fill) appends one step record describing what ran, with which inputs
+and outputs. ``release.fgdc`` (PR-D) consumes
+``manifest.json.steps[]`` to populate FGDC CSDGM
+``dataquality.lineage.processstep[]`` -- so this module is the single
+seam by which provenance flows from the live pipeline to the published
+data release.
+
+The flock pattern mirrors
+:func:`nhf_spatial_targets.aggregate._driver.update_manifest`: an
+advisory ``LOCK_EX`` on ``<manifest_path>.lock`` guards the
+read-modify-write so concurrent SLURM array workers don't lose each
+other's step appends.
+
+Public surface:
+
+- :func:`append_step` -- append a single step to ``manifest.json.steps``.
+- :func:`merge_source_and_append_step` -- atomic read-merge-write that
+  both updates ``manifest["sources"][source_key]`` and appends a step.
+  Replaces the bespoke ``_update_manifest`` patterns scattered across
+  fetch modules (see #180) with a single canonical implementation.
+- :func:`output_file_entry` / :func:`input_file_entry` -- shape helpers.
+  Outputs carry ``sha256`` (cheap to compute on a file we just wrote);
+  inputs carry only path + size + mtime, by design, so ``aggregate``
+  runs that read dozens of consolidated NCs don't pay an extra
+  full-file hash pass.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from nhf_spatial_targets import __version__ as _SOFTWARE_VERSION
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:  # Windows fallback (not used on HPC).
+    _HAVE_FLOCK = False
+
+
+# Kinds of pipeline steps we capture. Mirrors the table in
+# ``~/.claude/plans/a-requirement-is-pushlishing-vast-crayon.md``
+# (``Lineage capture`` section). The set is closed: PR-D's FGDC
+# generator pattern-matches on these strings to choose the right
+# CSDGM ``procdesc`` phrasing.
+STEP_KINDS = frozenset(
+    {"fetch", "consolidate", "aggregate", "target", "nn_fill", "validate"}
+)
+
+
+_SHA256_CHUNK_BYTES = 1024 * 1024
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 hex digest of *path*, streamed in 1 MiB blocks.
+
+    Used by :func:`output_file_entry` to fingerprint just-written files;
+    streaming keeps memory flat regardless of file size (consolidated
+    NCs are routinely multi-GB).
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            block = f.read(_SHA256_CHUNK_BYTES)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def _file_basics(path: Path) -> dict:
+    """Return ``{"path", "size_bytes", "mtime_utc"}`` for *path*."""
+    st = path.stat()
+    return {
+        "path": str(path),
+        "size_bytes": int(st.st_size),
+        "mtime_utc": datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat(),
+    }
+
+
+def output_file_entry(path: Path, *, compute_sha256: bool = True) -> dict:
+    """File-entry shape for ``step["outputs"]``.
+
+    Includes ``sha256`` by default -- the file was just written, so
+    hashing is cheap relative to the write itself. Pass
+    ``compute_sha256=False`` only for tests or for the rare case where
+    a step records an output that other consumers will hash later.
+
+    Parameters
+    ----------
+    path
+        Path to the just-written output file. Must exist.
+    compute_sha256
+        When ``True`` (default), include the file's SHA-256 hex digest.
+
+    Returns
+    -------
+    dict with keys ``path``, ``size_bytes``, ``mtime_utc`` and, when
+    ``compute_sha256`` is True, ``sha256``.
+    """
+    entry = _file_basics(path)
+    if compute_sha256:
+        entry["sha256"] = sha256_file(path)
+    return entry
+
+
+def input_file_entry(path: Path) -> dict:
+    """File-entry shape for ``step["inputs"]``.
+
+    No SHA-256 by design: an ``aggregate`` step over a 30-source fabric
+    reads dozens of multi-GB consolidated NCs, and hashing each input
+    would dominate runtime. Outputs do carry sha256 (see
+    :func:`output_file_entry`), which is what downstream consumers
+    really need for integrity checks of the published release.
+    """
+    return _file_basics(path)
+
+
+def _new_manifest_skeleton() -> dict:
+    """Return a fresh ``manifest.json`` skeleton.
+
+    Single source of truth: ``{"sources": {}, "steps": []}``. Used both
+    when ``manifest.json`` is absent and when this module is invoked
+    against a fresh project (validate stage).
+    """
+    return {"sources": {}, "steps": []}
+
+
+def _read_manifest(manifest_path: Path) -> dict:
+    """Read ``manifest.json`` or return a fresh skeleton.
+
+    Raises ``ValueError`` on parse failure -- a corrupt manifest is a
+    loud failure mode, not something to silently overwrite. The
+    aggregator and the per-fetch ``_update_manifest`` helpers all share
+    this contract.
+    """
+    if not manifest_path.exists():
+        return _new_manifest_skeleton()
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest.json at {manifest_path} is corrupt: {exc}") from exc
+    manifest.setdefault("sources", {})
+    manifest.setdefault("steps", [])
+    return manifest
+
+
+def _atomic_write_manifest(manifest_path: Path, manifest: dict) -> None:
+    """Write *manifest* to *manifest_path* via tempfile + rename.
+
+    Indented JSON keeps diffs auditable; ``Path.replace`` is atomic on
+    the same filesystem, so a partial manifest never lands at the final
+    path.
+    """
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=manifest_path.parent, suffix=".json.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            json.dump(manifest, f, indent=2)
+        Path(tmp_path).replace(manifest_path)
+    except Exception:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+
+
+def build_step_record(
+    *,
+    kind: str,
+    source_key: str | None,
+    inputs: list[dict] | None = None,
+    outputs: list[dict] | None = None,
+    params: dict | None = None,
+    tool: str = "nhf-targets",
+    command: str | None = None,
+    software_version: str | None = None,
+    timestamp_utc: str | None = None,
+) -> dict:
+    """Assemble a normalized step record. Pure function; no I/O.
+
+    Exposed for the rare in-process call site (the aggregator) that
+    already holds its own flock on ``manifest.json`` and just needs the
+    record shape -- calling :func:`append_step` from inside that lock
+    would deadlock. Most call sites should use :func:`append_step` or
+    :func:`merge_source_and_append_step` instead.
+    """
+    if kind not in STEP_KINDS:
+        raise ValueError(
+            f"Unknown step kind {kind!r}; expected one of {sorted(STEP_KINDS)}"
+        )
+    if timestamp_utc is None:
+        timestamp_utc = datetime.now(timezone.utc).isoformat()
+    if software_version is None:
+        software_version = _SOFTWARE_VERSION
+    record: dict = {
+        "kind": kind,
+        "source_key": source_key,
+        "timestamp_utc": timestamp_utc,
+        "software_version": software_version,
+        "tool": tool,
+        "command": command,
+        "inputs": list(inputs) if inputs else [],
+        "outputs": list(outputs) if outputs else [],
+        "params": dict(params) if params else {},
+    }
+    return record
+
+
+def _with_flock(lock_path: Path, body):
+    """Run *body* under an advisory ``LOCK_EX`` on *lock_path*.
+
+    Falls back to a bare invocation when ``fcntl`` is unavailable
+    (Windows; not used in production on this HPC pipeline, but keeps
+    the tests portable).
+    """
+    if not _HAVE_FLOCK:
+        return body()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a") as lock_f:
+        _fcntl.flock(lock_f, _fcntl.LOCK_EX)
+        try:
+            return body()
+        finally:
+            _fcntl.flock(lock_f, _fcntl.LOCK_UN)
+
+
+def append_step(
+    manifest_path: Path,
+    *,
+    kind: str,
+    source_key: str | None,
+    inputs: list[dict] | None = None,
+    outputs: list[dict] | None = None,
+    params: dict | None = None,
+    tool: str = "nhf-targets",
+    command: str | None = None,
+    software_version: str | None = None,
+    timestamp_utc: str | None = None,
+) -> dict:
+    """Append a single step to ``manifest.json.steps[]`` under flock.
+
+    Reads (or initializes) the manifest, appends one normalized step
+    record, and writes atomically. Concurrent callers see a sorted
+    sequence of appends (no torn writes, no lost step).
+
+    Parameters
+    ----------
+    manifest_path
+        Path to ``<project>/manifest.json``. Parent dir must already
+        exist; the file may or may not.
+    kind
+        One of :data:`STEP_KINDS`.
+    source_key
+        Catalog source key (e.g. ``"era5_land"``); ``None`` for
+        fabric-level steps (``validate``, the stitched ``target``).
+    inputs, outputs
+        File-entry lists. Use :func:`input_file_entry` /
+        :func:`output_file_entry` to build them. Default to ``[]``.
+    params
+        Step-specific parameters (e.g. ``{"batch_size": 10000}``).
+        Default ``{}``.
+    tool, command
+        Provenance for the CLI invocation that ran this step.
+    software_version
+        Defaults to ``nhf_spatial_targets.__version__``. Tests inject.
+    timestamp_utc
+        Defaults to ``datetime.now(timezone.utc).isoformat()``. Tests
+        inject for byte-stable golden files.
+
+    Returns
+    -------
+    The step record that was appended (useful for test assertions and
+    log lines).
+    """
+    record = build_step_record(
+        kind=kind,
+        source_key=source_key,
+        inputs=inputs or [],
+        outputs=outputs or [],
+        params=params,
+        tool=tool,
+        command=command,
+        software_version=software_version,
+        timestamp_utc=timestamp_utc,
+    )
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+
+    def _do() -> None:
+        manifest = _read_manifest(manifest_path)
+        manifest["steps"].append(record)
+        _atomic_write_manifest(manifest_path, manifest)
+
+    _with_flock(lock_path, _do)
+    logger.info(
+        "lineage: appended step kind=%s source_key=%s outputs=%d",
+        record["kind"],
+        record["source_key"],
+        len(record["outputs"]),
+    )
+    return record
+
+
+def merge_source_and_append_step(
+    manifest_path: Path,
+    source_key: str,
+    *,
+    source_updates: dict,
+    kind: str,
+    inputs: list[dict] | None = None,
+    outputs: list[dict] | None = None,
+    params: dict | None = None,
+    tool: str = "nhf-targets",
+    command: str | None = None,
+    software_version: str | None = None,
+    timestamp_utc: str | None = None,
+) -> dict:
+    """Atomic source-merge + step-append.
+
+    Replaces the bespoke ``_update_manifest`` helpers each fetch module
+    used to carry. The merge semantics match the pre-existing pattern:
+    ``manifest["sources"][source_key]`` is updated with *source_updates*
+    via ``dict.update`` (existing keys preserved unless overridden), so
+    e.g. era5_land's ``years`` block survives a re-fetch that only
+    rewrites ``last_consolidated_utc``.
+
+    Both operations happen inside the same flock, so a SLURM array
+    worker that crashes between source merge and step append cannot
+    leave the manifest with one but not the other.
+
+    Parameters
+    ----------
+    manifest_path
+        Path to ``<project>/manifest.json``.
+    source_key
+        Catalog source key (e.g. ``"merra2"``).
+    source_updates
+        Keys to merge into ``manifest["sources"][source_key]``. Must
+        not include ``"steps"``.
+    kind, inputs, outputs, params, tool, command, software_version,
+    timestamp_utc
+        Forwarded to the step record. See :func:`append_step`.
+
+    Returns
+    -------
+    The appended step record.
+    """
+    if "steps" in source_updates:
+        raise ValueError(
+            "source_updates must not include 'steps' -- the steps array "
+            "lives at the top level of manifest.json, not nested under a "
+            "source."
+        )
+    record = build_step_record(
+        kind=kind,
+        source_key=source_key,
+        inputs=inputs or [],
+        outputs=outputs or [],
+        params=params,
+        tool=tool,
+        command=command,
+        software_version=software_version,
+        timestamp_utc=timestamp_utc,
+    )
+    lock_path = manifest_path.with_suffix(manifest_path.suffix + ".lock")
+
+    def _do() -> None:
+        manifest = _read_manifest(manifest_path)
+        existing = manifest["sources"].get(source_key, {})
+        existing.update(source_updates)
+        manifest["sources"][source_key] = existing
+        manifest["steps"].append(record)
+        _atomic_write_manifest(manifest_path, manifest)
+
+    _with_flock(lock_path, _do)
+    logger.info(
+        "lineage: merged source=%s + appended step kind=%s outputs=%d",
+        source_key,
+        record["kind"],
+        len(record["outputs"]),
+    )
+    return record

--- a/src/nhf_spatial_targets/release/lineage.py
+++ b/src/nhf_spatial_targets/release/lineage.py
@@ -47,8 +47,13 @@ try:
     import fcntl as _fcntl
 
     _HAVE_FLOCK = True
-except ImportError:  # Windows fallback (not used on HPC).
+except ImportError:  # Windows fallback.
     _HAVE_FLOCK = False
+    logger.warning(
+        "lineage: fcntl unavailable on this platform; concurrent manifest "
+        "writes WILL lose lineage records under contention. Use a POSIX "
+        "system for production runs."
+    )
 
 
 # Kinds of pipeline steps we capture. Mirrors the table in

--- a/src/nhf_spatial_targets/targets/_driver.py
+++ b/src/nhf_spatial_targets/targets/_driver.py
@@ -234,6 +234,7 @@ def build_single_shot(
         nn_fill=bool(target_cfg["nn_fill"]),
         nn_max_candidates=int(target_cfg["nn_max_candidates"]),
         id_col=id_col,
+        target_key=adapter.target_key,
     )
 
 
@@ -360,6 +361,7 @@ def _build_year_chunked(
             nn_fill=nn_fill,
             nn_max_candidates=nn_max_candidates,
             id_col=id_col,
+            target_key=adapter.target_key,
         )
 
     # Prune orphans + compute stitch input from year_specs (#211).

--- a/src/nhf_spatial_targets/targets/_driver.py
+++ b/src/nhf_spatial_targets/targets/_driver.py
@@ -392,6 +392,8 @@ def _build_year_chunked(
         title=adapter.title,
         extra_global_attrs=stitch_attrs,
         sort_dim=id_col,
+        project=project,
+        lineage_kind="target",
     )
 
     if nn_fill:
@@ -411,6 +413,8 @@ def _build_year_chunked(
             title=adapter.nn_title,
             extra_global_attrs=nn_attrs,
             sort_dim=id_col,
+            project=project,
+            lineage_kind="nn_fill",
         )
 
 

--- a/src/nhf_spatial_targets/targets/_intermediates.py
+++ b/src/nhf_spatial_targets/targets/_intermediates.py
@@ -369,6 +369,8 @@ def stitch_year_chunks_to_target(
     title: str,
     extra_global_attrs: dict | None,
     sort_dim: str,
+    project: Project | None = None,
+    lineage_kind: str = "target",
 ) -> None:
     """Lazily open per-year target NCs and stream them into one canonical NC.
 
@@ -404,6 +406,16 @@ def stitch_year_chunks_to_target(
     sort_dim
         Dimension to sort ascending on before write (typically
         ``project.id_col``); also the HRU chunk dimension.
+    project
+        Optional :class:`~nhf_spatial_targets.workspace.Project` used to
+        append a lineage step to ``project.manifest_path`` after the
+        stitch completes (release PR-B). When ``None`` no step is
+        appended -- the pre-PR-B call shape is preserved so tests and
+        external callers that don't have a project remain functional.
+    lineage_kind
+        Step ``kind`` for the appended record; the year-chunked driver
+        passes ``"nn_fill"`` for the nn-filled stitch and ``"target"``
+        (default) for the honest-NaN stitch.
     """
     from datetime import datetime, timezone
 
@@ -503,3 +515,30 @@ def stitch_year_chunks_to_target(
         output_path,
         output_path.stat().st_size / 1e6,
     )
+
+    if project is not None:
+        # Release PR-B: the stitched NC is the canonical target file that
+        # gets published. Record one lineage step per stitch with the per-
+        # year intermediates as inputs (path+size+mtime, no sha256 -- they
+        # are the year-chunked builder's own outputs and were fingerprinted
+        # in their own ``kind=target`` steps already) and the stitched NC
+        # as the output (with sha256, since this is what FGDC consumers
+        # will hash-check).
+        from nhf_spatial_targets.release.lineage import (
+            append_step,
+            input_file_entry,
+            output_file_entry,
+        )
+
+        append_step(
+            project.manifest_path,
+            kind=lineage_kind,
+            source_key=None,
+            inputs=[input_file_entry(p) for p in intermediate_files if p.exists()],
+            outputs=[output_file_entry(output_path)],
+            params={
+                "stitched_from": len(intermediate_files),
+                "sort_dim": sort_dim,
+            },
+            command=f"stitch-{lineage_kind}",
+        )

--- a/src/nhf_spatial_targets/targets/_writers.py
+++ b/src/nhf_spatial_targets/targets/_writers.py
@@ -181,6 +181,7 @@ def write_bounds_target(
     nn_fill: bool,
     nn_max_candidates: int,
     id_col: str,
+    target_key: str | None = None,
 ) -> None:
     """Assemble + write a bounds-target Dataset, with optional NN-fill companion.
 
@@ -240,6 +241,12 @@ def write_bounds_target(
         HRU id column name (e.g. ``"nhm_id"``); the dataset is sorted
         ascending on this dim at emission per the #93 canonical-row-order
         invariant.
+    target_key
+        Canonical target identifier from the adapter (``"runoff"``,
+        ``"aet"``, ``"rch"``, ``"som"``, ``"sca"``, ``"swe"``); used to
+        build the lineage step ``command`` field as ``run-<target_key>``.
+        Falls back to ``"target"`` when ``None`` so out-of-pipeline callers
+        without an adapter still work.
     """
     # Avoid a circular-import by deferring this helper-internal import.
     from nhf_spatial_targets.normalize.methods import nn_fill_bounds
@@ -330,6 +337,7 @@ def write_bounds_target(
         project=project,
         output_path=output_path,
         kind="target",
+        target_key=target_key,
         params={
             "bounds_long_name_kind": bounds_long_name_kind,
             "n_sources_count": int(n_sources_count),
@@ -384,6 +392,7 @@ def write_bounds_target(
         project=project,
         output_path=nn_path,
         kind="nn_fill",
+        target_key=target_key,
         params={
             "bounds_long_name_kind": bounds_long_name_kind,
             "nn_fill_max_candidates": int(nn_max_candidates),
@@ -401,33 +410,27 @@ def _append_target_step(
     kind: str,
     params: dict,
     extra_global_attrs: dict,
+    target_key: str | None,
 ) -> None:
     """Append one target-stage lineage step for *output_path*.
 
-    Helper for :func:`write_bounds_target` (release PR-B). Lifts the
-    sha256 + size + mtime fingerprint of the just-written NC onto
-    ``manifest.json.steps[]`` so PR-D's FGDC generator can populate
-    ``dataquality.lineage.processstep[]`` without re-walking the
-    targets dir. The catalog ``source`` (multi-source-derived target's
-    upstream key list) is forwarded into ``params["source"]`` so the
-    step record stays linkable to the parent aggregate steps.
+    Forwards the comma-separated upstream-source list from
+    ``extra_global_attrs["source"]`` onto the step so consumers don't
+    need to re-open the NC to recover provenance.
     """
     from nhf_spatial_targets.release.lineage import append_step, output_file_entry
 
     step_params = dict(params)
-    # ``extra_global_attrs["source"]`` carries the comma-separated upstream
-    # source list (e.g. ``"era5_land, gldas_noah_v21_monthly, mwbm_climgrid"``)
-    # built by ``_common_global_attrs``. Forwarding it onto the step record
-    # makes the multi-source provenance explicit without re-reading the NC.
     if "source" in extra_global_attrs:
         step_params["source"] = extra_global_attrs["source"]
     if "period" in extra_global_attrs:
         step_params["period"] = extra_global_attrs["period"]
+    command = f"run-{target_key}" if target_key else "run-target"
     append_step(
         project.manifest_path,
         kind=kind,
         source_key=None,
         outputs=[output_file_entry(output_path)],
         params=step_params,
-        command=f"run-{step_params.get('bounds_long_name_kind', 'target').split()[-1]}",
+        command=command,
     )

--- a/src/nhf_spatial_targets/targets/_writers.py
+++ b/src/nhf_spatial_targets/targets/_writers.py
@@ -326,6 +326,17 @@ def write_bounds_target(
         extra_global_attrs=extra_global_attrs,
         sort_dim=id_col,
     )
+    _append_target_step(
+        project=project,
+        output_path=output_path,
+        kind="target",
+        params={
+            "bounds_long_name_kind": bounds_long_name_kind,
+            "n_sources_count": int(n_sources_count),
+            "id_col": id_col,
+        },
+        extra_global_attrs=extra_global_attrs,
+    )
 
     n = ds_loaded["n_sources"].values
     total = n.size
@@ -368,4 +379,55 @@ def write_bounds_target(
         title=nn_title,
         extra_global_attrs=filled_attrs,
         sort_dim=id_col,
+    )
+    _append_target_step(
+        project=project,
+        output_path=nn_path,
+        kind="nn_fill",
+        params={
+            "bounds_long_name_kind": bounds_long_name_kind,
+            "nn_fill_max_candidates": int(nn_max_candidates),
+            "nn_fill_distance_crs": project.area_crs,
+            "id_col": id_col,
+        },
+        extra_global_attrs=filled_attrs,
+    )
+
+
+def _append_target_step(
+    *,
+    project: Project,
+    output_path: Path,
+    kind: str,
+    params: dict,
+    extra_global_attrs: dict,
+) -> None:
+    """Append one target-stage lineage step for *output_path*.
+
+    Helper for :func:`write_bounds_target` (release PR-B). Lifts the
+    sha256 + size + mtime fingerprint of the just-written NC onto
+    ``manifest.json.steps[]`` so PR-D's FGDC generator can populate
+    ``dataquality.lineage.processstep[]`` without re-walking the
+    targets dir. The catalog ``source`` (multi-source-derived target's
+    upstream key list) is forwarded into ``params["source"]`` so the
+    step record stays linkable to the parent aggregate steps.
+    """
+    from nhf_spatial_targets.release.lineage import append_step, output_file_entry
+
+    step_params = dict(params)
+    # ``extra_global_attrs["source"]`` carries the comma-separated upstream
+    # source list (e.g. ``"era5_land, gldas_noah_v21_monthly, mwbm_climgrid"``)
+    # built by ``_common_global_attrs``. Forwarding it onto the step record
+    # makes the multi-source provenance explicit without re-reading the NC.
+    if "source" in extra_global_attrs:
+        step_params["source"] = extra_global_attrs["source"]
+    if "period" in extra_global_attrs:
+        step_params["period"] = extra_global_attrs["period"]
+    append_step(
+        project.manifest_path,
+        kind=kind,
+        source_key=None,
+        outputs=[output_file_entry(output_path)],
+        params=step_params,
+        command=f"run-{step_params.get('bounds_long_name_kind', 'target').split()[-1]}",
     )

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -219,11 +219,12 @@ def validate_workspace(workdir: Path) -> None:
         workdir, config
     )  # config is the merged dict from _check_required_keys
 
-    # Record the validation event in the lineage trail (release PR-B).
-    # Inputs: the fabric file we validated. Outputs: the on-disk artifacts
-    # validate just produced. The append happens AFTER _write_manifest so
-    # the lineage helper sees the skeleton's ``steps`` array, not the
-    # carried-over-from-prior-run one.
+    # Append AFTER _write_manifest so the step lands in the freshly
+    # initialized skeleton, not a carried-over prior-run steps array.
+    # ``manifest.json`` is intentionally NOT listed as an output: a step
+    # recording the sha256 of the file it is being written into is
+    # paradoxical -- the recorded hash would describe the pre-append
+    # file, not the file as it now exists on disk.
     from nhf_spatial_targets.release.lineage import (
         append_step,
         input_file_entry,
@@ -240,7 +241,7 @@ def validate_workspace(workdir: Path) -> None:
         inputs=[input_file_entry(fabric_path)],
         outputs=[
             output_file_entry(p)
-            for p in (fabric_json_out, manifest_out, effective_config_out)
+            for p in (fabric_json_out, effective_config_out)
             if p.exists()
         ],
         params={

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -219,6 +219,40 @@ def validate_workspace(workdir: Path) -> None:
         workdir, config
     )  # config is the merged dict from _check_required_keys
 
+    # Record the validation event in the lineage trail (release PR-B).
+    # Inputs: the fabric file we validated. Outputs: the on-disk artifacts
+    # validate just produced. The append happens AFTER _write_manifest so
+    # the lineage helper sees the skeleton's ``steps`` array, not the
+    # carried-over-from-prior-run one.
+    from nhf_spatial_targets.release.lineage import (
+        append_step,
+        input_file_entry,
+        output_file_entry,
+    )
+
+    manifest_out = workdir / "manifest.json"
+    fabric_json_out = workdir / "fabric.json"
+    effective_config_out = workdir / "config.effective.yml"
+    append_step(
+        manifest_out,
+        kind="validate",
+        source_key=None,
+        inputs=[input_file_entry(fabric_path)],
+        outputs=[
+            output_file_entry(p)
+            for p in (fabric_json_out, manifest_out, effective_config_out)
+            if p.exists()
+        ],
+        params={
+            "fabric_sha256": fabric_meta["sha256"],
+            "hru_count": fabric_meta["hru_count"],
+            "id_col": id_col,
+            "id_col_sorted": fabric_meta["id_col_sorted"],
+            "buffer_deg": buffer_deg,
+        },
+        command="validate",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Step helpers

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import geopandas as gpd
@@ -36,6 +37,16 @@ def project(tmp_path):
 
 
 def test_update_manifest_writes_source_entry(project):
+    # Materialize the output NCs on disk so the lineage append has real
+    # files to fingerprint -- otherwise output_file_entry would skip them
+    # and the step's outputs list would be empty.
+    for rel in (
+        "data/aggregated/foo/foo_2000_agg.nc",
+        "data/aggregated/foo/foo_2001_agg.nc",
+    ):
+        abs_path = project.workdir / rel
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_bytes(b"placeholder-agg-nc")
     update_manifest(
         project=project,
         source_key="foo",
@@ -60,6 +71,18 @@ def test_update_manifest_writes_source_entry(project):
     ]
     assert entry["weight_files"] == ["weights/foo_batch0.csv"]
     assert "timestamp" in entry
+    # release PR-B: same flock atomically appends a kind=aggregate step
+    # with sha256-fingerprinted outputs.
+    assert len(manifest["steps"]) == 1
+    step = manifest["steps"][0]
+    assert step["kind"] == "aggregate"
+    assert step["source_key"] == "foo"
+    assert step["command"] == "agg foo"
+    assert {Path(o["path"]).name for o in step["outputs"]} == {
+        "foo_2000_agg.nc",
+        "foo_2001_agg.nc",
+    }
+    assert all("sha256" in o for o in step["outputs"])
 
 
 def test_update_manifest_preserves_existing_sources(project):

--- a/tests/test_era5_land.py
+++ b/tests/test_era5_land.py
@@ -911,6 +911,15 @@ def test_update_manifest_accumulates_years(tmp_path):
     years = [f["year"] for f in entry2["files"]]
     assert years == [1979, 1980]
 
+    # release PR-B: each _update_manifest call appends exactly one
+    # ``kind=consolidate`` lineage step, scoped to era5_land, with the
+    # years this call just wrote in params. Two calls -> two steps.
+    consolidate_steps = [s for s in m2["steps"] if s["kind"] == "consolidate"]
+    assert len(consolidate_steps) == 2
+    assert all(s["source_key"] == "era5_land" for s in consolidate_steps)
+    assert consolidate_steps[0]["params"]["years"] == [1979]
+    assert consolidate_steps[1]["params"]["years"] == [1980]
+
 
 def test_update_manifest_updates_existing_year(tmp_path):
     """Re-running for the same year replaces that year's file record."""

--- a/tests/test_release_lineage.py
+++ b/tests/test_release_lineage.py
@@ -1,0 +1,327 @@
+"""Tests for ``nhf_spatial_targets.release.lineage``.
+
+The lineage module is the foundation under every later release-stage
+PR (FGDC, ISO, README), so the invariants we lock here are:
+
+- ``append_step`` records the exact step record shape PR-D will
+  consume (no field renames downstream),
+- output file entries carry sha256 + size + mtime + path, input
+  entries carry the same minus sha256 (the cost asymmetry from the
+  plan's lineage section),
+- concurrent appenders never lose a step (the SLURM array hazard
+  the existing aggregator's ``update_manifest`` already addresses),
+- ``merge_source_and_append_step`` is the single canonical
+  read-modify-write that fetch modules can adopt without recreating
+  their bespoke flock code (#180).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from nhf_spatial_targets.release.lineage import (
+    STEP_KINDS,
+    append_step,
+    input_file_entry,
+    merge_source_and_append_step,
+    output_file_entry,
+    sha256_file,
+)
+
+
+@pytest.fixture
+def manifest_path(tmp_path: Path) -> Path:
+    """Fresh ``manifest.json`` path inside a tmp project."""
+    return tmp_path / "manifest.json"
+
+
+@pytest.fixture
+def sample_output(tmp_path: Path) -> Path:
+    """A small file standing in for an output NetCDF."""
+    p = tmp_path / "out.nc"
+    p.write_bytes(b"netcdf-payload-bytes-for-test")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# File-entry shape
+# ---------------------------------------------------------------------------
+
+
+def test_output_file_entry_includes_sha256_and_metadata(sample_output: Path) -> None:
+    """Outputs include sha256, size, mtime, path -- the exact shape PR-D
+    will read into FGDC ``processstep`` records.
+    """
+    entry = output_file_entry(sample_output)
+    assert set(entry) == {"path", "sha256", "size_bytes", "mtime_utc"}
+    assert entry["path"] == str(sample_output)
+    assert entry["size_bytes"] == len(b"netcdf-payload-bytes-for-test")
+    assert entry["sha256"] == sha256_file(sample_output)
+    # ISO-8601 with timezone offset
+    assert "T" in entry["mtime_utc"]
+    assert entry["mtime_utc"].endswith("+00:00")
+
+
+def test_output_file_entry_skip_sha256(sample_output: Path) -> None:
+    """``compute_sha256=False`` is the only knob for skipping the hash."""
+    entry = output_file_entry(sample_output, compute_sha256=False)
+    assert "sha256" not in entry
+    assert set(entry) == {"path", "size_bytes", "mtime_utc"}
+
+
+def test_input_file_entry_has_no_sha256(sample_output: Path) -> None:
+    """Inputs omit sha256 by design: aggregate over 30 sources reads dozens
+    of consolidated NCs, and full-file hashing would dominate runtime.
+    """
+    entry = input_file_entry(sample_output)
+    assert "sha256" not in entry
+    assert set(entry) == {"path", "size_bytes", "mtime_utc"}
+
+
+def test_sha256_file_matches_hashlib(sample_output: Path) -> None:
+    """Streamed sha256 matches a one-shot hashlib digest."""
+    import hashlib
+
+    one_shot = hashlib.sha256(sample_output.read_bytes()).hexdigest()
+    assert sha256_file(sample_output) == one_shot
+
+
+# ---------------------------------------------------------------------------
+# append_step: schema + lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_append_step_creates_manifest_with_skeleton(manifest_path: Path) -> None:
+    """First append into a fresh project creates manifest.json + skeleton."""
+    assert not manifest_path.exists()
+    append_step(
+        manifest_path,
+        kind="validate",
+        source_key=None,
+        timestamp_utc="2026-05-27T12:00:00+00:00",
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest == {
+        "sources": {},
+        "steps": [
+            {
+                "kind": "validate",
+                "source_key": None,
+                "timestamp_utc": "2026-05-27T12:00:00+00:00",
+                "software_version": manifest["steps"][0]["software_version"],
+                "tool": "nhf-targets",
+                "command": None,
+                "inputs": [],
+                "outputs": [],
+                "params": {},
+            }
+        ],
+    }
+
+
+def test_append_step_preserves_existing_sources(manifest_path: Path) -> None:
+    """Appending a step must NEVER clobber existing ``sources`` keys
+    (regression for #97 -- the validate-overwrites-fetch-provenance bug).
+    """
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "sources": {"era5_land": {"period": "1980/2024"}},
+                "steps": [],
+            }
+        )
+    )
+    append_step(manifest_path, kind="validate", source_key=None)
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["sources"] == {"era5_land": {"period": "1980/2024"}}
+    assert len(manifest["steps"]) == 1
+
+
+def test_append_step_appends_in_order(manifest_path: Path) -> None:
+    """Sequential appends preserve insertion order."""
+    for ts in ("2026-05-27T01:00:00+00:00", "2026-05-27T02:00:00+00:00"):
+        append_step(
+            manifest_path,
+            kind="aggregate",
+            source_key="era5_land",
+            timestamp_utc=ts,
+        )
+    manifest = json.loads(manifest_path.read_text())
+    assert [s["timestamp_utc"] for s in manifest["steps"]] == [
+        "2026-05-27T01:00:00+00:00",
+        "2026-05-27T02:00:00+00:00",
+    ]
+
+
+def test_append_step_records_inputs_and_outputs(
+    manifest_path: Path, sample_output: Path
+) -> None:
+    """Step records carry the input/output file lists verbatim."""
+    append_step(
+        manifest_path,
+        kind="target",
+        source_key=None,
+        inputs=[input_file_entry(sample_output)],
+        outputs=[output_file_entry(sample_output)],
+        params={"sort_dim": "nhm_id"},
+        command="run-runoff",
+    )
+    step = json.loads(manifest_path.read_text())["steps"][0]
+    assert step["inputs"][0]["path"] == str(sample_output)
+    assert "sha256" not in step["inputs"][0]
+    assert step["outputs"][0]["sha256"] == sha256_file(sample_output)
+    assert step["params"] == {"sort_dim": "nhm_id"}
+    assert step["command"] == "run-runoff"
+
+
+def test_append_step_rejects_unknown_kind(manifest_path: Path) -> None:
+    """Unknown kinds fail loud so PR-D's FGDC pattern-match stays closed."""
+    with pytest.raises(ValueError, match="Unknown step kind"):
+        append_step(manifest_path, kind="not-a-real-kind", source_key=None)
+
+
+def test_step_kinds_set_matches_plan() -> None:
+    """The closed set of step kinds matches the plan's Lineage capture
+    table; downstream FGDC generation depends on this contract.
+    """
+    assert STEP_KINDS == frozenset(
+        {"fetch", "consolidate", "aggregate", "target", "nn_fill", "validate"}
+    )
+
+
+def test_append_step_raises_on_corrupt_manifest(manifest_path: Path) -> None:
+    """A corrupt manifest is a loud failure mode -- matches the
+    aggregator's existing behavior so an operator can't silently
+    blow away their provenance.
+    """
+    manifest_path.write_text("{not valid json")
+    with pytest.raises(ValueError, match="corrupt"):
+        append_step(manifest_path, kind="validate", source_key=None)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_append_step_concurrent_writers_lose_no_steps(manifest_path: Path) -> None:
+    """4-thread concurrent appends produce exactly 4 steps, none lost.
+
+    The flock semantics under threads-of-one-process aren't a perfect
+    proxy for SLURM array workers (separate OS processes), but the
+    read-modify-write window is the same, and a faulty implementation
+    that just did ``manifest["steps"].append(); write()`` without
+    serializing would lose appends here too.
+    """
+    n_threads = 4
+
+    def _worker(worker_id: int) -> None:
+        append_step(
+            manifest_path,
+            kind="aggregate",
+            source_key=f"src_{worker_id}",
+            params={"worker_id": worker_id},
+        )
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    manifest = json.loads(manifest_path.read_text())
+    seen_workers = {s["source_key"] for s in manifest["steps"]}
+    assert seen_workers == {f"src_{i}" for i in range(n_threads)}
+    assert len(manifest["steps"]) == n_threads
+
+
+# ---------------------------------------------------------------------------
+# merge_source_and_append_step
+# ---------------------------------------------------------------------------
+
+
+def test_merge_source_and_append_step_updates_both(manifest_path: Path) -> None:
+    """Single call writes both the source entry and the step atomically."""
+    merge_source_and_append_step(
+        manifest_path,
+        "merra2",
+        source_updates={
+            "source_key": "merra2",
+            "period": "2010/2020",
+            "consolidated_nc": "/data/merra2/merra2_consolidated.nc",
+        },
+        kind="consolidate",
+        outputs=[],
+        params={"n_files": 132},
+        timestamp_utc="2026-05-27T12:00:00+00:00",
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["sources"]["merra2"]["period"] == "2010/2020"
+    assert manifest["sources"]["merra2"]["consolidated_nc"].endswith(
+        "merra2_consolidated.nc"
+    )
+    assert len(manifest["steps"]) == 1
+    step = manifest["steps"][0]
+    assert step["kind"] == "consolidate"
+    assert step["source_key"] == "merra2"
+    assert step["params"] == {"n_files": 132}
+
+
+def test_merge_source_preserves_existing_source_keys(manifest_path: Path) -> None:
+    """``dict.update`` semantics: existing keys survive unless overridden.
+
+    Mirrors the fetch-module read-merge-write contract from #97 / #119.
+    """
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "sources": {
+                    "snodas": {
+                        "source_key": "snodas",
+                        "years": [2003, 2004, 2005],
+                        "license": "Public domain",
+                    }
+                },
+                "steps": [],
+            }
+        )
+    )
+    merge_source_and_append_step(
+        manifest_path,
+        "snodas",
+        source_updates={"last_consolidated_utc": "2026-05-27T12:00:00+00:00"},
+        kind="consolidate",
+    )
+    snodas = json.loads(manifest_path.read_text())["sources"]["snodas"]
+    assert snodas["years"] == [2003, 2004, 2005]
+    assert snodas["license"] == "Public domain"
+    assert snodas["last_consolidated_utc"] == "2026-05-27T12:00:00+00:00"
+
+
+def test_merge_source_rejects_top_level_steps_collision(manifest_path: Path) -> None:
+    """``steps`` is top-level, not nested under a source; misuse must
+    fail loud so an accidentally nested step list is never created.
+    """
+    with pytest.raises(ValueError, match="must not include 'steps'"):
+        merge_source_and_append_step(
+            manifest_path,
+            "merra2",
+            source_updates={"steps": []},
+            kind="consolidate",
+        )
+
+
+def test_merge_source_returns_appended_record(manifest_path: Path) -> None:
+    """Returns the appended step record so callers can log + assert."""
+    record = merge_source_and_append_step(
+        manifest_path,
+        "merra2",
+        source_updates={"period": "2010/2020"},
+        kind="consolidate",
+    )
+    assert record["kind"] == "consolidate"
+    assert record["source_key"] == "merra2"

--- a/tests/test_targets_run.py
+++ b/tests/test_targets_run.py
@@ -91,6 +91,8 @@ def _make_runoff_project(
 
 
 def test_build_writes_unfilled_and_filled_files(tmp_path: Path):
+    import json as _json
+
     from nhf_spatial_targets.targets.run import build
     from nhf_spatial_targets.workspace import load
 
@@ -99,6 +101,25 @@ def test_build_writes_unfilled_and_filled_files(tmp_path: Path):
     build(project)
     assert (project.targets_dir() / "runoff_targets.nc").exists()
     assert (project.targets_dir() / "runoff_targets_nn_filled.nc").exists()
+
+    # release PR-B: build emits one target + one nn_fill lineage step.
+    # Command must be ``run-runoff`` -- not derived from string-mangling
+    # bounds_long_name_kind, which would yield ``run-runoff`` only by
+    # coincidence and produce wrong names for other targets.
+    manifest = _json.loads(project.manifest_path.read_text())
+    steps_by_kind: dict[str, list] = {}
+    for s in manifest["steps"]:
+        steps_by_kind.setdefault(s["kind"], []).append(s)
+    assert len(steps_by_kind.get("target", [])) == 1
+    assert len(steps_by_kind.get("nn_fill", [])) == 1
+    target_step = steps_by_kind["target"][0]
+    nn_step = steps_by_kind["nn_fill"][0]
+    assert target_step["command"] == "run-runoff"
+    assert nn_step["command"] == "run-runoff"
+    assert target_step["outputs"][0]["path"].endswith("runoff_targets.nc")
+    assert nn_step["outputs"][0]["path"].endswith("runoff_targets_nn_filled.nc")
+    assert "sha256" in target_step["outputs"][0]
+    assert "source" in target_step["params"]
 
 
 def test_build_emits_id_col_sorted_target_ncs(tmp_path: Path):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -300,7 +300,17 @@ def test_validate_writes_manifest_json(tmp_path, minimal_fabric, no_system_cred_
 
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["sources"] == {}
-    assert manifest["steps"] == []
+    # validate now appends a lineage step (release PR-B): exactly one
+    # ``kind=validate`` record per call, sha256-fingerprinting the
+    # on-disk artifacts it produced.
+    assert len(manifest["steps"]) == 1
+    step = manifest["steps"][0]
+    assert step["kind"] == "validate"
+    assert step["source_key"] is None
+    assert step["command"] == "validate"
+    out_paths = {entry["path"] for entry in step["outputs"]}
+    assert str(tmp_path / "fabric.json") in out_paths
+    assert str(tmp_path / "manifest.json") in out_paths
     assert "fabric" in manifest
     assert manifest["fabric"]["id_col"] == "nhm_id"
     assert manifest["fabric"]["hru_count"] == 3
@@ -369,9 +379,15 @@ def test_validate_rerun_preserves_sources_and_steps(
     assert "era5_land" in after["sources"]
     assert "gldas_noah_v21_monthly" in after["sources"]
     assert after["sources"]["era5_land"]["files"][0]["year"] == 2020
-    assert after["steps"] == [
-        {"step": "agg", "source": "era5_land", "utc": "2026-01-01"}
-    ]
+    # Prior synthetic step survives; the re-validate appends its own
+    # ``kind=validate`` step on top (release PR-B lineage capture).
+    assert after["steps"][0] == {
+        "step": "agg",
+        "source": "era5_land",
+        "utc": "2026-01-01",
+    }
+    assert after["steps"][-1]["kind"] == "validate"
+    assert sum(s.get("kind") == "validate" for s in after["steps"]) >= 1
     # created_utc is the original; last_validated_utc is refreshed.
     assert after["created_utc"] == original_created_utc
     assert after["last_validated_utc"] >= original_created_utc
@@ -388,7 +404,9 @@ def test_validate_first_run_writes_fresh_skeleton(
 
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["sources"] == {}
-    assert manifest["steps"] == []
+    # release PR-B: validate now appends one kind=validate step on every
+    # call. On a first-run manifest that is the only step present.
+    assert [s["kind"] for s in manifest["steps"]] == ["validate"]
     # On first run, created_utc and last_validated_utc are both fresh
     # and equal (no prior manifest to seed created_utc from).
     assert manifest["created_utc"] == manifest["last_validated_utc"]
@@ -412,7 +430,9 @@ def test_validate_recovers_from_corrupt_manifest(
 
     after = json.loads((tmp_path / "manifest.json").read_text())
     assert after["sources"] == {}
-    assert after["steps"] == []
+    # release PR-B: corrupt-manifest recovery seeds a fresh skeleton then
+    # validate appends its own kind=validate step.
+    assert [s["kind"] for s in after["steps"]] == ["validate"]
 
 
 def test_validate_preserves_unknown_keys(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -310,7 +310,10 @@ def test_validate_writes_manifest_json(tmp_path, minimal_fabric, no_system_cred_
     assert step["command"] == "validate"
     out_paths = {entry["path"] for entry in step["outputs"]}
     assert str(tmp_path / "fabric.json") in out_paths
-    assert str(tmp_path / "manifest.json") in out_paths
+    # manifest.json is intentionally NOT a step output: the step lives
+    # inside manifest.json, so its recorded sha256 would describe the
+    # pre-append state.
+    assert str(tmp_path / "manifest.json") not in out_paths
     assert "fabric" in manifest
     assert manifest["fabric"]["id_col"] == "nhm_id"
     assert manifest["fabric"]["hru_count"] == 3


### PR DESCRIPTION
## Summary

Second implementation phase of the ScienceBase data-release feature (#241). PR-A (#243, merged in #244) landed the catalog + config foundations; this PR introduces the `nhf_spatial_targets.release.lineage` module and instruments every manifest-writing call site in the pipeline so PR-D's FGDC generator can consume `manifest.json.steps[]` directly as `dataquality.lineage.processstep[]`.

Closes #245. Also closes #180 (MODIS / NLDAS / NCEP-NCAR / MERRA-2 / Reitz / pangaea / mwbm fetch `_update_manifest` missing flock) as a side effect of adopting the shared helper.

### New module

`src/nhf_spatial_targets/release/lineage.py`:
- `append_step(manifest_path, *, kind, source_key, inputs, outputs, params, ...)` — single-step append, flock-protected.
- `merge_source_and_append_step(manifest_path, source_key, *, source_updates, kind, ...)` — atomic source-merge + step-append under a single advisory `flock`.
- `build_step_record(...)` — pure step-record builder for callers that already hold their own flock (the aggregator).
- `output_file_entry(path)` / `input_file_entry(path)` — file-entry shape helpers. Outputs carry `sha256` by default; inputs carry only path + size + mtime so an aggregate step over 30 sources doesn't pay an extra full-file hash pass.

### Tests

`tests/test_release_lineage.py` (16 cases): schema, file-entry semantics, concurrent appenders (4-thread, no lost steps), corrupt-manifest failure mode, source-preservation under append (regression for #97), nested-`steps` collision guard.

`tests/test_validate.py` updated for the new `kind="validate"` step every validate now records.

### Instrumentation map

| Call site | Step kind | Mechanism |
|---|---|---|
| `validate.py::validate_workspace` | `validate` | `append_step` after fabric.json + manifest.json + config.effective.yml are written |
| `aggregate/_driver.py::update_manifest` | `aggregate` | `build_step_record` inside the existing flock; sha256s only the per-worker output_files slice |
| `targets/_writers.py::write_bounds_target` | `target`, `nn_fill` | `append_step` after each NC; forwards multi-source list from `extra_global_attrs["source"]` |
| `targets/_intermediates.py::stitch_year_chunks_to_target` | `target`, `nn_fill` | `append_step` for the stitched canonical NC; per-year intermediates as inputs without sha256 |
| Fetch (single-source-entry) | `consolidate` | `merge_source_and_append_step` — merra2, gldas, nldas, ncep_ncar, modis, reitz2017, pangaea, mwbm_climgrid |
| Fetch (multi-record merge: years / regions / water-years) | `consolidate` | `build_step_record` inside the existing flock — era5_land, snodas, ua_swe, margulis_wus_sr, daymet |

### Step record schema

```json
{
  "kind": "fetch|consolidate|aggregate|target|nn_fill|validate",
  "source_key": "era5_land",
  "timestamp_utc": "...",
  "software_version": "0.1.0",
  "tool": "nhf-targets",
  "command": "agg era5-land",
  "inputs":  [{"path": "...", "size_bytes": ..., "mtime_utc": "..."}],
  "outputs": [{"path": "...", "sha256": "...", "size_bytes": ..., "mtime_utc": "..."}],
  "params":  {"batch_size": 10000, "method": "area_weighted", ...}
}
```

## Test plan

- [x] `tests/test_release_lineage.py` — 16 passed
- [x] `tests/test_validate.py` + `tests/test_aggregate_driver.py` + lineage — 118 passed
- [x] `tests/test_targets_*.py` + `tests/test_cf_compliance.py` — 269 passed
- [x] All 13 fetch test files — 296 passed
- [x] `ruff format --check` + `ruff check` — clean
- [ ] CI on the PR — GH Actions will run the full suite
- [ ] After merge, smoke-test against a real project: run validate / agg / a target build and inspect `manifest.json.steps[]` for plausibility

## Out of scope for this PR

- PR-C will add the payload + checksum stage that reads `manifest.json.steps[]` and stages it into a per-fabric release tree.
- PR-D will add the MCF / FGDC / ISO templates that consume the lineage.
- The catalog `release_defaults.yml` is still mostly empty; populating its FGDC defaults is PR-D's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)