### PR TITLE
chore(release): OutputFileEntry annotations + residual task-decay marker sweep

### DIFF
--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -142,6 +142,7 @@ def update_manifest(
         # section so an interrupted SLURM array worker cannot leave the
         # manifest with the source-entry updated but no step appended.
         from nhf_spatial_targets.release.lineage import (
+            OutputFileEntry,
             build_step_record,
             output_file_entry,
         )
@@ -149,7 +150,7 @@ def update_manifest(
         # output_files is project-workdir-relative; resolve before stat.
         # Workers only hash the slice they just wrote -- total hash cost
         # scales with output size, not workspace size.
-        output_entries: list[dict] = []
+        output_entries: list[OutputFileEntry] = []
         missing_outputs: list[str] = []
         for rel in output_files:
             abs_path = (project.workdir / rel).resolve()

--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -319,9 +319,10 @@ def publishable_sources() -> dict:
     Order is preserved from the underlying YAML to keep deterministic
     output across release builds.
 
-    Note: this function is informational on PR-A. Downstream enforcement
-    (refusing to build a release for a non-publishable source) lands with
-    PR-D/PR-E. Callers that need a hard gate should not assume this
+    Note: this filter is *informational* -- it does not raise on a
+    non-publishable source. Downstream release stages (payload staging,
+    FGDC emission, publish) own the hard gates; callers that need a
+    hard gate should compose with those rather than assume this
     function's return value is acted on yet.
     """
     out: dict = {}

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -905,11 +905,12 @@ def _update_manifest(
         # ``outputs`` -- ``merged_files`` is the union across workers
         # and would over-attribute output_files to a single step.
         from nhf_spatial_targets.release.lineage import (
+            OutputFileEntry,
             build_step_record,
             output_file_entry,
         )
 
-        step_outputs: list[dict] = []
+        step_outputs: list[OutputFileEntry] = []
         for f_rec in files:
             for key in ("daily_path", "monthly_path", "path"):
                 nc = f_rec.get(key)

--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -772,11 +772,12 @@ def _update_manifest(
         manifest["sources"][_SOURCE_KEY] = entry
 
         from nhf_spatial_targets.release.lineage import (
+            OutputFileEntry,
             build_step_record,
             output_file_entry,
         )
 
-        step_outputs: list[dict] = []
+        step_outputs: list[OutputFileEntry] = []
         for rec in year_records:
             for key in ("consolidated_nc", "consolidated_path", "path"):
                 nc = rec.get(key)

--- a/src/nhf_spatial_targets/fetch/modis.py
+++ b/src/nhf_spatial_targets/fetch/modis.py
@@ -319,13 +319,14 @@ def _update_manifest(
 ) -> None:
     """Merge MODIS provenance + lineage step into manifest.json."""
     from nhf_spatial_targets.release.lineage import (
+        OutputFileEntry,
         merge_source_and_append_step,
         output_file_entry,
     )
 
     ws = _load_project(workdir)
     now_utc = datetime.now(timezone.utc).isoformat()
-    outputs: list[dict] = []
+    outputs: list[OutputFileEntry] = []
     for nc_path in consolidated_ncs.values():
         p = Path(nc_path)
         if p.exists():

--- a/src/nhf_spatial_targets/fetch/ncep_ncar.py
+++ b/src/nhf_spatial_targets/fetch/ncep_ncar.py
@@ -233,13 +233,14 @@ def _update_manifest(
 ) -> None:
     """Merge NCEP/NCAR provenance + lineage step into manifest.json."""
     from nhf_spatial_targets.release.lineage import (
+        OutputFileEntry,
         merge_source_and_append_step,
         output_file_entry,
     )
 
     ws = _load_project(workdir)
     consolidated_nc = consolidation.get("consolidated_nc")
-    outputs: list[dict] = []
+    outputs: list[OutputFileEntry] = []
     if consolidated_nc and Path(consolidated_nc).exists():
         outputs = [output_file_entry(Path(consolidated_nc))]
     merge_source_and_append_step(

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1268,11 +1268,12 @@ def _update_manifest(
         manifest["sources"][_SOURCE_KEY] = entry
 
         from nhf_spatial_targets.release.lineage import (
+            OutputFileEntry,
             build_step_record,
             output_file_entry,
         )
 
-        step_outputs: list[dict] = []
+        step_outputs: list[OutputFileEntry] = []
         for rec in year_records:
             for key in ("consolidated_nc", "consolidated_path"):
                 nc = rec.get(key)

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -591,11 +591,12 @@ def _update_manifest(
         manifest["sources"][_SOURCE_KEY] = entry
 
         from nhf_spatial_targets.release.lineage import (
+            OutputFileEntry,
             build_step_record,
             output_file_entry,
         )
 
-        step_outputs: list[dict] = []
+        step_outputs: list[OutputFileEntry] = []
         for rec in wy_records:
             for key in ("consolidated_nc", "consolidated_path", "path"):
                 nc = rec.get(key)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -387,7 +387,7 @@ def test_source_var_cell_methods_raises_on_unknown_variable():
 
 
 # ---------------------------------------------------------------------------
-# release block (PR-A foundation for the ScienceBase release workflow, #241/#243)
+# release block (ScienceBase release workflow)
 # ---------------------------------------------------------------------------
 
 
@@ -450,14 +450,14 @@ def test_release_block_defaults_apply_when_unset():
     """A source with no `release:` block reports the defaults."""
     from nhf_spatial_targets.catalog import release_block
 
-    # era5_land carries no release block on PR-A; it should default to
+    # era5_land carries no `release:` block; it should default to
     # publishable=True, distribution_kind="data", notes=None.
     rb = release_block("era5_land")
     assert rb == {"publishable": True, "distribution_kind": "data", "notes": None}
 
 
 def test_release_block_watergap22d_is_not_publishable():
-    """watergap22d is CC BY-NC; held back from the release per PR-A."""
+    """watergap22d is CC BY-NC; held back from the release."""
     from nhf_spatial_targets.catalog import release_block
 
     rb = release_block("watergap22d")
@@ -574,9 +574,9 @@ def test_publishable_sources_includes_daymet_and_margulis():
 
 
 def test_release_defaults_yml_loads_as_valid_yaml():
-    """Scaffold for repo-level FGDC defaults. Populated by PR-D/PR-E; we
-    just verify YAML parses cleanly so an accidental corruption is caught
-    before downstream code starts reading it.
+    """Scaffold for repo-level FGDC defaults. We verify YAML parses cleanly
+    so an accidental corruption is caught before downstream code starts
+    reading it.
     """
     import yaml
     from pathlib import Path
@@ -600,9 +600,9 @@ def test_release_defaults_yml_loads_as_valid_yaml():
 
 
 def test_release_registry_yml_loads_as_valid_yaml():
-    """Scaffold for the running publish-state registry. Populated by PR-E
-    as items are created on ScienceBase; we verify YAML parses cleanly and
-    the initial-state shape is what PR-E will expect.
+    """Scaffold for the running publish-state registry. Populated as items
+    are created on ScienceBase; we verify YAML parses cleanly and the
+    initial-state shape is what downstream publishing code expects.
     """
     import yaml
     from pathlib import Path

--- a/tests/test_release_rebuild.py
+++ b/tests/test_release_rebuild.py
@@ -624,9 +624,9 @@ def test_rebuild_default_stamps_sha256_skipped(project) -> None:
 
 
 def test_rebuild_with_sha256_does_not_stamp_skipped(project) -> None:
-    """``compute_sha256=True`` must NOT stamp ``sha256_skipped=True``
-    -- the precondition flip is what releases the ``release publish``
-    gate.
+    """``compute_sha256=True`` must NOT stamp ``sha256_skipped=True`` --
+    that flag is the gate the downstream ``release publish`` stage
+    reads to refuse unhashed outputs.
     """
     nc = _write_consolidated_nc(project.datastore, "merra2", "merra2_consolidated.nc")
     manifest = json.loads(project.manifest_path.read_text())

--- a/tests/test_release_rebuild.py
+++ b/tests/test_release_rebuild.py
@@ -1,14 +1,14 @@
 """Tests for ``nhf_spatial_targets.release.rebuild``.
 
-Bootstraps lineage steps for projects that predate PR-B (#246). The
-invariants we lock here:
+Bootstraps lineage steps for legacy projects with empty ``steps[]``.
+The invariants we lock here:
 
 - Each manifest source entry produces the right kind+source_key step
   shapes from on-disk evidence (consolidate, aggregate).
 - Target NCs in ``<project>/targets/`` produce target / nn_fill steps.
 - Idempotent: re-running rebuild_lineage doesn't duplicate steps even
-  when synthesized variants would conflict with live ones from the
-  post-PR-B pipeline.
+  when synthesized variants would conflict with live steps from the
+  live pipeline.
 - SHA256 is opt-in.
 - ``dry_run=True`` returns the same summary without mutating the file.
 """
@@ -255,12 +255,12 @@ def test_rebuild_is_idempotent(project) -> None:
     assert second["skipped_existing"] >= first["steps_added"]
 
 
-def test_rebuild_skips_live_steps_from_post_prb_pipeline(project) -> None:
-    """A live step from the post-PR-B pipeline wins the dedupe.
+def test_rebuild_skips_live_steps_from_live_pipeline(project) -> None:
+    """A live step from the live pipeline wins the dedupe.
 
-    Operators who ran agg AFTER PR-B will have one live aggregate step
-    per source. Re-running rebuild_lineage must not synthesize a
-    duplicate.
+    Operators who ran agg under the live (step-emitting) pipeline have
+    one live aggregate step per source. Re-running rebuild_lineage must
+    not synthesize a duplicate.
     """
     nc = _write_aggregated_nc(project.workdir, "era5_land", "era5_2010.nc")
     rel = str(nc.relative_to(project.workdir))
@@ -271,7 +271,7 @@ def test_rebuild_skips_live_steps_from_post_prb_pipeline(project) -> None:
         "period": "2010/2020",
         "timestamp": "2026-05-27T11:00:00+00:00",
     }
-    # Pre-existing live step from the post-PR-B aggregate run.
+    # Pre-existing live step from a prior aggregate run.
     manifest["steps"].append(
         {
             "kind": "aggregate",
@@ -370,7 +370,8 @@ def test_rebuild_missing_output_files_are_skipped(project, caplog) -> None:
     Stale on-disk evidence (a fetched NC the operator deleted to
     reclaim disk) yields a consolidate step with no outputs, a WARNING
     log line, and the vanished path recorded in
-    ``params["missing_outputs"]`` so PR-D can surface the gap.
+    ``params["missing_outputs"]`` so downstream consumers can surface
+    the gap.
     """
     import logging
 
@@ -398,7 +399,7 @@ def test_rebuild_missing_output_files_are_skipped(project, caplog) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Additional source-entry shapes (PR-B2 review fixup)
+# Additional source-entry shapes
 # ---------------------------------------------------------------------------
 
 
@@ -524,7 +525,7 @@ def test_rebuild_daymet_zarr_dir_skipped(project) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Failure-mode contracts (PR-B2 review fixup)
+# Failure-mode contracts
 # ---------------------------------------------------------------------------
 
 
@@ -541,7 +542,7 @@ def test_rebuild_missing_fabric_json_raises(project) -> None:
 
 
 def test_rebuild_skips_live_validate_step(project) -> None:
-    """A live ``kind=validate`` step from the post-PR-B pipeline must dedup.
+    """A live ``kind=validate`` step from the live pipeline must dedup.
 
     The synthesizer's outputs must exactly match the live writer's
     outputs (fabric.json + config.effective.yml; manifest.json is
@@ -587,8 +588,9 @@ def test_rebuild_validate_step_excludes_manifest_json(project) -> None:
     """The synthesized validate step must NOT list ``manifest.json`` in outputs.
 
     Recording the sha256 of the file the step lives in is the
-    self-hash paradox PR-B's review caught -- PR-B2 must not
-    reintroduce it.
+    self-hash paradox: the recorded hash would describe the pre-append
+    state, not the on-disk file as it now exists. The synthesizer must
+    match the live ``validate`` writer's behavior here.
     """
     rebuild_lineage(project, compute_sha256=True)
     manifest = json.loads(project.manifest_path.read_text())
@@ -601,8 +603,8 @@ def test_rebuild_default_stamps_sha256_skipped(project) -> None:
     """With ``compute_sha256=False`` (default), every output-bearing
     synthesized step is stamped with ``params.sha256_skipped=True``.
 
-    PR-F's release-publish stage gate reads this flag to refuse to
-    publish a release whose outputs lack integrity hashes.
+    The downstream ``release publish`` stage gate reads this flag to
+    refuse to publish a release whose outputs lack integrity hashes.
     """
     nc = _write_consolidated_nc(project.datastore, "merra2", "merra2_consolidated.nc")
     manifest = json.loads(project.manifest_path.read_text())
@@ -623,7 +625,8 @@ def test_rebuild_default_stamps_sha256_skipped(project) -> None:
 
 def test_rebuild_with_sha256_does_not_stamp_skipped(project) -> None:
     """``compute_sha256=True`` must NOT stamp ``sha256_skipped=True``
-    -- the precondition flip is what releases PR-F's gate.
+    -- the precondition flip is what releases the ``release publish``
+    gate.
     """
     nc = _write_consolidated_nc(project.datastore, "merra2", "merra2_consolidated.nc")
     manifest = json.loads(project.manifest_path.read_text())


### PR DESCRIPTION
Closes #251 and #254.

Two small follow-ups from the PR-B3 review (PR #250), bundled as a single chore PR. Pure typing + docs cleanup; on-disk JSON shape is unchanged.

## Summary

**#251 — \`list[dict]\` → \`list[OutputFileEntry]\` annotation sweep.** Narrows the lineage-producer output collectors so static analysis catches a hand-rolled wrong-shape entry. Seven sites: \`aggregate/_driver.py\` plus \`fetch/{era5_land,margulis_wus_sr,modis,ncep_ncar,snodas,ua_swe}.py\`. Other \`list[dict]\` annotations in fetch modules describe per-source file *records* (variant shape by source) and are deferred to #253 (\`SourceEntry\` per-shape TypedDicts).

**#254 — strip residual \`PR-A\` / \`PR-D/E\` / \`PR-F\` markers.** The per-PR comment cleanups left a handful behind:
- \`src/nhf_spatial_targets/catalog.py::publishable_sources\` docstring
- \`tests/test_catalog.py\` (release-block section + 3 test docstrings)
- \`tests/test_release_rebuild.py\` (module docstring, section headers, 4 test docstrings; one test renamed from \`*_post_prb_pipeline\` to \`*_live_pipeline\`)

A repo-wide \`grep -r 'PR-[A-G]' src/ tests/\` now returns zero hits.

## Test plan

- [x] \`pixi run -e dev fmt\` clean
- [x] \`pixi run -e dev lint\` clean
- [x] \`pytest tests/test_release_lineage.py tests/test_release_rebuild.py tests/test_catalog.py tests/test_aggregate_driver.py tests/test_era5_land.py\` (219 passed)
- [ ] GH Actions full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)