### PR TITLE
fix(release): consolidate steps record output checksums on live fetch path (#263)

### DIFF
--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -777,13 +777,15 @@ def _update_manifest(
             output_file_entry,
         )
 
+        # Each record stores the consolidated NC under ``daily_path`` (set
+        # from the consolidator's return value on both the fresh and the
+        # mtime-idempotent skip path), so a skipped-but-present year still
+        # contributes its output checksum to the consolidate step. (#263)
         step_outputs: list[OutputFileEntry] = []
         for rec in year_records:
-            for key in ("consolidated_nc", "consolidated_path", "path"):
-                nc = rec.get(key)
-                if nc and Path(nc).exists():
-                    step_outputs.append(output_file_entry(Path(nc)))
-                    break
+            nc = rec.get("daily_path")
+            if nc and Path(nc).exists():
+                step_outputs.append(output_file_entry(Path(nc)))
         manifest["steps"].append(
             build_step_record(
                 kind="consolidate",

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1273,13 +1273,15 @@ def _update_manifest(
             output_file_entry,
         )
 
+        # Each record stores the consolidated NC under ``daily_path`` (set
+        # from the consolidator's return value on both the fresh and the
+        # mtime-idempotent skip path), so a skipped-but-present year still
+        # contributes its output checksum to the consolidate step. (#263)
         step_outputs: list[OutputFileEntry] = []
         for rec in year_records:
-            for key in ("consolidated_nc", "consolidated_path"):
-                nc = rec.get(key)
-                if nc and Path(nc).exists():
-                    step_outputs.append(output_file_entry(Path(nc)))
-                    break
+            nc = rec.get("daily_path")
+            if nc and Path(nc).exists():
+                step_outputs.append(output_file_entry(Path(nc)))
         manifest["steps"].append(
             build_step_record(
                 kind="consolidate",

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -596,13 +596,15 @@ def _update_manifest(
             output_file_entry,
         )
 
+        # Each record stores the consolidated NC under ``daily_path`` (set
+        # from the consolidator's return value on both the fresh and the
+        # mtime-idempotent skip path), so a skipped-but-present WY still
+        # contributes its output checksum to the consolidate step. (#263)
         step_outputs: list[OutputFileEntry] = []
         for rec in wy_records:
-            for key in ("consolidated_nc", "consolidated_path", "path"):
-                nc = rec.get(key)
-                if nc and Path(nc).exists():
-                    step_outputs.append(output_file_entry(Path(nc)))
-                    break
+            nc = rec.get("daily_path")
+            if nc and Path(nc).exists():
+                step_outputs.append(output_file_entry(Path(nc)))
         manifest["steps"].append(
             build_step_record(
                 kind="consolidate",

--- a/tests/test_fetch_consolidate_step_outputs.py
+++ b/tests/test_fetch_consolidate_step_outputs.py
@@ -14,11 +14,19 @@ Issue #263: the step-output builders probed a fixed key tuple
 carried no output sha256 -- undercutting the release checksum/provenance
 feature (PR-C #258).
 
-These tests drive each module's ``_update_manifest`` directly with a record
-shaped exactly like the live loop produces (``daily_path`` -> a real NC on
-disk). They fail before the fix (empty ``outputs[]``) and pin the contract that
-a record carrying ``daily_path`` -- whether freshly consolidated or
-mtime-skipped -- attaches an output entry with a correct sha256.
+These tests drive each module's ``_update_manifest`` directly with records
+shaped like the live loop produces. They pin its read-and-checksum contract:
+
+- a record carrying ``daily_path`` -> an existing NC attaches an output entry
+  with a correct sha256 (fails before the fix -- empty ``outputs[]``);
+- a record with no ``daily_path`` (404 / download error / consolidate failure)
+  or a ``daily_path`` whose file has vanished is omitted, not crashed on.
+
+``_update_manifest`` is agnostic to *how* ``daily_path`` got set, so these tests
+do not exercise the consolidator skip path themselves -- that the consolidators
+populate ``daily_path`` on the mtime-skip too (so a skipped-but-present
+year/WY still contributes a checksum) is a property of the consolidators,
+covered by each module's consolidator-idempotency tests.
 """
 
 from __future__ import annotations
@@ -140,3 +148,96 @@ def test_margulis_consolidate_step_records_output_checksums(tmp_path: Path) -> N
         (-124.0, 42.0, -116.0, 46.0),
     )
     _assert_outputs_match(_consolidate_step(workdir, "margulis_wus_sr"), [nc])
+
+
+# ---------------------------------------------------------------------------
+# Omission semantics: records that produced no on-disk NC must be dropped from
+# ``outputs[]`` (not crashed on). A record gets no ``daily_path`` when the
+# download 404'd / errored or consolidation failed (those carry a
+# ``consolidate_error`` and stay visible in ``sources[<key>].years``); a
+# recorded ``daily_path`` may also have vanished from the datastore since. The
+# ``if nc and Path(nc).exists()`` guard is deliberate -- these tests pin that a
+# future refactor dropping it (which would KeyError / FileNotFoundError on a
+# gappy year in production) is a regression.
+# ---------------------------------------------------------------------------
+
+
+def test_ua_swe_consolidate_step_omits_records_without_existing_nc(
+    tmp_path: Path,
+) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "ua_swe" / "daily"
+    present = _write_tiny_nc(daily_dir / "ua_swe_daily_WY2010.nc")
+    wy_records = [
+        {"water_year": 2010, "status": "downloaded", "daily_path": str(present)},
+        {"water_year": 2011, "status": "missing_404"},  # no daily_path
+        {  # daily_path recorded but file never written / since vanished
+            "water_year": 2012,
+            "status": "downloaded",
+            "daily_path": str(daily_dir / "ua_swe_daily_WY2012.nc"),
+        },
+    ]
+    ua_swe._update_manifest(
+        workdir,
+        "2010/2012",
+        catalog.source("ua_swe"),
+        wy_records,
+        "https://example.org/archive",
+        None,
+    )
+    step = _consolidate_step(workdir, "ua_swe")
+    assert len(step["outputs"]) == 1
+    _assert_outputs_match(step, [present])
+
+
+def test_snodas_consolidate_step_omits_records_without_existing_nc(
+    tmp_path: Path,
+) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "snodas" / "daily"
+    present = _write_tiny_nc(daily_dir / "snodas_daily_2020.nc")
+    year_records = [
+        {"year": 2020, "daily_path": str(present)},
+        {"year": 2021, "consolidate_error": "boom"},  # no daily_path
+        {  # daily_path recorded but file never written / since vanished
+            "year": 2022,
+            "daily_path": str(daily_dir / "snodas_daily_2022.nc"),
+        },
+    ]
+    snodas._update_manifest(
+        workdir,
+        "2020/2022",
+        catalog.source("snodas"),
+        year_records,
+        "https://example.org/archive",
+    )
+    step = _consolidate_step(workdir, "snodas")
+    assert len(step["outputs"]) == 1
+    _assert_outputs_match(step, [present])
+
+
+def test_margulis_consolidate_step_omits_records_without_existing_nc(
+    tmp_path: Path,
+) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "margulis_wus_sr" / "daily"
+    present = _write_tiny_nc(daily_dir / "margulis_wus_sr_daily_2000.nc")
+    year_records = [
+        {"year": 2000, "daily_path": str(present)},
+        {"year": 2001, "consolidate_error": "boundary year"},  # no daily_path
+        {  # daily_path recorded but file never written / since vanished
+            "year": 2002,
+            "daily_path": str(daily_dir / "margulis_wus_sr_daily_2002.nc"),
+        },
+    ]
+    margulis_wus_sr._update_manifest(
+        workdir,
+        "2000/2002",
+        catalog.source("margulis_wus_sr"),
+        year_records,
+        {"fabrics": ["or"], "notes": "test"},
+        (-124.0, 42.0, -116.0, 46.0),
+    )
+    step = _consolidate_step(workdir, "margulis_wus_sr")
+    assert len(step["outputs"]) == 1
+    _assert_outputs_match(step, [present])

--- a/tests/test_fetch_consolidate_step_outputs.py
+++ b/tests/test_fetch_consolidate_step_outputs.py
@@ -1,0 +1,142 @@
+"""Live-path consolidate-step output checksums (issue #263).
+
+The live fetch path of ``ua_swe`` / ``snodas`` / ``margulis_wus_sr`` builds
+``manifest.json.steps[]`` ``kind=consolidate`` records from the per-year /
+per-water-year records produced by the download+consolidate loop. Each of
+those records stores the consolidated NC path under ``daily_path`` (set from
+the consolidator's return value on **both** the fresh-consolidate path and the
+mtime-idempotent skip path -- the consolidators return the existing ``out_path``
+when skipping).
+
+Issue #263: the step-output builders probed a fixed key tuple
+(``consolidated_nc`` / ``consolidated_path`` / ``path``) that never included
+``daily_path``, so ``step["outputs"]`` came out empty and the consolidate steps
+carried no output sha256 -- undercutting the release checksum/provenance
+feature (PR-C #258).
+
+These tests drive each module's ``_update_manifest`` directly with a record
+shaped exactly like the live loop produces (``daily_path`` -> a real NC on
+disk). They fail before the fix (empty ``outputs[]``) and pin the contract that
+a record carrying ``daily_path`` -- whether freshly consolidated or
+mtime-skipped -- attaches an output entry with a correct sha256.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+import yaml
+
+import nhf_spatial_targets.catalog as catalog
+from nhf_spatial_targets.fetch import margulis_wus_sr, snodas, ua_swe
+from nhf_spatial_targets.release.lineage import sha256_file
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Materialize a minimal project the workspace loader accepts.
+
+    ``_load_project`` needs ``config.yml`` + ``fabric.json``; the stub
+    fabric path need not exist on disk for these manifest-only tests.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    datastore = tmp_path / "datastore"
+    datastore.mkdir(exist_ok=True)
+    (tmp_path / "config.yml").write_text(
+        yaml.dump(
+            {
+                "fabric": {
+                    "path": str(tmp_path / "fabric.gpkg"),
+                    "id_col": "nhm_id",
+                },
+                "datastore": str(datastore),
+            }
+        )
+    )
+    (tmp_path / "fabric.json").write_text(json.dumps({"sha256": "f00"}))
+    return tmp_path
+
+
+def _write_tiny_nc(path: Path) -> Path:
+    """Write a small real NetCDF to stand in for a consolidated daily NC."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    xr.Dataset({"swe": ("x", np.arange(3.0, dtype="float32"))}).to_netcdf(path)
+    return path
+
+
+def _consolidate_step(workdir: Path, source_key: str) -> dict:
+    """Return the single ``kind=consolidate`` step for *source_key*."""
+    manifest = json.loads((workdir / "manifest.json").read_text())
+    steps = [
+        s
+        for s in manifest["steps"]
+        if s["kind"] == "consolidate" and s["source_key"] == source_key
+    ]
+    assert len(steps) == 1, f"expected one consolidate step, got {len(steps)}"
+    return steps[0]
+
+
+def _assert_outputs_match(step: dict, expected_ncs: list[Path]) -> None:
+    """The step's outputs must cover every consolidated NC with a real sha256."""
+    outputs = step["outputs"]
+    assert outputs, "consolidate step recorded empty outputs[] (issue #263)"
+    by_path = {o["path"]: o for o in outputs}
+    for nc in expected_ncs:
+        entry = by_path.get(str(nc))
+        assert entry is not None, f"no output entry for {nc}"
+        assert entry.get("sha256") == sha256_file(nc), f"sha256 mismatch for {nc}"
+
+
+def test_ua_swe_consolidate_step_records_output_checksums(tmp_path: Path) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "ua_swe" / "daily"
+    ncs = [
+        _write_tiny_nc(daily_dir / "ua_swe_daily_WY2010.nc"),
+        _write_tiny_nc(daily_dir / "ua_swe_daily_WY2011.nc"),
+    ]
+    wy_records = [
+        {"water_year": 2010, "status": "downloaded", "daily_path": str(ncs[0])},
+        {"water_year": 2011, "status": "downloaded", "daily_path": str(ncs[1])},
+    ]
+    ua_swe._update_manifest(
+        workdir,
+        "2010/2010",
+        catalog.source("ua_swe"),
+        wy_records,
+        "https://example.org/archive",
+        None,
+    )
+    _assert_outputs_match(_consolidate_step(workdir, "ua_swe"), ncs)
+
+
+def test_snodas_consolidate_step_records_output_checksums(tmp_path: Path) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "snodas" / "daily"
+    nc = _write_tiny_nc(daily_dir / "snodas_daily_2020.nc")
+    year_records = [{"year": 2020, "daily_path": str(nc)}]
+    snodas._update_manifest(
+        workdir,
+        "2020/2020",
+        catalog.source("snodas"),
+        year_records,
+        "https://example.org/archive",
+    )
+    _assert_outputs_match(_consolidate_step(workdir, "snodas"), [nc])
+
+
+def test_margulis_consolidate_step_records_output_checksums(tmp_path: Path) -> None:
+    workdir = _make_project(tmp_path)
+    daily_dir = workdir / "datastore" / "margulis_wus_sr" / "daily"
+    nc = _write_tiny_nc(daily_dir / "margulis_wus_sr_daily_2000.nc")
+    year_records = [{"year": 2000, "daily_path": str(nc)}]
+    margulis_wus_sr._update_manifest(
+        workdir,
+        "2000/2000",
+        catalog.source("margulis_wus_sr"),
+        year_records,
+        {"fabrics": ["or"], "notes": "test"},
+        (-124.0, 42.0, -116.0, 46.0),
+    )
+    _assert_outputs_match(_consolidate_step(workdir, "margulis_wus_sr"), [nc])


### PR DESCRIPTION
## Summary

The live lineage instrumentation (PR-B) recorded `manifest.json.steps[]` `kind=consolidate` steps with **empty `outputs[]`** for `ua_swe`, `snodas`, and `margulis_wus_sr`, so those sources' consolidate steps carried no output sha256 on the normal (non-backfill) fetch path — undercutting the release checksum/provenance feature (PR-C #258).

**Root cause — record key mismatch.** Each module built `step_outputs` by probing a fixed key tuple (`consolidated_nc` / `consolidated_path` / `path`) on the per-year / per-water-year records, but the consolidators store the consolidated NC path under `daily_path`. The probe never matched, so `outputs[]` stayed empty.

## Changes

- `ua_swe` / `snodas` / `margulis_wus_sr` `_update_manifest` now read the consolidated NC straight from `rec["daily_path"]`, mirroring how `nldas` / `merra2` read `consolidation["consolidated_nc"]`. The dead key-tuple probe is removed.
- **Skip-path decision (explicit):** a skipped-but-present water-year/year still attaches its output entry. All three consolidators return the existing `out_path` on the mtime-idempotent skip, so `daily_path` is populated on both the fresh and skip paths — matching the backfill (`rebuild_lineage`) behaviour of recording every NC on disk.
- New `tests/test_fetch_consolidate_step_outputs.py` (TDD failing-test-first) drives each module's live `_update_manifest` with a `daily_path` record and asserts the consolidate step records non-empty `outputs[]` with a correct sha256 per NC. No test asserted this before, which is why it slipped past PR-B.

Scope is the live fetch path only; `release/rebuild.py` (backfill) already reads paths correctly and is untouched.

## Test plan

- [x] `tests/test_fetch_consolidate_step_outputs.py` — RED before fix (empty `outputs[]`), GREEN after (sha256 matches each NC)
- [x] `pixi run -e dev fmt` + `pixi run -e dev lint` clean
- [x] `pixi run -e dev pytest tests/test_fetch_ua_swe.py tests/test_fetch_snodas.py tests/test_fetch_margulis_wus_sr.py tests/test_fetch_consolidate_step_outputs.py` — 100 passed
- [ ] CI green

Closes #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)