### PR TITLE
feature(release): PR-E2 registry + ScienceBase-client primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ htmlcov/
 # Claude Code runtime (settings.json and settings.local.json ARE tracked)
 .claude/scheduled_tasks.lock
 
+# Advisory flock sidecar for the release publish-state registry. Created by
+# release/registry.py's flock-protected writes; transient, never committed.
+catalog/release_registry.yml.lock
+
 # Inspection-notebook figures live under docs/figures/<group>/<project>/
 # and are committed — regenerate with `pixi run render-figures` (local) or
 # the inspect_*.slurm scripts (HPC). Cache files from notebook execution

--- a/catalog/release_registry.yml
+++ b/catalog/release_registry.yml
@@ -5,9 +5,18 @@
 #
 # Initial state below: `umbrella: null` signals "no first-publish yet";
 # loaders must handle that case explicitly rather than indexing into a
-# missing dict. Once published, the umbrella block carries sb_id, doi,
-# version, published_utc, and title — see docs/data_release/fgdc-field-map.md
-# for the post-PR-E schema and PR-E's writer for the authoritative shape.
+# missing dict. release/registry.py is the authoritative read-merge-write
+# layer (flock-protected, ruamel round-trip so this header survives writes).
+#
+# Per-item schema, written by registry.put_*:
+#   umbrella:                   {sb_id, doi, version, published_utc, title}
+#   consolidated_sources.<key>: {sb_id, uploaded_utc, file_count,
+#                                total_bytes, manifest_sha256}
+#   fabrics.<label>:            {sb_id, uploaded_utc, file_count,
+#                                total_bytes, manifest_sha256}
+# doi stays null until ScienceBase staff mints it post-IPDS approval (a
+# manual step — sciencebasepy does not mint DOIs). See
+# docs/data_release/fgdc-field-map.md for the FGDC field mapping.
 
 umbrella: null
 consolidated_sources: {}

--- a/pixi.lock
+++ b/pixi.lock
@@ -233,6 +233,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.0-ha63dd3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py313h16d504d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
@@ -522,6 +524,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py313h3b23316_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -797,6 +801,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.8.0-np2py313h4ce4a18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -1188,6 +1194,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.5-h40fa522_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.0-ha63dd3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py313h16d504d_1.conda
@@ -1580,6 +1588,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.5-h279115b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py313h3b23316_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
@@ -1954,6 +1964,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.15.5-h5739096_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.8.0-np2py313h4ce4a18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_0.conda
@@ -2304,6 +2316,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py313h843e2db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.5-h40fa522_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.0-ha63dd3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py313h16d504d_1.conda
@@ -2616,6 +2630,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py313h2c089d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.5-h279115b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py313h3b23316_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
@@ -2914,6 +2930,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.30.0-py313hfbe8231_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.15.5-h5739096_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.8.0-np2py313h4ce4a18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_0.conda
@@ -3222,6 +3240,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py313h16d504d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
@@ -3509,6 +3529,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py313h3b23316_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -3787,6 +3809,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.22.0-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.8.0-np2py313h4ce4a18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -18471,6 +18495,62 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 243419
   timestamp: 1764543047271
+- conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
+  sha256: b48bebe297a63ae60f52e50be328262e880702db4d9b4e86731473ada459c2a1
+  md5: 06ad944772941d5dae1e0d09848d8e49
+  depends:
+  - python >=3.10
+  - ruamel.yaml.clib >=0.2.15
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=hash-mapping
+  size: 98448
+  timestamp: 1767538149184
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py313h54dd161_1.conda
+  sha256: e7655f12e29add10ef6842ca7e06167fc326903f32b0a9e62f464afda4e0d3d1
+  md5: ef8c7c9f4ea478806d9056bbc9c9c093
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 149946
+  timestamp: 1766159512977
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py313h6688731_1.conda
+  sha256: d2050d1d9fb396bd8fb42758bcc6e5bf301c94856086be5411dfe21a0bb2da22
+  md5: ccc49acbc9df82571383070bc4591c45
+  depends:
+  - python
+  - python 3.13.* *_cp313
+  - __osx >=11.0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 132037
+  timestamp: 1766159543218
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py313h5fd188c_1.conda
+  sha256: aacaf0b6c3902ec080345fbe0c6b5195656e9a0700dd2eb6af48fd56f1c04c02
+  md5: de2843db9e03bb36fcfab5ca74d4679b
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
+  size: 105675
+  timestamp: 1766159549377
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.5-h40fa522_0.conda
   noarch: python
   sha256: da5d47b231a590257b4ee0f3459e6ec30012ae549e3c29601cd15de178dafe9c

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,10 @@ scipy = ">=1.17.1,<2"
 # lxml: FGDC XML pretty-print + optional well-formedness checks in the
 # release/ metadata renderers (PR-D2). Conda-forge build pulls libxml2.
 lxml = ">=5.0"
+# ruamel.yaml: round-trip (comment- and key-order-preserving) YAML for the
+# release publish-state registry (release/registry.py, PR-E2). plain
+# yaml.safe_dump would strip catalog/release_registry.yml's comment header.
+"ruamel.yaml" = ">=0.18"
 # gdptools: spatial aggregation (install from PyPI if not on conda-forge)
 # sciencebasepy: ScienceBase access
 # earthaccess: NASA EDL access for MODIS, MERRA-2, NLDAS

--- a/src/nhf_spatial_targets/release/__init__.py
+++ b/src/nhf_spatial_targets/release/__init__.py
@@ -68,6 +68,26 @@ from nhf_spatial_targets.release.payload import (
 )
 from nhf_spatial_targets.release.readme import render_readme
 from nhf_spatial_targets.release.rebuild import rebuild_lineage
+from nhf_spatial_targets.release.registry import (
+    CHILD_FIELDS,
+    DEFAULT_REGISTRY_PATH,
+    UMBRELLA_FIELDS,
+    get_fabric,
+    get_source,
+    get_umbrella,
+    load_registry,
+    put_fabric,
+    put_source,
+    put_umbrella,
+)
+from nhf_spatial_targets.release.sb_client import (
+    RETRYABLE_STATUS_CODES,
+    SbClient,
+    SbClientError,
+    UploadResult,
+    is_retryable,
+    remote_file_checksum,
+)
 from nhf_spatial_targets.release.validate_xml import (
     MpResult,
     mp_available,
@@ -76,10 +96,14 @@ from nhf_spatial_targets.release.validate_xml import (
 )
 
 __all__ = [
+    "CHILD_FIELDS",
+    "DEFAULT_REGISTRY_PATH",
     "MCF_VERSION",
+    "RETRYABLE_STATUS_CODES",
     "STEP_KINDS",
     "CHECKSUM_FILES",
     "RESERVED_METADATA_FILES",
+    "UMBRELLA_FIELDS",
     "BuildResult",
     "ChecksumMismatch",
     "DistributionKind",
@@ -89,10 +113,13 @@ __all__ = [
     "MpResult",
     "OutputFileEntry",
     "ReleasePayload",
+    "SbClient",
+    "SbClientError",
     "SourceChildPlan",
     "StepKind",
     "StepRecord",
     "UmbrellaPlan",
+    "UploadResult",
     "append_step",
     "build_all",
     "build_fabric_child",
@@ -103,7 +130,12 @@ __all__ = [
     "build_umbrella",
     "build_umbrella_mcf",
     "compute_checksums",
+    "get_fabric",
+    "get_source",
+    "get_umbrella",
     "input_file_entry",
+    "is_retryable",
+    "load_registry",
     "load_release_config",
     "load_release_defaults",
     "load_release_yml",
@@ -113,7 +145,11 @@ __all__ = [
     "plan_fabric_child",
     "plan_source_child",
     "plan_umbrella",
+    "put_fabric",
+    "put_source",
+    "put_umbrella",
     "rebuild_lineage",
+    "remote_file_checksum",
     "render_fgdc",
     "render_iso",
     "render_readme",

--- a/src/nhf_spatial_targets/release/registry.py
+++ b/src/nhf_spatial_targets/release/registry.py
@@ -1,0 +1,381 @@
+"""Read/merge/write ``catalog/release_registry.yml`` -- publish intent.
+
+The registry is the **source of truth for what we intend to have published**
+to ScienceBase: the umbrella DOI parent, one entry per consolidated-source
+child, and one entry per fabric child. ScienceBase itself remains the source
+of truth for *what actually exists*; reconciling the two (``diff_local_vs_remote``)
+needs live SB queries and lives in the publish/status layer (PR-E3), not here.
+This module stays pure-local.
+
+Two invariants drive the implementation:
+
+- **Read-merge-write under flock, never overwrite.** Two operators publishing
+  different fabrics could otherwise race and clobber each other's entries --
+  the same class of bug that wiped 13 sources of manifest provenance in #97.
+  Every ``put_*`` reloads the file inside an advisory ``LOCK_EX`` critical
+  section (reusing :func:`nhf_spatial_targets.release.lineage.with_flock`),
+  merges its one entry, and atomically renames the result into place. Sibling
+  entries (other sources, other fabrics, the umbrella) are preserved.
+
+- **Comment header + key order survive every write.** The committed scaffold
+  carries an explanatory comment block and the load-bearing ``umbrella: null``
+  sentinel; ``yaml.safe_dump`` would strip both. We use ``ruamel.yaml`` in
+  round-trip mode so the header and key order are preserved across writes.
+
+A corrupt registry is a **loud failure** (mirroring
+:func:`nhf_spatial_targets.release.lineage.read_manifest`), never a silent
+reset -- the file records real publish state and silently re-scaffolding it
+would orphan live ScienceBase items.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+from nhf_spatial_targets.release.lineage import with_flock
+
+logger = logging.getLogger(__name__)
+
+# Repo root is three parents up: release/ -> nhf_spatial_targets/ -> src/ -> root.
+_CATALOG_DIR = Path(__file__).resolve().parents[3] / "catalog"
+DEFAULT_REGISTRY_PATH = _CATALOG_DIR / "release_registry.yml"
+
+# Canonical top-level sections. ``umbrella`` is a single mapping (or ``None``);
+# the other two are key->entry mappings.
+_TOP_LEVEL_KEYS: tuple[str, ...] = ("umbrella", "consolidated_sources", "fabrics")
+
+# Field schema enforced by the put_* writers. Kept here so the scaffold
+# comment, the plan cheat-sheet, and the code can't drift apart silently.
+UMBRELLA_FIELDS: tuple[str, ...] = ("sb_id", "doi", "version", "published_utc", "title")
+CHILD_FIELDS: tuple[str, ...] = (
+    "sb_id",
+    "uploaded_utc",
+    "file_count",
+    "total_bytes",
+    "manifest_sha256",
+)
+
+# Seed document used only when the registry file is absent (it is normally
+# committed). Carries the header comment so a freshly-seeded file is still
+# self-documenting, matching the committed scaffold's intent.
+_SCAFFOLD_TEXT = """\
+# Running publish-state for the ScienceBase data release. Updated by
+# `nhf-targets release publish` as items are created or refreshed;
+# flock-protected on write so concurrent publishes don't clobber each other.
+#
+# `umbrella: null` signals "no first-publish yet"; loaders handle that case
+# explicitly rather than indexing into a missing dict.
+#
+# Per-item schema, written by registry.put_*:
+#   umbrella:                   {sb_id, doi, version, published_utc, title}
+#   consolidated_sources.<key>: {sb_id, uploaded_utc, file_count,
+#                                total_bytes, manifest_sha256}
+#   fabrics.<label>:            {sb_id, uploaded_utc, file_count,
+#                                total_bytes, manifest_sha256}
+
+umbrella: null
+consolidated_sources: {}
+fabrics: {}
+"""
+
+# Sentinel distinguishing "argument not supplied" (keep the current value)
+# from an explicit ``None`` (e.g. clearing a DOI). Used by put_umbrella so a
+# refresh that only sets the DOI doesn't blank out sb_id/version/etc.
+_KEEP = object()
+
+
+def _yaml() -> YAML:
+    """Return a round-trip YAML handler tuned for the registry.
+
+    Round-trip mode preserves the comment header and key order. A wide line
+    width stops ruamel from wrapping long values (e.g. titles) mid-write,
+    which would otherwise churn diffs.
+    """
+    y = YAML()  # default typ="rt" (round-trip)
+    y.preserve_quotes = True
+    y.width = 4096
+    return y
+
+
+def _load_doc(path: Path):
+    """Load the registry document, seeding from the scaffold if absent.
+
+    Returns the parsed mapping (a ruamel ``CommentedMap``) with all three
+    top-level keys guaranteed present. ``umbrella`` may be ``None``.
+
+    Raises
+    ------
+    ValueError
+        The file exists but does not parse, or its top level is not a
+        mapping. A corrupt registry is a loud failure, not a silent reset.
+    """
+    yaml = _yaml()
+    if not path.exists():
+        data = yaml.load(_SCAFFOLD_TEXT)
+    else:
+        try:
+            data = yaml.load(path.read_text())
+        except YAMLError as exc:
+            raise ValueError(
+                f"release_registry.yml at {path} is corrupt: {exc}. "
+                f"Inspect the file manually or restore from git; do NOT "
+                f"delete it -- it records live ScienceBase publish state."
+            ) from exc
+    if data is None:
+        # An empty (but present) file: re-seed in memory rather than crash,
+        # but warn -- a registry that lost its content is suspicious.
+        logger.warning(
+            "release_registry.yml at %s is empty; treating as the initial "
+            "scaffold. If items were published, restore the file from git.",
+            path,
+        )
+        data = yaml.load(_SCAFFOLD_TEXT)
+    if not hasattr(data, "get"):
+        raise ValueError(
+            f"release_registry.yml at {path} must be a YAML mapping at the "
+            f"top level; got {type(data).__name__}."
+        )
+    # Normalize: guarantee the two container sections exist so callers never
+    # index into a missing dict. ``umbrella`` is intentionally left as-is
+    # (its ``None`` sentinel is load-bearing).
+    if data.get("consolidated_sources") is None:
+        data["consolidated_sources"] = {}
+    if data.get("fabrics") is None:
+        data["fabrics"] = {}
+    return data
+
+
+def _atomic_dump(path: Path, data) -> None:
+    """Serialize *data* to *path* via tempfile + rename.
+
+    ``Path.replace`` is atomic on the same filesystem, so a partial registry
+    never lands at the final path even if the process dies mid-write.
+    """
+    yaml = _yaml()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    yaml.dump(data, buf)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".yml.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            f.write(buf.getvalue())
+        Path(tmp_path).replace(path)
+    except Exception:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+
+
+def _lock_path(path: Path) -> Path:
+    """Advisory-lock path for *path* (mirrors lineage's ``<file>.lock``)."""
+    return path.with_suffix(path.suffix + ".lock")
+
+
+def _resolve(path: Path | None) -> Path:
+    return DEFAULT_REGISTRY_PATH if path is None else path
+
+
+# ---------------------------------------------------------------------------
+# Pure-local readers
+# ---------------------------------------------------------------------------
+
+
+def load_registry(path: Path | None = None) -> dict:
+    """Load + normalize the registry.
+
+    Returns a mapping with ``umbrella`` (a dict or ``None``),
+    ``consolidated_sources`` (dict), and ``fabrics`` (dict). The returned
+    object is a live ruamel mapping; mutating it does **not** persist unless
+    written back via a ``put_*`` helper.
+
+    Parameters
+    ----------
+    path
+        Registry file path. Defaults to the committed
+        ``catalog/release_registry.yml``. Tests pass a tmp path.
+
+    Raises
+    ------
+    ValueError
+        The file is present but corrupt or not a top-level mapping.
+    """
+    return _load_doc(_resolve(path))
+
+
+def get_umbrella(path: Path | None = None) -> dict | None:
+    """Return the umbrella entry, or ``None`` if not yet published.
+
+    The ``umbrella: null`` sentinel is returned as ``None`` -- callers must
+    branch on it rather than assume a dict.
+    """
+    umbrella = load_registry(path).get("umbrella")
+    return dict(umbrella) if umbrella is not None else None
+
+
+def get_source(key: str, path: Path | None = None) -> dict | None:
+    """Return the consolidated-source entry for *key*, or ``None``."""
+    entry = load_registry(path)["consolidated_sources"].get(key)
+    return dict(entry) if entry is not None else None
+
+
+def get_fabric(label: str, path: Path | None = None) -> dict | None:
+    """Return the fabric entry for *label*, or ``None``."""
+    entry = load_registry(path)["fabrics"].get(label)
+    return dict(entry) if entry is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Flock-protected writers (read-merge-write, never overwrite)
+# ---------------------------------------------------------------------------
+
+
+def put_umbrella(
+    *,
+    sb_id: str,
+    version: str,
+    published_utc: str,
+    title: str,
+    doi: str | None = _KEEP,  # type: ignore[assignment]
+    path: Path | None = None,
+) -> dict:
+    """Write (merge) the umbrella entry under flock; return the merged dict.
+
+    The umbrella's own fields are set from the arguments; the two container
+    sections (``consolidated_sources``, ``fabrics``) are preserved untouched.
+    ``doi`` defaults to the sentinel ``_KEEP``: omitting it keeps any existing
+    DOI (so the post-IPDS ``--refresh-doi`` flow can set just the DOI without
+    re-supplying the rest, and a first publish leaves ``doi: null``).
+
+    Parameters
+    ----------
+    sb_id, version, published_utc, title
+        Umbrella item fields. See :data:`UMBRELLA_FIELDS`.
+    doi
+        DOI string, or ``None`` to record "no DOI yet". Omit to keep the
+        current value.
+    path
+        Registry path. Defaults to the committed file.
+    """
+    target = _resolve(path)
+
+    def _do() -> dict:
+        data = _load_doc(target)
+        current = data.get("umbrella") or {}
+        merged = dict(current)
+        merged["sb_id"] = sb_id
+        merged["version"] = version
+        merged["published_utc"] = published_utc
+        merged["title"] = title
+        if doi is not _KEEP:
+            merged["doi"] = doi
+        merged.setdefault("doi", None)
+        # Canonical field order so the serialized block reads predictably.
+        ordered = {k: merged[k] for k in UMBRELLA_FIELDS if k in merged}
+        data["umbrella"] = ordered
+        _atomic_dump(target, data)
+        return ordered
+
+    result = with_flock(_lock_path(target), _do)
+    logger.info("registry: put umbrella sb_id=%s version=%s", sb_id, version)
+    return result
+
+
+def _put_child(
+    section: str,
+    key: str,
+    *,
+    sb_id: str,
+    uploaded_utc: str,
+    file_count: int,
+    total_bytes: int,
+    manifest_sha256: str,
+    path: Path | None,
+) -> dict:
+    """Shared read-merge-write for a single source/fabric child entry."""
+    target = _resolve(path)
+
+    def _do() -> dict:
+        data = _load_doc(target)
+        container = data[section]
+        current = dict(container.get(key) or {})
+        current.update(
+            {
+                "sb_id": sb_id,
+                "uploaded_utc": uploaded_utc,
+                "file_count": file_count,
+                "total_bytes": total_bytes,
+                "manifest_sha256": manifest_sha256,
+            }
+        )
+        ordered = {k: current[k] for k in CHILD_FIELDS if k in current}
+        container[key] = ordered
+        _atomic_dump(target, data)
+        return ordered
+
+    return with_flock(_lock_path(target), _do)
+
+
+def put_source(
+    key: str,
+    *,
+    sb_id: str,
+    uploaded_utc: str,
+    file_count: int,
+    total_bytes: int,
+    manifest_sha256: str,
+    path: Path | None = None,
+) -> dict:
+    """Write (merge) a consolidated-source entry under flock.
+
+    Other sources, the fabrics section, and the umbrella are preserved.
+    Re-publishing the same *key* updates that entry in place. See
+    :data:`CHILD_FIELDS` for the recorded schema.
+    """
+    result = _put_child(
+        "consolidated_sources",
+        key,
+        sb_id=sb_id,
+        uploaded_utc=uploaded_utc,
+        file_count=file_count,
+        total_bytes=total_bytes,
+        manifest_sha256=manifest_sha256,
+        path=path,
+    )
+    logger.info("registry: put source %s sb_id=%s files=%d", key, sb_id, file_count)
+    return result
+
+
+def put_fabric(
+    label: str,
+    *,
+    sb_id: str,
+    uploaded_utc: str,
+    file_count: int,
+    total_bytes: int,
+    manifest_sha256: str,
+    path: Path | None = None,
+) -> dict:
+    """Write (merge) a fabric entry under flock.
+
+    Other fabrics, the sources section, and the umbrella are preserved.
+    Re-publishing the same *label* updates that entry in place. See
+    :data:`CHILD_FIELDS` for the recorded schema.
+    """
+    result = _put_child(
+        "fabrics",
+        label,
+        sb_id=sb_id,
+        uploaded_utc=uploaded_utc,
+        file_count=file_count,
+        total_bytes=total_bytes,
+        manifest_sha256=manifest_sha256,
+        path=path,
+    )
+    logger.info("registry: put fabric %s sb_id=%s files=%d", label, sb_id, file_count)
+    return result

--- a/src/nhf_spatial_targets/release/registry.py
+++ b/src/nhf_spatial_targets/release/registry.py
@@ -47,10 +47,6 @@ logger = logging.getLogger(__name__)
 _CATALOG_DIR = Path(__file__).resolve().parents[3] / "catalog"
 DEFAULT_REGISTRY_PATH = _CATALOG_DIR / "release_registry.yml"
 
-# Canonical top-level sections. ``umbrella`` is a single mapping (or ``None``);
-# the other two are key->entry mappings.
-_TOP_LEVEL_KEYS: tuple[str, ...] = ("umbrella", "consolidated_sources", "fabrics")
-
 # Field schema enforced by the put_* writers. Kept here so the scaffold
 # comment, the plan cheat-sheet, and the code can't drift apart silently.
 UMBRELLA_FIELDS: tuple[str, ...] = ("sb_id", "doi", "version", "published_utc", "title")
@@ -110,41 +106,49 @@ def _load_doc(path: Path):
     Returns the parsed mapping (a ruamel ``CommentedMap``) with all three
     top-level keys guaranteed present. ``umbrella`` may be ``None``.
 
+    A genuinely *absent* file is seeded in memory from the scaffold (the
+    first-run case). A file that exists but is empty is treated as suspicious
+    -- the same loud failure as a corrupt file -- because a registry truncated
+    to zero bytes (e.g. a crashed writer) must never be silently re-scaffolded
+    over live publish state.
+
     Raises
     ------
     ValueError
-        The file exists but does not parse, or its top level is not a
-        mapping. A corrupt registry is a loud failure, not a silent reset.
+        The file exists but is empty, does not parse, or its top level is not
+        a mapping. A populated registry is never silently reset.
     """
     yaml = _yaml()
     if not path.exists():
-        data = yaml.load(_SCAFFOLD_TEXT)
-    else:
-        try:
-            data = yaml.load(path.read_text())
-        except YAMLError as exc:
-            raise ValueError(
-                f"release_registry.yml at {path} is corrupt: {exc}. "
-                f"Inspect the file manually or restore from git; do NOT "
-                f"delete it -- it records live ScienceBase publish state."
-            ) from exc
+        return _normalize(yaml.load(_SCAFFOLD_TEXT))
+    try:
+        data = yaml.load(path.read_text())
+    except YAMLError as exc:
+        raise ValueError(
+            f"release_registry.yml at {path} is corrupt: {exc}. "
+            f"Inspect the file manually or restore from git; do NOT "
+            f"delete it -- it records live ScienceBase publish state."
+        ) from exc
     if data is None:
-        # An empty (but present) file: re-seed in memory rather than crash,
-        # but warn -- a registry that lost its content is suspicious.
-        logger.warning(
-            "release_registry.yml at %s is empty; treating as the initial "
-            "scaffold. If items were published, restore the file from git.",
-            path,
+        raise ValueError(
+            f"release_registry.yml at {path} exists but is empty. This is "
+            f"treated as corruption, not a fresh start: restore it from git "
+            f"(it records live ScienceBase publish state). Delete the file "
+            f"only if you intend to re-seed the scaffold from scratch."
         )
-        data = yaml.load(_SCAFFOLD_TEXT)
     if not hasattr(data, "get"):
         raise ValueError(
             f"release_registry.yml at {path} must be a YAML mapping at the "
             f"top level; got {type(data).__name__}."
         )
-    # Normalize: guarantee the two container sections exist so callers never
-    # index into a missing dict. ``umbrella`` is intentionally left as-is
-    # (its ``None`` sentinel is load-bearing).
+    return _normalize(data)
+
+
+def _normalize(data):
+    """Guarantee the two container sections exist so callers never index into
+    a missing dict. ``umbrella`` is intentionally left as-is (its ``None``
+    sentinel is load-bearing).
+    """
     if data.get("consolidated_sources") is None:
         data["consolidated_sources"] = {}
     if data.get("fabrics") is None:

--- a/src/nhf_spatial_targets/release/sb_client.py
+++ b/src/nhf_spatial_targets/release/sb_client.py
@@ -1,0 +1,357 @@
+"""Thin, retrying wrapper over :class:`sciencebasepy.SbSession`.
+
+This is the only place the rest of the release tooling touches ScienceBase.
+It exposes the handful of operations the publish orchestration (PR-E3) needs
+-- authenticate, look up / create / update an item, find a child by title,
+upload a file with a skip-if-unchanged fast path -- and wraps each underlying
+call in exponential-backoff retry for transient HTTP failures (429 + 5xx) and
+connection/timeout errors.
+
+Design constraints:
+
+- **Import is side-effect-free.** ``sciencebasepy`` is imported lazily inside
+  the authenticating factories, never at module load, so ``import sb_client``
+  costs nothing and needs no network or credentials. The retry machinery and
+  the pure helpers (:func:`remote_file_checksum`, :func:`is_retryable`) are
+  usable without ever constructing a session.
+- **The sleep is injectable.** Offline tests pass a no-op ``sleep`` so the
+  backoff path is exercised without wall-clock delay.
+- **No DOI minting.** ScienceBase mints DOIs as a manual staff step; a
+  DOI-locked umbrella still accepts new children, so nothing here tries to
+  create or refresh a DOI.
+
+sciencebasepy raises bare ``Exception`` objects carrying the HTTP status in
+their message (``"Too many requests"`` for 429, ``"Other HTTP error: 503: ..."``
+for the rest), so :func:`is_retryable` classifies by message text as well as
+by an attached ``response.status_code`` (for ``requests``-level errors).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# HTTP statuses worth retrying: 429 (rate limit) + the transient 5xx family.
+# 500/502/503/504 are typically a busy or restarting upstream; 501 (not
+# implemented) and other 5xx are not retried.
+RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+# sciencebasepy._check_errors wraps non-2xx responses in a bare Exception whose
+# text we pattern-match: "Too many requests" (429) and
+# "Other HTTP error: <code>: <body>" (the catch-all branch).
+_TOO_MANY_REQUESTS_MARKER = "Too many requests"
+_OTHER_HTTP_ERROR_RE = re.compile(r"Other HTTP error:\s*(\d{3})")
+
+
+class SbClientError(RuntimeError):
+    """Raised for client-side conditions the wrapper itself detects.
+
+    Distinct from the transport errors raised by sciencebasepy/requests: this
+    signals a logical problem the caller must resolve (e.g. an ambiguous title
+    match), not a transient failure to retry.
+    """
+
+
+def _status_from_exception(exc: BaseException) -> int | None:
+    """Best-effort HTTP status for *exc*, or ``None`` if not determinable.
+
+    Handles both ``requests``-level errors (status on ``exc.response``) and
+    sciencebasepy's message-only exceptions.
+    """
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    if isinstance(code, int):
+        return code
+    message = str(exc)
+    if _TOO_MANY_REQUESTS_MARKER in message:
+        return 429
+    match = _OTHER_HTTP_ERROR_RE.search(message)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """Return whether *exc* represents a transient, retryable failure.
+
+    Connection resets and timeouts are always retryable; HTTP errors are
+    retryable only for :data:`RETRYABLE_STATUS_CODES`.
+    """
+    if isinstance(
+        exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+    ):
+        return True
+    code = _status_from_exception(exc)
+    return code in RETRYABLE_STATUS_CODES
+
+
+def remote_file_checksum(item: dict | None, filename: str) -> str | None:
+    """Return the recorded checksum *value* for *filename* on *item*.
+
+    Searches both the top-level ``files`` list and any facet ``files`` lists,
+    returning the first ``checksum.value`` for an entry whose ``name`` matches.
+    Returns ``None`` when the item is empty, the file is absent, or no checksum
+    is recorded.
+
+    Note: ScienceBase records uploaded-file checksums as **MD5** (see
+    ``SbSession._replace_file``), so a SHA-256 passed to
+    :meth:`SbClient.upload_file`'s ``skip_if_sha256_matches`` only matches once
+    a SHA-256 is recorded on the remote file -- a responsibility of the publish
+    orchestration (PR-E3). When the recorded checksum is an MD5 that can't
+    match a SHA-256, the file simply re-uploads: correct, just not skipped.
+    """
+    if not item:
+        return None
+
+    def _scan(files: list[dict] | None) -> str | None:
+        for entry in files or []:
+            if entry.get("name") == filename:
+                checksum = entry.get("checksum") or {}
+                value = checksum.get("value")
+                if value is not None:
+                    return value
+        return None
+
+    value = _scan(item.get("files"))
+    if value is not None:
+        return value
+    for facet in item.get("facets") or []:
+        value = _scan(facet.get("files"))
+        if value is not None:
+            return value
+    return None
+
+
+@dataclass(frozen=True)
+class UploadResult:
+    """Outcome of :meth:`SbClient.upload_file`.
+
+    ``skipped`` is ``True`` when the remote checksum already matched and no
+    bytes were sent; ``item`` is the ScienceBase item JSON (post-upload when a
+    file was sent, pre-upload when skipped).
+    """
+
+    skipped: bool
+    name: str
+    item: dict
+
+
+def _new_session(env: str | None):
+    """Construct a fresh :class:`sciencebasepy.SbSession` (lazy import)."""
+    import sciencebasepy
+
+    return sciencebasepy.SbSession(env)
+
+
+class SbClient:
+    """Retrying facade over a :class:`sciencebasepy.SbSession`.
+
+    Construct via :meth:`login` or :meth:`from_token` for a real session, or
+    pass an already-built (or mock) session directly to the constructor.
+
+    Parameters
+    ----------
+    session
+        An object exposing the :class:`sciencebasepy.SbSession` surface used
+        here (``ping``, ``get_item``, ``create_item``, ``update_item``,
+        ``get_child_ids``, ``upload_file_to_item``, ``is_logged_in``). Tests
+        inject a mock.
+    max_retries
+        Maximum number of *retries* after the initial attempt for a retryable
+        error. ``0`` disables retrying.
+    base_delay, max_delay
+        Exponential backoff is ``min(max_delay, base_delay * 2 ** attempt)``
+        seconds, where ``attempt`` counts from ``0`` for the first retry.
+    sleep
+        Sleep callable, injectable so offline tests don't block. Defaults to
+        :func:`time.sleep`.
+    """
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        max_retries: int = 5,
+        base_delay: float = 1.0,
+        max_delay: float = 60.0,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._session = session
+        self._max_retries = max_retries
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._sleep = sleep
+
+    # -- construction ------------------------------------------------------
+
+    @classmethod
+    def login(
+        cls,
+        username: str,
+        password: str,
+        *,
+        env: str | None = None,
+        **kwargs: Any,
+    ) -> SbClient:
+        """Authenticate with a username/password and return a client."""
+        session = _new_session(env)
+        session.login(username, password)
+        return cls(session, **kwargs)
+
+    @classmethod
+    def from_token(
+        cls,
+        token: str,
+        *,
+        env: str | None = None,
+        **kwargs: Any,
+    ) -> SbClient:
+        """Authenticate with a Keycloak token JSON and return a client."""
+        session = _new_session(env)
+        session.add_token(token)
+        return cls(session, **kwargs)
+
+    @property
+    def session(self) -> Any:
+        """The wrapped session (escape hatch for advanced operations)."""
+        return self._session
+
+    # -- retry core --------------------------------------------------------
+
+    def _backoff_delay(self, attempt: int) -> float:
+        return min(self._max_delay, self._base_delay * (2**attempt))
+
+    def _call(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Invoke *fn* with exponential-backoff retry on transient failures.
+
+        Re-raises the last exception once retries are exhausted or the error
+        is non-retryable, preserving the original traceback for the operator.
+        """
+        attempt = 0
+        while True:
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:
+                if attempt >= self._max_retries or not is_retryable(exc):
+                    raise
+                delay = self._backoff_delay(attempt)
+                logger.warning(
+                    "sb_client: retryable error on %s (retry %d/%d in %.1fs): %s",
+                    getattr(fn, "__name__", repr(fn)),
+                    attempt + 1,
+                    self._max_retries,
+                    delay,
+                    exc,
+                )
+                self._sleep(delay)
+                attempt += 1
+
+    # -- auth / liveness ---------------------------------------------------
+
+    def ping(self) -> Any:
+        """Low-cost ScienceBase liveness check (retried)."""
+        return self._call(self._session.ping)
+
+    def whoami(self) -> dict:
+        """Return ``{"username", "logged_in"}`` from local session state.
+
+        No network call: ``logged_in`` reflects the local token's validity.
+        """
+        return {
+            "username": getattr(self._session, "_username", None),
+            "logged_in": bool(self._session.is_logged_in()),
+        }
+
+    # -- items -------------------------------------------------------------
+
+    def get_item(self, sb_id: str) -> dict:
+        """Fetch the ScienceBase item JSON for *sb_id* (retried)."""
+        return self._call(self._session.get_item, sb_id)
+
+    def create_item(self, parent_id: str, body: dict) -> dict:
+        """Create a child item under *parent_id* and return its JSON.
+
+        *body* is copied and stamped with ``parentId``; an ``id`` in *body* is
+        ignored by ScienceBase on create.
+        """
+        item = dict(body)
+        item["parentId"] = parent_id
+        return self._call(self._session.create_item, item)
+
+    def update_item(self, sb_id: str, body: dict) -> dict:
+        """Update item *sb_id* with *body* and return the updated JSON.
+
+        *body* is copied and stamped with ``id`` so the caller never has to
+        thread the id through the body dict.
+        """
+        item = dict(body)
+        item["id"] = sb_id
+        return self._call(self._session.update_item, item)
+
+    def find_child(self, parent_id: str, title: str) -> dict | None:
+        """Return the child of *parent_id* whose title equals *title* exactly.
+
+        Returns ``None`` when no child matches. Raises :class:`SbClientError`
+        when more than one child shares the exact title -- the publish layer
+        can't safely pick one, so the operator must rename or merge the
+        duplicates. (Title comparison is exact, not the fuzzy Lucene match
+        ScienceBase search would do.)
+        """
+        child_ids = self._call(self._session.get_child_ids, parent_id)
+        matches = []
+        for child_id in child_ids:
+            item = self._call(self._session.get_item, child_id)
+            if item.get("title") == title:
+                matches.append(item)
+        if len(matches) > 1:
+            raise SbClientError(
+                f"{len(matches)} children of {parent_id} share the exact "
+                f"title {title!r}; cannot disambiguate. Rename or merge the "
+                f"duplicates before publishing."
+            )
+        return matches[0] if matches else None
+
+    def upload_file(
+        self,
+        sb_id: str,
+        path: str | Path,
+        *,
+        skip_if_sha256_matches: str | None = None,
+        scrape_file: bool = True,
+    ) -> UploadResult:
+        """Upload *path* to item *sb_id*, replacing any same-named file.
+
+        When *skip_if_sha256_matches* is given and the remote item already
+        carries a file with the same basename whose recorded checksum value
+        equals it, the upload is skipped (no bytes sent) and an
+        :class:`UploadResult` with ``skipped=True`` is returned. This is the
+        partial-upload / re-publish fast path: a re-run skips files that are
+        already present and current.
+
+        Note: ScienceBase records MD5 checksums; see
+        :func:`remote_file_checksum` for why a SHA-256 only matches once the
+        orchestration layer records one.
+        """
+        path = Path(path)
+        item = self._call(self._session.get_item, sb_id)
+        if skip_if_sha256_matches is not None:
+            remote = remote_file_checksum(item, path.name)
+            if remote is not None and remote == skip_if_sha256_matches:
+                logger.info(
+                    "sb_client: skipping upload of %s to %s (checksum match)",
+                    path.name,
+                    sb_id,
+                )
+                return UploadResult(skipped=True, name=path.name, item=item)
+        updated = self._call(
+            self._session.upload_file_to_item, item, str(path), scrape_file
+        )
+        return UploadResult(skipped=False, name=path.name, item=updated)

--- a/src/nhf_spatial_targets/release/sb_client.py
+++ b/src/nhf_spatial_targets/release/sb_client.py
@@ -82,9 +82,14 @@ def _status_from_exception(exc: BaseException) -> int | None:
 def is_retryable(exc: BaseException) -> bool:
     """Return whether *exc* represents a transient, retryable failure.
 
-    Connection resets and timeouts are always retryable; HTTP errors are
-    retryable only for :data:`RETRYABLE_STATUS_CODES`.
+    Connection resets and timeouts are retryable; HTTP errors are retryable
+    only for :data:`RETRYABLE_STATUS_CODES`. ``SSLError`` and ``ProxyError``
+    subclass ``ConnectionError`` but signal *permanent* misconfiguration (bad
+    cert, broken proxy), so they are excluded -- retrying them just delays a
+    guaranteed failure and buries the real config problem under retry warnings.
     """
+    if isinstance(exc, (requests.exceptions.SSLError, requests.exceptions.ProxyError)):
+        return False
     if isinstance(
         exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
     ):
@@ -184,6 +189,13 @@ class SbClient:
         max_delay: float = 60.0,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0; got {max_retries}.")
+        if base_delay <= 0 or max_delay <= 0:
+            raise ValueError(
+                f"base_delay and max_delay must be > 0; got "
+                f"base_delay={base_delay}, max_delay={max_delay}."
+            )
         self._session = session
         self._max_retries = max_retries
         self._base_delay = base_delay

--- a/tests/test_release_registry.py
+++ b/tests/test_release_registry.py
@@ -385,6 +385,52 @@ def test_non_mapping_top_level_is_loud_failure(tmp_path: Path) -> None:
         registry.load_registry(path)
 
 
+def test_present_but_empty_file_is_loud_failure(tmp_path: Path) -> None:
+    """A present-but-empty file is corruption, not a fresh start.
+
+    A registry truncated to zero bytes (crashed writer) must never be silently
+    re-scaffolded over live publish state -- only a genuinely *absent* file
+    seeds. This is the asymmetry three reviewers flagged.
+    """
+    path = tmp_path / "release_registry.yml"
+    path.write_text("")
+    with pytest.raises(ValueError, match="empty"):
+        registry.load_registry(path)
+
+
+def test_atomic_dump_failure_leaves_original_intact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A serialization failure mid-write leaves no .tmp litter and an
+    unchanged original -- the atomic-write safety net for the #97-class
+    concern this module exists to prevent.
+    """
+    path = tmp_path / "release_registry.yml"
+    path.write_text(_SCAFFOLD)
+    before = path.read_text()
+
+    # Force the rename to fail after the tempfile is written.
+    def _boom(self, target):  # noqa: ANN001
+        raise OSError("simulated rename failure")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+
+    with pytest.raises(OSError, match="simulated rename failure"):
+        registry.put_source(
+            "era5_land",
+            sb_id="src1",
+            uploaded_utc="t1",
+            file_count=1,
+            total_bytes=10,
+            manifest_sha256="aaa",
+            path=path,
+        )
+
+    # Original content untouched and no leftover *.yml.tmp files.
+    assert path.read_text() == before
+    assert not list(tmp_path.glob("*.yml.tmp"))
+
+
 def test_put_does_not_reset_on_reload(reg_path: Path) -> None:
     """A second writer reloads fresh state, never an in-memory stale copy."""
     registry.put_source(
@@ -423,11 +469,17 @@ def test_concurrent_writers_lose_no_entries(reg_path: Path) -> None:
     """4-thread concurrent put_source produces exactly 4 entries, none lost.
 
     Mirrors the lineage concurrency test: the flock serializes the
-    read-merge-write so a naive load/append/dump can't drop a sibling.
+    read-merge-write so a naive load/append/dump can't drop a sibling. A
+    ``Barrier`` releases all workers into ``put_source`` simultaneously so the
+    read-modify-write windows genuinely overlap (without it, the GIL tends to
+    let each worker finish before the next starts, and the test would pass
+    even if the lock did nothing).
     """
     n_threads = 4
+    barrier = threading.Barrier(n_threads)
 
     def _worker(worker_id: int) -> None:
+        barrier.wait()
         registry.put_source(
             f"src_{worker_id}",
             sb_id=f"sb_{worker_id}",

--- a/tests/test_release_registry.py
+++ b/tests/test_release_registry.py
@@ -1,0 +1,450 @@
+"""Tests for ``nhf_spatial_targets.release.registry``.
+
+The registry is the publish-intent source of truth, so the invariants we
+lock here are the ones that, if broken, silently orphan live ScienceBase
+items or lose another operator's publish record:
+
+- the ``umbrella: null`` sentinel round-trips as ``None`` (loaders must
+  branch on it, never index a missing dict),
+- the comment header and top-level key order survive every write (ruamel
+  round-trip, not ``yaml.safe_dump``),
+- ``put_*`` is read-merge-write: writing one entry never clobbers siblings
+  or the other sections (the #97 manifest-overwrite class of bug),
+- concurrent writers under flock lose no entries,
+- a corrupt file is a loud failure, never a silent re-scaffold.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from nhf_spatial_targets.release import registry
+
+# A scaffold carrying a distinctive comment header so the preservation test
+# asserts on something unmistakable. Mirrors the committed file's shape.
+_SCAFFOLD = """\
+# SENTINEL-HEADER-LINE: this comment must survive every write.
+# Second header line.
+
+umbrella: null
+consolidated_sources: {}
+fabrics: {}
+"""
+
+
+@pytest.fixture
+def reg_path(tmp_path: Path) -> Path:
+    """A fresh registry file seeded from the scaffold, inside a tmp dir."""
+    path = tmp_path / "release_registry.yml"
+    path.write_text(_SCAFFOLD)
+    return path
+
+
+def _load_raw(path: Path):
+    """Parse *path* with a bare ruamel handler (no normalization)."""
+    return YAML().load(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# umbrella: null sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_get_umbrella_returns_none_on_scaffold(reg_path: Path) -> None:
+    """The ``umbrella: null`` sentinel reads back as ``None``."""
+    assert registry.get_umbrella(reg_path) is None
+
+
+def test_committed_registry_scaffold_is_unpublished() -> None:
+    """The committed catalog/release_registry.yml is still the empty scaffold.
+
+    Guards against accidentally committing real publish state (as happened
+    once during development) -- the committed file must always start clean.
+    """
+    assert registry.get_umbrella(registry.DEFAULT_REGISTRY_PATH) is None
+    assert registry.get_source("era5_land") is None
+    assert registry.get_fabric("gfv2") is None
+
+
+def test_load_registry_normalizes_missing_containers(tmp_path: Path) -> None:
+    """A file missing the container sections still yields empty dicts."""
+    path = tmp_path / "release_registry.yml"
+    path.write_text("umbrella: null\n")
+    reg = registry.load_registry(path)
+    assert reg["consolidated_sources"] == {}
+    assert reg["fabrics"] == {}
+    assert reg.get("umbrella") is None
+
+
+def test_load_registry_seeds_when_file_absent(tmp_path: Path) -> None:
+    """An absent file is seeded in-memory (not crash) with the null sentinel."""
+    path = tmp_path / "does_not_exist.yml"
+    reg = registry.load_registry(path)
+    assert reg.get("umbrella") is None
+    assert reg["consolidated_sources"] == {}
+    assert reg["fabrics"] == {}
+
+
+# ---------------------------------------------------------------------------
+# put_umbrella: round-trip + doi sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_put_umbrella_round_trips(reg_path: Path) -> None:
+    """A written umbrella reads back field-for-field."""
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="2026-05-28T00:00:00+00:00",
+        title="NHF Calibration Targets",
+        path=reg_path,
+    )
+    umbrella = registry.get_umbrella(reg_path)
+    assert umbrella == {
+        "sb_id": "umb1",
+        "doi": None,
+        "version": "1.0",
+        "published_utc": "2026-05-28T00:00:00+00:00",
+        "title": "NHF Calibration Targets",
+    }
+
+
+def test_put_umbrella_first_publish_leaves_doi_null(reg_path: Path) -> None:
+    """Omitting ``doi`` on first publish records ``doi: null`` (no DOI yet)."""
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="2026-05-28T00:00:00+00:00",
+        title="Title",
+        path=reg_path,
+    )
+    assert registry.get_umbrella(reg_path)["doi"] is None
+
+
+def test_put_umbrella_doi_omit_keeps_existing(reg_path: Path) -> None:
+    """A later put that omits ``doi`` keeps a previously-set DOI.
+
+    Mirrors the ``--refresh-doi`` flow's inverse: re-publishing the umbrella
+    body must not blank a DOI that staff already minted.
+    """
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="2026-05-28T00:00:00+00:00",
+        title="Title",
+        doi="10.5066/P9XXXXXX",
+        path=reg_path,
+    )
+    # Re-publish the body without re-supplying the DOI.
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.1",
+        published_utc="2026-06-01T00:00:00+00:00",
+        title="Title v1.1",
+        path=reg_path,
+    )
+    umbrella = registry.get_umbrella(reg_path)
+    assert umbrella["doi"] == "10.5066/P9XXXXXX"
+    assert umbrella["version"] == "1.1"
+
+
+def test_put_umbrella_can_set_doi_explicitly(reg_path: Path) -> None:
+    """Passing ``doi`` sets it (the refresh-doi path)."""
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="2026-05-28T00:00:00+00:00",
+        title="Title",
+        path=reg_path,
+    )
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="2026-05-28T00:00:00+00:00",
+        title="Title",
+        doi="10.5066/P9NEWDOI",
+        path=reg_path,
+    )
+    assert registry.get_umbrella(reg_path)["doi"] == "10.5066/P9NEWDOI"
+
+
+# ---------------------------------------------------------------------------
+# put_source / put_fabric: round-trip + merge-not-overwrite
+# ---------------------------------------------------------------------------
+
+
+def test_put_source_round_trips(reg_path: Path) -> None:
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="2026-05-28T01:00:00+00:00",
+        file_count=3,
+        total_bytes=12345,
+        manifest_sha256="deadbeef",
+        path=reg_path,
+    )
+    assert registry.get_source("era5_land", reg_path) == {
+        "sb_id": "src1",
+        "uploaded_utc": "2026-05-28T01:00:00+00:00",
+        "file_count": 3,
+        "total_bytes": 12345,
+        "manifest_sha256": "deadbeef",
+    }
+
+
+def test_put_source_preserves_sibling_sources(reg_path: Path) -> None:
+    """Writing one source must not drop a previously-written sibling (#97)."""
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=10,
+        manifest_sha256="aaa",
+        path=reg_path,
+    )
+    registry.put_source(
+        "merra2",
+        sb_id="src2",
+        uploaded_utc="t2",
+        file_count=2,
+        total_bytes=20,
+        manifest_sha256="bbb",
+        path=reg_path,
+    )
+    assert registry.get_source("era5_land", reg_path)["sb_id"] == "src1"
+    assert registry.get_source("merra2", reg_path)["sb_id"] == "src2"
+
+
+def test_put_source_updates_in_place(reg_path: Path) -> None:
+    """Re-publishing a source updates that entry without duplicating it."""
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=10,
+        manifest_sha256="aaa",
+        path=reg_path,
+    )
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t2",
+        file_count=5,
+        total_bytes=99,
+        manifest_sha256="zzz",
+        path=reg_path,
+    )
+    entry = registry.get_source("era5_land", reg_path)
+    assert entry["file_count"] == 5
+    assert entry["manifest_sha256"] == "zzz"
+    # exactly one entry under consolidated_sources
+    assert list(registry.load_registry(reg_path)["consolidated_sources"]) == [
+        "era5_land"
+    ]
+
+
+def test_put_fabric_round_trips_and_preserves_siblings(reg_path: Path) -> None:
+    registry.put_fabric(
+        "gfv2",
+        sb_id="fab1",
+        uploaded_utc="t1",
+        file_count=40,
+        total_bytes=1000,
+        manifest_sha256="f1",
+        path=reg_path,
+    )
+    registry.put_fabric(
+        "oregon",
+        sb_id="fab2",
+        uploaded_utc="t2",
+        file_count=12,
+        total_bytes=500,
+        manifest_sha256="f2",
+        path=reg_path,
+    )
+    assert registry.get_fabric("gfv2", reg_path)["sb_id"] == "fab1"
+    assert registry.get_fabric("oregon", reg_path)["sb_id"] == "fab2"
+
+
+def test_writes_across_sections_do_not_interfere(reg_path: Path) -> None:
+    """Umbrella, sources, and fabrics each survive writes to the others."""
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="t0",
+        title="Title",
+        path=reg_path,
+    )
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=10,
+        manifest_sha256="aaa",
+        path=reg_path,
+    )
+    registry.put_fabric(
+        "gfv2",
+        sb_id="fab1",
+        uploaded_utc="t2",
+        file_count=40,
+        total_bytes=1000,
+        manifest_sha256="f1",
+        path=reg_path,
+    )
+    assert registry.get_umbrella(reg_path)["sb_id"] == "umb1"
+    assert registry.get_source("era5_land", reg_path)["sb_id"] == "src1"
+    assert registry.get_fabric("gfv2", reg_path)["sb_id"] == "fab1"
+
+
+# ---------------------------------------------------------------------------
+# Comment header + key order preservation
+# ---------------------------------------------------------------------------
+
+
+def test_comment_header_survives_writes(reg_path: Path) -> None:
+    """The scaffold's comment header is preserved through put_* writes.
+
+    This is the whole reason we use ruamel round-trip mode instead of
+    yaml.safe_dump.
+    """
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="t0",
+        title="Title",
+        path=reg_path,
+    )
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=10,
+        manifest_sha256="aaa",
+        path=reg_path,
+    )
+    text = reg_path.read_text()
+    assert "# SENTINEL-HEADER-LINE: this comment must survive every write." in text
+    assert "# Second header line." in text
+
+
+def test_top_level_key_order_preserved(reg_path: Path) -> None:
+    """Top-level keys stay umbrella -> consolidated_sources -> fabrics."""
+    registry.put_fabric(
+        "gfv2",
+        sb_id="fab1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=1,
+        manifest_sha256="f1",
+        path=reg_path,
+    )
+    raw = _load_raw(reg_path)
+    assert list(raw) == ["umbrella", "consolidated_sources", "fabrics"]
+
+
+def test_umbrella_field_order_canonical(reg_path: Path) -> None:
+    """Serialized umbrella fields follow the canonical schema order."""
+    registry.put_umbrella(
+        sb_id="umb1",
+        version="1.0",
+        published_utc="t0",
+        title="Title",
+        path=reg_path,
+    )
+    raw = _load_raw(reg_path)
+    assert list(raw["umbrella"]) == list(registry.UMBRELLA_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-file loud failure
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_registry_is_loud_failure(tmp_path: Path) -> None:
+    """An unparseable registry raises ValueError, never a silent reset."""
+    path = tmp_path / "release_registry.yml"
+    path.write_text("umbrella: [unterminated\nconsolidated_sources: {}\n")
+    with pytest.raises(ValueError, match="corrupt"):
+        registry.load_registry(path)
+
+
+def test_non_mapping_top_level_is_loud_failure(tmp_path: Path) -> None:
+    """A top-level list (not mapping) raises rather than being mis-handled."""
+    path = tmp_path / "release_registry.yml"
+    path.write_text("- not\n- a\n- mapping\n")
+    with pytest.raises(ValueError, match="mapping"):
+        registry.load_registry(path)
+
+
+def test_put_does_not_reset_on_reload(reg_path: Path) -> None:
+    """A second writer reloads fresh state, never an in-memory stale copy."""
+    registry.put_source(
+        "era5_land",
+        sb_id="src1",
+        uploaded_utc="t1",
+        file_count=1,
+        total_bytes=10,
+        manifest_sha256="aaa",
+        path=reg_path,
+    )
+    # Simulate an out-of-band edit landing between writes.
+    text = reg_path.read_text()
+    reg_path.write_text(text.replace("src1", "src1-edited"))
+    registry.put_source(
+        "merra2",
+        sb_id="src2",
+        uploaded_utc="t2",
+        file_count=2,
+        total_bytes=20,
+        manifest_sha256="bbb",
+        path=reg_path,
+    )
+    # The out-of-band edit survived (we merged, didn't overwrite from a
+    # stale in-memory snapshot).
+    assert registry.get_source("era5_land", reg_path)["sb_id"] == "src1-edited"
+    assert registry.get_source("merra2", reg_path)["sb_id"] == "src2"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writers_lose_no_entries(reg_path: Path) -> None:
+    """4-thread concurrent put_source produces exactly 4 entries, none lost.
+
+    Mirrors the lineage concurrency test: the flock serializes the
+    read-merge-write so a naive load/append/dump can't drop a sibling.
+    """
+    n_threads = 4
+
+    def _worker(worker_id: int) -> None:
+        registry.put_source(
+            f"src_{worker_id}",
+            sb_id=f"sb_{worker_id}",
+            uploaded_utc="t",
+            file_count=worker_id,
+            total_bytes=worker_id * 10,
+            manifest_sha256=f"h{worker_id}",
+            path=reg_path,
+        )
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    reg = registry.load_registry(reg_path)
+    assert set(reg["consolidated_sources"]) == {f"src_{i}" for i in range(n_threads)}
+    # File still parses cleanly (no torn write) and the header survived.
+    assert "# SENTINEL-HEADER-LINE" in reg_path.read_text()

--- a/tests/test_release_sb_client_offline.py
+++ b/tests/test_release_sb_client_offline.py
@@ -1,0 +1,403 @@
+"""Offline tests for ``nhf_spatial_targets.release.sb_client``.
+
+No real network: every test injects a mock session and a no-op sleep, so the
+retry/backoff path is exercised without wall-clock delay. Live ScienceBase
+tests are gated behind ``@pytest.mark.integration`` and live in a later PR.
+
+The contracts locked here:
+
+- :func:`is_retryable` classifies 429 + transient 5xx + connection/timeout as
+  retryable and everything else as fatal -- matching the bare-``Exception``
+  messages sciencebasepy actually raises,
+- ``_call`` retries with exponential backoff using the injected sleep and
+  re-raises once retries are exhausted,
+- ``upload_file`` skips the byte transfer when the remote checksum matches,
+- ``create_item`` / ``update_item`` / ``find_child`` dispatch to the right
+  underlying session calls with the id/parentId stamped correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from nhf_spatial_targets.release import sb_client
+from nhf_spatial_targets.release.sb_client import (
+    SbClient,
+    SbClientError,
+    UploadResult,
+    is_retryable,
+    remote_file_checksum,
+)
+
+
+@pytest.fixture
+def sleeps() -> list[float]:
+    """Collect the durations passed to the injected sleep."""
+    return []
+
+
+@pytest.fixture
+def client_factory(sleeps: list[float]):
+    """Build an SbClient over a MagicMock session with a recording sleep."""
+
+    def _make(session=None, **kwargs):
+        session = session if session is not None else MagicMock()
+        kwargs.setdefault("base_delay", 0.5)
+        kwargs.setdefault("max_delay", 100.0)
+        kwargs.setdefault("sleep", sleeps.append)
+        return SbClient(session, **kwargs)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# is_retryable classification
+# ---------------------------------------------------------------------------
+
+
+def test_too_many_requests_is_retryable() -> None:
+    """sciencebasepy raises ``Exception('Too many requests')`` for 429."""
+    assert is_retryable(Exception("Too many requests")) is True
+
+
+@pytest.mark.parametrize("code", [500, 502, 503, 504])
+def test_transient_5xx_is_retryable(code: int) -> None:
+    """sciencebasepy's catch-all ``Other HTTP error: <code>`` for 5xx."""
+    assert is_retryable(Exception(f"Other HTTP error: {code}: upstream busy"))
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 501])
+def test_non_retryable_status_codes(code: int) -> None:
+    """Client errors and 501 are fatal, not retried."""
+    assert is_retryable(Exception(f"Other HTTP error: {code}: nope")) is False
+
+
+def test_unauthorized_message_is_not_retryable() -> None:
+    assert is_retryable(Exception("Unauthorized access")) is False
+
+
+def test_connection_and_timeout_errors_are_retryable() -> None:
+    assert is_retryable(requests.exceptions.ConnectionError("reset")) is True
+    assert is_retryable(requests.exceptions.Timeout("slow")) is True
+
+
+def test_http_error_with_response_status_is_retryable() -> None:
+    """A requests.HTTPError carrying a 503 response is retryable."""
+    exc = requests.exceptions.HTTPError("boom")
+    exc.response = SimpleNamespace(status_code=503)
+    assert is_retryable(exc) is True
+    exc.response = SimpleNamespace(status_code=404)
+    assert is_retryable(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Retry / backoff
+# ---------------------------------------------------------------------------
+
+
+def test_retry_on_429_then_success(client_factory, sleeps: list[float]) -> None:
+    """Two 429s then a success: 3 calls, 2 backoff sleeps, value returned."""
+    session = MagicMock()
+    session.ping.side_effect = [
+        Exception("Too many requests"),
+        Exception("Too many requests"),
+        {"ok": True},
+    ]
+    client = client_factory(session, max_retries=5)
+
+    result = client.ping()
+
+    assert result == {"ok": True}
+    assert session.ping.call_count == 3
+    # Exponential: base_delay=0.5 -> [0.5, 1.0].
+    assert sleeps == [0.5, 1.0]
+
+
+def test_retry_on_503_then_success(client_factory, sleeps: list[float]) -> None:
+    session = MagicMock()
+    session.get_item.side_effect = [
+        Exception("Other HTTP error: 503: service unavailable"),
+        {"id": "abc", "title": "T"},
+    ]
+    client = client_factory(session, max_retries=3)
+
+    result = client.get_item("abc")
+
+    assert result["id"] == "abc"
+    assert session.get_item.call_count == 2
+    assert sleeps == [0.5]
+
+
+def test_non_retryable_raises_immediately(client_factory, sleeps: list[float]) -> None:
+    """A fatal error is raised on the first attempt with no sleep."""
+    session = MagicMock()
+    session.get_item.side_effect = Exception("Unauthorized access")
+    client = client_factory(session, max_retries=5)
+
+    with pytest.raises(Exception, match="Unauthorized access"):
+        client.get_item("abc")
+    assert session.get_item.call_count == 1
+    assert sleeps == []
+
+
+def test_retries_exhausted_reraises(client_factory, sleeps: list[float]) -> None:
+    """After max_retries the last exception propagates."""
+    session = MagicMock()
+    session.ping.side_effect = Exception("Too many requests")
+    client = client_factory(session, max_retries=2)
+
+    with pytest.raises(Exception, match="Too many requests"):
+        client.ping()
+    # initial attempt + 2 retries = 3 calls; 2 sleeps.
+    assert session.ping.call_count == 3
+    assert sleeps == [0.5, 1.0]
+
+
+def test_max_delay_caps_backoff(client_factory, sleeps: list[float]) -> None:
+    """Backoff never exceeds max_delay."""
+    session = MagicMock()
+    session.ping.side_effect = Exception("Too many requests")
+    client = client_factory(session, max_retries=4, base_delay=1.0, max_delay=3.0)
+
+    with pytest.raises(Exception, match="Too many requests"):
+        client.ping()
+    # 1, 2, 4->capped 3, 8->capped 3
+    assert sleeps == [1.0, 2.0, 3.0, 3.0]
+
+
+def test_max_retries_zero_disables_retry(client_factory, sleeps: list[float]) -> None:
+    session = MagicMock()
+    session.ping.side_effect = Exception("Too many requests")
+    client = client_factory(session, max_retries=0)
+
+    with pytest.raises(Exception, match="Too many requests"):
+        client.ping()
+    assert session.ping.call_count == 1
+    assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# Item dispatch: get / create / update
+# ---------------------------------------------------------------------------
+
+
+def test_get_item_dispatches(client_factory) -> None:
+    session = MagicMock()
+    session.get_item.return_value = {"id": "abc", "title": "T"}
+    client = client_factory(session)
+
+    assert client.get_item("abc") == {"id": "abc", "title": "T"}
+    session.get_item.assert_called_once_with("abc")
+
+
+def test_create_item_stamps_parent_id(client_factory) -> None:
+    """create_item adds parentId and does not mutate the caller's body."""
+    session = MagicMock()
+    session.create_item.return_value = {"id": "new", "title": "T"}
+    client = client_factory(session)
+
+    body = {"title": "T", "summary": "s"}
+    result = client.create_item("parent123", body)
+
+    assert result["id"] == "new"
+    session.create_item.assert_called_once_with(
+        {"title": "T", "summary": "s", "parentId": "parent123"}
+    )
+    assert "parentId" not in body  # caller's dict untouched
+
+
+def test_update_item_stamps_id(client_factory) -> None:
+    session = MagicMock()
+    session.update_item.return_value = {"id": "abc", "title": "T2"}
+    client = client_factory(session)
+
+    body = {"title": "T2"}
+    result = client.update_item("abc", body)
+
+    assert result["title"] == "T2"
+    session.update_item.assert_called_once_with({"title": "T2", "id": "abc"})
+    assert "id" not in body
+
+
+# ---------------------------------------------------------------------------
+# find_child
+# ---------------------------------------------------------------------------
+
+
+def test_find_child_returns_exact_title_match(client_factory) -> None:
+    session = MagicMock()
+    session.get_child_ids.return_value = ["c1", "c2"]
+    session.get_item.side_effect = lambda cid: {
+        "c1": {"id": "c1", "title": "ERA5-Land"},
+        "c2": {"id": "c2", "title": "MERRA-2"},
+    }[cid]
+    client = client_factory(session)
+
+    match = client.find_child("parent", "MERRA-2")
+    assert match["id"] == "c2"
+    session.get_child_ids.assert_called_once_with("parent")
+
+
+def test_find_child_returns_none_when_no_match(client_factory) -> None:
+    session = MagicMock()
+    session.get_child_ids.return_value = ["c1"]
+    session.get_item.return_value = {"id": "c1", "title": "Other"}
+    client = client_factory(session)
+
+    assert client.find_child("parent", "ERA5-Land") is None
+
+
+def test_find_child_raises_on_ambiguous_titles(client_factory) -> None:
+    """Two children with the same exact title is unrecoverable here."""
+    session = MagicMock()
+    session.get_child_ids.return_value = ["c1", "c2"]
+    session.get_item.side_effect = lambda cid: {"id": cid, "title": "DUP"}
+    client = client_factory(session)
+
+    with pytest.raises(SbClientError, match="disambiguate"):
+        client.find_child("parent", "DUP")
+
+
+# ---------------------------------------------------------------------------
+# upload_file: skip-if-checksum-matches
+# ---------------------------------------------------------------------------
+
+
+def _item_with_file(name: str, sha: str) -> dict:
+    return {
+        "id": "child1",
+        "files": [{"name": name, "checksum": {"type": "SHA-256", "value": sha}}],
+    }
+
+
+def test_upload_file_skips_when_checksum_matches(client_factory, tmp_path) -> None:
+    """A remote file with a matching checksum means no bytes are sent."""
+    f = tmp_path / "data.nc"
+    f.write_bytes(b"payload")
+    sha = "abc123sha"
+
+    session = MagicMock()
+    session.get_item.return_value = _item_with_file("data.nc", sha)
+    client = client_factory(session)
+
+    result = client.upload_file("child1", f, skip_if_sha256_matches=sha)
+
+    assert isinstance(result, UploadResult)
+    assert result.skipped is True
+    assert result.name == "data.nc"
+    session.upload_file_to_item.assert_not_called()
+
+
+def test_upload_file_uploads_when_checksum_differs(client_factory, tmp_path) -> None:
+    f = tmp_path / "data.nc"
+    f.write_bytes(b"payload")
+
+    session = MagicMock()
+    session.get_item.return_value = _item_with_file("data.nc", "OLDsha")
+    session.upload_file_to_item.return_value = {"id": "child1", "files": []}
+    client = client_factory(session)
+
+    result = client.upload_file("child1", f, skip_if_sha256_matches="NEWsha")
+
+    assert result.skipped is False
+    session.upload_file_to_item.assert_called_once()
+    # the staged file path is forwarded
+    args = session.upload_file_to_item.call_args.args
+    assert args[1] == str(f)
+
+
+def test_upload_file_uploads_when_no_skip_requested(client_factory, tmp_path) -> None:
+    f = tmp_path / "data.nc"
+    f.write_bytes(b"payload")
+
+    session = MagicMock()
+    session.get_item.return_value = {"id": "child1", "files": []}
+    session.upload_file_to_item.return_value = {"id": "child1"}
+    client = client_factory(session)
+
+    result = client.upload_file("child1", f)
+
+    assert result.skipped is False
+    session.upload_file_to_item.assert_called_once()
+
+
+def test_upload_file_uploads_when_remote_file_absent(client_factory, tmp_path) -> None:
+    """skip requested but the remote item has no such file: upload anyway."""
+    f = tmp_path / "data.nc"
+    f.write_bytes(b"payload")
+
+    session = MagicMock()
+    session.get_item.return_value = {"id": "child1", "files": []}
+    session.upload_file_to_item.return_value = {"id": "child1"}
+    client = client_factory(session)
+
+    result = client.upload_file("child1", f, skip_if_sha256_matches="whatever")
+    assert result.skipped is False
+    session.upload_file_to_item.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# remote_file_checksum helper
+# ---------------------------------------------------------------------------
+
+
+def test_remote_file_checksum_in_files() -> None:
+    item = _item_with_file("a.nc", "SHA-A")
+    assert remote_file_checksum(item, "a.nc") == "SHA-A"
+
+
+def test_remote_file_checksum_in_facets() -> None:
+    item = {
+        "files": [],
+        "facets": [
+            {"files": [{"name": "b.nc", "checksum": {"value": "SHA-B"}}]},
+        ],
+    }
+    assert remote_file_checksum(item, "b.nc") == "SHA-B"
+
+
+def test_remote_file_checksum_absent_returns_none() -> None:
+    assert remote_file_checksum({"files": []}, "missing.nc") is None
+    assert remote_file_checksum(None, "missing.nc") is None
+    # present but no checksum recorded
+    assert remote_file_checksum({"files": [{"name": "c.nc"}]}, "c.nc") is None
+
+
+# ---------------------------------------------------------------------------
+# whoami + factories (offline)
+# ---------------------------------------------------------------------------
+
+
+def test_whoami_reads_local_session_state(client_factory) -> None:
+    session = MagicMock()
+    session._username = "jdoe"
+    session.is_logged_in.return_value = True
+    client = client_factory(session)
+
+    assert client.whoami() == {"username": "jdoe", "logged_in": True}
+
+
+def test_login_factory_dispatches(monkeypatch) -> None:
+    """login() builds a session and calls session.login (no network)."""
+    fake = MagicMock()
+    monkeypatch.setattr(sb_client, "_new_session", lambda env: fake)
+
+    client = SbClient.login("user", "pass", env="beta", max_retries=2)
+
+    assert isinstance(client, SbClient)
+    assert client.session is fake
+    fake.login.assert_called_once_with("user", "pass")
+
+
+def test_from_token_factory_dispatches(monkeypatch) -> None:
+    fake = MagicMock()
+    monkeypatch.setattr(sb_client, "_new_session", lambda env: fake)
+
+    client = SbClient.from_token("token-json", env="beta")
+
+    assert client.session is fake
+    fake.add_token.assert_called_once_with("token-json")

--- a/tests/test_release_sb_client_offline.py
+++ b/tests/test_release_sb_client_offline.py
@@ -85,6 +85,14 @@ def test_connection_and_timeout_errors_are_retryable() -> None:
     assert is_retryable(requests.exceptions.Timeout("slow")) is True
 
 
+def test_permanent_connection_subclasses_are_not_retryable() -> None:
+    """SSLError/ProxyError subclass ConnectionError but are permanent config
+    failures -- retrying them just buries the real problem.
+    """
+    assert is_retryable(requests.exceptions.SSLError("bad cert")) is False
+    assert is_retryable(requests.exceptions.ProxyError("bad proxy")) is False
+
+
 def test_http_error_with_response_status_is_retryable() -> None:
     """A requests.HTTPError carrying a 503 response is retryable."""
     exc = requests.exceptions.HTTPError("boom")
@@ -379,6 +387,20 @@ def test_whoami_reads_local_session_state(client_factory) -> None:
     client = client_factory(session)
 
     assert client.whoami() == {"username": "jdoe", "logged_in": True}
+
+
+def test_whoami_tolerates_missing_username() -> None:
+    """A token session may not set ``_username``; whoami yields None, not raise.
+
+    (Uses a bare object rather than MagicMock, whose attribute auto-vivifies.)
+    """
+
+    class _Session:
+        def is_logged_in(self):
+            return False
+
+    client = SbClient(_Session(), sleep=lambda _: None)
+    assert client.whoami() == {"username": None, "logged_in": False}
 
 
 def test_login_factory_dispatches(monkeypatch) -> None:


### PR DESCRIPTION
Closes #271. Part of the ScienceBase data-release effort; PR-E split into E2 (this) + E3 (publish orchestration), mirroring the D1/D2 and E1/E2 splits.

## Summary

Two new **offline-testable primitives** the publish orchestration (PR-E3) will build on, plus one dependency:

- **`release/registry.py`** — flock-protected read-merge-write of `catalog/release_registry.yml` (the source of truth for publish *intent*). ruamel.yaml round-trip mode preserves the comment header + key order across every write; the `umbrella: null` "no first-publish yet" sentinel is handled explicitly; a corrupt file is a **loud** `ValueError`, never a silent re-scaffold. `put_umbrella` / `put_source` / `put_fabric` each merge a single entry without clobbering siblings or the other sections (the #97 manifest-overwrite class of bug). Pure-local: `diff_local_vs_remote` (needs SB queries) is deferred to PR-E3.
- **`release/sb_client.py`** — thin retrying facade over `sciencebasepy.SbSession`: `login`/`from_token`, `ping`, `whoami`, `get_item`, `find_child`, `create_item`, `update_item`, `upload_file` (with a `skip_if_sha256_matches` fast path). Exponential backoff on HTTP 429/5xx + connection/timeout, with an **injectable sleep** so offline tests don't block. sciencebasepy is imported lazily, so module load needs no network or credentials.
- **`pixi.toml`** — add `ruamel.yaml >=0.18` (conda-forge). `sciencebasepy`, `lxml`, `pygeometa` were already present.

## Notes / decisions

- ScienceBase records uploaded-file checksums as **MD5** (not SHA-256). `remote_file_checksum` + `upload_file` compare against whatever value the remote records; the docstrings note that a SHA-256 skip only fires once PR-E3 records a SHA-256 on the remote file. When the recorded checksum can't match, the file simply re-uploads — correct, just not skipped.
- `find_child` raises `SbClientError` on duplicate exact-title children (the publish layer can't safely disambiguate); the create-vs-adopt decision itself lives in PR-E3.
- Added `catalog/release_registry.yml.lock` (the flock sidecar) to `.gitignore`.

## Out of scope (later PRs)

`release/publish.py` + `dry_run.py` (PR-E3, idempotent create-vs-update + read-only SB parity + mp); `release/cli.py` (PR-F); `materialize_sciencebase_token` + `.credentials.yml` `sciencebase:` block + live `@pytest.mark.integration` tests + docs (PR-G). No XSD validation.

## Test plan

- [x] `pixi run -e dev fmt` + `lint` clean
- [x] `tests/test_release_registry.py` + `tests/test_release_sb_client_offline.py` — 55 passed (round-trip, `umbrella:null` sentinel, comment-header + key-order preservation, 4-thread concurrent flock writers, corrupt-file loud failure, merge-not-overwrite; retry-on-429/503 with patched sleep, backoff caps, skip-if-checksum-matches, create/update/find_child dispatch)
- [x] Related release suite (defaults/config/lineage/build/payload/checksums) — 97 passed; package import sanity OK
- [ ] Full suite on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review fixups applied (commit cbfb897)

The offline review (code / type-design / silent-failure / test-coverage) found **no correctness bug** in the flock read-merge-write or the `doi=_KEEP` sentinel. Applied fix-now bundle:

- **must-fix** — `is_retryable` no longer retries permanent `ConnectionError` subclasses (`SSLError`/`ProxyError`).
- present-but-empty registry is now a loud `ValueError` (matching corrupt-file), removing the warn+reseed seam that contradicted the "never a silent reset" invariant.
- `SbClient.__init__` validates retry params; dropped a dead constant.
- tests: `threading.Barrier` in the concurrency test; new coverage for empty-file loud-fail, `_atomic_dump` rollback, SSL/Proxy non-retryable, `whoami` missing-`_username`. **59 offline tests pass.**

## Roadmap (deferred to PR-E3, which has the registry/orchestration context)

These are orchestration-layer concerns the primitive deliberately doesn't own:

- On a 404, `get_item`/`upload_file` propagate sciencebasepy's opaque `"Resource not found"`. E3 (which knows the `sb_id` came from the registry) should catch it and surface "registry `sb_id` is stale — item deleted on ScienceBase." The primitive shouldn't assume staleness.
- `find_child` N+1 per-child failure context; introduce **typed records** at the orchestration boundary instead of plain dicts; `UploadResult.item` → `Mapping`; base `SbClientError` on a small `ReleaseError` hierarchy so E3 can catch release-layer errors uniformly.

Not fixed (parity): `_atomic_dump` leaks the raw `tmp_fd` only if `os.fdopen` itself raises (unreachable in practice) — `lineage.atomic_write_manifest` uses the identical accepted pattern, so not diverging here.
