### PR TITLE
feature(release): PR-D2 FGDC + ISO renderers + mp XML validation

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -778,6 +778,13 @@ sources:
       type: nsidc_https
       url: https://nsidc.org/data/g02158
       archive_url: https://noaadata.apps.nsidc.org/NOAA/G02158/masked/
+      bbox_nwse: [53.0, -125.0, 24.7, -66.0]
+      bbox_notes: >
+        CONUS analysis domain of the SNODAS `masked/` subtree (2003-present),
+        expressed as [N, W, S, E] to match era5_land. SNODAS fetches by date
+        rather than by bbox, so this is the published spatial extent, not a
+        download subset; it satisfies the mandatory FGDC <bounding> element
+        for the consolidated-source release child.
       # CMR collection record (granule-less metadata stub) — kept for
       # provenance and to flag the trap for the next reader; do NOT use
       # earthaccess.search_data on this short_name, it returns 0 hits.

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,8 +40,11 @@ gdptools = ">=0.3.13"
 sciencebasepy = "*"
 earthaccess = "*"
 # pygeometa: MCF v3 intermediate representation + ISO 19139 emission for
-# the ScienceBase data release (release/mcf.py, release/iso.py).
-pygeometa = ">=0.16"
+# the ScienceBase data release (release/mcf.py, release/iso.py). Pinned to a
+# compatible-release range: the ISO XML goldens (tests/test_release_iso.py)
+# assert byte-equality, so a pygeometa minor bump that reflows its output
+# would red the suite. Bump deliberately and regenerate the goldens.
+pygeometa = "~=0.21.1"
 # jinja2: README + FGDC templates (release/readme.py, release/fgdc.py).
 jinja2 = ">=3.1"
 

--- a/src/nhf_spatial_targets/release/__init__.py
+++ b/src/nhf_spatial_targets/release/__init__.py
@@ -27,6 +27,8 @@ from nhf_spatial_targets.release.defaults import (
     load_release_defaults,
     validate_release_defaults,
 )
+from nhf_spatial_targets.release.fgdc import render_fgdc
+from nhf_spatial_targets.release.iso import render_iso
 from nhf_spatial_targets.release.lineage import (
     STEP_KINDS,
     InputFileEntry,
@@ -59,6 +61,12 @@ from nhf_spatial_targets.release.payload import (
 )
 from nhf_spatial_targets.release.readme import render_readme
 from nhf_spatial_targets.release.rebuild import rebuild_lineage
+from nhf_spatial_targets.release.validate_xml import (
+    MpResult,
+    mp_available,
+    validate_xml_file,
+    validate_xml_string,
+)
 
 __all__ = [
     "MCF_VERSION",
@@ -70,6 +78,7 @@ __all__ = [
     "FabricChildPlan",
     "FileEntry",
     "InputFileEntry",
+    "MpResult",
     "OutputFileEntry",
     "ReleasePayload",
     "SourceChildPlan",
@@ -87,11 +96,14 @@ __all__ = [
     "load_release_defaults",
     "load_release_yml",
     "merge_source_and_append_step",
+    "mp_available",
     "output_file_entry",
     "plan_fabric_child",
     "plan_source_child",
     "plan_umbrella",
     "rebuild_lineage",
+    "render_fgdc",
+    "render_iso",
     "render_readme",
     "resolve_fabric_label",
     "scaffold_release_yml",
@@ -103,5 +115,7 @@ __all__ = [
     "stage_umbrella",
     "validate_release_config",
     "validate_release_defaults",
+    "validate_xml_file",
+    "validate_xml_string",
     "verify_csv",
 ]

--- a/src/nhf_spatial_targets/release/fgdc.py
+++ b/src/nhf_spatial_targets/release/fgdc.py
@@ -1,0 +1,328 @@
+"""Render FGDC CSDGM 2.0 XML from an MCF dict via Jinja2 templates.
+
+pygeometa ships no FGDC output schema, so the Federal Geographic Data
+Committee *Content Standard for Digital Geospatial Metadata* (CSDGM,
+FGDC-STD-001-1998) is rendered here from the same MCF dict that
+:mod:`nhf_spatial_targets.release.mcf` builds for ISO and README. Building one
+MCF and rendering it three ways keeps FGDC, ISO and README from drifting.
+
+The renderer is a **pure function of the MCF dict**: it flattens the dict into
+a template context (mirroring :mod:`nhf_spatial_targets.release.readme`) and
+renders one of the per-item-type templates under ``templates/fgdc/``. Every
+date already lives in the MCF (``now`` was injected at build time), so the
+output is byte-stable -- no ``datetime.now()`` is called here.
+
+Two FGDC subtleties are handled in this module rather than the templates:
+
+- **CSDGM element order is strict** -- ``mp`` (the USGS Metadata Parser)
+  rejects out-of-order elements. The base template fixes the order; the
+  ``<procstep>`` order in particular is ``procdesc -> srcused* -> procdate ->
+  proctime -> srcprod*`` with ``srcused``/``srcprod`` repeatable.
+- **Source Citation Abbreviations.** ``<srcused>``/``<srcprod>`` carry short
+  abbreviations that must resolve to ``<srcinfo>`` blocks in the same
+  document. :func:`_srcinfo_entries` derives one ``<srcinfo>`` per unique
+  process-step basename (abbreviation == basename), so the references always
+  resolve.
+
+After Jinja renders the tree it is parsed and pretty-printed with ``lxml``
+(``remove_blank_text`` + ``pretty_print``) so indentation is deterministic and
+the result is guaranteed well-formed regardless of template whitespace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jinja2
+from lxml import etree
+
+_TEMPLATE_DIR = Path(__file__).parent / "templates" / "fgdc"
+
+_KINDS = ("umbrella", "source", "fabric")
+
+# autoescape=True is essential here (unlike the README renderer): abstracts and
+# use-constraints contain ``&``, ``<``, ``>`` (e.g. "kg/m²", ">=1",
+# "min(a, b)") that must become XML entities. Jinja macros return Markup under
+# autoescape, so the cntinfo() macro output is spliced without double-escaping.
+_ENV = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=True,
+    trim_blocks=True,
+    lstrip_blocks=True,
+    undefined=jinja2.StrictUndefined,
+)
+
+# ISO maintenance / status / access codelist values -> FGDC free-text phrases.
+_PROGRESS = {"completed": "Complete", "onGoing": "In work", "planned": "Planned"}
+_UPDATE = {
+    "asNeeded": "As needed",
+    "continual": "Continually",
+    "annually": "Annually",
+}
+_ACCCONST = {"otherRestrictions": "None. Please see Use Constraints."}
+
+# spatial.datatype -> FGDC citation <geoform>.
+_GEOFORM = {"grid": "raster digital data", "vector": "vector digital data"}
+
+# Filename extension -> FGDC <formname>.
+_FORMNAME = {
+    ".nc": "NetCDF",
+    ".gpkg": "GeoPackage",
+    ".json": "JSON",
+    ".csv": "CSV",
+    ".md": "Text",
+}
+
+# Per-item-type entity-type labels for the <eainfo><detailed><enttyp> block.
+_ENTTYP = {
+    "source": (
+        "Consolidated NetCDF variables",
+        "Variables carried in the consolidated CF-1.6 NetCDF files for this "
+        "source dataset.",
+    ),
+    "fabric": (
+        "Calibration target variables",
+        "Calibration-target variables provided for this hydrologic fabric.",
+    ),
+}
+
+
+def _fgdc_date(iso: str | None) -> str | None:
+    """``"2026-05-28"`` -> ``"20260528"``; ``None`` -> ``None``.
+
+    Partial values (a bare ``"1979"``) and the CSDGM special tokens
+    (``"Unknown"``, ``"Present"``) pass through with dashes stripped.
+    """
+    if not iso:
+        return None
+    return iso.replace("-", "")
+
+
+def _origins(citation: dict) -> list[str]:
+    """Originator names for the citation ``<origin>`` elements.
+
+    Structured authors (``{given, family, ...}``) render ``Family, Given``;
+    free-text source citations pass through. CSDGM requires at least one
+    ``<origin>``, so an empty author list falls back to the USGS.
+    """
+    out: list[str] = []
+    for author in citation.get("authors", []):
+        if isinstance(author, dict):
+            name = f"{author.get('family', '')}, {author.get('given', '')}".strip(", ")
+            out.append(name or "U.S. Geological Survey")
+        else:
+            out.append(str(author))
+    return out or ["U.S. Geological Survey"]
+
+
+def _onlinks(ident: dict) -> list[str]:
+    """Online-linkage URLs: DOI, item URL, and any informational dist entries."""
+    out: list[str] = []
+    for url in (ident.get("doi"), ident.get("url")):
+        if url and url not in out:
+            out.append(url)
+    return out
+
+
+def _info_onlinks(distribution: dict, existing: list[str]) -> list[str]:
+    """Landing/upstream (function=information) URLs not already linked."""
+    out: list[str] = []
+    for entry in (distribution or {}).values():
+        url = entry.get("url")
+        if entry.get("function") == "information" and url and url not in existing:
+            if url not in out:
+                out.append(url)
+    return out
+
+
+def _supplinf(ident: dict, lineage: dict) -> str | None:
+    """Supplemental-information prose: edition + versioning + lineage summary.
+
+    CSDGM lineage has no free-text statement element, so the MCF
+    ``dataquality.lineage.statement`` (and the umbrella's edition / versioning
+    policy) live here.
+    """
+    parts: list[str] = []
+    if ident.get("edition"):
+        parts.append(f"Edition: {ident['edition']}.")
+    if ident.get("versioning_policy"):
+        parts.append(ident["versioning_policy"])
+    if lineage.get("statement"):
+        parts.append(lineage["statement"])
+    return "\n\n".join(parts) or None
+
+
+def _cntinfo(contact: dict) -> dict:
+    """Flatten an MCF contact entry into the cntinfo() macro's field names."""
+    return {
+        "cntper": contact.get("individualname", ""),
+        "cntorg": contact.get("organization", ""),
+        "cntpos": contact.get("positionname", ""),
+        "address": contact.get("address", ""),
+        "city": contact.get("city", ""),
+        "state": contact.get("administrativearea", ""),
+        "postal": contact.get("postalcode", ""),
+        "country": contact.get("country", ""),
+        "cntvoice": contact.get("phone", ""),
+        "cntfax": contact.get("fax", ""),
+        "cntemail": contact.get("email", ""),
+    }
+
+
+def _digforms(distribution: dict) -> list[dict]:
+    """One digital-form entry per downloadable distribution file."""
+    out: list[dict] = []
+    for name, entry in (distribution or {}).items():
+        if entry.get("function") != "download":
+            continue
+        suffix = Path(name).suffix
+        out.append(
+            {
+                "formname": _FORMNAME.get(suffix, "Text"),
+                "networkr": entry.get("url", name),
+            }
+        )
+    return out
+
+
+def _producing_procdate(procsteps: list[dict], basename: str) -> str | None:
+    for step in procsteps:
+        if basename in (step.get("srcprod") or []):
+            return step.get("procdate") or None
+    return None
+
+
+def _srcinfo_entries(procsteps: list[dict]) -> list[dict]:
+    """One ``<srcinfo>`` per unique process-step basename.
+
+    ``<srcused>``/``<srcprod>`` carry Source Citation Abbreviations that must
+    resolve to a ``<srcinfo>`` block; we use the basename itself as the
+    abbreviation so the mapping is 1:1 and stable. A basename's source date is
+    the process date of the step that produced it (it appears in that step's
+    ``srcprod``); pure inputs that the pipeline never produced fall back to the
+    CSDGM ``"Unknown"`` token.
+    """
+    names: set[str] = set()
+    for step in procsteps:
+        names.update(step.get("srcused") or [])
+        names.update(step.get("srcprod") or [])
+    entries: list[dict] = []
+    for name in sorted(names):
+        caldate = _producing_procdate(procsteps, name) or "Unknown"
+        entries.append(
+            {
+                "srccitea": name,
+                "title": name,
+                "origin": "U.S. Geological Survey",
+                "caldate": caldate,
+                "typesrc": "Digital data",
+                "srccurr": "Process date",
+                "srccontr": (
+                    "Intermediate or source dataset processed by the "
+                    "nhf-spatial-targets pipeline."
+                ),
+            }
+        )
+    return entries
+
+
+def _context(mcf: dict, *, kind: str) -> dict:
+    ident = mcf.get("identification", {})
+    extents = ident.get("extents", {})
+    spatial = (extents.get("spatial") or [{}])[0]
+    temporal = (extents.get("temporal") or [{}])[0]
+    keywords = ident.get("keywords", {})
+    contact = mcf.get("contact", {})
+    point_of_contact = contact.get("pointOfContact", {})
+    distributor = contact.get("distributor", {})
+    lineage = mcf.get("dataquality", {}).get("lineage", {})
+    procsteps = lineage.get("processstep", [])
+    srcinfo_entries = _srcinfo_entries(procsteps)
+
+    onlinks = _onlinks(ident)
+    onlinks += _info_onlinks(mcf.get("distribution", {}), onlinks)
+
+    enttypl, enttypd = _ENTTYP.get(kind, ("", ""))
+
+    return {
+        "metadata_date": _fgdc_date(mcf.get("metadata", {}).get("datestamp")),
+        # idinfo / citation
+        "origins": _origins(ident.get("citation", {})),
+        "pubdate": _fgdc_date(ident.get("dates", {}).get("publication")),
+        "title": ident.get("title", ""),
+        "geoform": _GEOFORM.get(mcf.get("spatial", {}).get("datatype"), "digital data"),
+        "pub_place": ", ".join(
+            p
+            for p in (distributor.get("city"), distributor.get("administrativearea"))
+            if p
+        ),
+        "publisher": distributor.get("organization", ""),
+        "onlinks": onlinks,
+        # idinfo / descript
+        "abstract": ident.get("abstract", ""),
+        "purpose": ident.get("purpose", ""),
+        "supplinf": _supplinf(ident, lineage),
+        # idinfo / timeperd
+        "begdate": _fgdc_date(temporal.get("begin")) or "Unknown",
+        "enddate": _fgdc_date(temporal.get("end")) or "Present",
+        # idinfo / status
+        "progress": _PROGRESS.get(ident.get("status"), "Complete"),
+        "update": _UPDATE.get(ident.get("maintenancefrequency"), "As needed"),
+        # idinfo / spdom
+        "bbox": spatial.get("bbox"),
+        # idinfo / keywords
+        "theme_keywords": keywords.get("theme", {}).get("keywords", []),
+        "topic_categories": ident.get("topiccategory", []),
+        "place_keywords": keywords.get("place", {}).get("keywords", []),
+        # idinfo / constraints
+        "accconst": _ACCCONST.get(
+            ident.get("accessconstraints"), ident.get("accessconstraints", "None.")
+        ),
+        "useconst": ident.get("useconstraints", ""),
+        "point_of_contact": _cntinfo(point_of_contact),
+        # dataqual / lineage
+        "has_lineage": bool(procsteps or srcinfo_entries),
+        "srcinfo_entries": srcinfo_entries,
+        "procsteps": procsteps,
+        # spref
+        "spref": mcf.get("spatial_reference", {}),
+        # eainfo (rendered by the per-kind child template)
+        "entityandattribute": ident.get("entityandattribute", []),
+        "enttypl": enttypl,
+        "enttypd": enttypd,
+        # distinfo
+        "distributor": _cntinfo(distributor),
+        "distliab": mcf.get("distribution_liability", ""),
+        "digforms": _digforms(mcf.get("distribution", {})),
+        "fees": ident.get("fees", "None."),
+    }
+
+
+def render_fgdc(mcf: dict, *, kind: str) -> str:
+    """Render the FGDC CSDGM 2.0 XML for one release item.
+
+    Parameters
+    ----------
+    mcf
+        The MCF dict from :func:`nhf_spatial_targets.release.mcf.build_*_mcf`.
+    kind
+        One of ``"umbrella"``, ``"source"``, ``"fabric"`` -- selects the
+        template and the entity/attribute flavor.
+
+    Returns
+    -------
+    Pretty-printed, well-formed FGDC XML with an XML declaration.
+
+    Raises
+    ------
+    ValueError
+        *kind* is not a recognized item type.
+    """
+    if kind not in _KINDS:
+        raise ValueError(f"Unknown FGDC kind {kind!r}; expected one of {_KINDS}.")
+    raw = _ENV.get_template(f"{kind}.xml.j2").render(**_context(mcf, kind=kind))
+    parser = etree.XMLParser(remove_blank_text=True)
+    tree = etree.fromstring(raw.encode("utf-8"), parser=parser)
+    return etree.tostring(
+        tree, pretty_print=True, xml_declaration=True, encoding="UTF-8"
+    ).decode("utf-8")

--- a/src/nhf_spatial_targets/release/fgdc.py
+++ b/src/nhf_spatial_targets/release/fgdc.py
@@ -88,10 +88,13 @@ _ENTTYP = {
 
 
 def _fgdc_date(iso: str | None) -> str | None:
-    """``"2026-05-28"`` -> ``"20260528"``; ``None`` -> ``None``.
+    """Convert an ISO date to the CSDGM ``YYYYMMDD`` form.
 
-    Partial values (a bare ``"1979"``) and the CSDGM special tokens
-    (``"Unknown"``, ``"Present"``) pass through with dashes stripped.
+    ``"2026-05-28"`` -> ``"20260528"``; ``None`` -> ``None``. A partial value
+    (a bare ``"1979"``) keeps its precision (dashes are simply removed). The
+    CSDGM ``"Unknown"`` / ``"Present"`` fallbacks are supplied by
+    :func:`_context`, not here -- this function only ever sees a real ISO date
+    or ``None``.
     """
     if not iso:
         return None
@@ -178,7 +181,7 @@ def _digforms(distribution: dict) -> list[dict]:
         suffix = Path(name).suffix
         out.append(
             {
-                "formname": _FORMNAME.get(suffix, "Text"),
+                "formname": _FORMNAME.get(suffix, "Digital data"),
                 "networkr": entry.get("url", name),
             }
         )
@@ -316,11 +319,24 @@ def render_fgdc(mcf: dict, *, kind: str) -> str:
     Raises
     ------
     ValueError
-        *kind* is not a recognized item type.
+        *kind* is not a recognized item type, or the item has no bounding box
+        (CSDGM ``<spdom>`` is mandatory, so an item with no extent cannot
+        produce valid FGDC).
     """
     if kind not in _KINDS:
         raise ValueError(f"Unknown FGDC kind {kind!r}; expected one of {_KINDS}.")
-    raw = _ENV.get_template(f"{kind}.xml.j2").render(**_context(mcf, kind=kind))
+    context = _context(mcf, kind=kind)
+    if context["bbox"] is None:
+        # CSDGM <spdom><bounding> is mandatory; emitting the record without it
+        # produces XML that mp rejects. Fail loudly here (pointing at the
+        # catalog fix) rather than shipping silently-invalid metadata.
+        raise ValueError(
+            f"Cannot render FGDC for {kind!r} item {mcf.get('identification', {}).get('title', '')!r}: "
+            "it has no bounding box, but CSDGM <spdom> is mandatory. Add "
+            "`access.bbox_nwse` to the source's catalog entry (see the snodas "
+            "entry) or ensure fabric.json carries a bbox."
+        )
+    raw = _ENV.get_template(f"{kind}.xml.j2").render(**context)
     parser = etree.XMLParser(remove_blank_text=True)
     tree = etree.fromstring(raw.encode("utf-8"), parser=parser)
     return etree.tostring(

--- a/src/nhf_spatial_targets/release/iso.py
+++ b/src/nhf_spatial_targets/release/iso.py
@@ -1,0 +1,30 @@
+"""Render ISO 19139 XML from an MCF dict via pygeometa.
+
+Unlike FGDC (which pygeometa cannot emit, see :mod:`nhf_spatial_targets.
+release.fgdc`), ISO 19139 is produced directly by pygeometa's output schema.
+This module is a thin, pure wrapper so the release pipeline has one symmetric
+``render_iso(mcf)`` / ``render_fgdc(mcf, kind=...)`` surface and so the ISO
+render path is covered by a golden test alongside FGDC.
+
+The MCF dict is the contract: every date is already baked in (``now`` injected
+at build time), so the output is byte-stable for a pinned pygeometa version.
+"""
+
+from __future__ import annotations
+
+from pygeometa.schemas.iso19139 import ISO19139OutputSchema
+
+
+def render_iso(mcf: dict) -> str:
+    """Render the ISO 19139 XML for one release item from its MCF dict.
+
+    Parameters
+    ----------
+    mcf
+        The MCF dict from :func:`nhf_spatial_targets.release.mcf.build_*_mcf`.
+
+    Returns
+    -------
+    The ISO 19139 XML as a string (includes the XML declaration).
+    """
+    return ISO19139OutputSchema().write(mcf)

--- a/src/nhf_spatial_targets/release/mcf.py
+++ b/src/nhf_spatial_targets/release/mcf.py
@@ -21,6 +21,7 @@ pygeometa ignores but the FGDC Jinja templates read:
   ``<eainfo>`` records
 - ``dataquality.lineage.processstep`` -- ``<procstep>`` blocks built from
   ``manifest.json.steps[]``
+- ``distribution_liability`` (top level) -- FGDC ``<distliab>`` boilerplate
 
 The builders are **pure**: every input is passed in (the populated
 ``catalog/release_defaults.yml`` via :mod:`release.defaults`, the per-source
@@ -854,6 +855,12 @@ def _assemble(
         "distribution": distribution,
         "dataquality": dataquality,
         "spatial_reference": dict(defaults.get("spatial_reference", {})),
+        # FGDC <distliab> is mandatory within <distinfo>; pygeometa/ISO ignore
+        # this key. Sourced from release_defaults so the boilerplate is edited
+        # in one place and flows to every rendered FGDC document.
+        "distribution_liability": _collapse_ws(
+            defaults.get("distribution", {}).get("liability_statement", "")
+        ),
     }
     if version is not None:
         mcf["identification"]["edition"] = version

--- a/src/nhf_spatial_targets/release/templates/fgdc/base.xml.j2
+++ b/src/nhf_spatial_targets/release/templates/fgdc/base.xml.j2
@@ -1,0 +1,211 @@
+{#-
+  FGDC CSDGM 2.0 (FGDC-STD-001-1998) base template. Element order is fixed and
+  load-bearing -- `mp` rejects out-of-order elements. Per-item-type templates
+  (umbrella / source / fabric) extend this and override {% block eainfo %}.
+  Output is pretty-printed by lxml after rendering, so whitespace here is only
+  for human readability.
+-#}
+{%- macro cntinfo(c) -%}
+<cntinfo>
+  {%- if c.cntper %}
+  <cntperp>
+    <cntper>{{ c.cntper }}</cntper>
+    {%- if c.cntorg %}
+    <cntorg>{{ c.cntorg }}</cntorg>
+    {%- endif %}
+  </cntperp>
+  {%- else %}
+  <cntorgp>
+    <cntorg>{{ c.cntorg }}</cntorg>
+  </cntorgp>
+  {%- endif %}
+  {%- if c.cntpos %}
+  <cntpos>{{ c.cntpos }}</cntpos>
+  {%- endif %}
+  <cntaddr>
+    <addrtype>mailing and physical</addrtype>
+    <address>{{ c.address }}</address>
+    <city>{{ c.city }}</city>
+    <state>{{ c.state }}</state>
+    <postal>{{ c.postal }}</postal>
+    <country>{{ c.country }}</country>
+  </cntaddr>
+  <cntvoice>{{ c.cntvoice }}</cntvoice>
+  {%- if c.cntfax %}
+  <cntfax>{{ c.cntfax }}</cntfax>
+  {%- endif %}
+  {%- if c.cntemail %}
+  <cntemail>{{ c.cntemail }}</cntemail>
+  {%- endif %}
+</cntinfo>
+{%- endmacro -%}
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        {% for o in origins %}
+        <origin>{{ o }}</origin>
+        {% endfor %}
+        <pubdate>{{ pubdate }}</pubdate>
+        <title>{{ title }}</title>
+        <geoform>{{ geoform }}</geoform>
+        <pubinfo>
+          <pubplace>{{ pub_place }}</pubplace>
+          <publish>{{ publisher }}</publish>
+        </pubinfo>
+        {% for u in onlinks %}
+        <onlink>{{ u }}</onlink>
+        {% endfor %}
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>{{ abstract }}</abstract>
+      <purpose>{{ purpose }}</purpose>
+      {% if supplinf %}
+      <supplinf>{{ supplinf }}</supplinf>
+      {% endif %}
+    </descript>
+    <timeperd>
+      <timeinfo>
+        <rngdates>
+          <begdate>{{ begdate }}</begdate>
+          <enddate>{{ enddate }}</enddate>
+        </rngdates>
+      </timeinfo>
+      <current>ground condition</current>
+    </timeperd>
+    <status>
+      <progress>{{ progress }}</progress>
+      <update>{{ update }}</update>
+    </status>
+    {% if bbox %}
+    <spdom>
+      <bounding>
+        <westbc>{{ bbox[0] }}</westbc>
+        <eastbc>{{ bbox[2] }}</eastbc>
+        <northbc>{{ bbox[3] }}</northbc>
+        <southbc>{{ bbox[1] }}</southbc>
+      </bounding>
+    </spdom>
+    {% endif %}
+    <keywords>
+      <theme>
+        <themekt>None</themekt>
+        {% for k in theme_keywords %}
+        <themekey>{{ k }}</themekey>
+        {% endfor %}
+      </theme>
+      {% if topic_categories %}
+      <theme>
+        <themekt>ISO 19115 Topic Category</themekt>
+        {% for k in topic_categories %}
+        <themekey>{{ k }}</themekey>
+        {% endfor %}
+      </theme>
+      {% endif %}
+      {% if place_keywords %}
+      <place>
+        <placekt>None</placekt>
+        {% for k in place_keywords %}
+        <placekey>{{ k }}</placekey>
+        {% endfor %}
+      </place>
+      {% endif %}
+    </keywords>
+    <accconst>{{ accconst }}</accconst>
+    <useconst>{{ useconst }}</useconst>
+    <ptcontac>{{ cntinfo(point_of_contact) }}</ptcontac>
+  </idinfo>
+  {% if has_lineage %}
+  <dataqual>
+    <lineage>
+      {% for s in srcinfo_entries %}
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>{{ s.origin }}</origin>
+            <pubdate>{{ s.caldate }}</pubdate>
+            <title>{{ s.title }}</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>{{ s.typesrc }}</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>{{ s.caldate }}</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>{{ s.srccurr }}</srccurr>
+        </srctime>
+        <srccitea>{{ s.srccitea }}</srccitea>
+        <srccontr>{{ s.srccontr }}</srccontr>
+      </srcinfo>
+      {% endfor %}
+      {% for p in procsteps %}
+      <procstep>
+        <procdesc>{{ p.procdesc }}</procdesc>
+        {% for u in p.srcused %}
+        <srcused>{{ u }}</srcused>
+        {% endfor %}
+        <procdate>{{ p.procdate or "Unknown" }}</procdate>
+        {% if p.proctime %}
+        <proctime>{{ p.proctime }}</proctime>
+        {% endif %}
+        {% for u in p.srcprod %}
+        <srcprod>{{ u }}</srcprod>
+        {% endfor %}
+      </procstep>
+      {% endfor %}
+    </lineage>
+  </dataqual>
+  {% endif %}
+  {% if spref %}
+  <spref>
+    <horizsys>
+      <geograph>
+        <latres>{{ spref.latres }}</latres>
+        <longres>{{ spref.longres }}</longres>
+        <geogunit>{{ spref.geogunit }}</geogunit>
+      </geograph>
+      <geodetic>
+        <horizdn>{{ spref.horizontal_datum }}</horizdn>
+        <ellips>{{ spref.ellipsoid }}</ellips>
+        <semiaxis>{{ spref.semiaxis }}</semiaxis>
+        <denflat>{{ spref.denflat }}</denflat>
+      </geodetic>
+    </horizsys>
+  </spref>
+  {% endif %}
+  {% block eainfo %}{% endblock %}
+  <distinfo>
+    <distrib>{{ cntinfo(distributor) }}</distrib>
+    <distliab>{{ distliab }}</distliab>
+    {% if digforms %}
+    <stdorder>
+      {% for d in digforms %}
+      <digform>
+        <digtinfo>
+          <formname>{{ d.formname }}</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>{{ d.networkr }}</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      {% endfor %}
+      <fees>{{ fees }}</fees>
+    </stdorder>
+    {% endif %}
+  </distinfo>
+  <metainfo>
+    <metd>{{ metadata_date }}</metd>
+    <metc>{{ cntinfo(point_of_contact) }}</metc>
+    <metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
+    <metstdv>FGDC-STD-001-1998</metstdv>
+  </metainfo>
+</metadata>

--- a/src/nhf_spatial_targets/release/templates/fgdc/fabric.xml.j2
+++ b/src/nhf_spatial_targets/release/templates/fgdc/fabric.xml.j2
@@ -1,0 +1,27 @@
+{#- Fabric child FGDC. The entity-and-attribute section lists the calibration
+    targets; the unrepresentable-domain text carries units, the range method,
+    and any range notes. -#}
+{% extends "base.xml.j2" %}
+{% block eainfo %}
+{% if entityandattribute %}
+<eainfo>
+  <detailed>
+    <enttyp>
+      <enttypl>{{ enttypl }}</enttypl>
+      <enttypd>{{ enttypd }}</enttypd>
+      <enttypds>Producer defined</enttypds>
+    </enttyp>
+    {% for v in entityandattribute %}
+    <attr>
+      <attrlabl>{{ v.name }}</attrlabl>
+      <attrdef>{{ v.definition }}</attrdef>
+      <attrdefs>Producer defined</attrdefs>
+      <attrdomv>
+        <udom>Units: {{ v.units or "dimensionless" }}. Range method: {{ v.range_method or "n/a" }}.{% if v.range_notes %} {{ v.range_notes }}{% endif %}</udom>
+      </attrdomv>
+    </attr>
+    {% endfor %}
+  </detailed>
+</eainfo>
+{% endif %}
+{% endblock %}

--- a/src/nhf_spatial_targets/release/templates/fgdc/source.xml.j2
+++ b/src/nhf_spatial_targets/release/templates/fgdc/source.xml.j2
@@ -1,0 +1,27 @@
+{#- Consolidated-source child FGDC. The entity-and-attribute section lists the
+    NetCDF variables; the unrepresentable-domain text carries CF units and
+    cell_methods. -#}
+{% extends "base.xml.j2" %}
+{% block eainfo %}
+{% if entityandattribute %}
+<eainfo>
+  <detailed>
+    <enttyp>
+      <enttypl>{{ enttypl }}</enttypl>
+      <enttypd>{{ enttypd }}</enttypd>
+      <enttypds>Producer defined</enttypds>
+    </enttyp>
+    {% for v in entityandattribute %}
+    <attr>
+      <attrlabl>{{ v.name }}</attrlabl>
+      <attrdef>{{ v.definition }}</attrdef>
+      <attrdefs>Producer defined</attrdefs>
+      <attrdomv>
+        <udom>Units: {{ v.units or "dimensionless" }}. Cell methods: {{ v.cell_methods or "n/a" }}.</udom>
+      </attrdomv>
+    </attr>
+    {% endfor %}
+  </detailed>
+</eainfo>
+{% endif %}
+{% endblock %}

--- a/src/nhf_spatial_targets/release/templates/fgdc/umbrella.xml.j2
+++ b/src/nhf_spatial_targets/release/templates/fgdc/umbrella.xml.j2
@@ -1,0 +1,4 @@
+{#- Umbrella (DOI parent / series) FGDC. No entity-and-attribute section: the
+    umbrella carries no data files of its own, only child items. Everything
+    else comes from base.xml.j2. -#}
+{% extends "base.xml.j2" %}

--- a/src/nhf_spatial_targets/release/validate_xml.py
+++ b/src/nhf_spatial_targets/release/validate_xml.py
@@ -24,6 +24,9 @@ from lxml import etree
 
 _MP_TIMEOUT_S = 120
 
+_ERROR_HEADERS = {"error", "errors"}
+_WARNING_HEADERS = {"warning", "warnings"}
+
 
 class MpResult(NamedTuple):
     """Outcome of an XML validation: overall pass flag plus message lists."""
@@ -54,9 +57,18 @@ def _wellformed(path: Path) -> MpResult:
 def _parse_mp_report(report: str) -> tuple[list[str], list[str]]:
     """Split an ``mp`` error report into (warnings, errors).
 
-    ``mp`` groups messages under ``Warnings:`` / ``Errors:`` section headers,
-    one indented message per line. Lines before the first header (the banner)
-    are ignored. If ``mp``'s format differs in a given install, refine here.
+    ``mp`` groups its messages under ``Errors:`` / ``Warnings:`` section
+    headers, one message per (indented) line. A line is treated as a section
+    header only when it is *exactly* that header token (``"Errors:"`` /
+    ``"Warnings:"``, case-insensitive, trailing colon optional) -- so a
+    message body that happens to begin with the word "error"/"warning" stays
+    in its section instead of being mistaken for a header and dropped. Lines
+    before the first header (mp's banner) carry no section and are ignored.
+
+    This categorization is best-effort and used only for human-readable
+    reporting: :func:`validate_xml_file` keys the pass/fail decision on mp's
+    exit status, so a format mismatch here cannot turn an mp failure into a
+    silent pass.
     """
     warnings: list[str] = []
     errors: list[str] = []
@@ -65,11 +77,11 @@ def _parse_mp_report(report: str) -> tuple[list[str], list[str]]:
         stripped = line.strip()
         if not stripped:
             continue
-        low = stripped.lower()
-        if low.startswith("error"):
+        token = stripped.rstrip(":").strip().lower()
+        if token in _ERROR_HEADERS:
             bucket = errors
             continue
-        if low.startswith("warning"):
+        if token in _WARNING_HEADERS:
             bucket = warnings
             continue
         if bucket is not None:
@@ -90,8 +102,9 @@ def validate_xml_file(path: str | Path, *, mp_path: str = "mp") -> MpResult:
     Returns
     -------
     MpResult
-        ``ok`` is False only when ``mp`` reports errors (or, in fallback mode,
-        the XML is not well-formed). ``mp``-absent is a warning, not a failure.
+        ``ok`` is False when ``mp`` exits non-zero or reports errors (or, in
+        fallback mode, the XML is not well-formed). ``mp``-absent is a warning,
+        not a failure.
     """
     path = Path(path)
     if not mp_available(mp_path):
@@ -108,9 +121,19 @@ def validate_xml_file(path: str | Path, *, mp_path: str = "mp") -> MpResult:
             )
         except subprocess.TimeoutExpired:
             return MpResult(False, [], [f"mp timed out after {_MP_TIMEOUT_S}s."])
-        report = err_file.read_text() if err_file.exists() else proc.stdout
+        report = err_file.read_text() if err_file.exists() else (proc.stdout or "")
     warnings, errors = _parse_mp_report(report)
-    return MpResult(not errors, warnings, errors)
+    # mp's exit status is authoritative for pass/fail; the parsed lists are
+    # only for human-readable categorization. A non-zero exit we could not
+    # attribute to a parsed error (mp aborted, or wrote a report format we did
+    # not recognize) must surface as a failure rather than a silent pass.
+    if proc.returncode != 0 and not errors:
+        errors = [
+            f"mp exited with status {proc.returncode}; "
+            f"report: {report.strip() or '(empty)'}"
+        ]
+    ok = proc.returncode == 0 and not errors
+    return MpResult(ok, warnings, errors)
 
 
 def validate_xml_string(xml: str, *, mp_path: str = "mp") -> MpResult:

--- a/src/nhf_spatial_targets/release/validate_xml.py
+++ b/src/nhf_spatial_targets/release/validate_xml.py
@@ -1,0 +1,121 @@
+"""Validate rendered metadata XML with the USGS Metadata Parser (``mp``).
+
+``mp`` is the canonical FGDC CSDGM validator but is an operator-installed
+external tool, not a Python dependency. This module wraps it defensively:
+
+- ``mp`` on PATH -> run it, return parsed ``(ok, warnings, errors)``.
+- ``mp`` absent -> fall back to an ``lxml`` well-formedness check (warn-only),
+  so a missing validator never hard-fails a build.
+
+The result is a :class:`MpResult` NamedTuple, so callers can unpack it as
+``ok, warnings, errors = validate_xml_file(path)`` (the tuple shape the design
+plan specifies) or use the attribute names.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import NamedTuple
+
+from lxml import etree
+
+_MP_TIMEOUT_S = 120
+
+
+class MpResult(NamedTuple):
+    """Outcome of an XML validation: overall pass flag plus message lists."""
+
+    ok: bool
+    warnings: list[str]
+    errors: list[str]
+
+
+def mp_available(mp_path: str = "mp") -> bool:
+    """True if the ``mp`` executable is resolvable on PATH (or as given)."""
+    return shutil.which(mp_path) is not None
+
+
+def _wellformed(path: Path) -> MpResult:
+    """lxml-only fallback when ``mp`` is unavailable: check well-formedness."""
+    try:
+        etree.parse(str(path))
+    except etree.XMLSyntaxError as exc:
+        return MpResult(False, [], [f"XML is not well-formed: {exc}"])
+    return MpResult(
+        True,
+        ["mp not found on PATH; validated XML well-formedness only (no CSDGM check)."],
+        [],
+    )
+
+
+def _parse_mp_report(report: str) -> tuple[list[str], list[str]]:
+    """Split an ``mp`` error report into (warnings, errors).
+
+    ``mp`` groups messages under ``Warnings:`` / ``Errors:`` section headers,
+    one indented message per line. Lines before the first header (the banner)
+    are ignored. If ``mp``'s format differs in a given install, refine here.
+    """
+    warnings: list[str] = []
+    errors: list[str] = []
+    bucket: list[str] | None = None
+    for line in report.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        low = stripped.lower()
+        if low.startswith("error"):
+            bucket = errors
+            continue
+        if low.startswith("warning"):
+            bucket = warnings
+            continue
+        if bucket is not None:
+            bucket.append(stripped)
+    return warnings, errors
+
+
+def validate_xml_file(path: str | Path, *, mp_path: str = "mp") -> MpResult:
+    """Validate an FGDC XML file with ``mp``, or fall back to well-formedness.
+
+    Parameters
+    ----------
+    path
+        Path to the XML file to validate.
+    mp_path
+        Name or path of the ``mp`` executable (default ``"mp"``).
+
+    Returns
+    -------
+    MpResult
+        ``ok`` is False only when ``mp`` reports errors (or, in fallback mode,
+        the XML is not well-formed). ``mp``-absent is a warning, not a failure.
+    """
+    path = Path(path)
+    if not mp_available(mp_path):
+        return _wellformed(path)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        err_file = Path(tmp) / "mp_errors.txt"
+        try:
+            proc = subprocess.run(
+                [mp_path, "-e", str(err_file), str(path)],
+                capture_output=True,
+                text=True,
+                timeout=_MP_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return MpResult(False, [], [f"mp timed out after {_MP_TIMEOUT_S}s."])
+        report = err_file.read_text() if err_file.exists() else proc.stdout
+    warnings, errors = _parse_mp_report(report)
+    return MpResult(not errors, warnings, errors)
+
+
+def validate_xml_string(xml: str, *, mp_path: str = "mp") -> MpResult:
+    """Validate an XML string by writing it to a temp file and running ``mp``."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "metadata.xml"
+        path.write_text(xml, encoding="utf-8")
+        return validate_xml_file(path, mp_path=mp_path)

--- a/tests/fixtures/release/expected_fabric_gfv2_fgdc.xml
+++ b/tests/fixtures/release/expected_fabric_gfv2_fgdc.xml
@@ -1,0 +1,394 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        <origin>Doe, Jane</origin>
+        <origin>Roe, John</origin>
+        <pubdate>20260528</pubdate>
+        <title>Calibration targets for the gfv2 hydrologic fabric, U.S. Geological Survey National Hydrologic Model</title>
+        <geoform>vector digital data</geoform>
+        <pubinfo>
+          <pubplace>Denver, CO</pubplace>
+          <publish>U.S. Geological Survey - ScienceBase</publish>
+        </pubinfo>
+        <onlink>https://www.sciencebase.gov</onlink>
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>This child item provides calibration-target datasets for the gfv2 hydrologic fabric (109951 hydrologic response units) of the USGS National Hydrologic Model. Targets: runoff, aet, snow_water_equivalent. Participating sources: daymet, era5_land, gldas_noah_v21_monthly, snodas. Project-specific note appended to the fabric abstract.</abstract>
+      <purpose>Provide calibration targets aggregated to the gfv2 fabric for parameter estimation of the USGS National Hydrologic Model.</purpose>
+      <supplinf>Each gridded source dataset was area-weighted to the gfv2 fabric with gdptools, then combined into per-target ranges by the nhf-spatial-targets pipeline.</supplinf>
+    </descript>
+    <timeperd>
+      <timeinfo>
+        <rngdates>
+          <begdate>20000101</begdate>
+          <enddate>Present</enddate>
+        </rngdates>
+      </timeinfo>
+      <current>ground condition</current>
+    </timeperd>
+    <status>
+      <progress>Complete</progress>
+      <update>As needed</update>
+    </status>
+    <spdom>
+      <bounding>
+        <westbc>-124.7</westbc>
+        <eastbc>-66.95</eastbc>
+        <northbc>49.4</northbc>
+        <southbc>24.5</southbc>
+      </bounding>
+    </spdom>
+    <keywords>
+      <theme>
+        <themekt>None</themekt>
+        <themekey>hydrology</themekey>
+        <themekey>National Hydrologic Model</themekey>
+        <themekey>hydrologic response unit</themekey>
+        <themekey>calibration targets</themekey>
+        <themekey>runoff</themekey>
+        <themekey>aet</themekey>
+        <themekey>snow_water_equivalent</themekey>
+      </theme>
+      <theme>
+        <themekt>ISO 19115 Topic Category</themekt>
+        <themekey>inlandWaters</themekey>
+        <themekey>climatologyMeteorologyAtmosphere</themekey>
+      </theme>
+      <place>
+        <placekt>None</placekt>
+        <placekey>gfv2</placekey>
+      </place>
+    </keywords>
+    <accconst>None. Please see Use Constraints.</accconst>
+    <useconst>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+
+Participating source dataset licenses: public domain (NASA / ORNL DAAC); Copernicus license (free, attribution); public domain (NASA); public domain (NSIDC / NOAA).
+
+These data are distributed by the Oak Ridge National Laboratory Distributed Active Archive Center (ORNL DAAC), Oak Ridge, Tennessee, USA.
+
+This dataset was generated using Copernicus Climate Change Service (C3S) information (ECMWF ERA5-Land). Neither the European Commission nor ECMWF is responsible for any use of the Copernicus information or data it contains.
+
+These data were obtained from the NASA Earthdata system. We acknowledge the use of data products from the NASA Earth science data systems.
+
+These data are distributed by the NASA National Snow and Ice Data Center Distributed Active Archive Center (NSIDC DAAC).</useconst>
+    <ptcontac>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </ptcontac>
+  </idinfo>
+  <dataqual>
+    <lineage>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260522</pubdate>
+            <title>era5_land_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260522</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>era5_land_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260521</pubdate>
+            <title>era5_land_monthly_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260521</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>era5_land_monthly_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260524</pubdate>
+            <title>runoff_targets.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260524</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>runoff_targets.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260521</pubdate>
+            <title>snodas_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260521</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>snodas_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <procstep>
+        <procdesc>consolidate via nhf-targets 0.7.0; command: fetch era5-land; params: resample=monthly</procdesc>
+        <srcused>era5_land_2003.nc</srcused>
+        <procdate>20260521</procdate>
+        <proctime>103015</proctime>
+        <srcprod>era5_land_monthly_2003.nc</srcprod>
+      </procstep>
+      <procstep>
+        <procdesc>aggregate via nhf-targets 0.7.0; command: agg era5-land; params: batch_size=500, method=area_weighted</procdesc>
+        <srcused>era5_land_monthly_2003.nc</srcused>
+        <procdate>20260522</procdate>
+        <proctime>080000</proctime>
+        <srcprod>era5_land_2003.nc</srcprod>
+      </procstep>
+      <procstep>
+        <procdesc>consolidate via nhf-targets 0.7.0; command: fetch snodas</procdesc>
+        <procdate>20260521</procdate>
+        <proctime>124500</proctime>
+        <srcprod>snodas_2003.nc</srcprod>
+      </procstep>
+      <procstep>
+        <procdesc>target via nhf-targets 0.7.0; command: run-runoff; params: range_method=multi_source_minmax</procdesc>
+        <srcused>era5_land_2003.nc</srcused>
+        <procdate>20260524</procdate>
+        <proctime>091530</proctime>
+        <srcprod>runoff_targets.nc</srcprod>
+      </procstep>
+      <procstep>
+        <procdesc>validate via nhf-targets 0.7.0; command: validate</procdesc>
+        <procdate>20260525</procdate>
+        <proctime>000000</proctime>
+      </procstep>
+    </lineage>
+  </dataqual>
+  <spref>
+    <horizsys>
+      <geograph>
+        <latres>0.001</latres>
+        <longres>0.001</longres>
+        <geogunit>Decimal degrees</geogunit>
+      </geograph>
+      <geodetic>
+        <horizdn>WGS_1984</horizdn>
+        <ellips>WGS_1984</ellips>
+        <semiaxis>6378137.0</semiaxis>
+        <denflat>298.257223563</denflat>
+      </geodetic>
+    </horizsys>
+  </spref>
+  <eainfo>
+    <detailed>
+      <enttyp>
+        <enttypl>Calibration target variables</enttypl>
+        <enttypd>Calibration-target variables provided for this hydrologic fabric.</enttypd>
+        <enttypds>Producer defined</enttypds>
+      </enttyp>
+      <attr>
+        <attrlabl>runoff</attrlabl>
+        <attrdef>Monthly basin mean runoff. Range is min/max across two reanalysis sources per HRU and time step.</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: cfs. Range method: multi_source_minmax. ERA5-Land 'ro' (m water equivalent), GLDAS-2.1 NOAH 'Qs_acc + Qsb_acc' (kg/m² ≡ mm), and MWBM ClimGrid 'runoff' (mm/month) are aggregated to HRU polygons via gdptools, harmonized to mm/month, then converted to cfs using HRU area and days-in-month. Per-HRU per-month: lower_bound = nanmin(era5, gldas, mwbm), upper_bound = nanmax(era5, gldas, mwbm). nanmin/nanmax (xr.concat([...]).min(skipna=True)) means a bound is defined whenever &gt;=1 source is finite at that (HRU, time); only all-NaN cells produce NaN. mwbm_climgrid (Wieczorek et al. 2024, ClimGrid-forced) is the third source; all three are consumed by targets/run.py.</udom>
+        </attrdomv>
+      </attr>
+      <attr>
+        <attrlabl>aet</attrlabl>
+        <attrdef>Monthly actual evapotranspiration. Range is min/max across three independent source datasets per HRU and time step. Absolute values used (not normalized); range reflects inter-product spread.</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: inches/day. Range method: multi_source_minmax. For each HRU and time step: lower_bound = min(src1, src2, src3), upper_bound = max(src1, src2, src3). All sources must be spatially aggregated to HRU polygons via gdptools before comparison. AET is NOT normalized — absolute values are compared directly. mwbm_climgrid contributes the MWBM-family AET trace (Wieczorek et al. 2024, mm/month native). MOD16A2 v061 flat seasonality was traced to fill-value contamination during sinusoidal→WGS84 reprojection (rioxarray Resampling.average averaging special codes into valid neighbours); fixed in PR #88 by masking ET_500m fills before reprojection. All three sources are now included. Existing consolidated/aggregated NCs produced before PR #88 must be re-fetched and re-aggregated.</udom>
+        </attrdomv>
+      </attr>
+      <attr>
+        <attrlabl>snow_water_equivalent</attrlabl>
+        <attrdef>Daily basin snow water equivalent. Range is min/max across four independent SWE sources per HRU and time step. Margulis Western US Snow Reanalysis is fabric-scoped to Oregon only (see fabric_scope in catalog/sources.yml); non-Oregon fabrics are bounded by the remaining three sources. Absolute values used (not normalized).</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: inches. Range method: multi_source_minmax. Daymet 'swe' (kg/m² ≡ mm), SNODAS 'swe' (kg/m² ≡ mm), ERA5-Land 'sd' (m water-eq → mm), Margulis WUS-SR 'SWE' (m water-eq → mm) are aggregated to HRU polygons via gdptools and harmonized to mm, then converted to inches in the target builder to match the PRMS variable pkwater_equiv (per TM 6-B7). Per-HRU per-day: lower_bound = nanmin(daymet, snodas, era5_sd, margulis), upper_bound = nanmax(daymet, snodas, era5_sd, margulis). nanmin/nanmax (xr.concat([...]).min(skipna=True)) means a bound is defined whenever &gt;=1 source is finite at that (HRU, time); only all-NaN cells produce NaN. Margulis WUS-SR is fabric-scoped to Oregon (see catalog/sources.yml fabric_scope); for non-OR fabrics it is excluded by the target builder so the bound reduces to a 3-source min/max.</udom>
+        </attrdomv>
+      </attr>
+    </detailed>
+  </eainfo>
+  <distinfo>
+    <distrib>
+      <cntinfo>
+        <cntperp>
+          <cntper>ScienceBase Data Release Team</cntper>
+          <cntorg>U.S. Geological Survey - ScienceBase</cntorg>
+        </cntperp>
+        <cntpos>Distributor</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>sciencebase@usgs.gov</cntemail>
+      </cntinfo>
+    </distrib>
+    <distliab>Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty.</distliab>
+    <stdorder>
+      <digform>
+        <digtinfo>
+          <formname>GeoPackage</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>fabric.gpkg</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>aggregated/era5_land/era5_land_2003.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>aggregated/snodas/snodas_2003.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>targets/runoff_targets.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>targets/swe_targets.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>JSON</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>manifest.json</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <fees>None.</fees>
+    </stdorder>
+  </distinfo>
+  <metainfo>
+    <metd>20260528</metd>
+    <metc>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </metc>
+    <metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
+    <metstdv>FGDC-STD-001-1998</metstdv>
+  </metainfo>
+</metadata>

--- a/tests/fixtures/release/expected_fabric_gfv2_iso.xml
+++ b/tests/fixtures/release/expected_fabric_gfv2_iso.xml
@@ -1,0 +1,540 @@
+<?xml version="1.0" ?>
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>urn:usgs:nhf-release:fabric:gfv2</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="en">en</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:dateStamp>
+    <gco:Date>2026-05-28</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:spatialRepresentationInfo>
+    <gmd:MD_VectorSpatialRepresentation>
+      <gmd:topologyLevel>
+        <gmd:MD_TopologyLevelCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopologyLevelCode" codeSpace="ISOTC211/19115" codeListValue="geometryOnly">geometryOnly</gmd:MD_TopologyLevelCode>
+      </gmd:topologyLevel>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode" codeSpace="ISOTC211/19115" codeListValue="surface">surface</gmd:MD_GeometricObjectTypeCode>
+          </gmd:geometricObjectType>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+    </gmd:MD_VectorSpatialRepresentation>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:authority>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>European Petroleum Survey Group (EPSG) Geodetic Parameter Registry</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>European Petroleum Survey Group</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                          </gmd:linkage>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="originator">originator</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:authority>
+          <gmd:code>
+            <gco:CharacterString>urn:ogc:def:crs:EPSG:4326</gco:CharacterString>
+          </gmd:code>
+          <gmd:version>
+            <gco:CharacterString>6.18.3</gco:CharacterString>
+          </gmd:version>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Calibration targets for the gfv2 hydrologic fabric, U.S. Geological Survey National Hydrologic Model</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>This child item provides calibration-target datasets for the gfv2 hydrologic fabric (109951 hydrologic response units) of the USGS National Hydrologic Model. Targets: runoff, aet, snow_water_equivalent. Participating sources: daymet, era5_land, gldas_noah_v21_monthly, snodas. Project-specific note appended to the fabric abstract.</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="completed">completed</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty id="contact-pointOfContact">
+          <gmd:individualName>
+            <gco:CharacterString>National Hydrologic Model Calibration Targets Team</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gco:CharacterString>Point of Contact</gco:CharacterString>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                  </gmd:voice>
+                  <gmd:facsimile gco:nilReason="missing"/>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>Denver</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>CO</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:postalCode>
+                    <gco:CharacterString>80225</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>USA</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>gs-w-nhm_calibration@usgs.gov</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.usgs.gov</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>hydrology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>National Hydrologic Model</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>hydrologic response unit</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>calibration targets</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>runoff</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>aet</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>snow_water_equivalent</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>gfv2</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+Participating source dataset licenses: public domain (NASA / ORNL DAAC); Copernicus license (free, attribution); public domain (NASA); public domain (NSIDC / NOAA).
+These data are distributed by the Oak Ridge National Laboratory Distributed Active Archive Center (ORNL DAAC), Oak Ridge, Tennessee, USA.
+This dataset was generated using Copernicus Climate Change Service (C3S) information (ECMWF ERA5-Land). Neither the European Commission nor ECMWF is responsible for any use of the Copernicus information or data it contains.
+These data were obtained from the NASA Earthdata system. We acknowledge the use of data products from the NASA Earth science data systems.
+These data are distributed by the NASA National Snow and Ice Data Center Distributed Active Archive Center (NSIDC DAAC).</gco:CharacterString>
+          </gmd:useLimitation>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString/>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeSpace="ISOTC211/19115" codeListValue="vector">vector</gmd:MD_SpatialRepresentationTypeCode>
+      </gmd:spatialRepresentationType>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="eng">eng</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>inlandWaters</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-124.7</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-66.95</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>24.5</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>49.4</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="T001">
+                  <gml:beginPosition>2000-01-01</gml:beginPosition>
+                  <gml:endPosition>None</gml:endPosition>
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:supplementalInformation>
+        <gco:CharacterString>https://www.sciencebase.gov</gco:CharacterString>
+      </gmd:supplementalInformation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty id="contact-distributor">
+              <gmd:individualName>
+                <gco:CharacterString>ScienceBase Data Release Team</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>U.S. Geological Survey - ScienceBase</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:positionName>
+                <gco:CharacterString>Distributor</gco:CharacterString>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                      </gmd:voice>
+                      <gmd:facsimile gco:nilReason="missing"/>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>Denver</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:administrativeArea>
+                        <gco:CharacterString>CO</gco:CharacterString>
+                      </gmd:administrativeArea>
+                      <gmd:postalCode>
+                        <gco:CharacterString>80225</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>USA</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sciencebase@usgs.gov</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:function>
+                        <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                      </gmd:function>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>ScienceBase landing page</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Data release landing page.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>fabric.gpkg</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>fabric.gpkg</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Hydrologic fabric GeoPackage.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>aggregated/era5_land/era5_land_2003.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>aggregated/era5_land/era5_land_2003.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Source dataset area-weighted to the fabric (CF-1.6 NetCDF).</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>aggregated/snodas/snodas_2003.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>aggregated/snodas/snodas_2003.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Source dataset area-weighted to the fabric (CF-1.6 NetCDF).</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>targets/runoff_targets.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>targets/runoff_targets.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Calibration-target dataset (CF-1.6 NetCDF).</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>targets/swe_targets.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>targets/swe_targets.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Calibration-target dataset (CF-1.6 NetCDF).</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>manifest.json</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>manifest.json</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Provenance manifest.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Each gridded source dataset was area-weighted to the gfv2 fabric with gdptools, then combined into per-target ranges by the nhf-spatial-targets pipeline.</gco:CharacterString>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance>
+    <gmd:MD_MaintenanceInformation>
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+      </gmd:maintenanceAndUpdateFrequency>
+      <gmd:maintenanceNote>
+        <gco:CharacterString>This metadata record was generated by pygeometa-0.21.1 (https://github.com/geopython/pygeometa)</gco:CharacterString>
+      </gmd:maintenanceNote>
+    </gmd:MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</gmd:MD_Metadata>

--- a/tests/fixtures/release/expected_fabric_gfv2_mcf.json
+++ b/tests/fixtures/release/expected_fabric_gfv2_mcf.json
@@ -265,5 +265,6 @@
     "longres": 0.001,
     "geogunit": "Decimal degrees",
     "epsg": 4326
-  }
+  },
+  "distribution_liability": "Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty."
 }

--- a/tests/fixtures/release/expected_source_era5_fgdc.xml
+++ b/tests/fixtures/release/expected_source_era5_fgdc.xml
@@ -1,0 +1,282 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        <origin>Muñoz-Sabater, J., and others, 2021, doi:10.5194/essd-13-4349-2021</origin>
+        <pubdate>20260528</pubdate>
+        <title>ECMWF ERA5-Land Reanalysis (consolidated for NHF)</title>
+        <geoform>raster digital data</geoform>
+        <pubinfo>
+          <pubplace>Denver, CO</pubplace>
+          <publish>U.S. Geological Survey - ScienceBase</publish>
+        </pubinfo>
+        <onlink>https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land</onlink>
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>ECMWF ERA5-Land hourly reanalysis. Total runoff (ro), surface runoff (sro), sub-surface runoff (ssro), and snow depth water equivalent (sd) downloaded for CONUS plus contributing watersheds (Canada/ Mexico). Used as a source for the runoff calibration target (ro), the recharge calibration target (ssro, as drainage proxy), and the snow water equivalent calibration target (sd). These data were consolidated to CF-1.6 NetCDF as part of the USGS National Hydrologic Model calibration-targets workflow.</abstract>
+      <purpose>Document and distribute the consolidated form of the ECMWF ERA5-Land Reanalysis dataset as used in the USGS National Hydrologic Model workflow.</purpose>
+      <supplinf>Source granules for ECMWF ERA5-Land Reanalysis were downloaded and consolidated to CF-1.6 NetCDF by the nhf-spatial-targets pipeline.</supplinf>
+    </descript>
+    <timeperd>
+      <timeinfo>
+        <rngdates>
+          <begdate>19790101</begdate>
+          <enddate>Present</enddate>
+        </rngdates>
+      </timeinfo>
+      <current>ground condition</current>
+    </timeperd>
+    <status>
+      <progress>Complete</progress>
+      <update>As needed</update>
+    </status>
+    <spdom>
+      <bounding>
+        <westbc>-125.0</westbc>
+        <eastbc>-66.0</eastbc>
+        <northbc>53.0</northbc>
+        <southbc>24.7</southbc>
+      </bounding>
+    </spdom>
+    <keywords>
+      <theme>
+        <themekt>None</themekt>
+        <themekey>hydrology</themekey>
+        <themekey>reanalysis</themekey>
+        <themekey>remote sensing</themekey>
+        <themekey>gridded climate data</themekey>
+        <themekey>total runoff</themekey>
+        <themekey>surface runoff</themekey>
+        <themekey>sub-surface runoff</themekey>
+        <themekey>snow depth water equivalent</themekey>
+      </theme>
+      <theme>
+        <themekt>ISO 19115 Topic Category</themekt>
+        <themekey>inlandWaters</themekey>
+        <themekey>climatologyMeteorologyAtmosphere</themekey>
+      </theme>
+      <place>
+        <placekt>None</placekt>
+        <placekey>CONUS+contributing-watersheds</placekey>
+      </place>
+    </keywords>
+    <accconst>None. Please see Use Constraints.</accconst>
+    <useconst>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+
+Source dataset license: Copernicus license (free, attribution).
+
+This dataset was generated using Copernicus Climate Change Service (C3S) information (ECMWF ERA5-Land). Neither the European Commission nor ECMWF is responsible for any use of the Copernicus information or data it contains.</useconst>
+    <ptcontac>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </ptcontac>
+  </idinfo>
+  <dataqual>
+    <lineage>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260522</pubdate>
+            <title>era5_land_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260522</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>era5_land_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260521</pubdate>
+            <title>era5_land_monthly_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260521</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>era5_land_monthly_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <procstep>
+        <procdesc>consolidate via nhf-targets 0.7.0; command: fetch era5-land; params: resample=monthly</procdesc>
+        <srcused>era5_land_2003.nc</srcused>
+        <procdate>20260521</procdate>
+        <proctime>103015</proctime>
+        <srcprod>era5_land_monthly_2003.nc</srcprod>
+      </procstep>
+      <procstep>
+        <procdesc>aggregate via nhf-targets 0.7.0; command: agg era5-land; params: batch_size=500, method=area_weighted</procdesc>
+        <srcused>era5_land_monthly_2003.nc</srcused>
+        <procdate>20260522</procdate>
+        <proctime>080000</proctime>
+        <srcprod>era5_land_2003.nc</srcprod>
+      </procstep>
+    </lineage>
+  </dataqual>
+  <spref>
+    <horizsys>
+      <geograph>
+        <latres>0.001</latres>
+        <longres>0.001</longres>
+        <geogunit>Decimal degrees</geogunit>
+      </geograph>
+      <geodetic>
+        <horizdn>WGS_1984</horizdn>
+        <ellips>WGS_1984</ellips>
+        <semiaxis>6378137.0</semiaxis>
+        <denflat>298.257223563</denflat>
+      </geodetic>
+    </horizsys>
+  </spref>
+  <eainfo>
+    <detailed>
+      <enttyp>
+        <enttypl>Consolidated NetCDF variables</enttypl>
+        <enttypd>Variables carried in the consolidated CF-1.6 NetCDF files for this source dataset.</enttypd>
+        <enttypds>Producer defined</enttypds>
+      </enttyp>
+      <attr>
+        <attrlabl>ro</attrlabl>
+        <attrdef>total runoff</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: m. Cell methods: time: sum.</udom>
+        </attrdomv>
+      </attr>
+      <attr>
+        <attrlabl>sro</attrlabl>
+        <attrdef>surface runoff</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: m. Cell methods: time: sum.</udom>
+        </attrdomv>
+      </attr>
+      <attr>
+        <attrlabl>ssro</attrlabl>
+        <attrdef>sub-surface runoff</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: m. Cell methods: time: sum.</udom>
+        </attrdomv>
+      </attr>
+      <attr>
+        <attrlabl>sd</attrlabl>
+        <attrdef>snow depth water equivalent</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: m. Cell methods: time: point.</udom>
+        </attrdomv>
+      </attr>
+    </detailed>
+  </eainfo>
+  <distinfo>
+    <distrib>
+      <cntinfo>
+        <cntperp>
+          <cntper>ScienceBase Data Release Team</cntper>
+          <cntorg>U.S. Geological Survey - ScienceBase</cntorg>
+        </cntperp>
+        <cntpos>Distributor</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>sciencebase@usgs.gov</cntemail>
+      </cntinfo>
+    </distrib>
+    <distliab>Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty.</distliab>
+    <stdorder>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>monthly/era5_land_monthly_2003.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>daily/era5_land_daily_2003.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <fees>None.</fees>
+    </stdorder>
+  </distinfo>
+  <metainfo>
+    <metd>20260528</metd>
+    <metc>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </metc>
+    <metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
+    <metstdv>FGDC-STD-001-1998</metstdv>
+  </metainfo>
+</metadata>

--- a/tests/fixtures/release/expected_source_era5_iso.xml
+++ b/tests/fixtures/release/expected_source_era5_iso.xml
@@ -1,0 +1,452 @@
+<?xml version="1.0" ?>
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>urn:usgs:nhf-release:source:era5_land</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="en">en</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:dateStamp>
+    <gco:Date>2026-05-28</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:spatialRepresentationInfo>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:authority>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>European Petroleum Survey Group (EPSG) Geodetic Parameter Registry</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>European Petroleum Survey Group</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                          </gmd:linkage>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="originator">originator</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:authority>
+          <gmd:code>
+            <gco:CharacterString>urn:ogc:def:crs:EPSG:4326</gco:CharacterString>
+          </gmd:code>
+          <gmd:version>
+            <gco:CharacterString>6.18.3</gco:CharacterString>
+          </gmd:version>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>ECMWF ERA5-Land Reanalysis (consolidated for NHF)</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>ECMWF ERA5-Land hourly reanalysis. Total runoff (ro), surface runoff (sro), sub-surface runoff (ssro), and snow depth water equivalent (sd) downloaded for CONUS plus contributing watersheds (Canada/ Mexico). Used as a source for the runoff calibration target (ro), the recharge calibration target (ssro, as drainage proxy), and the snow water equivalent calibration target (sd). These data were consolidated to CF-1.6 NetCDF as part of the USGS National Hydrologic Model calibration-targets workflow.</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="completed">completed</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty id="contact-pointOfContact">
+          <gmd:individualName>
+            <gco:CharacterString>National Hydrologic Model Calibration Targets Team</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gco:CharacterString>Point of Contact</gco:CharacterString>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                  </gmd:voice>
+                  <gmd:facsimile gco:nilReason="missing"/>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>Denver</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>CO</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:postalCode>
+                    <gco:CharacterString>80225</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>USA</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>gs-w-nhm_calibration@usgs.gov</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.usgs.gov</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>hydrology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>reanalysis</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>remote sensing</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>gridded climate data</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>total runoff</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>surface runoff</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>sub-surface runoff</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>snow depth water equivalent</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>CONUS+contributing-watersheds</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+Source dataset license: Copernicus license (free, attribution).
+This dataset was generated using Copernicus Climate Change Service (C3S) information (ECMWF ERA5-Land). Neither the European Commission nor ECMWF is responsible for any use of the Copernicus information or data it contains.</gco:CharacterString>
+          </gmd:useLimitation>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString/>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeSpace="ISOTC211/19115" codeListValue="grid">grid</gmd:MD_SpatialRepresentationTypeCode>
+      </gmd:spatialRepresentationType>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="eng">eng</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>inlandWaters</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-125.0</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-66.0</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>24.7</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>53.0</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="T001">
+                  <gml:beginPosition>1979-01-01</gml:beginPosition>
+                  <gml:endPosition>None</gml:endPosition>
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:supplementalInformation>
+        <gco:CharacterString>https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land</gco:CharacterString>
+      </gmd:supplementalInformation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty id="contact-distributor">
+              <gmd:individualName>
+                <gco:CharacterString>ScienceBase Data Release Team</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>U.S. Geological Survey - ScienceBase</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:positionName>
+                <gco:CharacterString>Distributor</gco:CharacterString>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                      </gmd:voice>
+                      <gmd:facsimile gco:nilReason="missing"/>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>Denver</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:administrativeArea>
+                        <gco:CharacterString>CO</gco:CharacterString>
+                      </gmd:administrativeArea>
+                      <gmd:postalCode>
+                        <gco:CharacterString>80225</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>USA</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sciencebase@usgs.gov</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:function>
+                        <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                      </gmd:function>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>Upstream source archive</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Original data provider's landing page.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>monthly/era5_land_monthly_2003.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>monthly/era5_land_monthly_2003.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Consolidated CF-1.6 NetCDF.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>daily/era5_land_daily_2003.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>daily/era5_land_daily_2003.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Consolidated CF-1.6 NetCDF.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Source granules for ECMWF ERA5-Land Reanalysis were downloaded and consolidated to CF-1.6 NetCDF by the nhf-spatial-targets pipeline.</gco:CharacterString>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance>
+    <gmd:MD_MaintenanceInformation>
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+      </gmd:maintenanceAndUpdateFrequency>
+      <gmd:maintenanceNote>
+        <gco:CharacterString>This metadata record was generated by pygeometa-0.21.1 (https://github.com/geopython/pygeometa)</gco:CharacterString>
+      </gmd:maintenanceNote>
+    </gmd:MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</gmd:MD_Metadata>

--- a/tests/fixtures/release/expected_source_era5_mcf.json
+++ b/tests/fixtures/release/expected_source_era5_mcf.json
@@ -205,5 +205,6 @@
     "longres": 0.001,
     "geogunit": "Decimal degrees",
     "epsg": 4326
-  }
+  },
+  "distribution_liability": "Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty."
 }

--- a/tests/fixtures/release/expected_source_snodas_fgdc.xml
+++ b/tests/fixtures/release/expected_source_snodas_fgdc.xml
@@ -1,0 +1,214 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        <origin>National Operational Hydrologic Remote Sensing Center, 2004, doi:10.7265/N5TB14TC</origin>
+        <pubdate>20260528</pubdate>
+        <title>SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) (consolidated for NHF)</title>
+        <geoform>raster digital data</geoform>
+        <pubinfo>
+          <pubplace>Denver, CO</pubplace>
+          <publish>U.S. Geological Survey - ScienceBase</publish>
+        </pubinfo>
+        <onlink>https://doi.org/10.7265/N5TB14TC</onlink>
+        <onlink>https://nsidc.org/data/g02158</onlink>
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>NOAA NOHRSC SNODAS daily snow products distributed by NSIDC (collection G02158). Daily 1 km CONUS analysis combining satellite observations, ground stations, and an energy-balance snow model. Used as one source for the SWE calibration target. These data were consolidated to CF-1.6 NetCDF as part of the USGS National Hydrologic Model calibration-targets workflow.</abstract>
+      <purpose>Document and distribute the consolidated form of the SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) dataset as used in the USGS National Hydrologic Model workflow.</purpose>
+      <supplinf>Source granules for SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) were downloaded and consolidated to CF-1.6 NetCDF by the nhf-spatial-targets pipeline.</supplinf>
+    </descript>
+    <timeperd>
+      <timeinfo>
+        <rngdates>
+          <begdate>20030101</begdate>
+          <enddate>Present</enddate>
+        </rngdates>
+      </timeinfo>
+      <current>ground condition</current>
+    </timeperd>
+    <status>
+      <progress>Complete</progress>
+      <update>As needed</update>
+    </status>
+    <spdom>
+      <bounding>
+        <westbc>-125.0</westbc>
+        <eastbc>-66.0</eastbc>
+        <northbc>53.0</northbc>
+        <southbc>24.7</southbc>
+      </bounding>
+    </spdom>
+    <keywords>
+      <theme>
+        <themekt>None</themekt>
+        <themekey>hydrology</themekey>
+        <themekey>reanalysis</themekey>
+        <themekey>remote sensing</themekey>
+        <themekey>gridded climate data</themekey>
+        <themekey>snow water equivalent</themekey>
+      </theme>
+      <theme>
+        <themekt>ISO 19115 Topic Category</themekt>
+        <themekey>inlandWaters</themekey>
+        <themekey>climatologyMeteorologyAtmosphere</themekey>
+      </theme>
+      <place>
+        <placekt>None</placekt>
+        <placekey>CONUS</placekey>
+      </place>
+    </keywords>
+    <accconst>None. Please see Use Constraints.</accconst>
+    <useconst>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+
+Source dataset license: public domain (NSIDC / NOAA).
+
+These data are distributed by the NASA National Snow and Ice Data Center Distributed Active Archive Center (NSIDC DAAC).</useconst>
+    <ptcontac>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </ptcontac>
+  </idinfo>
+  <dataqual>
+    <lineage>
+      <srcinfo>
+        <srccite>
+          <citeinfo>
+            <origin>U.S. Geological Survey</origin>
+            <pubdate>20260521</pubdate>
+            <title>snodas_2003.nc</title>
+          </citeinfo>
+        </srccite>
+        <typesrc>Digital data</typesrc>
+        <srctime>
+          <timeinfo>
+            <sngdate>
+              <caldate>20260521</caldate>
+            </sngdate>
+          </timeinfo>
+          <srccurr>Process date</srccurr>
+        </srctime>
+        <srccitea>snodas_2003.nc</srccitea>
+        <srccontr>Intermediate or source dataset processed by the nhf-spatial-targets pipeline.</srccontr>
+      </srcinfo>
+      <procstep>
+        <procdesc>consolidate via nhf-targets 0.7.0; command: fetch snodas</procdesc>
+        <procdate>20260521</procdate>
+        <proctime>124500</proctime>
+        <srcprod>snodas_2003.nc</srcprod>
+      </procstep>
+    </lineage>
+  </dataqual>
+  <spref>
+    <horizsys>
+      <geograph>
+        <latres>0.001</latres>
+        <longres>0.001</longres>
+        <geogunit>Decimal degrees</geogunit>
+      </geograph>
+      <geodetic>
+        <horizdn>WGS_1984</horizdn>
+        <ellips>WGS_1984</ellips>
+        <semiaxis>6378137.0</semiaxis>
+        <denflat>298.257223563</denflat>
+      </geodetic>
+    </horizsys>
+  </spref>
+  <eainfo>
+    <detailed>
+      <enttyp>
+        <enttypl>Consolidated NetCDF variables</enttypl>
+        <enttypd>Variables carried in the consolidated CF-1.6 NetCDF files for this source dataset.</enttypd>
+        <enttypds>Producer defined</enttypds>
+      </enttyp>
+      <attr>
+        <attrlabl>swe</attrlabl>
+        <attrdef>snow water equivalent</attrdef>
+        <attrdefs>Producer defined</attrdefs>
+        <attrdomv>
+          <udom>Units: kg m-2. Cell methods: time: point.</udom>
+        </attrdomv>
+      </attr>
+    </detailed>
+  </eainfo>
+  <distinfo>
+    <distrib>
+      <cntinfo>
+        <cntperp>
+          <cntper>ScienceBase Data Release Team</cntper>
+          <cntorg>U.S. Geological Survey - ScienceBase</cntorg>
+        </cntperp>
+        <cntpos>Distributor</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>sciencebase@usgs.gov</cntemail>
+      </cntinfo>
+    </distrib>
+    <distliab>Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty.</distliab>
+    <stdorder>
+      <digform>
+        <digtinfo>
+          <formname>NetCDF</formname>
+        </digtinfo>
+        <digtopt>
+          <onlinopt>
+            <computer>
+              <networka>
+                <networkr>daily/snodas_2003.nc</networkr>
+              </networka>
+            </computer>
+          </onlinopt>
+        </digtopt>
+      </digform>
+      <fees>None.</fees>
+    </stdorder>
+  </distinfo>
+  <metainfo>
+    <metd>20260528</metd>
+    <metc>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </metc>
+    <metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
+    <metstdv>FGDC-STD-001-1998</metstdv>
+  </metainfo>
+</metadata>

--- a/tests/fixtures/release/expected_source_snodas_iso.xml
+++ b/tests/fixtures/release/expected_source_snodas_iso.xml
@@ -1,0 +1,424 @@
+<?xml version="1.0" ?>
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>urn:usgs:nhf-release:source:snodas</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="en">en</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:dateStamp>
+    <gco:Date>2026-05-28</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:spatialRepresentationInfo>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:authority>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>European Petroleum Survey Group (EPSG) Geodetic Parameter Registry</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>European Petroleum Survey Group</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                          </gmd:linkage>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="originator">originator</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:authority>
+          <gmd:code>
+            <gco:CharacterString>urn:ogc:def:crs:EPSG:4326</gco:CharacterString>
+          </gmd:code>
+          <gmd:version>
+            <gco:CharacterString>6.18.3</gco:CharacterString>
+          </gmd:version>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) (consolidated for NHF)</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>NOAA NOHRSC SNODAS daily snow products distributed by NSIDC (collection G02158). Daily 1 km CONUS analysis combining satellite observations, ground stations, and an energy-balance snow model. Used as one source for the SWE calibration target. These data were consolidated to CF-1.6 NetCDF as part of the USGS National Hydrologic Model calibration-targets workflow.</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="completed">completed</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty id="contact-pointOfContact">
+          <gmd:individualName>
+            <gco:CharacterString>National Hydrologic Model Calibration Targets Team</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gco:CharacterString>Point of Contact</gco:CharacterString>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                  </gmd:voice>
+                  <gmd:facsimile gco:nilReason="missing"/>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>Denver</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>CO</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:postalCode>
+                    <gco:CharacterString>80225</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>USA</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>gs-w-nhm_calibration@usgs.gov</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.usgs.gov</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>hydrology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>reanalysis</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>remote sensing</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>gridded climate data</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>snow water equivalent</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>CONUS</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.
+Source dataset license: public domain (NSIDC / NOAA).
+These data are distributed by the NASA National Snow and Ice Data Center Distributed Active Archive Center (NSIDC DAAC).</gco:CharacterString>
+          </gmd:useLimitation>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString/>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeSpace="ISOTC211/19115" codeListValue="grid">grid</gmd:MD_SpatialRepresentationTypeCode>
+      </gmd:spatialRepresentationType>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="eng">eng</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>inlandWaters</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-125.0</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-66.0</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>24.7</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>53.0</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="T001">
+                  <gml:beginPosition>2003-01-01</gml:beginPosition>
+                  <gml:endPosition>None</gml:endPosition>
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:supplementalInformation>
+        <gco:CharacterString>https://doi.org/10.7265/N5TB14TC</gco:CharacterString>
+      </gmd:supplementalInformation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty id="contact-distributor">
+              <gmd:individualName>
+                <gco:CharacterString>ScienceBase Data Release Team</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>U.S. Geological Survey - ScienceBase</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:positionName>
+                <gco:CharacterString>Distributor</gco:CharacterString>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                      </gmd:voice>
+                      <gmd:facsimile gco:nilReason="missing"/>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>Denver</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:administrativeArea>
+                        <gco:CharacterString>CO</gco:CharacterString>
+                      </gmd:administrativeArea>
+                      <gmd:postalCode>
+                        <gco:CharacterString>80225</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>USA</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sciencebase@usgs.gov</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:function>
+                        <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                      </gmd:function>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://nsidc.org/data/g02158</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>Upstream source archive</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Original data provider's landing page.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>daily/snodas_2003.nc</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>daily/snodas_2003.nc</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Consolidated CF-1.6 NetCDF.</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Source granules for SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) were downloaded and consolidated to CF-1.6 NetCDF by the nhf-spatial-targets pipeline.</gco:CharacterString>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance>
+    <gmd:MD_MaintenanceInformation>
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+      </gmd:maintenanceAndUpdateFrequency>
+      <gmd:maintenanceNote>
+        <gco:CharacterString>This metadata record was generated by pygeometa-0.21.1 (https://github.com/geopython/pygeometa)</gco:CharacterString>
+      </gmd:maintenanceNote>
+    </gmd:MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</gmd:MD_Metadata>

--- a/tests/fixtures/release/expected_source_snodas_mcf.json
+++ b/tests/fixtures/release/expected_source_snodas_mcf.json
@@ -51,7 +51,12 @@
     "extents": {
       "spatial": [
         {
-          "bbox": null,
+          "bbox": [
+            -125.0,
+            24.7,
+            -66.0,
+            53.0
+          ],
           "crs": 4326
         }
       ],
@@ -159,5 +164,6 @@
     "longres": 0.001,
     "geogunit": "Decimal degrees",
     "epsg": 4326
-  }
+  },
+  "distribution_liability": "Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty."
 }

--- a/tests/fixtures/release/expected_source_snodas_readme.md
+++ b/tests/fixtures/release/expected_source_snodas_readme.md
@@ -15,6 +15,7 @@ DOI: https://doi.org/10.7265/N5TB14TC
 ## Extent
 
 - Temporal: 2003-01-01 to present
+- Bounding coordinates (W, S, E, N): -125.0, 24.7, -66.0, 53.0
 
 ## Variables
 

--- a/tests/fixtures/release/expected_umbrella_fgdc.xml
+++ b/tests/fixtures/release/expected_umbrella_fgdc.xml
@@ -1,0 +1,150 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<metadata>
+  <idinfo>
+    <citation>
+      <citeinfo>
+        <origin>Doe, Jane</origin>
+        <origin>Roe, John</origin>
+        <pubdate>20260528</pubdate>
+        <title>Calibration-target datasets for the U.S. Geological Survey National Hydrologic Model (version 1.0)</title>
+        <geoform>raster digital data</geoform>
+        <pubinfo>
+          <pubplace>Denver, CO</pubplace>
+          <publish>U.S. Geological Survey - ScienceBase</publish>
+        </pubinfo>
+        <onlink>https://www.sciencebase.gov</onlink>
+      </citeinfo>
+    </citation>
+    <descript>
+      <abstract>This data release provides curated calibration-target datasets for the U.S. Geological Survey (USGS) National Hydrologic Model (NHM). The release is organized as an umbrella collection of 3 child items: ECMWF ERA5-Land Reanalysis (consolidated for NHF); SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) (consolidated for NHF); Calibration targets for the gfv2 hydrologic fabric, U.S. Geological Survey National Hydrologic Model.</abstract>
+      <purpose>Provide reproducible, provenance-tracked calibration targets for parameter estimation of the USGS National Hydrologic Model.</purpose>
+      <supplinf>Edition: 1.0.
+
+New fabrics or refreshed source data are added as child items under the existing DOI without a version bump.
+
+Calibration targets were produced by the nhf-spatial-targets pipeline. Per-item process steps are recorded on the individual child items.</supplinf>
+    </descript>
+    <timeperd>
+      <timeinfo>
+        <rngdates>
+          <begdate>19790101</begdate>
+          <enddate>Present</enddate>
+        </rngdates>
+      </timeinfo>
+      <current>ground condition</current>
+    </timeperd>
+    <status>
+      <progress>Complete</progress>
+      <update>As needed</update>
+    </status>
+    <spdom>
+      <bounding>
+        <westbc>-125.0</westbc>
+        <eastbc>-66.0</eastbc>
+        <northbc>53.0</northbc>
+        <southbc>24.5</southbc>
+      </bounding>
+    </spdom>
+    <keywords>
+      <theme>
+        <themekt>None</themekt>
+        <themekey>hydrology</themekey>
+        <themekey>National Hydrologic Model</themekey>
+        <themekey>calibration</themekey>
+        <themekey>water cycle</themekey>
+      </theme>
+      <theme>
+        <themekt>ISO 19115 Topic Category</themekt>
+        <themekey>inlandWaters</themekey>
+        <themekey>climatologyMeteorologyAtmosphere</themekey>
+      </theme>
+      <place>
+        <placekt>None</placekt>
+        <placekey>United States</placekey>
+        <placekey>Conterminous United States</placekey>
+      </place>
+    </keywords>
+    <accconst>None. Please see Use Constraints.</accconst>
+    <useconst>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.</useconst>
+    <ptcontac>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </ptcontac>
+  </idinfo>
+  <spref>
+    <horizsys>
+      <geograph>
+        <latres>0.001</latres>
+        <longres>0.001</longres>
+        <geogunit>Decimal degrees</geogunit>
+      </geograph>
+      <geodetic>
+        <horizdn>WGS_1984</horizdn>
+        <ellips>WGS_1984</ellips>
+        <semiaxis>6378137.0</semiaxis>
+        <denflat>298.257223563</denflat>
+      </geodetic>
+    </horizsys>
+  </spref>
+  <distinfo>
+    <distrib>
+      <cntinfo>
+        <cntperp>
+          <cntper>ScienceBase Data Release Team</cntper>
+          <cntorg>U.S. Geological Survey - ScienceBase</cntorg>
+        </cntperp>
+        <cntpos>Distributor</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>sciencebase@usgs.gov</cntemail>
+      </cntinfo>
+    </distrib>
+    <distliab>Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty.</distliab>
+  </distinfo>
+  <metainfo>
+    <metd>20260528</metd>
+    <metc>
+      <cntinfo>
+        <cntperp>
+          <cntper>National Hydrologic Model Calibration Targets Team</cntper>
+          <cntorg>U.S. Geological Survey</cntorg>
+        </cntperp>
+        <cntpos>Point of Contact</cntpos>
+        <cntaddr>
+          <addrtype>mailing and physical</addrtype>
+          <address>Building 810, Mail Stop 302, Denver Federal Center</address>
+          <city>Denver</city>
+          <state>CO</state>
+          <postal>80225</postal>
+          <country>USA</country>
+        </cntaddr>
+        <cntvoice>1-888-275-8747</cntvoice>
+        <cntemail>gs-w-nhm_calibration@usgs.gov</cntemail>
+      </cntinfo>
+    </metc>
+    <metstdn>FGDC Content Standard for Digital Geospatial Metadata</metstdn>
+    <metstdv>FGDC-STD-001-1998</metstdv>
+  </metainfo>
+</metadata>

--- a/tests/fixtures/release/expected_umbrella_iso.xml
+++ b/tests/fixtures/release/expected_umbrella_iso.xml
@@ -1,0 +1,416 @@
+<?xml version="1.0" ?>
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>urn:usgs:nhf-release:umbrella</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="en">en</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="series">series</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:dateStamp>
+    <gco:Date>2026-05-28</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:spatialRepresentationInfo>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:authority>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>European Petroleum Survey Group (EPSG) Geodetic Parameter Registry</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-11-12</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>European Petroleum Survey Group</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                      <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                          <gmd:linkage>
+                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                          </gmd:linkage>
+                        </gmd:CI_OnlineResource>
+                      </gmd:onlineResource>
+                    </gmd:CI_Contact>
+                  </gmd:contactInfo>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="originator">originator</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:authority>
+          <gmd:code>
+            <gco:CharacterString>urn:ogc:def:crs:EPSG:4326</gco:CharacterString>
+          </gmd:code>
+          <gmd:version>
+            <gco:CharacterString>6.18.3</gco:CharacterString>
+          </gmd:version>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Calibration-target datasets for the U.S. Geological Survey National Hydrologic Model (version 1.0)</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2026-05-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeSpace="ISOTC211/19115" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:edition>
+            <gco:CharacterString>1.0</gco:CharacterString>
+          </gmd:edition>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>This data release provides curated calibration-target datasets for the U.S. Geological Survey (USGS) National Hydrologic Model (NHM). The release is organized as an umbrella collection of 3 child items: ECMWF ERA5-Land Reanalysis (consolidated for NHF); SNODAS Snow Data Assimilation System Data Products (NSIDC G02158) (consolidated for NHF); Calibration targets for the gfv2 hydrologic fabric, U.S. Geological Survey National Hydrologic Model.</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="completed">completed</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty id="contact-pointOfContact">
+          <gmd:individualName>
+            <gco:CharacterString>National Hydrologic Model Calibration Targets Team</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gco:CharacterString>U.S. Geological Survey</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gco:CharacterString>Point of Contact</gco:CharacterString>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                  </gmd:voice>
+                  <gmd:facsimile gco:nilReason="missing"/>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint>
+                    <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>Denver</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:administrativeArea>
+                    <gco:CharacterString>CO</gco:CharacterString>
+                  </gmd:administrativeArea>
+                  <gmd:postalCode>
+                    <gco:CharacterString>80225</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>USA</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>gs-w-nhm_calibration@usgs.gov</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.usgs.gov</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>hydrology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>National Hydrologic Model</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>calibration</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>water cycle</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>United States</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Conterminous United States</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>None. Users are advised to read the dataset's metadata thoroughly to understand appropriate use and data limitations.</gco:CharacterString>
+          </gmd:useLimitation>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString/>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeSpace="ISOTC211/19115" codeListValue="grid">grid</gmd:MD_SpatialRepresentationTypeCode>
+      </gmd:spatialRepresentationType>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="eng">eng</gmd:LanguageCode>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>inlandWaters</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-125.0</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-66.0</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>24.5</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>53.0</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="T001">
+                  <gml:beginPosition>1979-01-01</gml:beginPosition>
+                  <gml:endPosition>None</gml:endPosition>
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:supplementalInformation>
+        <gco:CharacterString>https://www.sciencebase.gov</gco:CharacterString>
+      </gmd:supplementalInformation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty id="contact-distributor">
+              <gmd:individualName>
+                <gco:CharacterString>ScienceBase Data Release Team</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>U.S. Geological Survey - ScienceBase</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:positionName>
+                <gco:CharacterString>Distributor</gco:CharacterString>
+              </gmd:positionName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:phone>
+                    <gmd:CI_Telephone>
+                      <gmd:voice>
+                        <gco:CharacterString>1-888-275-8747</gco:CharacterString>
+                      </gmd:voice>
+                      <gmd:facsimile gco:nilReason="missing"/>
+                    </gmd:CI_Telephone>
+                  </gmd:phone>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:deliveryPoint>
+                        <gco:CharacterString>Building 810, Mail Stop 302, Denver Federal Center</gco:CharacterString>
+                      </gmd:deliveryPoint>
+                      <gmd:city>
+                        <gco:CharacterString>Denver</gco:CharacterString>
+                      </gmd:city>
+                      <gmd:administrativeArea>
+                        <gco:CharacterString>CO</gco:CharacterString>
+                      </gmd:administrativeArea>
+                      <gmd:postalCode>
+                        <gco:CharacterString>80225</gco:CharacterString>
+                      </gmd:postalCode>
+                      <gmd:country>
+                        <gco:CharacterString>USA</gco:CharacterString>
+                      </gmd:country>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>sciencebase@usgs.gov</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </gmd:protocol>
+                      <gmd:function>
+                        <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" codeSpace="ISOTC211/19115">information</gmd:CI_OnLineFunctionCode>
+                      </gmd:function>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeSpace="ISOTC211/19115" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://www.sciencebase.gov</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name>
+                <gco:CharacterString>ScienceBase landing page</gco:CharacterString>
+              </gmd:name>
+              <gmd:description>
+                <gco:CharacterString>Data release landing page (DOI).</gco:CharacterString>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeSpace="ISOTC211/19115" codeListValue="series">series</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement>
+            <gco:CharacterString>Calibration targets were produced by the nhf-spatial-targets pipeline. Per-item process steps are recorded on the individual child items.</gco:CharacterString>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmd:metadataMaintenance>
+    <gmd:MD_MaintenanceInformation>
+      <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeSpace="ISOTC211/19115" codeListValue="asNeeded">asNeeded</gmd:MD_MaintenanceFrequencyCode>
+      </gmd:maintenanceAndUpdateFrequency>
+      <gmd:maintenanceNote>
+        <gco:CharacterString>This metadata record was generated by pygeometa-0.21.1 (https://github.com/geopython/pygeometa)</gco:CharacterString>
+      </gmd:maintenanceNote>
+    </gmd:MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</gmd:MD_Metadata>

--- a/tests/fixtures/release/expected_umbrella_mcf.json
+++ b/tests/fixtures/release/expected_umbrella_mcf.json
@@ -152,5 +152,6 @@
     "longres": 0.001,
     "geogunit": "Decimal degrees",
     "epsg": 4326
-  }
+  },
+  "distribution_liability": "Although these data have been processed successfully on a computer system at the U.S. Geological Survey (USGS), no warranty expressed or implied is made regarding the display or utility of the data on any other system or for general or scientific purposes, nor shall the act of distribution constitute any such warranty."
 }

--- a/tests/test_release_fgdc.py
+++ b/tests/test_release_fgdc.py
@@ -251,3 +251,80 @@ def test_special_characters_are_escaped(config, fabric, defaults, manifest):
     root = etree.fromstring(xml.encode("utf-8"))
     udoms = " ".join(e.text or "" for e in root.findall(".//udom"))
     assert ">=1 source is finite" in udoms
+
+
+# ---------------------------------------------------------------------------
+# Fallback branches the clean-fixture goldens never reach
+# ---------------------------------------------------------------------------
+
+
+def _minimal_mcf(**overrides) -> dict:
+    """A bbox-carrying MCF with empty optional sections, for edge branches."""
+    m = {
+        "metadata": {"datestamp": "2026-05-28"},
+        "spatial": {"datatype": "grid"},
+        "identification": {
+            "title": "Minimal",
+            "abstract": "A",
+            "purpose": "P",
+            "dates": {"publication": "2026-05-28"},
+            "extents": {
+                "spatial": [{"bbox": [-1.0, -2.0, 3.0, 4.0]}],
+                "temporal": [{"begin": "2000-01-01", "end": "2001-12-31"}],
+            },
+            "keywords": {"theme": {"keywords": ["k"]}, "place": {"keywords": []}},
+            "citation": {"authors": []},
+            "useconstraints": "U",
+            "accessconstraints": "otherRestrictions",
+            "fees": "None.",
+            "entityandattribute": [],
+        },
+        "contact": {},
+        "distribution": {},
+        "dataquality": {"lineage": {"statement": "", "processstep": []}},
+        "spatial_reference": {},
+        "distribution_liability": "L",
+    }
+    m["identification"].update(overrides.get("identification", {}))
+    return m
+
+
+def test_bbox_required_raises(defaults, manifest):
+    """A bbox-less item cannot render valid FGDC (CSDGM <spdom> is mandatory).
+
+    merra2 is global and carries no catalog bbox, so its MCF bbox is None.
+    """
+    merra2_mcf = mcf.build_source_mcf(
+        "merra2", defaults=defaults, manifest=manifest, now=NOW
+    )
+    with pytest.raises(ValueError, match="no bounding box"):
+        fgdc.render_fgdc(merra2_mcf, kind="source")
+
+
+def test_supplinf_omitted_when_no_lineage_or_edition():
+    root = etree.fromstring(fgdc.render_fgdc(_minimal_mcf(), kind="source").encode())
+    assert root.find(".//supplinf") is None
+
+
+def test_begdate_unknown_and_enddate_present_when_open():
+    m = _minimal_mcf(
+        identification={
+            "extents": {
+                "spatial": [{"bbox": [-1.0, -2.0, 3.0, 4.0]}],
+                "temporal": [{"begin": None, "end": None}],
+            }
+        }
+    )
+    root = etree.fromstring(fgdc.render_fgdc(m, kind="source").encode())
+    assert root.findtext(".//begdate") == "Unknown"
+    assert root.findtext(".//enddate") == "Present"
+
+
+def test_srcinfo_unknown_caldate_for_pure_input():
+    """A basename only ever *used* (never produced) gets caldate 'Unknown'."""
+    steps = [
+        {"srcused": ["raw_input.grib"], "srcprod": ["out.nc"], "procdate": "20260101"}
+    ]
+    entries = {e["srccitea"]: e for e in fgdc._srcinfo_entries(steps)}
+    assert entries["raw_input.grib"]["caldate"] == "Unknown"
+    assert entries["out.nc"]["caldate"] == "20260101"

--- a/tests/test_release_fgdc.py
+++ b/tests/test_release_fgdc.py
@@ -1,0 +1,253 @@
+"""Golden-file tests for nhf_spatial_targets.release.fgdc.
+
+Each item type is built from the same canned fixtures as test_release_mcf.py
+(with an injected timestamp), rendered to FGDC CSDGM 2.0 XML, then byte-equal
+compared against a committed golden. Regenerate after an intentional change
+with::
+
+    REGEN_GOLDENS=1 pixi run -e dev test -k test_release_fgdc
+
+The per-source XML goldens (era5_land, snodas) are representative examples,
+not an exhaustive registry: adding a new catalog source must not require
+touching them. Spot-check tests assert the load-bearing CSDGM invariants
+(strict <procstep> element order, srcused/srcprod -> <srcinfo> referential
+integrity, bbox -> bounding mapping) so intent is visible without diffing the
+large golden XML.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from lxml import etree
+
+from nhf_spatial_targets.defaults import apply_defaults
+from nhf_spatial_targets.release import fgdc, mcf
+from nhf_spatial_targets.release.defaults import load_release_defaults
+
+FX = Path(__file__).parent / "fixtures" / "release"
+
+# Injected so metadata.datestamp / dates are byte-stable in the golden.
+NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+SRC_FILES = {
+    "era5_land": [
+        "monthly/era5_land_monthly_2003.nc",
+        "daily/era5_land_daily_2003.nc",
+    ],
+    "snodas": ["daily/snodas_2003.nc"],
+}
+FABRIC_FILES = [
+    "fabric.gpkg",
+    "aggregated/era5_land/era5_land_2003.nc",
+    "aggregated/snodas/snodas_2003.nc",
+    "targets/runoff_targets.nc",
+    "targets/swe_targets.nc",
+    "manifest.json",
+]
+
+
+@pytest.fixture
+def defaults() -> dict:
+    return load_release_defaults(FX / "fixture_release_defaults.yml")
+
+
+@pytest.fixture
+def config() -> dict:
+    return apply_defaults(
+        yaml.safe_load((FX / "fixture_project_config.yml").read_text())
+    )
+
+
+@pytest.fixture
+def fabric() -> dict:
+    return json.loads((FX / "fixture_fabric.json").read_text())
+
+
+@pytest.fixture
+def manifest() -> dict:
+    return json.loads((FX / "fixture_manifest.json").read_text())
+
+
+def _check_golden(text: str, name: str) -> None:
+    path = FX / name
+    if os.environ.get("REGEN_GOLDENS"):
+        path.write_text(text)
+    assert text == path.read_text()
+
+
+def _source_mcf(key: str, defaults: dict, manifest: dict) -> dict:
+    return mcf.build_source_mcf(
+        key,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=SRC_FILES.get(key),
+        now=NOW,
+    )
+
+
+def _fabric_mcf(config: dict, fabric: dict, defaults: dict, manifest: dict) -> dict:
+    return mcf.build_fabric_mcf(
+        config=config,
+        fabric=fabric,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=FABRIC_FILES,
+        now=NOW,
+    )
+
+
+def _umbrella_mcf(config: dict, fabric: dict, defaults: dict, manifest: dict) -> dict:
+    children = [
+        _source_mcf("era5_land", defaults, manifest),
+        _source_mcf("snodas", defaults, manifest),
+        _fabric_mcf(config, fabric, defaults, manifest),
+    ]
+    return mcf.build_umbrella_mcf(
+        defaults=defaults,
+        children=children,
+        authors=config["release"]["authors"],
+        version="1.0",
+        now=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden-file tests
+# ---------------------------------------------------------------------------
+
+
+def test_source_era5_fgdc_golden(defaults, manifest):
+    xml = fgdc.render_fgdc(_source_mcf("era5_land", defaults, manifest), kind="source")
+    _check_golden(xml, "expected_source_era5_fgdc.xml")
+
+
+def test_source_snodas_fgdc_golden(defaults, manifest):
+    xml = fgdc.render_fgdc(_source_mcf("snodas", defaults, manifest), kind="source")
+    _check_golden(xml, "expected_source_snodas_fgdc.xml")
+
+
+def test_fabric_fgdc_golden(config, fabric, defaults, manifest):
+    xml = fgdc.render_fgdc(
+        _fabric_mcf(config, fabric, defaults, manifest), kind="fabric"
+    )
+    _check_golden(xml, "expected_fabric_gfv2_fgdc.xml")
+
+
+def test_umbrella_fgdc_golden(config, fabric, defaults, manifest):
+    xml = fgdc.render_fgdc(
+        _umbrella_mcf(config, fabric, defaults, manifest), kind="umbrella"
+    )
+    _check_golden(xml, "expected_umbrella_fgdc.xml")
+
+
+# ---------------------------------------------------------------------------
+# Invariant spot-checks (intent visible without diffing the big goldens)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["source", "umbrella", "fabric"])
+def test_renders_wellformed_xml(kind, config, fabric, defaults, manifest):
+    if kind == "fabric":
+        m = _fabric_mcf(config, fabric, defaults, manifest)
+    elif kind == "umbrella":
+        m = _umbrella_mcf(config, fabric, defaults, manifest)
+    else:
+        m = _source_mcf("era5_land", defaults, manifest)
+    root = etree.fromstring(fgdc.render_fgdc(m, kind=kind).encode("utf-8"))
+    assert root.tag == "metadata"
+
+
+def test_unknown_kind_raises(defaults, manifest):
+    with pytest.raises(ValueError, match="Unknown FGDC kind"):
+        fgdc.render_fgdc(_source_mcf("era5_land", defaults, manifest), kind="bogus")
+
+
+def test_procstep_element_order_is_csdgm(defaults, manifest):
+    """CSDGM <procstep> order: procdesc -> srcused* -> procdate -> proctime ->
+    srcprod*. mp rejects any other order."""
+    root = etree.fromstring(
+        fgdc.render_fgdc(
+            _source_mcf("era5_land", defaults, manifest), kind="source"
+        ).encode("utf-8")
+    )
+    steps = root.findall(".//procstep")
+    assert steps
+    for step in steps:
+        tags = [child.tag for child in step]
+        assert tags[0] == "procdesc"
+        procdate_i = tags.index("procdate")
+        assert all(tags.index(t) < procdate_i for t in tags if t == "srcused")
+        assert all(tags.index(t) > procdate_i for t in tags if t == "srcprod")
+
+
+def test_srcused_srcprod_resolve_to_srcinfo(config, fabric, defaults, manifest):
+    """Every <srcused>/<srcprod> abbreviation has a matching <srccitea>.
+
+    Dangling Source Citation Abbreviations are an mp error; this guards the
+    basename -> srcinfo mapping in fgdc._srcinfo_entries.
+    """
+    root = etree.fromstring(
+        fgdc.render_fgdc(
+            _fabric_mcf(config, fabric, defaults, manifest), kind="fabric"
+        ).encode("utf-8")
+    )
+    defined = {e.text for e in root.findall(".//srccitea")}
+    referenced = {e.text for e in root.findall(".//srcused")} | {
+        e.text for e in root.findall(".//srcprod")
+    }
+    assert referenced <= defined
+
+
+def test_bbox_maps_to_bounding(defaults, manifest):
+    """MCF bbox [W, S, E, N] -> westbc/southbc/eastbc/northbc."""
+    root = etree.fromstring(
+        fgdc.render_fgdc(
+            _source_mcf("era5_land", defaults, manifest), kind="source"
+        ).encode("utf-8")
+    )
+    bounding = root.find(".//bounding")
+    assert bounding.findtext("westbc") == "-125.0"
+    assert bounding.findtext("eastbc") == "-66.0"
+    assert bounding.findtext("northbc") == "53.0"
+    assert bounding.findtext("southbc") == "24.7"
+
+
+def test_snodas_has_bounding(defaults, manifest):
+    """The inline catalog bbox fix gives SNODAS a mandatory FGDC <bounding>."""
+    root = etree.fromstring(
+        fgdc.render_fgdc(
+            _source_mcf("snodas", defaults, manifest), kind="source"
+        ).encode("utf-8")
+    )
+    assert root.find(".//bounding") is not None
+
+
+def test_umbrella_has_no_eainfo_or_dataqual(config, fabric, defaults, manifest):
+    """The umbrella carries no files and no per-step lineage of its own."""
+    root = etree.fromstring(
+        fgdc.render_fgdc(
+            _umbrella_mcf(config, fabric, defaults, manifest), kind="umbrella"
+        ).encode("utf-8")
+    )
+    assert root.find("eainfo") is None
+    assert root.find("dataqual") is None
+    # The lineage prose still surfaces in supplemental information.
+    assert root.findtext(".//supplinf")
+
+
+def test_special_characters_are_escaped(config, fabric, defaults, manifest):
+    """Range notes contain '>=' / '&' which must become XML entities."""
+    xml = fgdc.render_fgdc(
+        _fabric_mcf(config, fabric, defaults, manifest), kind="fabric"
+    )
+    assert "&gt;=1" in xml
+    # Round-trips: the escaped text parses back to the literal.
+    root = etree.fromstring(xml.encode("utf-8"))
+    udoms = " ".join(e.text or "" for e in root.findall(".//udom"))
+    assert ">=1 source is finite" in udoms

--- a/tests/test_release_iso.py
+++ b/tests/test_release_iso.py
@@ -1,0 +1,159 @@
+"""Golden-file tests for nhf_spatial_targets.release.iso.
+
+ISO 19139 is emitted by pygeometa from the same MCF dict that feeds FGDC and
+README. The render is deterministic for a pinned pygeometa version (every date
+is baked into the MCF), so a byte-equal golden catches both MCF-shape changes
+and pygeometa upgrades. Regenerate after an intentional change with::
+
+    REGEN_GOLDENS=1 pixi run -e dev test -k test_release_iso
+
+If a pygeometa version bump legitimately changes the output, regenerate and
+review the diff. The per-source goldens (era5_land, snodas) are representative
+examples; adding a new catalog source must not require touching them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from lxml import etree
+
+from nhf_spatial_targets.defaults import apply_defaults
+from nhf_spatial_targets.release import iso, mcf
+from nhf_spatial_targets.release.defaults import load_release_defaults
+
+FX = Path(__file__).parent / "fixtures" / "release"
+NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+SRC_FILES = {
+    "era5_land": [
+        "monthly/era5_land_monthly_2003.nc",
+        "daily/era5_land_daily_2003.nc",
+    ],
+    "snodas": ["daily/snodas_2003.nc"],
+}
+FABRIC_FILES = [
+    "fabric.gpkg",
+    "aggregated/era5_land/era5_land_2003.nc",
+    "aggregated/snodas/snodas_2003.nc",
+    "targets/runoff_targets.nc",
+    "targets/swe_targets.nc",
+    "manifest.json",
+]
+
+
+@pytest.fixture
+def defaults() -> dict:
+    return load_release_defaults(FX / "fixture_release_defaults.yml")
+
+
+@pytest.fixture
+def config() -> dict:
+    return apply_defaults(
+        yaml.safe_load((FX / "fixture_project_config.yml").read_text())
+    )
+
+
+@pytest.fixture
+def fabric() -> dict:
+    return json.loads((FX / "fixture_fabric.json").read_text())
+
+
+@pytest.fixture
+def manifest() -> dict:
+    return json.loads((FX / "fixture_manifest.json").read_text())
+
+
+def _check_golden(text: str, name: str) -> None:
+    path = FX / name
+    if os.environ.get("REGEN_GOLDENS"):
+        path.write_text(text)
+    assert text == path.read_text()
+
+
+def _source_mcf(key: str, defaults: dict, manifest: dict) -> dict:
+    return mcf.build_source_mcf(
+        key,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=SRC_FILES.get(key),
+        now=NOW,
+    )
+
+
+def _fabric_mcf(config: dict, fabric: dict, defaults: dict, manifest: dict) -> dict:
+    return mcf.build_fabric_mcf(
+        config=config,
+        fabric=fabric,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=FABRIC_FILES,
+        now=NOW,
+    )
+
+
+def _umbrella_mcf(config: dict, fabric: dict, defaults: dict, manifest: dict) -> dict:
+    children = [
+        _source_mcf("era5_land", defaults, manifest),
+        _source_mcf("snodas", defaults, manifest),
+        _fabric_mcf(config, fabric, defaults, manifest),
+    ]
+    return mcf.build_umbrella_mcf(
+        defaults=defaults,
+        children=children,
+        authors=config["release"]["authors"],
+        version="1.0",
+        now=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden-file tests
+# ---------------------------------------------------------------------------
+
+
+def test_source_era5_iso_golden(defaults, manifest):
+    _check_golden(
+        iso.render_iso(_source_mcf("era5_land", defaults, manifest)),
+        "expected_source_era5_iso.xml",
+    )
+
+
+def test_source_snodas_iso_golden(defaults, manifest):
+    _check_golden(
+        iso.render_iso(_source_mcf("snodas", defaults, manifest)),
+        "expected_source_snodas_iso.xml",
+    )
+
+
+def test_fabric_iso_golden(config, fabric, defaults, manifest):
+    _check_golden(
+        iso.render_iso(_fabric_mcf(config, fabric, defaults, manifest)),
+        "expected_fabric_gfv2_iso.xml",
+    )
+
+
+def test_umbrella_iso_golden(config, fabric, defaults, manifest):
+    _check_golden(
+        iso.render_iso(_umbrella_mcf(config, fabric, defaults, manifest)),
+        "expected_umbrella_iso.xml",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant spot-checks
+# ---------------------------------------------------------------------------
+
+
+def test_iso_is_wellformed_and_deterministic(defaults, manifest):
+    m = _source_mcf("era5_land", defaults, manifest)
+    xml1 = iso.render_iso(m)
+    xml2 = iso.render_iso(m)
+    assert xml1 == xml2
+    root = etree.fromstring(xml1.encode("utf-8"))
+    assert root.tag.endswith("MD_Metadata")

--- a/tests/test_release_mcf.py
+++ b/tests/test_release_mcf.py
@@ -162,12 +162,14 @@ def test_bbox_nwse_converted_to_wsen(defaults, manifest):
 
 
 def test_source_without_bbox_is_none(defaults, manifest):
-    """SNODAS has no access.bbox_nwse, so its MCF bbox is honestly None.
+    """A source with no access.bbox_nwse gets an honest None MCF bbox.
 
-    (FGDC bounding coordinates are mandatory; supplying a fallback or a
-    catalog bbox for CONUS-only sources is a PR-D2 follow-up.)
+    merra2 is global and subsets at aggregation time, so the catalog carries
+    no bbox for it. (SNODAS used to be the example here, but PR-D2 gave it a
+    catalog CONUS bbox so its FGDC <bounding> is valid; the code-side None
+    path is also covered by test_fabric_bbox_absent_is_none.)
     """
-    built = _build_source("snodas", defaults, manifest)
+    built = _build_source("merra2", defaults, manifest)
     assert built["identification"]["extents"]["spatial"][0]["bbox"] is None
 
 

--- a/tests/test_release_mp_validate.py
+++ b/tests/test_release_mp_validate.py
@@ -1,0 +1,84 @@
+"""Tests for nhf_spatial_targets.release.validate_xml.
+
+``mp`` (the USGS Metadata Parser) is operator-installed and absent in CI, so
+the deterministic tests here cover the report parser (with a synthetic ``mp``
+report) and the ``lxml`` well-formedness fallback (forced via monkeypatch).
+The actual ``mp`` run against the committed FGDC goldens is integration-gated
+and skipped unless ``mp`` is on PATH.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nhf_spatial_targets.release import validate_xml
+
+FX = Path(__file__).parent / "fixtures" / "release"
+
+FGDC_GOLDENS = [
+    "expected_source_era5_fgdc.xml",
+    "expected_source_snodas_fgdc.xml",
+    "expected_fabric_gfv2_fgdc.xml",
+    "expected_umbrella_fgdc.xml",
+]
+
+
+def _force_no_mp(monkeypatch) -> None:
+    monkeypatch.setattr(validate_xml.shutil, "which", lambda *a, **k: None)
+
+
+def test_mp_available_returns_bool():
+    assert isinstance(validate_xml.mp_available(), bool)
+
+
+def test_parse_mp_report_splits_warnings_and_errors():
+    report = (
+        "mp: metadata.xml\n"
+        "Warnings:\n"
+        "  3: optional element missing\n"
+        "Errors:\n"
+        "  10: element out of order\n"
+        "  11: undefined source citation abbreviation\n"
+    )
+    warnings, errors = validate_xml._parse_mp_report(report)
+    assert warnings == ["3: optional element missing"]
+    assert errors == [
+        "10: element out of order",
+        "11: undefined source citation abbreviation",
+    ]
+
+
+def test_wellformed_fallback_passes_valid_xml(monkeypatch):
+    _force_no_mp(monkeypatch)
+    good = (FX / "expected_source_era5_fgdc.xml").read_text()
+    result = validate_xml.validate_xml_string(good)
+    assert result.ok is True
+    assert result.errors == []
+    assert any("well-formed" in w for w in result.warnings)
+
+
+def test_wellformed_fallback_flags_malformed_xml(monkeypatch):
+    _force_no_mp(monkeypatch)
+    result = validate_xml.validate_xml_string("<a><b></a>")
+    assert result.ok is False
+    assert result.errors
+
+
+@pytest.mark.parametrize("name", FGDC_GOLDENS)
+def test_golden_fgdc_is_wellformed(name):
+    """A committed FGDC golden must at least be well-formed (mp-independent)."""
+    from lxml import etree
+
+    etree.parse(str(FX / name))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not validate_xml.mp_available(), reason="mp (USGS Metadata Parser) not on PATH"
+)
+@pytest.mark.parametrize("name", FGDC_GOLDENS)
+def test_mp_reports_no_errors_on_goldens(name):
+    result = validate_xml.validate_xml_file(FX / name)
+    assert not result.errors, result.errors

--- a/tests/test_release_mp_validate.py
+++ b/tests/test_release_mp_validate.py
@@ -50,6 +50,56 @@ def test_parse_mp_report_splits_warnings_and_errors():
     ]
 
 
+def test_parse_mp_report_message_body_is_not_mistaken_for_header():
+    """A message line beginning with 'Error'/'warning' stays in its section.
+
+    Only an exact ``Errors:`` / ``Warnings:`` token switches buckets, so the
+    message body is neither dropped nor treated as a new header.
+    """
+    report = (
+        "Errors:\n"
+        "  12: Error in source citation abbreviation\n"
+        "Warnings:\n"
+        "  3: warning suppressed in element foo\n"
+    )
+    warnings, errors = validate_xml._parse_mp_report(report)
+    assert errors == ["12: Error in source citation abbreviation"]
+    assert warnings == ["3: warning suppressed in element foo"]
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_nonzero_returncode_is_failure(monkeypatch, tmp_path):
+    """mp exiting non-zero with no parseable errors must not read as success."""
+    monkeypatch.setattr(validate_xml.shutil, "which", lambda *a, **k: "/usr/bin/mp")
+    monkeypatch.setattr(
+        validate_xml.subprocess, "run", lambda *a, **k: _FakeProc(2, stdout="")
+    )
+    f = tmp_path / "m.xml"
+    f.write_text("<metadata/>")
+    result = validate_xml.validate_xml_file(f)
+    assert result.ok is False
+    assert any("exited with status 2" in e for e in result.errors)
+
+
+def test_timeout_is_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(validate_xml.shutil, "which", lambda *a, **k: "/usr/bin/mp")
+
+    def _raise(*a, **k):
+        raise validate_xml.subprocess.TimeoutExpired(cmd="mp", timeout=120)
+
+    monkeypatch.setattr(validate_xml.subprocess, "run", _raise)
+    f = tmp_path / "m.xml"
+    f.write_text("<metadata/>")
+    result = validate_xml.validate_xml_file(f)
+    assert result.ok is False
+    assert any("timed out" in e for e in result.errors)
+
+
 def test_wellformed_fallback_passes_valid_xml(monkeypatch):
     _force_no_mp(monkeypatch)
     good = (FX / "expected_source_era5_fgdc.xml").read_text()


### PR DESCRIPTION
Closes #266. Second half of PR-D in the ScienceBase data-release phasing (#241); consumes the PR-D1 MCF builders (#264) and renders them to the two metadata XML formats plus a validator.

## Summary
- **`release/fgdc.py` + `templates/fgdc/{base,umbrella,source,fabric}.xml.j2`** — render FGDC CSDGM 2.0 XML from the MCF dict via Jinja2 (pygeometa has no FGDC schema). Pure function of the MCF dict; lxml pretty-print gives byte-stable, well-formed output. Handles strict CSDGM element order and the `<srcused>`/`<srcprod>` → `<srcinfo>` Source Citation Abbreviation mapping (abbreviation == process-step basename, 1:1).
- **`release/iso.py`** — thin wrapper over `pygeometa.schemas.iso19139.ISO19139OutputSchema().write(mcf)`.
- **`release/validate_xml.py`** — `mp` (USGS Metadata Parser) subprocess wrapper returning `(ok, warnings, errors)`; `lxml` well-formedness fallback when `mp` is absent (warn-only, never hard-fails).
- **`mcf.py`** — adds the FGDC-mandatory `distribution_liability` top-level key (sourced from `release_defaults`, pygeometa/ISO ignore it). MCF + README goldens regenerated.

### Inline SNODAS bbox fix
FGDC `<bounding>` is mandatory in CSDGM, but SNODAS had no `access.bbox_nwse` so its MCF bbox was `None`. Added the CONUS analysis-domain bbox (`[N, W, S, E]`, same convention as era5_land) to the catalog `snodas.access` block. Repointed `test_source_without_bbox_is_none` to merra2 (genuinely global/bbox-less) and regenerated the SNODAS MCF/README goldens. The code-side `None` path stays covered by `test_fabric_bbox_absent_is_none`.

## Test plan
- [x] `pixi run -e dev fmt` + `lint` clean
- [x] Golden-file tests (FGDC + ISO) byte-stable via the `REGEN_GOLDENS=1` pattern
- [x] `test_release_mcf.py` / `test_release_readme.py` / `test_catalog.py` pass after goldens regen
- [x] FGDC invariant spot-checks: strict `<procstep>` order, `<srcused>`/`<srcprod>` resolve to `<srcinfo>`, bbox→`<bounding>` mapping, XML entity escaping
- [x] `mp` validation tests gated on `mp` presence (skipped in CI; integration-marked for operator runs)
- [ ] GH Actions full suite (running)

## Out of scope
Payload wiring (`build.py`), SB client, registry, publish/dry-run, CLI → PR-E/PR-F. Issue #260 is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)