### PR TITLE
feature(release): PR-E1 offline build orchestrator (release/build.py)

### DIFF
--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -704,6 +704,13 @@ sources:
     access:
       type: zarr_verify
       url: https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=2129
+      bbox_nwse: [82.9, -178.1, 14.1, -53.1]
+      bbox_notes: >
+        Daymet V4 full coverage envelope (North America + Hawaii + Puerto
+        Rico), expressed as [N, W, S, E] to match era5_land. Daymet ships as a
+        metadata-only release child (no file payload), but CSDGM <bounding> is
+        still mandatory, so this records the published ORNL DAAC spatial extent
+        and satisfies the FGDC <bounding> element for the source child.
       stores:
         na: "{daymet_root}/daymet_na.zarr"
         hi: "{daymet_root}/daymet_hi.zarr"

--- a/catalog/sources.yml
+++ b/catalog/sources.yml
@@ -704,7 +704,7 @@ sources:
     access:
       type: zarr_verify
       url: https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=2129
-      bbox_nwse: [82.9, -178.1, 14.1, -53.1]
+      bbox_nwse: [82.9, -178.1, 14.1, -52.0]
       bbox_notes: >
         Daymet V4 full coverage envelope (North America + Hawaii + Puerto
         Rico), expressed as [N, W, S, E] to match era5_land. Daymet ships as a

--- a/src/nhf_spatial_targets/release/__init__.py
+++ b/src/nhf_spatial_targets/release/__init__.py
@@ -12,6 +12,13 @@ from nhf_spatial_targets.release._models import (
     SourceChildPlan,
     UmbrellaPlan,
 )
+from nhf_spatial_targets.release.build import (
+    BuildResult,
+    build_all,
+    build_fabric_child,
+    build_source_child,
+    build_umbrella,
+)
 from nhf_spatial_targets.release.checksums import (
     ChecksumMismatch,
     compute_checksums,
@@ -73,6 +80,7 @@ __all__ = [
     "STEP_KINDS",
     "CHECKSUM_FILES",
     "RESERVED_METADATA_FILES",
+    "BuildResult",
     "ChecksumMismatch",
     "DistributionKind",
     "FabricChildPlan",
@@ -86,9 +94,13 @@ __all__ = [
     "StepRecord",
     "UmbrellaPlan",
     "append_step",
+    "build_all",
+    "build_fabric_child",
     "build_fabric_mcf",
+    "build_source_child",
     "build_source_mcf",
     "build_step_record",
+    "build_umbrella",
     "build_umbrella_mcf",
     "compute_checksums",
     "input_file_entry",

--- a/src/nhf_spatial_targets/release/build.py
+++ b/src/nhf_spatial_targets/release/build.py
@@ -1,0 +1,320 @@
+"""Offline build orchestrator for the ScienceBase release.
+
+This module is the glue that turns the existing release pieces -- payload
+staging (:mod:`~nhf_spatial_targets.release.payload`), MCF construction
+(:mod:`~nhf_spatial_targets.release.mcf`), FGDC / ISO / README rendering
+(:mod:`~nhf_spatial_targets.release.fgdc` / :mod:`.iso` / :mod:`.readme`), and
+checksums (:mod:`~nhf_spatial_targets.release.checksums`) -- into a complete,
+self-contained release payload on disk under
+``<project>/release/build/<scope>/``.
+
+It is **entirely offline**: no ScienceBase client, registry, or network I/O.
+Publishing, the registry, and dry-run are a later phase (PR-E2); the CLI that
+drives this is PR-F. The build is **catalog- + manifest-driven**: source
+children flow from :func:`catalog.publishable_sources` (via
+:func:`payload.sources_used`) and fabric participation from the project
+``manifest.json`` -- never a hard-coded source list.
+
+Per-item build sequence (deterministic for a fixed ``now``)::
+
+    1. stage the payload         payload.stage_*()  (symlink by default; --copy)
+    2. load defaults + manifest  release_defaults.yml + <project>/manifest.json
+    3. declare distribution list  the staged relative paths (+ the not-yet-
+                                  written README/checksums for the fabric child)
+    4. build the MCF dict        mcf.build_*_mcf(distribution_files=<list>)
+    5. render metadata           fgdc.xml + iso.xml + README.md into the stage
+    6. compute checksums LAST     checksums.csv + SHA256SUMS (after every file
+                                  exists -- a manifest must not list itself)
+
+Distribution-list decision (see the PR write-up):
+    The MCF ``distribution.online`` list records the staged **downloadable
+    artifacts**, with the metadata *records* (``fgdc.xml`` / ``iso.xml``)
+    excluded -- they describe the item, they are not its data. Because the MCF
+    builder only records names (strings), the list can name files written
+    after the MCF is rendered (README, checksums), which is why the order is
+    *declare list -> render -> checksum last*.
+
+    - **Fabric child:** ``fabric.gpkg`` + every aggregated NC + every target NC
+      + ``manifest.json`` + ``README.md`` + ``checksums.csv`` + ``SHA256SUMS``.
+      This matches the fgdc-field-map's "every staged file" intent.
+    - **Source child:** the staged consolidated NetCDFs only. The PR-D1
+      source-distribution builder labels every listed entry "Consolidated
+      CF-1.6 NetCDF.", so listing README / checksums there would mislabel them;
+      those files are still staged and checksummed, just not enumerated in
+      ``distribution.online``. ``metadata_only`` sources (daymet) stage no data
+      and so carry only the upstream landing entry.
+    - **Umbrella:** metadata-only; no data files, just the landing entry.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from nhf_spatial_targets.release import checksums, fgdc, iso, mcf, payload, readme
+from nhf_spatial_targets.release._models import (
+    CHECKSUM_FILES,
+    RESERVED_METADATA_FILES,
+    FileEntry,
+)
+from nhf_spatial_targets.release.defaults import load_release_defaults
+from nhf_spatial_targets.workspace import Project
+
+# release build --scope choices; "fabric" is the default (one fabric child).
+BuildScope = Literal["fabric", "sources", "all"]
+ItemKind = Literal["umbrella", "source", "fabric"]
+
+# Generated metadata records (fgdc.xml / iso.xml) deliberately omitted from the
+# fabric distribution list -- they describe the item, they are not its data.
+# The human-readable README and the integrity manifests are kept.
+_FABRIC_EXTRA_DISTRIBUTION = ("README.md", "checksums.csv", "SHA256SUMS")
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    """The on-disk result of building one release item.
+
+    ``key`` is the source key for a source child, the fabric label for a
+    fabric child, and ``None`` for the umbrella. ``mcf`` is the dict the
+    metadata files were rendered from; ``entries`` is the checksum record of
+    every staged file (the same list backing ``checksums.csv`` / ``SHA256SUMS``).
+    """
+
+    kind: ItemKind
+    key: str | None
+    stage_dir: Path
+    mcf: dict
+    entries: tuple[FileEntry, ...]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_manifest(project: Project) -> dict:
+    """Load the project's live ``manifest.json`` (``{}`` if it is absent).
+
+    The fabric stage carries a point-in-time *copy* of this file (staged by
+    :func:`payload.stage_fabric_child`); the MCF lineage reads the same
+    content here so the metadata and the staged snapshot agree.
+    """
+    path = project.manifest_path
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _release_cfg(project: Project) -> dict:
+    """The merged ``release:`` config block (``{}`` if the project omits it)."""
+    return project.config.get("release") or {}
+
+
+def _staged_data_relpaths(stage_dir: Path) -> list[str]:
+    """Sorted POSIX relpaths of every staged **data** file under *stage_dir*.
+
+    Excludes the generated metadata records and integrity manifests (so the
+    list is identical whether or not a previous build left them behind), which
+    lets us declare the distribution list *before* those files are written.
+    Symlinks are kept (the default stager links data files); only directories
+    are skipped.
+    """
+    skip = set(RESERVED_METADATA_FILES) | set(CHECKSUM_FILES)
+    rels: list[str] = []
+    for path in stage_dir.rglob("*"):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(stage_dir).as_posix()
+        if rel in skip:
+            continue
+        rels.append(rel)
+    return sorted(rels)
+
+
+def _render_metadata(stage_dir: Path, mcf_dict: dict, *, kind: ItemKind) -> None:
+    """Render and write ``README.md`` / ``fgdc.xml`` / ``iso.xml`` to *stage_dir*.
+
+    A pure function of *mcf_dict* (every date is already baked into the MCF),
+    so re-rendering an unchanged MCF rewrites byte-identical files.
+    """
+    (stage_dir / "fgdc.xml").write_text(fgdc.render_fgdc(mcf_dict, kind=kind))
+    (stage_dir / "iso.xml").write_text(iso.render_iso(mcf_dict))
+    (stage_dir / "README.md").write_text(readme.render_readme(mcf_dict, kind=kind))
+
+
+def _finish(
+    stage_dir: Path, mcf_dict: dict, *, kind: ItemKind, key: str | None
+) -> BuildResult:
+    """Render metadata, checksum the finished stage, and package the result.
+
+    Shared tail of every ``build_*`` function: metadata records are written
+    first, then :func:`checksums.compute_checksums` runs **last** so it
+    fingerprints a complete payload (and never lists ``checksums.csv`` /
+    ``SHA256SUMS`` themselves).
+    """
+    _render_metadata(stage_dir, mcf_dict, kind=kind)
+    entries = checksums.compute_checksums(stage_dir)
+    return BuildResult(
+        kind=kind, key=key, stage_dir=stage_dir, mcf=mcf_dict, entries=tuple(entries)
+    )
+
+
+def _child_mcfs(
+    project: Project, *, defaults: dict, manifest: dict, now: datetime | None
+) -> list[dict]:
+    """Build the fabric + source child MCF dicts (no staging, no rendering).
+
+    The umbrella only needs each child's bbox / temporal extent / title to
+    union them, so this builds the MCF dicts directly without touching disk.
+    Distribution-file lists are irrelevant to the union and left unset.
+    """
+    children = [
+        mcf.build_fabric_mcf(
+            config=project.config,
+            fabric=project.fabric,
+            defaults=defaults,
+            manifest=manifest,
+            doi=_release_cfg(project).get("doi"),
+            now=now,
+        )
+    ]
+    for key in payload.sources_used(project):
+        children.append(
+            mcf.build_source_mcf(key, defaults=defaults, manifest=manifest, now=now)
+        )
+    return children
+
+
+# ---------------------------------------------------------------------------
+# Per-item builders
+# ---------------------------------------------------------------------------
+
+
+def build_source_child(
+    project: Project, key: str, *, copy: bool = False, now: datetime | None = None
+) -> BuildResult:
+    """Build the consolidated-source child for *key* under ``build/sources/<key>``.
+
+    Stages the source's consolidated NetCDFs (none for ``metadata_only``
+    sources such as daymet), then renders FGDC / ISO / README and checksums.
+    The distribution list is the staged NetCDFs; see the module docstring for
+    why README / checksums are not enumerated there for source children.
+    """
+    defaults = load_release_defaults()
+    manifest = _load_manifest(project)
+    plan = payload.stage_source_child(project, key, copy=copy)
+    mcf_dict = mcf.build_source_mcf(
+        key,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=_staged_data_relpaths(plan.stage_dir),
+        now=now,
+    )
+    return _finish(plan.stage_dir, mcf_dict, kind="source", key=key)
+
+
+def build_fabric_child(
+    project: Project, *, copy: bool = False, now: datetime | None = None
+) -> BuildResult:
+    """Build the fabric child under ``build/fabric/<label>``.
+
+    Stages ``fabric.gpkg`` + aggregated NCs + target NCs + a ``manifest.json``
+    snapshot, then renders FGDC / ISO / README and checksums. The distribution
+    list is every staged downloadable artifact (the metadata records aside);
+    see the module docstring.
+    """
+    defaults = load_release_defaults()
+    manifest = _load_manifest(project)
+    plan = payload.stage_fabric_child(project, copy=copy)
+    data = _staged_data_relpaths(plan.stage_dir)
+    distribution_files = sorted(set(data) | set(_FABRIC_EXTRA_DISTRIBUTION))
+    mcf_dict = mcf.build_fabric_mcf(
+        config=project.config,
+        fabric=project.fabric,
+        defaults=defaults,
+        manifest=manifest,
+        distribution_files=distribution_files,
+        doi=_release_cfg(project).get("doi"),
+        now=now,
+    )
+    return _finish(plan.stage_dir, mcf_dict, kind="fabric", key=plan.fabric_label)
+
+
+def build_umbrella(
+    project: Project,
+    *,
+    copy: bool = False,
+    children: list[dict] | None = None,
+    now: datetime | None = None,
+) -> BuildResult:
+    """Build the metadata-only umbrella under ``build/umbrella``.
+
+    The umbrella unions its children's spatial / temporal extents and lists
+    their titles. ``children`` is the list of already-built child MCF dicts;
+    when ``None`` (a standalone umbrella build), the fabric + source child MCFs
+    are rebuilt locally -- a local build unions exactly the children this
+    project would produce. The registry-driven cross-project union and DOI
+    refresh are a later phase (PR-E2); any operator-set DOI is read from
+    ``config.release.doi`` here.
+    """
+    defaults = load_release_defaults()
+    release_cfg = _release_cfg(project)
+    if children is None:
+        children = _child_mcfs(
+            project, defaults=defaults, manifest=_load_manifest(project), now=now
+        )
+    plan = payload.stage_umbrella(project, copy=copy)
+    mcf_dict = mcf.build_umbrella_mcf(
+        defaults=defaults,
+        children=children,
+        authors=list(release_cfg.get("authors") or []),
+        doi=release_cfg.get("doi"),
+        now=now,
+    )
+    return _finish(plan.stage_dir, mcf_dict, kind="umbrella", key=None)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def build_all(
+    project: Project,
+    *,
+    scope: BuildScope = "fabric",
+    copy: bool = False,
+    now: datetime | None = None,
+) -> list[BuildResult]:
+    """Build the items selected by *scope* and return their results in order.
+
+    - ``"fabric"`` (default): the fabric child only.
+    - ``"sources"``: one source child per publishable source the project used.
+    - ``"all"``: the fabric child, every source child, and the umbrella -- the
+      umbrella unions the children built in this same invocation.
+    """
+    if scope == "fabric":
+        return [build_fabric_child(project, copy=copy, now=now)]
+    if scope == "sources":
+        return [
+            build_source_child(project, key, copy=copy, now=now)
+            for key in payload.sources_used(project)
+        ]
+    if scope == "all":
+        results = [build_fabric_child(project, copy=copy, now=now)]
+        results += [
+            build_source_child(project, key, copy=copy, now=now)
+            for key in payload.sources_used(project)
+        ]
+        results.append(
+            build_umbrella(
+                project, copy=copy, children=[r.mcf for r in results], now=now
+            )
+        )
+        return results
+    raise ValueError(
+        f"Unknown scope {scope!r}; expected 'fabric', 'sources', or 'all'."
+    )

--- a/src/nhf_spatial_targets/release/build.py
+++ b/src/nhf_spatial_targets/release/build.py
@@ -11,9 +11,10 @@ self-contained release payload on disk under
 It is **entirely offline**: no ScienceBase client, registry, or network I/O.
 Publishing, the registry, and dry-run are a later phase (PR-E2); the CLI that
 drives this is PR-F. The build is **catalog- + manifest-driven**: source
-children flow from :func:`catalog.publishable_sources` (via
-:func:`payload.sources_used`) and fabric participation from the project
-``manifest.json`` -- never a hard-coded source list.
+children flow from :func:`payload.sources_used` (the intersection of
+:func:`catalog.publishable_sources` with the sources the project actually
+aggregated on disk) and fabric participation from the project ``manifest.json``
+-- never a hard-coded source list.
 
 Per-item build sequence (deterministic for a fixed ``now``)::
 
@@ -26,7 +27,7 @@ Per-item build sequence (deterministic for a fixed ``now``)::
     6. compute checksums LAST     checksums.csv + SHA256SUMS (after every file
                                   exists -- a manifest must not list itself)
 
-Distribution-list decision (see the PR write-up):
+Distribution-list decision:
     The MCF ``distribution.online`` list records the staged **downloadable
     artifacts**, with the metadata *records* (``fgdc.xml`` / ``iso.xml``)
     excluded -- they describe the item, they are not its data. Because the MCF
@@ -49,6 +50,7 @@ Distribution-list decision (see the PR write-up):
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -89,6 +91,17 @@ class BuildResult:
     mcf: dict
     entries: tuple[FileEntry, ...]
 
+    def __post_init__(self) -> None:
+        # The umbrella is keyless; source/fabric children always carry a key.
+        # Guard the correlation the downstream publish phase will rely on
+        # (mirrors SourceChildPlan.__post_init__ in _models.py).
+        if (self.kind == "umbrella") != (self.key is None):
+            raise ValueError(
+                f"{self.kind!r} child key invariant violated: umbrella must "
+                f"have key=None and source/fabric a non-None key; got "
+                f"key={self.key!r}."
+            )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -101,11 +114,24 @@ def _load_manifest(project: Project) -> dict:
     The fabric stage carries a point-in-time *copy* of this file (staged by
     :func:`payload.stage_fabric_child`); the MCF lineage reads the same
     content here so the metadata and the staged snapshot agree.
+
+    An absent manifest is a legitimate state (e.g. a freshly-validated project)
+    and the MCF builders accept an empty mapping. A *corrupt* manifest is not:
+    silently falling back to ``{}`` would build a release with empty lineage
+    and an empty source list, so it is a loud failure here -- mirroring
+    :func:`nhf_spatial_targets.release.lineage._load_or_init`.
     """
     path = project.manifest_path
     if not path.exists():
         return {}
-    return json.loads(path.read_text())
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"manifest.json at {path} is corrupt: {exc}. The release lineage "
+            f"and source list are built from this file; inspect it manually or "
+            f"restore it before building."
+        ) from exc
 
 
 def _release_cfg(project: Project) -> dict:
@@ -121,10 +147,23 @@ def _staged_data_relpaths(stage_dir: Path) -> list[str]:
     lets us declare the distribution list *before* those files are written.
     Symlinks are kept (the default stager links data files); only directories
     are skipped.
+
+    A *dangling* symlink (the datastore can live on a separately-mounted drive)
+    is a hard error, not a silent inclusion: were it enumerated, it would be
+    advertised in ``distribution.online`` and baked into the rendered FGDC /
+    ISO / README before :func:`checksums.compute_checksums` caught it. Failing
+    here -- mirroring :func:`checksums._iter_staged_files` -- keeps the failure
+    early and names the real cause.
     """
     skip = set(RESERVED_METADATA_FILES) | set(CHECKSUM_FILES)
     rels: list[str] = []
     for path in stage_dir.rglob("*"):
+        if path.is_symlink() and not path.exists():
+            raise FileNotFoundError(
+                f"staged entry points at a missing target: {path} -> "
+                f"{os.readlink(path)}. The datastore drive may be unmounted, "
+                f"or the source file was removed after staging."
+            )
         if path.is_dir():
             continue
         rel = path.relative_to(stage_dir).as_posix()

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -1,0 +1,416 @@
+"""Tests for nhf_spatial_targets.release.build (offline build orchestrator).
+
+These assert *structure / presence / consistency*, not golden XML bytes:
+build.py only wires the existing pieces together, and the byte-stability of
+the rendered FGDC / ISO / README is already covered by test_release_fgdc /
+test_release_iso / test_release_readme. Here we check that each ``build_*``
+produces a complete, internally-consistent stage directory.
+
+The project fixture mirrors tests/test_release_payload.py's hand-built
+``Project`` (so build.py is exercised against the same staging rules) but adds
+the config / fabric.json / manifest.json content the MCF builders need.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from lxml import etree
+
+from nhf_spatial_targets.release import build, payload
+from nhf_spatial_targets.release.checksums import (
+    CHECKSUMS_CSV,
+    SHA256SUMS,
+    verify_csv,
+)
+from nhf_spatial_targets.workspace import Project
+
+# Clock-injected so a re-run renders byte-identical metadata (determinism check).
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+def _touch(path: Path, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _build_project(tmp_path, *, fabric_label: str = "gfv_test") -> Project:
+    """Synthesize a project + datastore exercising the build orchestrator.
+
+    Aggregated subdirs: era5_land (publishable, kept), watergap22d
+    (non-publishable, excluded), daymet (publishable metadata_only -- its
+    aggregated NCs still ship in the fabric child). Datastore carries era5_land
+    consolidated NCs (a data source child) and a daymet NC that must NOT stage
+    (metadata_only).
+    """
+    workdir = tmp_path / "proj"
+    datastore = tmp_path / "store"
+    fabric_file = _touch(tmp_path / "fab" / "gfv_test.gpkg", b"GPKG-bytes")
+
+    agg = workdir / "data" / "aggregated"
+    _touch(agg / "era5_land" / "era5_land_1980_agg.nc", b"era5-1980")
+    _touch(agg / "watergap22d" / "watergap22d_1980_agg.nc", b"wg-held")
+    _touch(agg / "daymet" / "daymet_na_1980_agg.nc", b"daymet-1980")
+    _touch(workdir / "targets" / "runoff_targets.nc", b"runoff")
+    _touch(workdir / "targets" / "aet_targets.nc", b"aet")
+
+    _touch(datastore / "era5_land" / "daily" / "era5_land_daily_1980.nc", b"d-1980")
+    _touch(datastore / "era5_land" / "monthly" / "era5_land_monthly_1980.nc", b"m-1980")
+    # metadata_only: present on disk but must never stage into the source child.
+    _touch(datastore / "daymet" / "daymet_consolidated.nc", b"should-not-stage")
+
+    (workdir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "sources": {"era5_land": {}, "watergap22d": {}},
+                "steps": [
+                    {
+                        "kind": "aggregate",
+                        "source_key": "era5_land",
+                        "timestamp_utc": "2026-01-02T03:04:05+00:00",
+                        "software_version": "0.7.0",
+                        "tool": "nhf-targets",
+                        "command": "agg era5-land",
+                        "inputs": [
+                            {
+                                "path": "/x/era5_land_daily_1980.nc",
+                                "size_bytes": 6,
+                                "mtime_utc": "2026-01-01T00:00:00+00:00",
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "path": "agg/era5_land/era5_land_1980_agg.nc",
+                                "sha256": "ab12",
+                                "size_bytes": 9,
+                                "mtime_utc": "2026-01-02T00:00:00+00:00",
+                            }
+                        ],
+                        "params": {"method": "area_weighted"},
+                    },
+                    {
+                        "kind": "validate",
+                        "source_key": None,
+                        "timestamp_utc": "2026-01-02T02:00:00+00:00",
+                        "software_version": "0.7.0",
+                        "tool": "nhf-targets",
+                        "command": "validate",
+                        "inputs": [],
+                        "outputs": [],
+                        "params": {},
+                    },
+                ],
+            }
+        )
+    )
+
+    config = {
+        "fabric": {"path": str(fabric_file), "id_col": "nhm_id"},
+        "release": {
+            "authors": [
+                {
+                    "given": "Jane",
+                    "family": "Doe",
+                    "affiliation": "U.S. Geological Survey",
+                }
+            ],
+            "fabric_label": fabric_label,
+            "doi": None,
+            "abstract_notes": "Synthetic project for build tests.",
+            "ipds_number": "IP-123456",
+        },
+        "targets": {
+            "runoff": {"enabled": True, "period": "1980/2020"},
+            "aet": {"enabled": True, "period": "2000/2010"},
+        },
+    }
+    fabric = {
+        "path": str(fabric_file),
+        "bbox": {"minx": -125.0, "miny": 24.0, "maxx": -66.0, "maxy": 53.0},
+        "hru_count": 4242,
+    }
+    return Project(
+        workdir=workdir,
+        datastore=datastore,
+        config=config,
+        fabric=fabric,
+        dir_mode=None,
+    )
+
+
+def _parse(path: Path) -> etree._Element:
+    """Parse an XML file, asserting it is well-formed (raises otherwise)."""
+    return etree.fromstring(path.read_bytes())
+
+
+def _checksum_paths(stage_dir: Path) -> set[str]:
+    """The ``path`` column of every row in the stage's checksums.csv."""
+    import csv
+
+    with (stage_dir / CHECKSUMS_CSV).open(newline="") as f:
+        return {row["path"] for row in csv.DictReader(f)}
+
+
+def _download_names(mcf: dict) -> set[str]:
+    """Names of every function=download entry in an MCF distribution block."""
+    return {
+        name
+        for name, entry in mcf["distribution"].items()
+        if entry.get("function") == "download"
+    }
+
+
+# ---------------------------------------------------------------------------
+# fabric child
+# ---------------------------------------------------------------------------
+
+
+def test_build_fabric_child_produces_full_stage(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_fabric_child(project, now=NOW)
+
+    assert result.kind == "fabric"
+    assert result.key == "gfv_test"
+    stage = result.stage_dir
+    assert stage == project.release_build_dir / "fabric" / "gfv_test"
+
+    # fabric.gpkg symlinked; data files present; metadata + integrity written.
+    gpkg = stage / "fabric.gpkg"
+    assert gpkg.is_symlink() and gpkg.read_bytes() == b"GPKG-bytes"
+    assert (stage / "aggregated" / "era5_land" / "era5_land_1980_agg.nc").is_symlink()
+    assert (stage / "targets" / "runoff_targets.nc").is_symlink()
+    for name in (
+        "manifest.json",
+        "README.md",
+        "fgdc.xml",
+        "iso.xml",
+        CHECKSUMS_CSV,
+        SHA256SUMS,
+    ):
+        assert (stage / name).is_file(), f"missing {name}"
+
+    # Non-publishable aggregated source must not have leaked in.
+    assert not (stage / "aggregated" / "watergap22d").exists()
+
+
+def test_build_fabric_child_xml_well_formed_and_consistent(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_fabric_child(project, now=NOW)
+    stage = result.stage_dir
+
+    # Both records parse (well-formed) ...
+    _parse(stage / "fgdc.xml")
+    _parse(stage / "iso.xml")
+    # ... and carry the same title the MCF declared.
+    title = result.mcf["identification"]["title"]
+    assert title and title in (stage / "fgdc.xml").read_text()
+    assert title in (stage / "iso.xml").read_text()
+
+
+def test_build_fabric_child_checksums_list_every_file_but_not_self(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_fabric_child(project, now=NOW)
+    stage = result.stage_dir
+
+    listed = _checksum_paths(stage)
+    # Data + metadata records + manifest are all fingerprinted ...
+    for name in (
+        "fabric.gpkg",
+        "manifest.json",
+        "README.md",
+        "fgdc.xml",
+        "iso.xml",
+        "aggregated/era5_land/era5_land_1980_agg.nc",
+        "targets/runoff_targets.nc",
+    ):
+        assert name in listed, f"checksums.csv omits {name}"
+    # ... but the integrity files never list themselves.
+    assert CHECKSUMS_CSV not in listed
+    assert SHA256SUMS not in listed
+
+    # result.entries is the same record set, and SHA256SUMS verifies.
+    assert {e.path for e in result.entries} == listed
+    verify_csv(stage)  # no raise
+
+
+def test_build_fabric_child_distribution_includes_extras_not_metadata(tmp_path):
+    """distribution.online lists every staged downloadable artifact: data +
+    manifest + README + checksums.csv + SHA256SUMS, but NOT the fgdc/iso
+    metadata records (the design decision flagged in the PR)."""
+    project = _build_project(tmp_path)
+    result = build.build_fabric_child(project, now=NOW)
+
+    downloads = _download_names(result.mcf)
+    for name in (
+        "fabric.gpkg",
+        "manifest.json",
+        "README.md",
+        CHECKSUMS_CSV,
+        SHA256SUMS,
+        "aggregated/era5_land/era5_land_1980_agg.nc",
+        "targets/runoff_targets.nc",
+    ):
+        assert name in downloads, f"distribution.online omits {name}"
+    assert "fgdc.xml" not in downloads
+    assert "iso.xml" not in downloads
+
+
+def test_build_fabric_child_copy_mode_real_files(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_fabric_child(project, copy=True, now=NOW)
+    gpkg = result.stage_dir / "fabric.gpkg"
+    assert not gpkg.is_symlink()
+    assert gpkg.read_bytes() == b"GPKG-bytes"
+    era = result.stage_dir / "aggregated" / "era5_land" / "era5_land_1980_agg.nc"
+    assert not era.is_symlink()
+    assert era.read_bytes() == b"era5-1980"
+    verify_csv(result.stage_dir)
+
+
+def test_build_is_deterministic_for_fixed_now(tmp_path):
+    """A second build with the same now rewrites byte-identical metadata."""
+    project = _build_project(tmp_path)
+    first = build.build_fabric_child(project, now=NOW)
+    fgdc_bytes = (first.stage_dir / "fgdc.xml").read_bytes()
+    iso_bytes = (first.stage_dir / "iso.xml").read_bytes()
+    build.build_fabric_child(project, now=NOW)
+    assert (first.stage_dir / "fgdc.xml").read_bytes() == fgdc_bytes
+    assert (first.stage_dir / "iso.xml").read_bytes() == iso_bytes
+
+
+# ---------------------------------------------------------------------------
+# source children
+# ---------------------------------------------------------------------------
+
+
+def test_build_source_child_data(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_source_child(project, "era5_land", now=NOW)
+    assert result.kind == "source" and result.key == "era5_land"
+    stage = result.stage_dir
+    assert stage == project.release_build_dir / "sources" / "era5_land"
+
+    # Consolidated NCs staged (subpaths preserved) + metadata + integrity.
+    assert (stage / "daily" / "era5_land_daily_1980.nc").is_symlink()
+    assert (stage / "monthly" / "era5_land_monthly_1980.nc").is_symlink()
+    for name in ("README.md", "fgdc.xml", "iso.xml", CHECKSUMS_CSV, SHA256SUMS):
+        assert (stage / name).is_file()
+    _parse(stage / "fgdc.xml")
+    _parse(stage / "iso.xml")
+    verify_csv(stage)
+
+    # The consolidated NCs are the source child's distribution payload.
+    downloads = _download_names(result.mcf)
+    assert "daily/era5_land_daily_1980.nc" in downloads
+    assert "monthly/era5_land_monthly_1980.nc" in downloads
+
+
+def test_build_source_child_metadata_only_renders_without_data(tmp_path):
+    """daymet (metadata_only) stages no data NCs but still gets a full set of
+    README / FGDC / ISO. FGDC needs a bbox; daymet now carries one in the
+    catalog (the bbox added in this PR)."""
+    project = _build_project(tmp_path)
+    result = build.build_source_child(project, "daymet", now=NOW)
+    stage = result.stage_dir
+
+    assert list(stage.rglob("*.nc")) == []  # no consolidated NC payload
+    for name in ("README.md", "fgdc.xml", "iso.xml", CHECKSUMS_CSV, SHA256SUMS):
+        assert (stage / name).is_file()
+    _parse(stage / "fgdc.xml")  # would raise if daymet had no bbox
+    _parse(stage / "iso.xml")
+    verify_csv(stage)
+
+    # No download entries -- only the upstream landing pointer.
+    assert _download_names(result.mcf) == set()
+
+
+# ---------------------------------------------------------------------------
+# umbrella
+# ---------------------------------------------------------------------------
+
+
+def test_build_umbrella_unions_children(tmp_path):
+    project = _build_project(tmp_path)
+    result = build.build_umbrella(project, now=NOW)
+    assert result.kind == "umbrella" and result.key is None
+    stage = result.stage_dir
+    assert stage == project.release_build_dir / "umbrella"
+
+    for name in ("README.md", "fgdc.xml", "iso.xml", CHECKSUMS_CSV, SHA256SUMS):
+        assert (stage / name).is_file()
+    _parse(stage / "fgdc.xml")  # union bbox is non-None (fabric + sources)
+    _parse(stage / "iso.xml")
+    verify_csv(stage)
+
+    # Umbrella is metadata-only: no data payload staged.
+    assert list(stage.rglob("*.nc")) == []
+    assert not (stage / "fabric.gpkg").exists()
+
+    # The union bbox spans the fabric bbox + the (wider) source bboxes.
+    bbox = result.mcf["identification"]["extents"]["spatial"][0]["bbox"]
+    assert bbox is not None
+    assert bbox[0] <= -125.0 and bbox[2] >= -66.0  # west/east at least the fabric
+
+
+def test_build_umbrella_with_explicit_children(tmp_path):
+    """Passing pre-built child MCFs unions exactly those (no local rebuild)."""
+    project = _build_project(tmp_path)
+    fab = build.build_fabric_child(project, now=NOW)
+    result = build.build_umbrella(project, children=[fab.mcf], now=NOW)
+    # Abstract reports the child count it was handed.
+    assert "1 child" in result.mcf["identification"]["abstract"]
+
+
+# ---------------------------------------------------------------------------
+# build_all dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_build_all_default_scope_is_fabric(tmp_path):
+    project = _build_project(tmp_path)
+    results = build.build_all(project, now=NOW)
+    assert [r.kind for r in results] == ["fabric"]
+
+
+def test_build_all_scope_sources(tmp_path):
+    project = _build_project(tmp_path)
+    results = build.build_all(project, scope="sources", now=NOW)
+    assert all(r.kind == "source" for r in results)
+    keys = {r.key for r in results}
+    assert keys == {"era5_land", "daymet"}  # publishable, present; watergap22d excluded
+
+
+def test_build_all_scope_all(tmp_path):
+    project = _build_project(tmp_path)
+    results = build.build_all(project, scope="all", now=NOW)
+    kinds = [r.kind for r in results]
+    assert kinds[0] == "fabric"
+    assert kinds[-1] == "umbrella"
+    assert sorted(r.kind for r in results) == ["fabric", "source", "source", "umbrella"]
+
+    # The umbrella unioned the children built in this invocation (fabric + 2
+    # sources), so its abstract reports three child items.
+    umbrella = results[-1]
+    assert "3 child" in umbrella.mcf["identification"]["abstract"]
+    # Every built item verifies on disk.
+    for r in results:
+        verify_csv(r.stage_dir)
+
+
+def test_build_all_unknown_scope_raises(tmp_path):
+    project = _build_project(tmp_path)
+    with pytest.raises(ValueError, match="Unknown scope"):
+        build.build_all(project, scope="bogus", now=NOW)  # type: ignore[arg-type]
+
+
+def test_build_all_scope_all_matches_payload_sources_used(tmp_path):
+    """The dispatcher is catalog/manifest-driven: the source children it builds
+    are exactly payload.sources_used (no hard-coded list)."""
+    project = _build_project(tmp_path)
+    results = build.build_all(project, scope="all", now=NOW)
+    source_keys = sorted(r.key for r in results if r.kind == "source")
+    assert source_keys == sorted(payload.sources_used(project))

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -14,6 +14,7 @@ the config / fabric.json / manifest.json content the MCF builders need.
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -272,14 +273,20 @@ def test_build_fabric_child_copy_mode_real_files(tmp_path):
 
 
 def test_build_is_deterministic_for_fixed_now(tmp_path):
-    """A second build with the same now rewrites byte-identical metadata."""
+    """A second build with the same now rewrites byte-identical metadata, and
+    the re-build's distribution list still excludes the metadata records left
+    on disk by the first build (the load-bearing skip-set in
+    _staged_data_relpaths)."""
     project = _build_project(tmp_path)
     first = build.build_fabric_child(project, now=NOW)
     fgdc_bytes = (first.stage_dir / "fgdc.xml").read_bytes()
     iso_bytes = (first.stage_dir / "iso.xml").read_bytes()
-    build.build_fabric_child(project, now=NOW)
-    assert (first.stage_dir / "fgdc.xml").read_bytes() == fgdc_bytes
-    assert (first.stage_dir / "iso.xml").read_bytes() == iso_bytes
+    second = build.build_fabric_child(project, now=NOW)
+    assert (second.stage_dir / "fgdc.xml").read_bytes() == fgdc_bytes
+    assert (second.stage_dir / "iso.xml").read_bytes() == iso_bytes
+    downloads = _download_names(second.mcf)
+    assert "fgdc.xml" not in downloads
+    assert "iso.xml" not in downloads
 
 
 # ---------------------------------------------------------------------------
@@ -303,10 +310,16 @@ def test_build_source_child_data(tmp_path):
     _parse(stage / "iso.xml")
     verify_csv(stage)
 
-    # The consolidated NCs are the source child's distribution payload.
+    # The consolidated NCs are the source child's distribution payload ...
     downloads = _download_names(result.mcf)
     assert "daily/era5_land_daily_1980.nc" in downloads
     assert "monthly/era5_land_monthly_1980.nc" in downloads
+    # ... and the README / metadata records / integrity files are staged and
+    # checksummed but deliberately NOT enumerated there (the inverse of the
+    # fabric-child decision: the source-distribution builder labels every entry
+    # a NetCDF, so listing them would mislabel them).
+    for name in ("README.md", "fgdc.xml", "iso.xml", CHECKSUMS_CSV, SHA256SUMS):
+        assert name not in downloads
 
 
 def test_build_source_child_metadata_only_renders_without_data(tmp_path):
@@ -354,6 +367,12 @@ def test_build_umbrella_unions_children(tmp_path):
     bbox = result.mcf["identification"]["extents"]["spatial"][0]["bbox"]
     assert bbox is not None
     assert bbox[0] <= -125.0 and bbox[2] >= -66.0  # west/east at least the fabric
+
+    # The temporal extent unions the children's periods (fabric targets span
+    # 1980/2020 + 2000/2010, source periods differ); the union must start no
+    # later than the earliest child begin.
+    begin = result.mcf["identification"]["extents"]["temporal"][0]["begin"]
+    assert begin is not None and begin <= "1980-01-01"
 
 
 def test_build_umbrella_with_explicit_children(tmp_path):
@@ -414,3 +433,53 @@ def test_build_all_scope_all_matches_payload_sources_used(tmp_path):
     results = build.build_all(project, scope="all", now=NOW)
     source_keys = sorted(r.key for r in results if r.kind == "source")
     assert source_keys == sorted(payload.sources_used(project))
+
+
+# ---------------------------------------------------------------------------
+# manifest / dangling-symlink failure modes + BuildResult invariant
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_manifest_is_a_loud_failure(tmp_path):
+    """A corrupt manifest.json fails loudly rather than silently building a
+    release with empty lineage + source list."""
+    project = _build_project(tmp_path)
+    project.manifest_path.write_text("{not valid json")
+    with pytest.raises(ValueError, match="manifest.json.*corrupt"):
+        build.build_fabric_child(project, now=NOW)
+
+
+def test_missing_manifest_builds_without_snapshot(tmp_path):
+    """An absent manifest.json is legitimate: the build succeeds and the
+    fabric stage simply carries no manifest snapshot (and never lists one)."""
+    project = _build_project(tmp_path)
+    project.manifest_path.unlink()
+    result = build.build_fabric_child(project, now=NOW)
+    assert not (result.stage_dir / "manifest.json").exists()
+    assert "manifest.json" not in _download_names(result.mcf)
+    verify_csv(result.stage_dir)
+
+
+def test_staged_data_relpaths_rejects_dangling_symlink(tmp_path):
+    """A dangling staged symlink is rejected up front -- before any file is
+    enumerated into distribution.online or rendered into the metadata records
+    (mirrors checksums._iter_staged_files)."""
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    target = _touch(tmp_path / "source.nc", b"data")
+    os.symlink(target, stage / "data.nc")
+    target.unlink()  # the staged link now dangles
+    with pytest.raises(FileNotFoundError, match="missing target"):
+        build._staged_data_relpaths(stage)
+
+
+def test_build_result_enforces_kind_key_invariant():
+    """umbrella must be keyless; source/fabric must carry a key."""
+    with pytest.raises(ValueError, match="key invariant violated"):
+        build.BuildResult(
+            kind="umbrella", key="oops", stage_dir=Path("/x"), mcf={}, entries=()
+        )
+    with pytest.raises(ValueError, match="key invariant violated"):
+        build.BuildResult(
+            kind="source", key=None, stage_dir=Path("/x"), mcf={}, entries=()
+        )


### PR DESCRIPTION
## Summary

PR-E1 of a split PR-E (mirroring the D1/D2 split). Adds the **offline build orchestrator** `src/nhf_spatial_targets/release/build.py` — the glue that turns the existing PR-C/PR-D pieces into a complete on-disk release payload under `<project>/release/build/<scope>/`. No ScienceBase client, registry, publish, or dry-run (those are PR-E2); no CLI (PR-F).

`build.py` **consumes** the existing public API (`payload`, `mcf`, `fgdc`, `iso`, `readme`, `checksums`, `defaults`, `catalog`) and does not re-derive staging, MCF, rendering, or checksums.

### Public functions
- `build_source_child(project, key, *, copy=False, now=None)`
- `build_fabric_child(project, *, copy=False, now=None)`
- `build_umbrella(project, *, copy=False, children=None, now=None)`
- `build_all(project, *, scope="fabric", copy=False, now=None)` — dispatcher for `release build --scope fabric|sources|all`

Each returns a `BuildResult(kind, key, stage_dir, mcf, entries)`. The build is **catalog/manifest-driven** via `payload.sources_used()` — never a hard-coded source list.

### Per-item sequence (deterministic for a fixed `now`)
1. stage payload (`payload.stage_*`; symlink by default, `--copy` for real files)
2. load `release_defaults.yml` + the project `manifest.json`
3. declare the distribution file list (staged relpaths + the not-yet-written README/checksums for the fabric child)
4. build the MCF (`mcf.build_*_mcf(distribution_files=…)`)
5. render `fgdc.xml` + `iso.xml` + `README.md`
6. `compute_checksums` **last** (after every file exists; a manifest must not list itself)

`now` is injectable **only for deterministic tests**; production lets it default to `datetime.now(UTC)`.

## Design decision flagged: which staged files go in MCF `distribution.online`

The fgdc-field-map says "every staged file", but the PR-D2 golden passed only data + manifest. Reconciled as:

- **Fabric child** → every staged downloadable artifact: `fabric.gpkg` + every aggregated NC + every target NC + `manifest.json` + `README.md` + `checksums.csv` + `SHA256SUMS`. The `fgdc.xml`/`iso.xml` *metadata records* are excluded (they describe the item, they are not its data). Since the MCF builder only records names, `README`/`checksums`/`SHA256SUMS` can be listed even though they're written after the MCF renders — hence *declare list → render → checksum last*.
- **Source child** → the staged consolidated NetCDFs only. The frozen PR-D1 `_source_distribution` labels every listed entry "Consolidated CF-1.6 NetCDF.", so listing README/checksums there would mislabel them; they are still staged and checksummed, just not enumerated. `metadata_only` sources (daymet) stage no data → only the upstream landing entry.
- **Umbrella** → metadata-only; landing entry only.

Net: `distribution.online` and `checksums.csv` differ by exactly the metadata/integrity split — `distribution` has `checksums.csv`+`SHA256SUMS` but not `fgdc.xml`/`iso.xml`; `checksums.csv` is the inverse.

## Catalog fix bundled (approved)
daymet is the only `metadata_only` source and had **no** `access.bbox_nwse`, so the frozen `render_fgdc` raised (`CSDGM <spdom>` is mandatory). Added a North-America `bbox_nwse: [82.9, -178.1, 14.1, -53.1]` to `catalog/sources.yml`, mirroring PR-D2's inline SNODAS bbox fix, so daymet's source child can emit FGDC. No existing test pinned daymet's bbox to `None`.

## Tests
`tests/test_release_build.py` (15 tests) — structure/presence/consistency, **not** golden-XML bytes (byte-stability is already covered by test_release_fgdc/iso/readme). Fabric/source/umbrella stage trees; well-formed + MCF-consistent XML (lxml parse); `checksums.csv` lists every staged file and not itself; `SHA256SUMS` verifies via `verify_csv`; metadata_only daymet renders README+fgdc+iso with no data; `--copy` produces real files; `build_all` scope dispatch + union; deterministic re-render.

## Out of scope (later PRs)
`registry.py`, `sb_client.py`, `publish.py`, `dry_run.py` (PR-E2); `release/cli.py` + root wiring (PR-F); credentials + integration + docs (PR-G). Not bundling #260 or #268. No XSD validation (deferred per project decision).

## Test plan
- [x] `pixi run -e dev fmt` + `lint` clean
- [x] `pixi run -e dev pytest tests/test_release_build.py` (15 passed)
- [x] catalog + release tests unaffected by the daymet bbox (`test_catalog`, `test_release_{mcf,fgdc,iso,payload}` — 133 passed)
- [ ] full suite via CI

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)