### PR TITLE
chore(ua_swe): explicit release: block for NSIDC-0719 source

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -1008,3 +1008,24 @@ sources:
     units: kg m-2 (mm water equivalent), mm
     license: public domain (NASA NSIDC)
     status: current
+    release:
+      # Explicit decision (not inherited defaults) for a newly added source.
+      # NSIDC-0719 is a NASA-distributed public product (NSIDC DAAC); the
+      # consolidated per-water-year NCs (~3.8 GB total across 42 files) are
+      # small enough to ship and are redistributable as a USGS-derivative
+      # consolidated-source child — same posture as snodas / margulis_wus_sr
+      # (also NSIDC public-domain). NOT metadata_only: unlike daymet (4.6 TB
+      # on ORNL DAAC) the payload fits in the release.
+      publishable: true
+      distribution_kind: data
+      notes: >
+        NASA NSIDC public-domain product; the consolidated source NCs ship
+        in the ScienceBase release as a USGS-derivative consolidated-source
+        child. No use restrictions, but the NSIDC DAAC requests data
+        citation, so the FGDC useconst for ua_swe should carry an
+        attribution line (the NSIDC-0719 analogue of the Copernicus
+        attribution ERA5-Land records in its `license:` field): cite
+        Broxton, P., Zeng, X. & Dawson, N. (2019), "Daily 4 km Gridded SWE
+        and Snow Depth from Assimilated In-Situ and Modeled Data over the
+        Conterminous US, Version 1", NSIDC DAAC, doi:10.5067/0GGPB220EX6A,
+        and acknowledge the NASA National Snow and Ice Data Center DAAC.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -484,6 +484,27 @@ def test_release_block_margulis_publishable_despite_fabric_scope():
     assert rb["distribution_kind"] == "data"
 
 
+def test_release_block_ua_swe_explicit_decision():
+    """ua_swe carries a deliberate release decision (not inherited defaults).
+
+    A newly added source gets an explicit publishable/distribution_kind call
+    plus the NSIDC-0719 citation/attribution text in `notes`, which the FGDC
+    useconst builder should surface as a use constraint. Locking it here keeps
+    the decision from silently regressing to the bare defaults.
+    """
+    from nhf_spatial_targets.catalog import release_block, source
+
+    # The block must be physically present, not the inherited default.
+    assert source("ua_swe").get("release") is not None
+
+    rb = release_block("ua_swe")
+    assert rb["publishable"] is True
+    assert rb["distribution_kind"] == "data"
+    # Attribution requirement recorded for the FGDC useconst.
+    assert "10.5067/0GGPB220EX6A" in rb["notes"]
+    assert "NSIDC" in rb["notes"]
+
+
 def test_release_block_watergap22d_preserves_distribution_kind_default():
     """Partial-override: setting `publishable` alone must leave the
     `distribution_kind` default in place. Locks the per-key merge contract


### PR DESCRIPTION
## Summary

Give the newly added `ua_swe` (NSIDC-0719) source a **deliberate** `release:` decision in `catalog/sources.yml` rather than silently inheriting the defaults (`publishable: true` / `distribution_kind: data` / `notes: null`). A new source deserves an explicit call, the same way it gets a magnitude-validation pass. Part of umbrella #237.

- **`publishable: true`, `distribution_kind: data`** (explicit) — NSIDC public NASA product; the ~3.8 GB consolidated per-water-year NCs are redistributable as a USGS-derivative consolidated-source child, same posture as `snodas` / `margulis_wus_sr`. Not `metadata_only` (that's daymet's 4.6 TB ORNL-hosted case).
- **`notes:`** records the NSIDC DAAC citation/attribution requirement (Broxton, Zeng & Dawson 2019, doi:10.5067/0GGPB220EX6A) so the FGDC `useconst` builder can surface it as a use constraint — the NSIDC-0719 analogue of the Copernicus attribution ERA5-Land carries in its `license:` field.
- Adds `test_release_block_ua_swe_explicit_decision`, mirroring the existing `watergap22d` / `daymet` / `margulis` per-source release tests.

## Schema note

The release-block schema (even after PR-C #258) supports only the three keys `publishable` / `distribution_kind` / `notes` and rejects unknown keys — there is no `useconst` field in `src/` yet. So the attribution text lives in `notes` for now; a later release PR that adds FGDC `useconst` generation can lift it (or introduce a dedicated key).

## Scope

- Catalog data + test only — **no release-workflow code changes** (this is data hygiene).
- Does not close #237.

## Test plan

- [ ] CI green (`fmt-check`, `lint`, full pytest — 1370 passed locally incl. the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)