### PR TITLE
feature(release): PR-E3 idempotent publish + dry-run orchestration

### DIFF
--- a/src/nhf_spatial_targets/release/__init__.py
+++ b/src/nhf_spatial_targets/release/__init__.py
@@ -8,6 +8,7 @@ from nhf_spatial_targets.release._models import (
     DistributionKind,
     FabricChildPlan,
     FileEntry,
+    ReleaseError,
     ReleasePayload,
     SourceChildPlan,
     UmbrellaPlan,
@@ -31,8 +32,20 @@ from nhf_spatial_targets.release.config import (
     validate_release_config,
 )
 from nhf_spatial_targets.release.defaults import (
+    REQUIRED_POPULATED_PATHS,
     load_release_defaults,
+    missing_release_defaults,
+    require_populated_release_defaults,
     validate_release_defaults,
+)
+
+# Only the result types are re-exported here, NOT the ``dry_run`` function:
+# re-exporting it would bind ``release.dry_run`` to the function and shadow the
+# ``release.dry_run`` submodule. Import the function as
+# ``from nhf_spatial_targets.release.dry_run import dry_run``.
+from nhf_spatial_targets.release.dry_run import (
+    DryRunItem,
+    DryRunReport,
 )
 from nhf_spatial_targets.release.fgdc import render_fgdc
 from nhf_spatial_targets.release.iso import render_iso
@@ -65,6 +78,16 @@ from nhf_spatial_targets.release.payload import (
     stage_fabric_child,
     stage_source_child,
     stage_umbrella,
+)
+from nhf_spatial_targets.release.publish import (
+    PreflightError,
+    PublishResult,
+    ScopeDiff,
+    StaleRegistryError,
+    diff_local_vs_remote,
+    publish_fabric_child,
+    publish_source_child,
+    publish_umbrella,
 )
 from nhf_spatial_targets.release.readme import render_readme
 from nhf_spatial_targets.release.rebuild import rebuild_lineage
@@ -99,6 +122,7 @@ __all__ = [
     "CHILD_FIELDS",
     "DEFAULT_REGISTRY_PATH",
     "MCF_VERSION",
+    "REQUIRED_POPULATED_PATHS",
     "RETRYABLE_STATUS_CODES",
     "STEP_KINDS",
     "CHECKSUM_FILES",
@@ -107,15 +131,22 @@ __all__ = [
     "BuildResult",
     "ChecksumMismatch",
     "DistributionKind",
+    "DryRunItem",
+    "DryRunReport",
     "FabricChildPlan",
     "FileEntry",
     "InputFileEntry",
     "MpResult",
     "OutputFileEntry",
+    "PreflightError",
+    "PublishResult",
+    "ReleaseError",
     "ReleasePayload",
     "SbClient",
     "SbClientError",
+    "ScopeDiff",
     "SourceChildPlan",
+    "StaleRegistryError",
     "StepKind",
     "StepRecord",
     "UmbrellaPlan",
@@ -130,6 +161,7 @@ __all__ = [
     "build_umbrella",
     "build_umbrella_mcf",
     "compute_checksums",
+    "diff_local_vs_remote",
     "get_fabric",
     "get_source",
     "get_umbrella",
@@ -140,11 +172,15 @@ __all__ = [
     "load_release_defaults",
     "load_release_yml",
     "merge_source_and_append_step",
+    "missing_release_defaults",
     "mp_available",
     "output_file_entry",
     "plan_fabric_child",
     "plan_source_child",
     "plan_umbrella",
+    "publish_fabric_child",
+    "publish_source_child",
+    "publish_umbrella",
     "put_fabric",
     "put_source",
     "put_umbrella",
@@ -153,6 +189,7 @@ __all__ = [
     "render_fgdc",
     "render_iso",
     "render_readme",
+    "require_populated_release_defaults",
     "resolve_fabric_label",
     "scaffold_release_yml",
     "sha256_file",

--- a/src/nhf_spatial_targets/release/_models.py
+++ b/src/nhf_spatial_targets/release/_models.py
@@ -15,6 +15,11 @@ filenames are recorded on every plan) but **not** generated in this
 phase -- metadata rendering is a later phase. ``checksums.py`` only
 fingerprints files that actually exist, so the reserved slots do not
 appear in ``SHA256SUMS`` until those files exist.
+
+This module also hosts :class:`ReleaseError`, the shared base for every
+deliberate release-layer error. It lives here -- the dependency-free leaf
+both ``sb_client`` and ``publish`` import -- so they can subclass it without
+an import cycle.
 """
 
 from __future__ import annotations

--- a/src/nhf_spatial_targets/release/_models.py
+++ b/src/nhf_spatial_targets/release/_models.py
@@ -23,6 +23,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+
+class ReleaseError(RuntimeError):
+    """Base for every error the release tooling raises deliberately.
+
+    Lives here (the dependency-free shared-types module) so both the
+    foundational :mod:`~nhf_spatial_targets.release.sb_client` primitive and
+    the publish/dry-run orchestration can subclass it without an import cycle.
+    Catching :class:`ReleaseError` catches every release-layer condition --
+    a stale registry, an ambiguous title, a failed pre-flight gate -- as
+    opposed to a transient transport failure (which the client retries) or a
+    genuine bug (which should propagate).
+    """
+
+
 # The two recognized source distribution kinds, mirroring
 # ``catalog.DISTRIBUTION_KIND_TOKENS``. A test asserts the two stay in
 # sync. "data" ships the consolidated NetCDFs; "metadata_only" ships only

--- a/src/nhf_spatial_targets/release/defaults.py
+++ b/src/nhf_spatial_targets/release/defaults.py
@@ -39,6 +39,45 @@ REQUIRED_SECTIONS: tuple[str, ...] = (
     "spatial_reference",
 )
 
+# Dotted paths into a defaults document that must be *populated* (truthy) for a
+# release to be publishable. This is the publish-time gate the loader's
+# shape-only check deliberately omits: the committed scaffold may ship empty
+# sections and an operator builds/dry-runs against them, but publishing
+# metadata with an empty title template or no distributor contact would emit a
+# broken FGDC/ISO record. Every path here is read by a
+# :mod:`nhf_spatial_targets.release.mcf` builder; an empty value renders an
+# empty (and invalid) metadata field.
+#
+# A path segment navigates nested mappings; the leaf must be truthy after the
+# same normalization the renderers see (non-empty string, list, or mapping; a
+# nonzero number such as the EPSG code). Kept beside REQUIRED_SECTIONS so the
+# two can't drift.
+REQUIRED_POPULATED_PATHS: tuple[str, ...] = (
+    "contacts.distributor",
+    "contacts.point_of_contact",
+    "distribution.use_constraints",
+    "distribution.liability_statement",
+    "distribution.fallback_landing_url",
+    "distribution.distribution_protocol",
+    "keywords.topiccategory",
+    "keywords.umbrella.theme",
+    "keywords.source.theme",
+    "keywords.fabric.theme",
+    "umbrella.title_template",
+    "umbrella.abstract_template",
+    "umbrella.purpose",
+    "umbrella.lineage_statement",
+    "umbrella.versioning_policy",
+    "source.abstract_suffix",
+    "source.purpose_template",
+    "source.lineage_statement_template",
+    "fabric.title_template",
+    "fabric.abstract_template",
+    "fabric.purpose_template",
+    "fabric.lineage_statement_template",
+    "spatial_reference.epsg",
+)
+
 
 def validate_release_defaults(
     data: dict, *, source: str = "release_defaults.yml"
@@ -84,6 +123,79 @@ def validate_release_defaults(
                 f"{source}: section '{section}' must be a mapping; "
                 f"got {type(value).__name__}."
             )
+
+
+def _resolve_path(data: dict, dotted: str) -> object | None:
+    """Navigate *dotted* (e.g. ``"umbrella.title_template"``) into *data*.
+
+    Returns the leaf value, or ``None`` if any intermediate segment is absent
+    or not a mapping. A literal ``None`` leaf is indistinguishable from a
+    missing one here, which is fine: both are "not populated".
+    """
+    node: object = data
+    for segment in dotted.split("."):
+        if not isinstance(node, dict) or segment not in node:
+            return None
+        node = node[segment]
+    return node
+
+
+def _is_populated(value: object) -> bool:
+    """Whether *value* counts as filled in for publish purposes.
+
+    A string is populated only if it has non-whitespace content (folded YAML
+    scalars can leave a bare newline); a list/mapping must be non-empty; a
+    number (the EPSG code) is populated when nonzero. ``None`` is never
+    populated.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) > 0
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    return True
+
+
+def missing_release_defaults(data: dict) -> list[str]:
+    """Return the dotted paths in :data:`REQUIRED_POPULATED_PATHS` left empty.
+
+    Pure inspection -- no I/O, no raising. An empty list means every
+    publish-required field is populated. Used by both the publish pre-flight
+    (which raises on a non-empty result) and the read-only dry-run report
+    (which surfaces it without failing).
+    """
+    return [
+        p for p in REQUIRED_POPULATED_PATHS if not _is_populated(_resolve_path(data, p))
+    ]
+
+
+def require_populated_release_defaults(
+    data: dict, *, source: str = "release_defaults.yml"
+) -> None:
+    """Raise ``ValueError`` if any publish-required default is unpopulated.
+
+    The hard "fully populated" gate the module docstring defers to publish
+    time. Distinct from :func:`validate_release_defaults` (shape only): this
+    fails when a required field is *present-but-empty*, which the loader
+    deliberately tolerates so a half-filled scaffold can still build/dry-run.
+
+    Raises
+    ------
+    ValueError
+        One or more paths in :data:`REQUIRED_POPULATED_PATHS` are empty; the
+        message lists every empty path so an operator fills them in one pass.
+    """
+    missing = missing_release_defaults(data)
+    if missing:
+        raise ValueError(
+            f"{source}: release defaults are not fully populated; publishing "
+            f"would emit incomplete metadata. Fill in: {missing}."
+        )
 
 
 def load_release_defaults(path: Path | None = None) -> dict:

--- a/src/nhf_spatial_targets/release/dry_run.py
+++ b/src/nhf_spatial_targets/release/dry_run.py
@@ -1,0 +1,200 @@
+"""Read-only dry-run report for a ScienceBase release.
+
+A dry run answers "what *would* publishing do, and is the payload valid?"
+without touching ScienceBase. It:
+
+1. runs the offline build (idempotent) for the requested scope,
+2. validates each rendered ``fgdc.xml`` with the USGS Metadata Parser
+   (:func:`~nhf_spatial_targets.release.validate_xml.validate_xml_file`),
+   which warns -- rather than fails -- when ``mp`` is absent, and
+3. queries ScienceBase **read-only** (via the injected client, reusing
+   :func:`~nhf_spatial_targets.release.publish.diff_local_vs_remote`) for a
+   parity check: would each item be created, or does it already exist / drift?
+
+It writes nothing to ScienceBase. It returns a structured :class:`DryRunReport`
+(so the CLI and tests can assert on it without scraping the rendered table) and,
+unless suppressed, prints a Rich summary table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+
+from nhf_spatial_targets.release import publish
+from nhf_spatial_targets.release.build import BuildResult, BuildScope, build_all
+from nhf_spatial_targets.release.publish import ScopeDiff
+from nhf_spatial_targets.release.sb_client import SbClient
+from nhf_spatial_targets.release.validate_xml import MpResult, validate_xml_file
+from nhf_spatial_targets.workspace import Project
+
+
+@dataclass(frozen=True)
+class DryRunItem:
+    """One item's dry-run findings: payload size, mp result, and SB parity."""
+
+    scope: str
+    key: str | None
+    sb_id: str | None
+    file_count: int
+    total_bytes: int
+    mp: MpResult
+    diff: ScopeDiff
+
+    @property
+    def label(self) -> str:
+        return self.scope if self.key is None else f"{self.scope}/{self.key}"
+
+    @property
+    def mp_status(self) -> str:
+        """``"ok"`` / ``"warn"`` / ``"err"`` from the mp result."""
+        if self.mp.errors:
+            return "err"
+        if self.mp.warnings:
+            return "warn"
+        return "ok"
+
+    @property
+    def remote_label(self) -> str:
+        """ScienceBase parity word: ``exists`` / ``drift`` / ``missing``."""
+        return "exists" if self.diff.remote == "present" else self.diff.remote
+
+
+@dataclass(frozen=True)
+class DryRunReport:
+    """The structured result of a dry run; ``items`` in build order."""
+
+    items: tuple[DryRunItem, ...]
+
+    @property
+    def ok(self) -> bool:
+        """True when every item's FGDC XML validated without mp errors."""
+        return all(not item.mp.errors for item in self.items)
+
+    @property
+    def would_create(self) -> tuple[DryRunItem, ...]:
+        return tuple(i for i in self.items if i.diff.remote == "missing")
+
+
+def _payload_size(build_result: BuildResult) -> tuple[int, int]:
+    """Return (file_count, total_bytes) of everything publish would upload.
+
+    ``BuildResult.entries`` covers every staged file except the two integrity
+    manifests; add those so the count matches the real upload set.
+    """
+    count = len(build_result.entries)
+    total = sum(e.size for e in build_result.entries)
+    for extra in ("checksums.csv", "SHA256SUMS"):
+        path = build_result.stage_dir / extra
+        if path.exists():
+            count += 1
+            total += path.stat().st_size
+    return count, total
+
+
+def _human_bytes(num: int) -> str:
+    value = float(num)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TiB"  # unreachable; satisfies the type checker
+
+
+def _render_table(report: DryRunReport, console: Console) -> None:
+    table = Table(title="ScienceBase release dry run")
+    table.add_column("scope")
+    table.add_column("ScienceBase id")
+    table.add_column("files", justify="right")
+    table.add_column("size", justify="right")
+    table.add_column("mp")
+    table.add_column("sb")
+    for item in report.items:
+        table.add_row(
+            item.label,
+            item.sb_id or "would create",
+            str(item.file_count),
+            _human_bytes(item.total_bytes),
+            item.mp_status,
+            item.remote_label,
+        )
+    console.print(table)
+
+
+def dry_run(
+    project: Project,
+    client: SbClient,
+    *,
+    scope: BuildScope = "fabric",
+    now: datetime | None = None,
+    registry_path: Path | None = None,
+    console: Console | None = None,
+    render: bool = True,
+) -> DryRunReport:
+    """Build, validate, and read-only-diff the requested scope; report findings.
+
+    Parameters
+    ----------
+    project, client
+        The project to report on and an already-constructed (mock or live)
+        ScienceBase client. Only read-only client methods are called.
+    scope
+        ``"fabric"`` (default), ``"sources"``, or ``"all"`` -- the same scope
+        vocabulary as :func:`~nhf_spatial_targets.release.build.build_all`.
+    now
+        Injectable build clock (keeps rendered metadata deterministic in tests).
+    registry_path
+        Registry file path (tests pass a tmp path); defaults to the committed
+        registry.
+    console, render
+        ``console`` overrides the output target (e.g. a captured console);
+        ``render=False`` suppresses printing entirely (the report is still
+        returned). Neither affects what is queried.
+
+    Returns
+    -------
+    DryRunReport
+        One :class:`DryRunItem` per built item, in build order. **No ScienceBase
+        writes occur.**
+    """
+    build_results = build_all(project, scope=scope, now=now)
+    diffs = {
+        (d.scope, d.key): d
+        for d in publish.diff_local_vs_remote(
+            project, client, scope=scope, registry_path=registry_path
+        )
+    }
+
+    items: list[DryRunItem] = []
+    for result in build_results:
+        diff = diffs.get((result.kind, result.key))
+        if diff is None:
+            # Defensive: build and diff enumerate the same scope set, so a build
+            # result without a matching diff means the two drifted -- surface it
+            # rather than silently dropping the item from the report.
+            raise RuntimeError(
+                f"dry-run: built {result.kind}/{result.key} has no matching "
+                f"ScienceBase diff; build and diff scope enumeration disagree."
+            )
+        mp = validate_xml_file(result.stage_dir / "fgdc.xml")
+        file_count, total_bytes = _payload_size(result)
+        items.append(
+            DryRunItem(
+                scope=result.kind,
+                key=result.key,
+                sb_id=diff.sb_id,
+                file_count=file_count,
+                total_bytes=total_bytes,
+                mp=mp,
+                diff=diff,
+            )
+        )
+
+    report = DryRunReport(items=tuple(items))
+    if render:
+        _render_table(report, console or Console())
+    return report

--- a/src/nhf_spatial_targets/release/dry_run.py
+++ b/src/nhf_spatial_targets/release/dry_run.py
@@ -27,7 +27,7 @@ from rich.table import Table
 
 from nhf_spatial_targets.release import publish
 from nhf_spatial_targets.release.build import BuildResult, BuildScope, build_all
-from nhf_spatial_targets.release.publish import ScopeDiff
+from nhf_spatial_targets.release.publish import Scope, ScopeDiff
 from nhf_spatial_targets.release.sb_client import SbClient
 from nhf_spatial_targets.release.validate_xml import MpResult, validate_xml_file
 from nhf_spatial_targets.workspace import Project
@@ -37,7 +37,7 @@ from nhf_spatial_targets.workspace import Project
 class DryRunItem:
     """One item's dry-run findings: payload size, mp result, and SB parity."""
 
-    scope: str
+    scope: Scope
     key: str | None
     sb_id: str | None
     file_count: int

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -27,8 +27,8 @@ Per-item sequence (mirrors the plan's idempotency matrix)::
     6. record                         registry.put_* (flock read-merge-write)
 
 **The MD5 decision (per the plan).** ScienceBase records uploaded-file
-checksums as **MD5**, not SHA-256 (verified in sciencebasepy 2.0.22
-``SbSession._replace_file``), and
+checksums as **MD5**, not SHA-256 (sciencebasepy's
+``SbSession._replace_file`` stamps ``checksum = {'type': 'MD5', ...}``), and
 :meth:`SbClient.upload_file`'s ``skip_if_sha256_matches`` does plain
 value-equality against the remote file's recorded ``checksum.value``. The
 skip-if-unchanged fast path therefore computes the **local file's MD5** and
@@ -72,7 +72,7 @@ from nhf_spatial_targets.release.build import (
     build_source_child,
     build_umbrella,
 )
-from nhf_spatial_targets.release.checksums import verify_csv
+from nhf_spatial_targets.release.checksums import ChecksumMismatch, verify_csv
 from nhf_spatial_targets.release.defaults import (
     load_release_defaults,
     require_populated_release_defaults,
@@ -132,7 +132,10 @@ class PublishResult:
     remote files no longer in the staged payload; ``orphans_deleted`` is the
     subset actually removed (only with ``delete_orphans``). ``body_patched``
     lists the item-body fields changed on update (empty on create).
-    ``registry_entry`` is the merged record written back to the registry.
+    ``registry_entry`` is a shallow snapshot of the merged record written back
+    to the registry (a plain dict because its shape varies by scope -- umbrella
+    carries version/doi, children carry file_count/total_bytes); treat it as
+    read-only even though this dataclass is frozen.
     """
 
     scope: Scope
@@ -146,6 +149,16 @@ class PublishResult:
     orphans_deleted: tuple[str, ...]
     body_patched: tuple[str, ...]
     registry_entry: dict
+
+    def __post_init__(self) -> None:
+        # The umbrella is keyless; source/fabric children always carry a key.
+        # Same invariant BuildResult guards -- enforced here so a future second
+        # producer (the PR-F CLI / status command) can't construct a mismatch.
+        if (self.scope == "umbrella") != (self.key is None):
+            raise ValueError(
+                f"{self.scope!r} key invariant violated: umbrella must have "
+                f"key=None and source/fabric a non-None key; got key={self.key!r}."
+            )
 
 
 LocalStatus = Literal["built", "stale", "missing"]
@@ -171,6 +184,13 @@ class ScopeDiff:
     remote: RemoteStatus
     detail: str | None = None
 
+    def __post_init__(self) -> None:
+        if (self.scope == "umbrella") != (self.key is None):
+            raise ValueError(
+                f"{self.scope!r} key invariant violated: umbrella must have "
+                f"key=None and source/fabric a non-None key; got key={self.key!r}."
+            )
+
 
 # ---------------------------------------------------------------------------
 # Small pure helpers
@@ -190,20 +210,33 @@ def _file_md5(path: Path) -> str:
     return h.hexdigest()
 
 
-def _is_not_found(exc: BaseException) -> bool:
-    """Best-effort "ScienceBase says this id does not exist" classifier.
+# sciencebasepy wraps a missing item in a bare ``Exception`` whose text is
+# either ``"Resource not found"`` or the catch-all ``"Other HTTP error: 404:
+# ..."`` (mirrors ``sb_client._OTHER_HTTP_ERROR_RE``). Matching only these
+# recognized shapes -- never a bare "not found" substring or a "404" appearing
+# anywhere in a 5xx body -- keeps a non-404 error from being mistaken for a
+# missing item, which under ``create_new`` would wrongly mint a duplicate.
+_RESOURCE_NOT_FOUND_MARKER = "resource not found"
+_HTTP_ERROR_CODE_RE = re.compile(r"Other HTTP error:\s*(\d{3})")
 
-    sciencebasepy surfaces a missing item as a bare ``Exception`` whose text is
-    ``"Resource not found"`` or ``"Other HTTP error: 404: ..."``; a
-    ``requests``-level error carries ``response.status_code == 404``.
+
+def _is_not_found(exc: BaseException) -> bool:
+    """Whether *exc* is ScienceBase reporting that an id does not exist.
+
+    Recognizes a ``requests``-level ``response.status_code == 404``, the
+    literal ``"Resource not found"`` marker, and the
+    ``"Other HTTP error: 404"`` catch-all form -- and deliberately nothing
+    looser, so a 5xx whose body merely contains the words "not found" or "404"
+    is not misread as a missing item.
     """
     response = getattr(exc, "response", None)
     if getattr(response, "status_code", None) == 404:
         return True
-    message = str(exc).lower()
-    if "not found" in message:
+    message = str(exc)
+    if _RESOURCE_NOT_FOUND_MARKER in message.lower():
         return True
-    return bool(re.search(r"\b404\b", message))
+    match = _HTTP_ERROR_CODE_RE.search(message)
+    return bool(match and match.group(1) == "404")
 
 
 @dataclass(frozen=True)
@@ -385,6 +418,12 @@ def _resolve_target(
             raise
         if not item:
             if create_new:
+                logger.warning(
+                    "publish: registry %s sb_id=%s returned an empty item; "
+                    "create_new set -- minting a fresh item.",
+                    scope if key is None else f"{scope}/{key}",
+                    sb_id,
+                )
                 return ("create", None, None, False)
             raise _stale_registry_error(scope, key, sb_id)
         return ("update", sb_id, item, False)
@@ -417,7 +456,10 @@ def _upload_payload(
     """Upload each payload file, skipping ones whose remote MD5 already matches.
 
     On create the item has no files, so nothing skips and every file uploads --
-    same code path as update.
+    same code path as update. Each transfer is logged at INFO before the next
+    so that a mid-loop failure (a multi-GB child can be many files) leaves a
+    record of how far the upload got -- the propagated exception aborts before
+    the aggregate summary in :func:`_reconcile_and_publish` would run.
     """
     uploaded: list[str] = []
     skipped: list[str] = []
@@ -425,7 +467,12 @@ def _upload_payload(
         result = client.upload_file(
             sb_id, pf.abs_path, skip_if_sha256_matches=_file_md5(pf.abs_path)
         )
-        (skipped if result.skipped else uploaded).append(pf.name)
+        if result.skipped:
+            skipped.append(pf.name)
+            logger.info("publish: skipped %s on %s (checksum match)", pf.name, sb_id)
+        else:
+            uploaded.append(pf.name)
+            logger.info("publish: uploaded %s to %s", pf.name, sb_id)
     return uploaded, skipped
 
 
@@ -524,9 +571,16 @@ def _reconcile_and_publish(
         orphans = tuple(sorted(set(_remote_files(remote_item)) - staged_names))
         if orphans:
             if delete_orphans:
+                # Deletes are destructive and the registry is only re-stamped
+                # after the whole loop, so log each one as it lands -- a
+                # mid-loop failure then leaves a trail of what was removed
+                # rather than silent, un-recoverable divergence.
+                deleted: list[str] = []
                 for name in orphans:
                     client.delete_file(sb_id, name)
-                orphans_deleted = orphans
+                    deleted.append(name)
+                    logger.info("publish: deleted orphan %s from %s", name, sb_id)
+                orphans_deleted = tuple(deleted)
             else:
                 logger.warning(
                     "publish: %s has %d orphan file(s) on ScienceBase not in the "
@@ -695,9 +749,11 @@ def _local_status(stage_dir: Path) -> LocalStatus:
         return "missing"
     try:
         verify_csv(stage_dir)
-    except Exception:
-        # ChecksumMismatch (drift / unlisted / missing file) or a dangling
-        # symlink: the stage exists but is not a clean, complete payload.
+    except (ChecksumMismatch, FileNotFoundError, OSError):
+        # Genuine drift / unlisted / missing-file, or a dangling symlink: the
+        # stage exists but is not a clean, complete payload. A narrow catch --
+        # a programming error inside verify_csv must surface loudly, not be
+        # reported to the operator as benign "stale".
         return "stale"
     return "built"
 

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -1,0 +1,808 @@
+"""Idempotent publish orchestration for the ScienceBase data release.
+
+This module composes the offline build (:mod:`~nhf_spatial_targets.release.build`)
+with the registry (:mod:`~nhf_spatial_targets.release.registry`, publish *intent*)
+and the ScienceBase client (:mod:`~nhf_spatial_targets.release.sb_client`, what
+actually *exists*) into the create-vs-update reconciliation that publishes one
+umbrella / source-child / fabric-child item and records the result.
+
+**Dependency injection.** Every ``publish_*`` takes an already-constructed
+:class:`~nhf_spatial_targets.release.sb_client.SbClient`. Resolving credentials
+and building a real session is PR-G's job; here the client is assumed ready, so
+the whole module is offline-testable against a mock client (the mock patterns
+in ``tests/test_release_sb_client_offline.py``).
+
+Per-item sequence (mirrors the plan's idempotency matrix)::
+
+    1. pre-flight (cheap, fail-fast)  manifest present+parses, release_defaults
+                                      populated, config authors non-empty, and
+                                      -- for a child -- the umbrella sb_id is known
+    2. build (idempotent)             build.build_*()  -> BuildResult
+    3. verify staged checksums        checksums.verify_csv() (ChecksumMismatch)
+    4. reconcile intent vs reality    registry sb_id? -> get_item (404 => stale,
+                                      fatal unless create_new); else find_child by
+                                      title -> one adopts / zero creates / many fail
+    5. create or update               create_item+upload all, or patch changed
+                                      body fields + per-file skip/replace + orphans
+    6. record                         registry.put_* (flock read-merge-write)
+
+**The MD5 decision (per the plan).** ScienceBase records uploaded-file
+checksums as **MD5**, not SHA-256 (verified in sciencebasepy 2.0.22
+``SbSession._replace_file``), and
+:meth:`SbClient.upload_file`'s ``skip_if_sha256_matches`` does plain
+value-equality against the remote file's recorded ``checksum.value``. The
+skip-if-unchanged fast path therefore computes the **local file's MD5** and
+passes *that* (option (a) in the plan): a genuine content match -- local MD5
+== remote MD5 -- skips the byte transfer, and any mismatch re-uploads. The
+comparison is honest in both directions: an MD5 hex string (32 chars) can
+never equal a SHA-256 (64 chars), so if a remote file ever records a SHA-256
+the local MD5 simply won't match and the file re-uploads -- correct, just not
+skipped. We pass MD5 through the (SHA-256-named) parameter rather than
+extending the merged PR-E2 primitive: the "what checksum does ScienceBase
+actually use" knowledge belongs in this orchestration layer.
+
+**Flat ScienceBase namespace.** A staged payload is a nested tree
+(``aggregated/<source>/<nc>``, ``targets/<nc>``), but a ScienceBase item holds
+a flat ``files`` list keyed by basename. :func:`_payload_files` raises if two
+staged files collapse to the same basename, rather than letting one silently
+overwrite the other on upload.
+
+**``manifest_sha256`` in the registry** is the SHA-256 of the staged
+``SHA256SUMS`` file -- a single fingerprint of the *entire* payload that exists
+for every child (a source child stages no ``manifest.json``). Its content is
+the sorted ``<sha256>  <path>`` list, so the fingerprint changes iff any file's
+content or the file set changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from nhf_spatial_targets.release import registry
+from nhf_spatial_targets.release._models import ReleaseError
+from nhf_spatial_targets.release.build import (
+    BuildResult,
+    build_fabric_child,
+    build_source_child,
+    build_umbrella,
+)
+from nhf_spatial_targets.release.checksums import verify_csv
+from nhf_spatial_targets.release.defaults import (
+    load_release_defaults,
+    require_populated_release_defaults,
+)
+from nhf_spatial_targets.release.lineage import read_manifest, sha256_file
+from nhf_spatial_targets.release.payload import resolve_fabric_label, sources_used
+from nhf_spatial_targets.release.sb_client import SbClient, SbClientError
+from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
+
+Scope = Literal["umbrella", "source", "fabric"]
+PublishMode = Literal["create", "update"]
+
+# Item-body fields this layer manages on a ScienceBase item. The rich FGDC /
+# ISO metadata travels as uploaded *files* (fgdc.xml / iso.xml); the item JSON
+# itself carries only the landing-page title + descriptions. `title` MUST equal
+# the MCF title so a re-publish can re-adopt the item via find_child.
+_BODY_FIELDS: tuple[str, ...] = ("title", "summary", "body")
+
+_MD5_CHUNK_BYTES = 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class PreflightError(ReleaseError):
+    """A fatal pre-flight gate failed; nothing was published."""
+
+
+class StaleRegistryError(ReleaseError):
+    """The registry names a ScienceBase id that the server reports as gone.
+
+    The recorded ``sb_id`` resolves to not-found on ScienceBase -- the item was
+    deleted, or the id is stale. Publishing escapes this with ``create_new`` to
+    mint a fresh item (and overwrite the registry id); otherwise it is fatal so
+    a typo or a deleted item can't silently fork a second copy.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Typed result records (orchestration boundary)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Outcome of publishing one item.
+
+    ``key`` is the source key / fabric label, ``None`` for the umbrella.
+    ``mode`` is ``"create"`` or ``"update"``; ``adopted`` is True when an
+    existing same-title item was adopted (a registry entry without an sb_id
+    matched a child by title). ``uploaded`` / ``skipped`` are the basenames of
+    files sent vs skipped (remote checksum already matched). ``orphans`` are
+    remote files no longer in the staged payload; ``orphans_deleted`` is the
+    subset actually removed (only with ``delete_orphans``). ``body_patched``
+    lists the item-body fields changed on update (empty on create).
+    ``registry_entry`` is the merged record written back to the registry.
+    """
+
+    scope: Scope
+    key: str | None
+    sb_id: str
+    mode: PublishMode
+    adopted: bool
+    uploaded: tuple[str, ...]
+    skipped: tuple[str, ...]
+    orphans: tuple[str, ...]
+    orphans_deleted: tuple[str, ...]
+    body_patched: tuple[str, ...]
+    registry_entry: dict
+
+
+LocalStatus = Literal["built", "stale", "missing"]
+RemoteStatus = Literal["present", "drift", "missing"]
+
+
+@dataclass(frozen=True)
+class ScopeDiff:
+    """Read-only intent-vs-reality diff for one item (status / dry-run).
+
+    ``local`` reflects the staged payload on disk: ``built`` (checksums
+    verify), ``stale`` (staged but checksums drifted / incomplete), or
+    ``missing`` (not built). ``remote`` reflects ScienceBase: ``present``
+    (item exists and its files match the staged payload), ``drift`` (item
+    exists but files differ), or ``missing`` (not in the registry, or the
+    registry id is stale). ``detail`` carries a human-readable note.
+    """
+
+    scope: Scope
+    key: str | None
+    sb_id: str | None
+    local: LocalStatus
+    remote: RemoteStatus
+    detail: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Small pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso(now: datetime | None) -> str:
+    return (now if now is not None else datetime.now(timezone.utc)).isoformat()
+
+
+def _file_md5(path: Path) -> str:
+    """Streamed MD5 hex digest of *path* (ScienceBase's native checksum)."""
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(_MD5_CHUNK_BYTES), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _is_not_found(exc: BaseException) -> bool:
+    """Best-effort "ScienceBase says this id does not exist" classifier.
+
+    sciencebasepy surfaces a missing item as a bare ``Exception`` whose text is
+    ``"Resource not found"`` or ``"Other HTTP error: 404: ..."``; a
+    ``requests``-level error carries ``response.status_code == 404``.
+    """
+    response = getattr(exc, "response", None)
+    if getattr(response, "status_code", None) == 404:
+        return True
+    message = str(exc).lower()
+    if "not found" in message:
+        return True
+    return bool(re.search(r"\b404\b", message))
+
+
+@dataclass(frozen=True)
+class _PayloadFile:
+    """One file to upload: absolute path, ScienceBase basename, size."""
+
+    abs_path: Path
+    name: str
+    rel: str
+    size: int
+
+
+def _payload_files(result: BuildResult) -> list[_PayloadFile]:
+    """The full upload set for *result*, sorted, with a flat-name collision guard.
+
+    ``result.entries`` already fingerprints every staged file except the two
+    integrity manifests (``checksums.csv`` / ``SHA256SUMS``), which are added
+    here so the published item carries them too. Two staged files that share a
+    basename would collide in ScienceBase's flat namespace, so that is a loud
+    failure rather than a silent overwrite.
+    """
+    stage = result.stage_dir
+    rels = [e.path for e in result.entries]
+    for extra in ("checksums.csv", "SHA256SUMS"):
+        if (stage / extra).exists():
+            rels.append(extra)
+
+    files: list[_PayloadFile] = []
+    by_name: dict[str, str] = {}
+    for rel in sorted(set(rels)):
+        path = stage / rel
+        name = path.name
+        if name in by_name:
+            raise ReleaseError(
+                f"two staged files collapse to the ScienceBase file name "
+                f"{name!r}: {by_name[name]!r} and {rel!r}. ScienceBase stores "
+                f"files in a flat namespace; rename one before publishing."
+            )
+        by_name[name] = rel
+        files.append(
+            _PayloadFile(abs_path=path, name=name, rel=rel, size=path.stat().st_size)
+        )
+    return files
+
+
+def _remote_files(item: dict | None) -> dict[str, int | None]:
+    """Map ScienceBase file ``name`` -> ``size`` across ``files`` + facets."""
+    out: dict[str, int | None] = {}
+    if not item:
+        return out
+    for entry in item.get("files") or []:
+        out[entry["name"]] = entry.get("size")
+    for facet in item.get("facets") or []:
+        for entry in facet.get("files") or []:
+            out[entry["name"]] = entry.get("size")
+    return out
+
+
+def _item_body(mcf: dict) -> dict:
+    """Derive the managed ScienceBase item body from an MCF dict.
+
+    ``title`` must equal the MCF title (find_child adopts by exact title);
+    ``body`` is the abstract; ``summary`` is the concise purpose (abstract as a
+    fallback). The full FGDC/ISO record rides along as uploaded files, not item
+    JSON fields.
+    """
+    ident = mcf.get("identification", {})
+    abstract = ident.get("abstract", "")
+    return {
+        "title": ident.get("title", ""),
+        "body": abstract,
+        "summary": ident.get("purpose") or abstract,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight gates
+# ---------------------------------------------------------------------------
+
+
+def _preflight_common(project: Project) -> None:
+    """Fatal, cheap, fail-fast checks shared by every publish scope.
+
+    Credential resolvability is intentionally *not* checked here: PR-E3 assumes
+    a ready, injected client (the credential/session wiring is PR-G).
+    """
+    manifest_path = project.manifest_path
+    if not manifest_path.exists():
+        raise PreflightError(
+            f"manifest.json not found at {manifest_path}; run validate / aggregate "
+            f"before publishing (the release lineage and source list come from it)."
+        )
+    try:
+        read_manifest(manifest_path)
+    except ValueError as exc:
+        raise PreflightError(
+            f"manifest.json at {manifest_path} is unreadable: {exc}"
+        ) from exc
+
+    try:
+        require_populated_release_defaults(load_release_defaults())
+    except (ValueError, FileNotFoundError) as exc:
+        raise PreflightError(str(exc)) from exc
+
+    authors = (project.config.get("release") or {}).get("authors") or []
+    if not authors:
+        raise PreflightError(
+            "config.yml release.authors is empty; add at least one author "
+            "(given/family) before publishing."
+        )
+
+
+def _require_umbrella_sb_id(registry_path: Path | None) -> str:
+    """Return the umbrella sb_id or raise -- a child can't be parented without it.
+
+    The plan's ``--create-umbrella`` affordance (publish the umbrella and a
+    child in one invocation) is a CLI-level composition (PR-F) of
+    :func:`publish_umbrella` then a child publish; the library keeps the gate
+    single-purpose so a child never silently lands under a missing parent.
+    """
+    umbrella = registry.get_umbrella(registry_path)
+    if not umbrella or not umbrella.get("sb_id"):
+        raise PreflightError(
+            "the umbrella item has no recorded ScienceBase id in the registry; "
+            "publish the umbrella first (publish_umbrella) before a child."
+        )
+    return umbrella["sb_id"]
+
+
+# ---------------------------------------------------------------------------
+# Create-vs-update reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _stale_registry_error(
+    scope: Scope, key: str | None, sb_id: str
+) -> StaleRegistryError:
+    target = scope if key is None else f"{scope}/{key}"
+    return StaleRegistryError(
+        f"the registry records sb_id={sb_id!r} for {target}, but ScienceBase "
+        f"reports it not-found: the item was deleted or the id is stale. "
+        f"Re-publish with create_new=True to mint a new item (the registry id "
+        f"is then overwritten), or restore the registry from git."
+    )
+
+
+def _resolve_target(
+    client: SbClient,
+    reg_entry: dict | None,
+    parent_id: str,
+    title: str,
+    *,
+    create_new: bool,
+    scope: Scope,
+    key: str | None,
+) -> tuple[PublishMode, str | None, dict | None, bool]:
+    """Decide create vs update for one item; return (mode, sb_id, item, adopted).
+
+    Implements the plan's matrix: a registry sb_id is fetched (not-found is
+    fatal unless ``create_new``); without one, an exact-title child is sought
+    under *parent_id* -- one match adopts (update + new sb_id), zero creates,
+    and many is fatal (raised by :meth:`SbClient.find_child`).
+    """
+    if reg_entry and reg_entry.get("sb_id"):
+        sb_id = reg_entry["sb_id"]
+        try:
+            item = client.get_item(sb_id)
+        except Exception as exc:
+            if _is_not_found(exc):
+                if create_new:
+                    logger.warning(
+                        "publish: registry %s sb_id=%s not found on ScienceBase; "
+                        "create_new set -- minting a fresh item.",
+                        scope if key is None else f"{scope}/{key}",
+                        sb_id,
+                    )
+                    return ("create", None, None, False)
+                raise _stale_registry_error(scope, key, sb_id) from exc
+            raise
+        if not item:
+            if create_new:
+                return ("create", None, None, False)
+            raise _stale_registry_error(scope, key, sb_id)
+        return ("update", sb_id, item, False)
+
+    # No recorded sb_id: adopt an existing same-title child, else create.
+    try:
+        match = client.find_child(parent_id, title)
+    except SbClientError:
+        raise  # ambiguous title -- already a contextual ReleaseError
+    except Exception as exc:
+        raise SbClientError(
+            f"failed to enumerate children of {parent_id!r} while searching for a "
+            f"child titled {title!r} to adopt "
+            f"(for {scope if key is None else f'{scope}/{key}'}): {exc}"
+        ) from exc
+    if match is not None:
+        logger.info(
+            "publish: adopting ScienceBase item %s titled %r for %s",
+            match.get("id"),
+            title,
+            scope if key is None else f"{scope}/{key}",
+        )
+        return ("update", match["id"], match, True)
+    return ("create", None, None, False)
+
+
+def _upload_payload(
+    client: SbClient, sb_id: str, payload: list[_PayloadFile]
+) -> tuple[list[str], list[str]]:
+    """Upload each payload file, skipping ones whose remote MD5 already matches.
+
+    On create the item has no files, so nothing skips and every file uploads --
+    same code path as update.
+    """
+    uploaded: list[str] = []
+    skipped: list[str] = []
+    for pf in payload:
+        result = client.upload_file(
+            sb_id, pf.abs_path, skip_if_sha256_matches=_file_md5(pf.abs_path)
+        )
+        (skipped if result.skipped else uploaded).append(pf.name)
+    return uploaded, skipped
+
+
+def _patch_body(
+    client: SbClient, sb_id: str, remote_item: dict, body: dict
+) -> tuple[str, ...]:
+    """Patch only the item-body fields that differ from the remote item."""
+    patch = {k: v for k, v in body.items() if remote_item.get(k) != v}
+    if patch:
+        client.update_item(sb_id, patch)
+    return tuple(sorted(patch))
+
+
+def _registry_get(
+    scope: Scope, key: str | None, registry_path: Path | None
+) -> dict | None:
+    if scope == "umbrella":
+        return registry.get_umbrella(registry_path)
+    if scope == "source":
+        return registry.get_source(key, registry_path)  # type: ignore[arg-type]
+    return registry.get_fabric(key, registry_path)  # type: ignore[arg-type]
+
+
+def _registry_put(
+    scope: Scope,
+    key: str | None,
+    *,
+    sb_id: str,
+    payload: list[_PayloadFile],
+    build_result: BuildResult,
+    title: str,
+    mcf: dict,
+    now: datetime | None,
+    registry_path: Path | None,
+) -> dict:
+    timestamp = _now_iso(now)
+    if scope == "umbrella":
+        version = mcf.get("identification", {}).get("edition", "1.0")
+        doi = mcf.get("identification", {}).get("doi")
+        doi_kwargs = {"doi": doi} if doi else {}
+        return registry.put_umbrella(
+            sb_id=sb_id,
+            version=version,
+            published_utc=timestamp,
+            title=title,
+            path=registry_path,
+            **doi_kwargs,
+        )
+    put = registry.put_source if scope == "source" else registry.put_fabric
+    return put(
+        key,  # type: ignore[arg-type]
+        sb_id=sb_id,
+        uploaded_utc=timestamp,
+        file_count=len(payload),
+        total_bytes=sum(pf.size for pf in payload),
+        manifest_sha256=sha256_file(build_result.stage_dir / "SHA256SUMS"),
+        path=registry_path,
+    )
+
+
+def _reconcile_and_publish(
+    *,
+    client: SbClient,
+    build_result: BuildResult,
+    parent_id: str,
+    scope: Scope,
+    key: str | None,
+    create_new: bool,
+    delete_orphans: bool,
+    now: datetime | None,
+    registry_path: Path | None,
+) -> PublishResult:
+    """Shared create-vs-update body for every publish scope."""
+    mcf = build_result.mcf
+    title = mcf["identification"]["title"]
+    reg_entry = _registry_get(scope, key, registry_path)
+    mode, sb_id, remote_item, adopted = _resolve_target(
+        client, reg_entry, parent_id, title, create_new=create_new, scope=scope, key=key
+    )
+    body = _item_body(mcf)
+    payload = _payload_files(build_result)
+
+    orphans: tuple[str, ...] = ()
+    orphans_deleted: tuple[str, ...] = ()
+    body_patched: tuple[str, ...] = ()
+
+    if mode == "create":
+        created = client.create_item(parent_id, body)
+        sb_id = created["id"]
+        uploaded, skipped = _upload_payload(client, sb_id, payload)
+    else:
+        assert sb_id is not None and remote_item is not None  # set by _resolve_target
+        body_patched = _patch_body(client, sb_id, remote_item, body)
+        uploaded, skipped = _upload_payload(client, sb_id, payload)
+        staged_names = {pf.name for pf in payload}
+        orphans = tuple(sorted(set(_remote_files(remote_item)) - staged_names))
+        if orphans:
+            if delete_orphans:
+                for name in orphans:
+                    client.delete_file(sb_id, name)
+                orphans_deleted = orphans
+            else:
+                logger.warning(
+                    "publish: %s has %d orphan file(s) on ScienceBase not in the "
+                    "staged payload: %s. Re-run with delete_orphans=True to remove.",
+                    scope if key is None else f"{scope}/{key}",
+                    len(orphans),
+                    ", ".join(orphans),
+                )
+
+    entry = _registry_put(
+        scope,
+        key,
+        sb_id=sb_id,
+        payload=payload,
+        build_result=build_result,
+        title=title,
+        mcf=mcf,
+        now=now,
+        registry_path=registry_path,
+    )
+    logger.info(
+        "publish: %s %s sb_id=%s (uploaded=%d skipped=%d orphans=%d)",
+        mode,
+        scope if key is None else f"{scope}/{key}",
+        sb_id,
+        len(uploaded),
+        len(skipped),
+        len(orphans),
+    )
+    return PublishResult(
+        scope=scope,
+        key=key,
+        sb_id=sb_id,
+        mode=mode,
+        adopted=adopted,
+        uploaded=tuple(uploaded),
+        skipped=tuple(skipped),
+        orphans=orphans,
+        orphans_deleted=orphans_deleted,
+        body_patched=body_patched,
+        registry_entry=dict(entry),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public publish entry points
+# ---------------------------------------------------------------------------
+
+
+def publish_umbrella(
+    project: Project,
+    client: SbClient,
+    *,
+    parent_id: str,
+    create_new: bool = False,
+    delete_orphans: bool = False,
+    now: datetime | None = None,
+    registry_path: Path | None = None,
+) -> PublishResult:
+    """Publish (create or update) the metadata-only umbrella under *parent_id*.
+
+    *parent_id* is the ScienceBase community / folder that hosts the release.
+    The version + DOI recorded in the registry follow the built MCF (edition /
+    identification.doi), so an operator-set ``config.release.doi`` flows into
+    the registry on the next publish.
+    """
+    _preflight_common(project)
+    build_result = build_umbrella(project, now=now)
+    verify_csv(build_result.stage_dir)
+    return _reconcile_and_publish(
+        client=client,
+        build_result=build_result,
+        parent_id=parent_id,
+        scope="umbrella",
+        key=None,
+        create_new=create_new,
+        delete_orphans=delete_orphans,
+        now=now,
+        registry_path=registry_path,
+    )
+
+
+def publish_source_child(
+    project: Project,
+    client: SbClient,
+    source_key: str,
+    *,
+    create_new: bool = False,
+    delete_orphans: bool = False,
+    now: datetime | None = None,
+    registry_path: Path | None = None,
+) -> PublishResult:
+    """Publish (create or update) the consolidated-source child for *source_key*.
+
+    Parented under the umbrella item recorded in the registry (a missing
+    umbrella sb_id is a fatal pre-flight error).
+    """
+    _preflight_common(project)
+    parent_id = _require_umbrella_sb_id(registry_path)
+    build_result = build_source_child(project, source_key, now=now)
+    verify_csv(build_result.stage_dir)
+    return _reconcile_and_publish(
+        client=client,
+        build_result=build_result,
+        parent_id=parent_id,
+        scope="source",
+        key=source_key,
+        create_new=create_new,
+        delete_orphans=delete_orphans,
+        now=now,
+        registry_path=registry_path,
+    )
+
+
+def publish_fabric_child(
+    project: Project,
+    client: SbClient,
+    *,
+    create_new: bool = False,
+    delete_orphans: bool = False,
+    now: datetime | None = None,
+    registry_path: Path | None = None,
+) -> PublishResult:
+    """Publish (create or update) the fabric child for *project*.
+
+    Parented under the umbrella item recorded in the registry (a missing
+    umbrella sb_id is a fatal pre-flight error). The registry key is the
+    resolved fabric label.
+    """
+    _preflight_common(project)
+    parent_id = _require_umbrella_sb_id(registry_path)
+    build_result = build_fabric_child(project, now=now)
+    verify_csv(build_result.stage_dir)
+    return _reconcile_and_publish(
+        client=client,
+        build_result=build_result,
+        parent_id=parent_id,
+        scope="fabric",
+        key=build_result.key,
+        create_new=create_new,
+        delete_orphans=delete_orphans,
+        now=now,
+        registry_path=registry_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read-only diff (intent vs reality) -- used by dry-run and status (PR-F)
+# ---------------------------------------------------------------------------
+
+DiffScope = Literal["umbrella", "sources", "fabric", "all"]
+
+
+def _stage_dir(project: Project, scope: Scope, key: str | None) -> Path:
+    root = project.release_build_dir
+    if scope == "umbrella":
+        return root / "umbrella"
+    if scope == "source":
+        return root / "sources" / key  # type: ignore[operator]
+    return root / "fabric" / key  # type: ignore[operator]
+
+
+def _local_status(stage_dir: Path) -> LocalStatus:
+    """Classify the staged payload on disk without rebuilding it."""
+    if not (stage_dir / "checksums.csv").exists():
+        return "missing"
+    try:
+        verify_csv(stage_dir)
+    except Exception:
+        # ChecksumMismatch (drift / unlisted / missing file) or a dangling
+        # symlink: the stage exists but is not a clean, complete payload.
+        return "stale"
+    return "built"
+
+
+def _staged_names_sizes(stage_dir: Path) -> dict[str, int]:
+    """Basename -> size for every regular file under *stage_dir* (read-only).
+
+    Follows symlinks (the size that would upload); dangling links are skipped
+    rather than raised, since this is the read-only diff path. Basename
+    collisions resolve last-wins -- acceptable for an overview (the authoritative
+    guard is in :func:`_payload_files` on the publish path).
+    """
+    out: dict[str, int] = {}
+    for path in stage_dir.rglob("*"):
+        if path.is_symlink() and not path.exists():
+            continue
+        if not path.is_file():
+            continue
+        out[path.name] = path.stat().st_size
+    return out
+
+
+def _remote_status(
+    client: SbClient,
+    reg_entry: dict | None,
+    stage_dir: Path,
+    local: LocalStatus,
+) -> tuple[RemoteStatus, str | None, str | None]:
+    """Classify the ScienceBase side; return (status, sb_id, detail)."""
+    if not reg_entry or not reg_entry.get("sb_id"):
+        return ("missing", None, "no ScienceBase id recorded -- would create")
+    sb_id = reg_entry["sb_id"]
+    try:
+        item = client.get_item(sb_id)
+    except Exception as exc:
+        if _is_not_found(exc):
+            return ("missing", sb_id, "registry sb_id is stale -- item not found")
+        raise
+    if not item:
+        return ("missing", sb_id, "registry sb_id is stale -- item not found")
+    if local == "missing":
+        return ("present", sb_id, "item exists; local payload not built for comparison")
+
+    staged = _staged_names_sizes(stage_dir)
+    remote = _remote_files(item)
+    missing_remote = sorted(set(staged) - set(remote))
+    extra_remote = sorted(set(remote) - set(staged))
+    size_drift = sorted(
+        name
+        for name in set(staged) & set(remote)
+        if remote[name] is not None and remote[name] != staged[name]
+    )
+    if missing_remote or extra_remote or size_drift:
+        parts = []
+        if missing_remote:
+            parts.append(f"not on ScienceBase: {missing_remote}")
+        if extra_remote:
+            parts.append(f"orphaned on ScienceBase: {extra_remote}")
+        if size_drift:
+            parts.append(f"size differs: {size_drift}")
+        return ("drift", sb_id, "; ".join(parts))
+    return ("present", sb_id, None)
+
+
+def _diff_one(
+    project: Project,
+    client: SbClient,
+    scope: Scope,
+    key: str | None,
+    registry_path: Path | None,
+) -> ScopeDiff:
+    stage_dir = _stage_dir(project, scope, key)
+    local = _local_status(stage_dir)
+    reg_entry = _registry_get(scope, key, registry_path)
+    remote, sb_id, detail = _remote_status(client, reg_entry, stage_dir, local)
+    return ScopeDiff(
+        scope=scope, key=key, sb_id=sb_id, local=local, remote=remote, detail=detail
+    )
+
+
+def diff_local_vs_remote(
+    project: Project,
+    client: SbClient,
+    *,
+    scope: DiffScope = "all",
+    registry_path: Path | None = None,
+) -> list[ScopeDiff]:
+    """Read-only intent-vs-reality diff for the requested scope(s).
+
+    Does **not** build or write anything: it inspects the existing stage dirs
+    (built / stale / missing), the registry (recorded sb_ids), and ScienceBase
+    (present / drift / missing) via the injected client. Source children come
+    from :func:`payload.sources_used` and the fabric label from
+    :func:`payload.resolve_fabric_label`, so the scope set is catalog- /
+    project-driven, never hard-coded.
+    """
+    diffs: list[ScopeDiff] = []
+    if scope in ("fabric", "all"):
+        label = resolve_fabric_label(project)
+        diffs.append(_diff_one(project, client, "fabric", label, registry_path))
+    if scope in ("sources", "all"):
+        for source_key in sources_used(project):
+            diffs.append(
+                _diff_one(project, client, "source", source_key, registry_path)
+            )
+    if scope in ("umbrella", "all"):
+        diffs.append(_diff_one(project, client, "umbrella", None, registry_path))
+    return diffs

--- a/src/nhf_spatial_targets/release/sb_client.py
+++ b/src/nhf_spatial_targets/release/sb_client.py
@@ -37,6 +37,8 @@ from typing import Any, Callable
 
 import requests
 
+from nhf_spatial_targets.release._models import ReleaseError
+
 logger = logging.getLogger(__name__)
 
 # HTTP statuses worth retrying: 429 (rate limit) + the transient 5xx family.
@@ -51,12 +53,13 @@ _TOO_MANY_REQUESTS_MARKER = "Too many requests"
 _OTHER_HTTP_ERROR_RE = re.compile(r"Other HTTP error:\s*(\d{3})")
 
 
-class SbClientError(RuntimeError):
+class SbClientError(ReleaseError):
     """Raised for client-side conditions the wrapper itself detects.
 
     Distinct from the transport errors raised by sciencebasepy/requests: this
     signals a logical problem the caller must resolve (e.g. an ambiguous title
-    match), not a transient failure to retry.
+    match), not a transient failure to retry. A :class:`ReleaseError` subclass
+    so the orchestration layer can catch all release-layer errors uniformly.
     """
 
 
@@ -367,3 +370,16 @@ class SbClient:
             self._session.upload_file_to_item, item, str(path), scrape_file
         )
         return UploadResult(skipped=False, name=path.name, item=updated)
+
+    def delete_file(self, sb_id: str, name: str) -> dict:
+        """Delete every file named *name* from item *sb_id*; return its JSON.
+
+        Fetches the item, then dispatches to
+        :meth:`sciencebasepy.SbSession.delete_file`, which drops all matching
+        entries from both the top-level ``files`` list and any facet ``files``
+        lists and PUTs the trimmed item back. Used by the publish layer's
+        ``--delete-orphans`` path to remove files left on a ScienceBase item
+        that the current staged payload no longer contains.
+        """
+        item = self._call(self._session.get_item, sb_id)
+        return self._call(self._session.delete_file, name, item)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,10 @@ with the ``_home`` parameter rather than relying on module-level patching.
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -21,6 +24,8 @@ import pandas as pd
 import pytest
 import xarray as xr
 import yaml
+
+from nhf_spatial_targets.workspace import Project
 
 
 @pytest.fixture()
@@ -93,3 +98,209 @@ def make_minimal_project(tmp_path, fabric_path: str | None = None):
     )
     (workdir / "fabric.json").write_text(json.dumps({"id_col": "nhm_id"}))
     return workdir
+
+
+# ---------------------------------------------------------------------------
+# Release publish/dry-run test helpers (PR-E3)
+# ---------------------------------------------------------------------------
+
+# A populated author list satisfies the publish pre-flight; tests pass
+# ``authors=[]`` to exercise the empty-authors gate.
+DEFAULT_RELEASE_AUTHORS = [
+    {"given": "Jane", "family": "Doe", "affiliation": "U.S. Geological Survey"}
+]
+
+
+def build_release_project(
+    tmp_path,
+    *,
+    fabric_label: str = "gfv_test",
+    authors: list | None = None,
+    with_manifest: bool = True,
+) -> Project:
+    """Synthesize a release-ready ``Project`` on disk for publish/dry-run tests.
+
+    Mirrors tests/test_release_build.py's project fixture (publishable
+    era5_land kept, watergap22d excluded, daymet metadata-only) and adds the
+    knobs the publish pre-flight exercises: ``authors`` (``[]`` triggers the
+    empty-authors gate) and ``with_manifest`` (``False`` removes manifest.json
+    to trigger the missing-manifest gate).
+    """
+    workdir = tmp_path / "proj"
+    datastore = tmp_path / "store"
+    fabric_file = tmp_path / "fab" / "gfv_test.gpkg"
+    fabric_file.parent.mkdir(parents=True, exist_ok=True)
+    fabric_file.write_bytes(b"GPKG-bytes")
+
+    def _touch(path: Path, content: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+    agg = workdir / "data" / "aggregated"
+    _touch(agg / "era5_land" / "era5_land_1980_agg.nc", b"era5-1980")
+    _touch(agg / "watergap22d" / "watergap22d_1980_agg.nc", b"wg-held")
+    _touch(agg / "daymet" / "daymet_na_1980_agg.nc", b"daymet-1980")
+    _touch(workdir / "targets" / "runoff_targets.nc", b"runoff")
+    _touch(workdir / "targets" / "aet_targets.nc", b"aet")
+
+    _touch(datastore / "era5_land" / "daily" / "era5_land_daily_1980.nc", b"d-1980")
+    _touch(datastore / "era5_land" / "monthly" / "era5_land_monthly_1980.nc", b"m-1980")
+    _touch(datastore / "daymet" / "daymet_consolidated.nc", b"should-not-stage")
+
+    if with_manifest:
+        (workdir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "sources": {"era5_land": {}, "watergap22d": {}},
+                    "steps": [
+                        {
+                            "kind": "aggregate",
+                            "source_key": "era5_land",
+                            "timestamp_utc": "2026-01-02T03:04:05+00:00",
+                            "software_version": "0.7.0",
+                            "tool": "nhf-targets",
+                            "command": "agg era5-land",
+                            "inputs": [],
+                            "outputs": [],
+                            "params": {"method": "area_weighted"},
+                        }
+                    ],
+                }
+            )
+        )
+
+    config = {
+        "fabric": {"path": str(fabric_file), "id_col": "nhm_id"},
+        "release": {
+            "authors": DEFAULT_RELEASE_AUTHORS if authors is None else authors,
+            "fabric_label": fabric_label,
+            "doi": None,
+            "abstract_notes": "Synthetic project for publish tests.",
+            "ipds_number": "IP-123456",
+        },
+        "targets": {
+            "runoff": {"enabled": True, "period": "1980/2020"},
+            "aet": {"enabled": True, "period": "2000/2010"},
+        },
+    }
+    fabric = {
+        "path": str(fabric_file),
+        "bbox": {"minx": -125.0, "miny": 24.0, "maxx": -66.0, "maxy": 53.0},
+        "hru_count": 4242,
+    }
+    return Project(
+        workdir=workdir,
+        datastore=datastore,
+        config=config,
+        fabric=fabric,
+        dir_mode=None,
+    )
+
+
+def _md5_file(filename: str) -> str:
+    h = hashlib.md5()
+    with open(filename, "rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+class FakeSbSession:
+    """In-memory stand-in for ``sciencebasepy.SbSession`` for offline tests.
+
+    Maintains an item store keyed by id and records every mutating call so a
+    test can assert read-only behavior (``created`` / ``updated`` / ``uploaded``
+    / ``deleted``). ``upload_file_to_item`` records each file's **MD5** as its
+    checksum value -- matching ScienceBase, which stores MD5 -- so the
+    SbClient skip-if-checksum-matches fast path fires on an unchanged re-upload.
+
+    A missing id raises ``Exception("Resource not found")``, mirroring
+    sciencebasepy, so the publish layer's stale-registry detection is exercised.
+    """
+
+    def __init__(self) -> None:
+        self.items: dict[str, dict] = {}
+        self._counter = 0
+        self.created: list[dict] = []
+        self.updated: list[dict] = []
+        self.uploaded: list[tuple[str, str]] = []
+        self.deleted: list[tuple[str, str]] = []
+
+    # -- helpers for tests to pre-seed remote state -----------------------
+    def seed_item(
+        self,
+        sb_id: str,
+        *,
+        title: str,
+        parent_id: str | None = None,
+        files: list[dict] | None = None,
+    ) -> dict:
+        item = {"id": sb_id, "title": title, "files": list(files or [])}
+        if parent_id is not None:
+            item["parentId"] = parent_id
+        self.items[sb_id] = item
+        return item
+
+    # -- sciencebasepy surface used by SbClient ---------------------------
+    def get_item(self, itemid, params=None):
+        if itemid not in self.items:
+            raise Exception("Resource not found")
+        return copy.deepcopy(self.items[itemid])
+
+    def create_item(self, item_json):
+        self.created.append(copy.deepcopy(item_json))
+        self._counter += 1
+        new_id = f"sb{self._counter}"
+        item = copy.deepcopy(item_json)
+        item["id"] = new_id
+        item.setdefault("files", [])
+        self.items[new_id] = item
+        return copy.deepcopy(item)
+
+    def update_item(self, item_json):
+        self.updated.append(copy.deepcopy(item_json))
+        sb_id = item_json["id"]
+        self.items[sb_id].update(copy.deepcopy(item_json))
+        return copy.deepcopy(self.items[sb_id])
+
+    def get_child_ids(self, parentid):
+        return [i for i, it in self.items.items() if it.get("parentId") == parentid]
+
+    def upload_file_to_item(self, item, filename, scrape_file=True):
+        sb_id = item["id"]
+        stored = self.items[sb_id]
+        name = os.path.basename(filename)
+        files = [f for f in stored.get("files", []) if f["name"] != name]
+        files.append(
+            {
+                "name": name,
+                "size": os.path.getsize(filename),
+                "checksum": {"type": "MD5", "value": _md5_file(filename)},
+            }
+        )
+        stored["files"] = files
+        self.uploaded.append((sb_id, name))
+        return copy.deepcopy(stored)
+
+    def delete_file(self, sb_filename, item):
+        sb_id = item["id"]
+        stored = self.items[sb_id]
+        stored["files"] = [
+            f for f in stored.get("files", []) if f["name"] != sb_filename
+        ]
+        self.deleted.append((sb_filename, sb_id))
+        return copy.deepcopy(stored)
+
+    def is_logged_in(self):
+        return True
+
+    def ping(self):
+        return {"ok": True}
+
+
+def make_sb_client(session, **kwargs):
+    """Wrap *session* in an SbClient with a no-op sleep (no wall-clock backoff)."""
+    from nhf_spatial_targets.release.sb_client import SbClient
+
+    kwargs.setdefault("sleep", lambda _: None)
+    return SbClient(session, **kwargs)

--- a/tests/test_release_defaults.py
+++ b/tests/test_release_defaults.py
@@ -8,8 +8,11 @@ import pytest
 import yaml
 
 from nhf_spatial_targets.release.defaults import (
+    REQUIRED_POPULATED_PATHS,
     REQUIRED_SECTIONS,
     load_release_defaults,
+    missing_release_defaults,
+    require_populated_release_defaults,
     validate_release_defaults,
 )
 
@@ -70,3 +73,37 @@ def test_non_mapping_top_level_fails():
 def test_missing_file_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_release_defaults(tmp_path / "does-not-exist.yml")
+
+
+# ---------------------------------------------------------------------------
+# publish-time populated-check (separate from the shape-only loader)
+# ---------------------------------------------------------------------------
+
+
+def test_committed_defaults_are_fully_populated():
+    """The committed catalog/release_defaults.yml passes the publish gate."""
+    data = load_release_defaults()
+    assert missing_release_defaults(data) == []
+    require_populated_release_defaults(data)  # no raise
+
+
+def test_empty_scaffold_reports_every_required_path():
+    """A shape-valid but empty scaffold is loadable but not publishable."""
+    empty = {s: {} for s in REQUIRED_SECTIONS}
+    validate_release_defaults(empty)  # shape-only check passes
+    missing = missing_release_defaults(empty)
+    assert set(missing) == set(REQUIRED_POPULATED_PATHS)
+    with pytest.raises(ValueError, match="not fully populated"):
+        require_populated_release_defaults(empty)
+
+
+def test_single_blank_leaf_is_reported(tmp_path):
+    """A present-but-blank required field (folded YAML can leave whitespace)
+    is reported by path, while the rest stay populated."""
+    data = load_release_defaults()
+    data["umbrella"] = dict(data["umbrella"])
+    data["umbrella"]["title_template"] = "   \n  "  # whitespace only
+    missing = missing_release_defaults(data)
+    assert missing == ["umbrella.title_template"]
+    with pytest.raises(ValueError, match="umbrella.title_template"):
+        require_populated_release_defaults(data)

--- a/tests/test_release_dry_run.py
+++ b/tests/test_release_dry_run.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from rich.console import Console
 
 import nhf_spatial_targets.release.dry_run as dry_run_mod
-from nhf_spatial_targets.release import registry
+from nhf_spatial_targets.release import publish, registry
 from nhf_spatial_targets.release.build import build_fabric_child
 from nhf_spatial_targets.release.dry_run import dry_run
 from nhf_spatial_targets.release.validate_xml import MpResult
@@ -216,4 +216,52 @@ def test_render_writes_a_table_without_touching_sciencebase(tmp_path):
     output = console.file.getvalue()
     assert "dry run" in output.lower()
     assert "would create" in output  # nothing is in the registry yet
+    _assert_no_writes(session)
+
+
+# ---------------------------------------------------------------------------
+# diff_local_vs_remote: stale local + stale remote sb_id (read-only, no build)
+# ---------------------------------------------------------------------------
+
+
+def test_diff_reports_stale_local_when_staged_file_drifts(tmp_path):
+    """diff does NOT rebuild, so a staged file edited after build surfaces as
+    a 'stale' local payload via the narrowed verify_csv catch."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    build_fabric_child(project, now=NOW)  # stage exists with checksums.csv
+    # Edit a staged data file's content (via its symlink target) -> verify fails.
+    (project.workdir / "targets" / "runoff_targets.nc").write_bytes(b"DRIFTED-CONTENT")
+
+    diffs = publish.diff_local_vs_remote(
+        project, make_sb_client(session), scope="fabric", registry_path=reg
+    )
+    assert diffs[0].local == "stale"
+    _assert_no_writes(session)
+
+
+def test_diff_reports_stale_remote_sb_id_as_missing(tmp_path):
+    """A registry sb_id that ScienceBase 404s reads as remote 'missing' with a
+    stale-id note (the get_item-404 path in the read-only diff)."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()  # store is empty -> get_item raises not-found
+    build_fabric_child(project, now=NOW)  # local payload built
+    registry.put_fabric(
+        LABEL,
+        sb_id="GONE",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=1,
+        total_bytes=1,
+        manifest_sha256="x",
+        path=reg,
+    )
+
+    diffs = publish.diff_local_vs_remote(
+        project, make_sb_client(session), scope="fabric", registry_path=reg
+    )
+    assert diffs[0].local == "built"
+    assert diffs[0].remote == "missing"
+    assert "stale" in (diffs[0].detail or "")
     _assert_no_writes(session)

--- a/tests/test_release_dry_run.py
+++ b/tests/test_release_dry_run.py
@@ -1,0 +1,219 @@
+"""Offline tests for release.dry_run -- the read-only publish preview.
+
+A dry run builds + validates locally and queries ScienceBase read-only; it must
+never mutate the remote. These tests assert the structured report (would-create
+vs exists vs drift), the mp warn/err degradation, and -- centrally -- that no
+mutating client method is ever called.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rich.console import Console
+
+import nhf_spatial_targets.release.dry_run as dry_run_mod
+from nhf_spatial_targets.release import registry
+from nhf_spatial_targets.release.build import build_fabric_child
+from nhf_spatial_targets.release.dry_run import dry_run
+from nhf_spatial_targets.release.validate_xml import MpResult
+from tests.conftest import FakeSbSession, build_release_project, make_sb_client
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+LABEL = "gfv_test"
+
+
+def _registry(tmp_path):
+    return tmp_path / "release_registry.yml"
+
+
+def _staged_names(project) -> set[str]:
+    """ScienceBase basenames of everything publish would upload for the fabric."""
+    result = build_fabric_child(project, now=NOW)
+    names = {Path(e.path).name for e in result.entries}
+    names |= {"checksums.csv", "SHA256SUMS"}
+    return names
+
+
+def _assert_no_writes(session: FakeSbSession) -> None:
+    assert session.created == []
+    assert session.updated == []
+    assert session.uploaded == []
+    assert session.deleted == []
+
+
+# ---------------------------------------------------------------------------
+# would-create / exists / drift
+# ---------------------------------------------------------------------------
+
+
+def test_would_create_when_not_in_registry(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="fabric",
+        now=NOW,
+        registry_path=reg,
+        render=False,
+    )
+    assert len(report.items) == 1
+    item = report.items[0]
+    assert item.scope == "fabric"
+    assert item.sb_id is None
+    assert item.diff.remote == "missing"
+    assert item.remote_label == "missing"
+    assert report.would_create == (item,)
+    assert item.file_count > 0 and item.total_bytes > 0
+    _assert_no_writes(session)
+
+
+def test_exists_when_remote_matches_staged(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    # A remote item carrying exactly the staged file set (size omitted -> the
+    # parity check compares names only when remote size is unknown).
+    files = [{"name": n} for n in _staged_names(project)]
+    session.seed_item("FAB", title="t", files=files)
+    registry.put_fabric(
+        LABEL,
+        sb_id="FAB",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=len(files),
+        total_bytes=1,
+        manifest_sha256="x",
+        path=reg,
+    )
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="fabric",
+        now=NOW,
+        registry_path=reg,
+        render=False,
+    )
+    item = report.items[0]
+    assert item.sb_id == "FAB"
+    assert item.diff.remote == "present"
+    assert item.remote_label == "exists"
+    _assert_no_writes(session)
+
+
+def test_drift_when_remote_has_extra_file(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    files = [{"name": n} for n in _staged_names(project)]
+    files.append({"name": "orphan_old.nc"})  # not in staged payload -> drift
+    session.seed_item("FAB", title="t", files=files)
+    registry.put_fabric(
+        LABEL,
+        sb_id="FAB",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=len(files),
+        total_bytes=1,
+        manifest_sha256="x",
+        path=reg,
+    )
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="fabric",
+        now=NOW,
+        registry_path=reg,
+        render=False,
+    )
+    item = report.items[0]
+    assert item.diff.remote == "drift"
+    assert item.remote_label == "drift"
+    assert "orphan_old.nc" in (item.diff.detail or "")
+    _assert_no_writes(session)
+
+
+# ---------------------------------------------------------------------------
+# mp warn / err degradation
+# ---------------------------------------------------------------------------
+
+
+def test_mp_absent_degrades_to_warn(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    monkeypatch.setattr(
+        dry_run_mod,
+        "validate_xml_file",
+        lambda path: MpResult(
+            True, ["mp not found on PATH; well-formedness only."], []
+        ),
+    )
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="fabric",
+        now=NOW,
+        registry_path=reg,
+        render=False,
+    )
+    assert report.items[0].mp_status == "warn"
+    assert report.ok is True  # warnings do not fail a dry run
+    _assert_no_writes(session)
+
+
+def test_mp_errors_make_report_not_ok(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    monkeypatch.setattr(
+        dry_run_mod,
+        "validate_xml_file",
+        lambda path: MpResult(False, [], ["element <bounding> is missing"]),
+    )
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="fabric",
+        now=NOW,
+        registry_path=reg,
+        render=False,
+    )
+    assert report.items[0].mp_status == "err"
+    assert report.ok is False
+
+
+# ---------------------------------------------------------------------------
+# rendering + multi-scope
+# ---------------------------------------------------------------------------
+
+
+def test_render_writes_a_table_without_touching_sciencebase(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+    console = Console(file=io.StringIO(), width=120)
+
+    report = dry_run(
+        project,
+        make_sb_client(session),
+        scope="all",
+        now=NOW,
+        registry_path=reg,
+        console=console,
+        render=True,
+    )
+    # all scope: fabric + 2 source children (era5_land, daymet) + umbrella.
+    kinds = sorted(i.scope for i in report.items)
+    assert kinds == ["fabric", "source", "source", "umbrella"]
+    output = console.file.getvalue()
+    assert "dry run" in output.lower()
+    assert "would create" in output  # nothing is in the registry yet
+    _assert_no_writes(session)

--- a/tests/test_release_idempotency.py
+++ b/tests/test_release_idempotency.py
@@ -1,0 +1,282 @@
+"""Offline create-vs-update decision-matrix tests for release.publish.
+
+Every test injects a :class:`tests.conftest.FakeSbSession` (no network) and a
+tmp registry path, and drives the publish orchestration through the plan's
+idempotency matrix:
+
+    registry sb_id + found              -> update
+    registry sb_id + not-found          -> fatal (StaleRegistryError); create_new -> create
+    no sb_id + one same-title child     -> adopt (update) + write sb_id to registry
+    no sb_id + zero matches             -> create
+    no sb_id + multiple same-title      -> SbClientError (ambiguous)
+    per-file: unchanged                 -> skipped; changed -> re-uploaded
+    orphan remote file                  -> warn+leave; delete_orphans -> deleted
+
+It also asserts registry.put_* is called with the right counts/bytes and that
+the flock read-merge-write preserves sibling entries (the umbrella survives a
+fabric publish).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from nhf_spatial_targets.release import publish, registry
+from nhf_spatial_targets.release.build import build_fabric_child
+from nhf_spatial_targets.release.sb_client import SbClientError
+from tests.conftest import FakeSbSession, build_release_project, make_sb_client
+
+# Clock-injected so each build renders byte-identical metadata.
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+LABEL = "gfv_test"
+
+
+def _registry(tmp_path):
+    return tmp_path / "release_registry.yml"
+
+
+def _seed_umbrella(reg, sb_id="UMB"):
+    registry.put_umbrella(
+        sb_id=sb_id,
+        version="1.0",
+        published_utc="2026-01-01T00:00:00+00:00",
+        title="Umbrella",
+        path=reg,
+    )
+
+
+def _publish(project, session, reg, **kwargs):
+    return publish.publish_fabric_child(
+        project, make_sb_client(session), registry_path=reg, now=NOW, **kwargs
+    )
+
+
+def _fabric_title(project) -> str:
+    """The title the fabric child would publish under (for adopt seeding)."""
+    return build_fabric_child(project, now=NOW).mcf["identification"]["title"]
+
+
+# ---------------------------------------------------------------------------
+# create / update / adopt
+# ---------------------------------------------------------------------------
+
+
+def test_first_publish_creates_then_second_updates(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+
+    first = _publish(project, session, reg)
+    assert first.mode == "create"
+    assert first.adopted is False
+    assert first.sb_id  # a real id was assigned
+    # Every payload file was sent on create (nothing skipped).
+    assert first.skipped == ()
+    assert "runoff_targets.nc" in first.uploaded
+    assert len(session.created) == 1
+
+    # The registry now records the child under the freshly-minted sb_id.
+    entry = registry.get_fabric(LABEL, reg)
+    assert entry["sb_id"] == first.sb_id
+
+    # Second publish sees the registry sb_id, fetches the item -> update.
+    second = _publish(project, session, reg)
+    assert second.mode == "update"
+    assert second.adopted is False
+    assert second.sb_id == first.sb_id
+    assert len(session.created) == 1  # no second create
+
+
+def test_registry_sb_id_not_found_is_fatal(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    # Registry points at an item ScienceBase does not have.
+    registry.put_fabric(
+        LABEL,
+        sb_id="GONE",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=1,
+        total_bytes=1,
+        manifest_sha256="deadbeef",
+        path=reg,
+    )
+    session = FakeSbSession()  # store has no "GONE"
+
+    with pytest.raises(publish.StaleRegistryError, match="stale"):
+        _publish(project, session, reg)
+
+
+def test_create_new_overrides_stale_registry(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    registry.put_fabric(
+        LABEL,
+        sb_id="GONE",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=1,
+        total_bytes=1,
+        manifest_sha256="deadbeef",
+        path=reg,
+    )
+    session = FakeSbSession()
+
+    result = _publish(project, session, reg, create_new=True)
+    assert result.mode == "create"
+    assert result.sb_id != "GONE"
+    # The registry id was overwritten with the fresh one.
+    assert registry.get_fabric(LABEL, reg)["sb_id"] == result.sb_id
+
+
+def test_adopts_single_same_title_child_and_writes_registry(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    # An existing child under the umbrella with the exact title, but no
+    # registry entry yet (e.g. published out-of-band): publish must adopt it.
+    session.seed_item("ADOPT", title=_fabric_title(project), parent_id="UMB")
+
+    result = _publish(project, session, reg)
+    assert result.mode == "update"
+    assert result.adopted is True
+    assert result.sb_id == "ADOPT"
+    assert len(session.created) == 0  # adopted, not created
+    # The registry now records the adopted id.
+    assert registry.get_fabric(LABEL, reg)["sb_id"] == "ADOPT"
+
+
+def test_zero_title_matches_creates(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    # A child with a *different* title is not a match.
+    session.seed_item("OTHER", title="Some other dataset", parent_id="UMB")
+
+    result = _publish(project, session, reg)
+    assert result.mode == "create"
+    assert result.adopted is False
+
+
+def test_multiple_same_title_children_is_ambiguous(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    title = _fabric_title(project)
+    session.seed_item("DUP1", title=title, parent_id="UMB")
+    session.seed_item("DUP2", title=title, parent_id="UMB")
+
+    with pytest.raises(SbClientError, match="disambiguate"):
+        _publish(project, session, reg)
+
+
+# ---------------------------------------------------------------------------
+# per-file skip vs replace
+# ---------------------------------------------------------------------------
+
+
+def test_per_file_skip_then_replace_on_content_change(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+
+    _publish(project, session, reg)  # create: uploads everything
+
+    # No change -> the unchanged data NC is skipped on re-publish.
+    second = _publish(project, session, reg)
+    assert second.mode == "update"
+    assert "runoff_targets.nc" in second.skipped
+    assert "aet_targets.nc" in second.skipped
+
+    # Change one source file's content -> only that file re-uploads.
+    (project.workdir / "targets" / "runoff_targets.nc").write_bytes(b"runoff-v2")
+    third = _publish(project, session, reg)
+    assert "runoff_targets.nc" in third.uploaded
+    assert "aet_targets.nc" in third.skipped
+
+
+# ---------------------------------------------------------------------------
+# orphan handling
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_is_warned_and_left_by_default(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+
+    first = _publish(project, session, reg)
+    # A file present on the remote item but never in the staged payload.
+    session.items[first.sb_id]["files"].append(
+        {
+            "name": "legacy_extra.nc",
+            "size": 3,
+            "checksum": {"type": "MD5", "value": "x"},
+        }
+    )
+
+    result = _publish(project, session, reg)
+    assert "legacy_extra.nc" in result.orphans
+    assert result.orphans_deleted == ()
+    assert session.deleted == []  # nothing deleted by default
+
+
+def test_orphan_is_deleted_with_delete_orphans(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+
+    first = _publish(project, session, reg)
+    session.items[first.sb_id]["files"].append(
+        {
+            "name": "legacy_extra.nc",
+            "size": 3,
+            "checksum": {"type": "MD5", "value": "x"},
+        }
+    )
+
+    result = _publish(project, session, reg, delete_orphans=True)
+    assert "legacy_extra.nc" in result.orphans_deleted
+    assert ("legacy_extra.nc", first.sb_id) in session.deleted
+
+
+# ---------------------------------------------------------------------------
+# registry put: counts/bytes + flock merge preserves siblings
+# ---------------------------------------------------------------------------
+
+
+def test_registry_records_counts_bytes_and_preserves_umbrella(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg, sb_id="UMB")
+    session = FakeSbSession()
+
+    result = _publish(project, session, reg)
+
+    entry = registry.get_fabric(LABEL, reg)
+    # file_count / total_bytes match the staged payload publish uploaded.
+    assert entry["file_count"] == len(result.uploaded) + len(result.skipped)
+    assert entry["total_bytes"] > 0
+    assert len(entry["manifest_sha256"]) == 64  # a SHA-256 hex digest
+
+    # The flock read-merge-write left the umbrella entry untouched.
+    assert registry.get_umbrella(reg)["sb_id"] == "UMB"
+
+
+def test_child_publish_without_umbrella_is_fatal(tmp_path):
+    """A child can't be parented without a recorded umbrella sb_id."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)  # no umbrella seeded
+    session = FakeSbSession()
+
+    with pytest.raises(publish.PreflightError, match="umbrella"):
+        _publish(project, session, reg)

--- a/tests/test_release_idempotency.py
+++ b/tests/test_release_idempotency.py
@@ -194,12 +194,41 @@ def test_per_file_skip_then_replace_on_content_change(tmp_path):
     assert second.mode == "update"
     assert "runoff_targets.nc" in second.skipped
     assert "aet_targets.nc" in second.skipped
+    sha_before = registry.get_fabric(LABEL, reg)["manifest_sha256"]
 
     # Change one source file's content -> only that file re-uploads.
     (project.workdir / "targets" / "runoff_targets.nc").write_bytes(b"runoff-v2")
     third = _publish(project, session, reg)
     assert "runoff_targets.nc" in third.uploaded
     assert "aet_targets.nc" in third.skipped
+    # The recorded payload fingerprint is content-sensitive: it must change.
+    assert registry.get_fabric(LABEL, reg)["manifest_sha256"] != sha_before
+
+
+def test_empty_item_response_is_treated_as_stale(tmp_path):
+    """A registry sb_id whose get_item returns an empty/falsy item (vs raising)
+    is the same stale condition -- fatal unless create_new."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    registry.put_fabric(
+        LABEL,
+        sb_id="EMPTY",
+        uploaded_utc="2026-01-01T00:00:00+00:00",
+        file_count=1,
+        total_bytes=1,
+        manifest_sha256="deadbeef",
+        path=reg,
+    )
+    session = FakeSbSession()
+    session.items["EMPTY"] = {}  # get_item returns a falsy item
+
+    with pytest.raises(publish.StaleRegistryError):
+        _publish(project, session, reg)
+
+    result = _publish(project, session, reg, create_new=True)
+    assert result.mode == "create"
+    assert result.sb_id != "EMPTY"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -8,10 +8,14 @@ fabric child against an in-memory ScienceBase (the :class:`FakeSbSession`).
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
+import requests
 
 from nhf_spatial_targets.release import publish, registry
+from nhf_spatial_targets.release._models import FileEntry, ReleaseError
+from nhf_spatial_targets.release.build import BuildResult
 from nhf_spatial_targets.release.checksums import ChecksumMismatch
 from tests.conftest import FakeSbSession, build_release_project, make_sb_client
 
@@ -157,3 +161,105 @@ def test_fabric_create_then_update_patches_changed_body(tmp_path):
     third = publish.publish_fabric_child(project, client, registry_path=reg, now=NOW)
     assert "body" in third.body_patched
     assert session.items[first.sb_id]["body"] != "STALE DESCRIPTION"
+
+
+def test_source_child_create_then_update_skips(tmp_path):
+    """A source child re-published with no change goes to update + skips its NCs."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    client = make_sb_client(session)
+
+    first = publish.publish_source_child(
+        project, client, "era5_land", registry_path=reg, now=NOW
+    )
+    assert first.mode == "create"
+
+    second = publish.publish_source_child(
+        project, client, "era5_land", registry_path=reg, now=NOW
+    )
+    assert second.mode == "update"
+    assert "era5_land_daily_1980.nc" in second.skipped
+    assert registry.get_source("era5_land", reg)["sb_id"] == first.sb_id
+
+
+# ---------------------------------------------------------------------------
+# _payload_files flat-namespace collision guard
+# ---------------------------------------------------------------------------
+
+
+def test_payload_files_raises_on_basename_collision(tmp_path):
+    """Two staged files with the same basename would collide in ScienceBase's
+    flat namespace -- _payload_files must refuse rather than silently overwrite."""
+    stage = tmp_path / "stage"
+    (stage / "a").mkdir(parents=True)
+    (stage / "b").mkdir(parents=True)
+    (stage / "a" / "data.nc").write_bytes(b"x")
+    (stage / "b" / "data.nc").write_bytes(b"y")
+    entries = (
+        FileEntry(path="a/data.nc", sha256="0" * 64, size=1, mtime="t"),
+        FileEntry(path="b/data.nc", sha256="0" * 64, size=1, mtime="t"),
+    )
+    result = BuildResult(
+        kind="fabric", key="x", stage_dir=stage, mcf={}, entries=entries
+    )
+    with pytest.raises(ReleaseError, match="flat namespace"):
+        publish._payload_files(result)
+
+
+# ---------------------------------------------------------------------------
+# _is_not_found classifier (the tightened 404 detection)
+# ---------------------------------------------------------------------------
+
+
+def test_is_not_found_recognizes_real_not_found_shapes():
+    assert publish._is_not_found(Exception("Resource not found")) is True
+    assert publish._is_not_found(Exception("Other HTTP error: 404: missing")) is True
+    exc = requests.exceptions.HTTPError("boom")
+    exc.response = SimpleNamespace(status_code=404)
+    assert publish._is_not_found(exc) is True
+
+
+def test_is_not_found_rejects_misleading_messages():
+    """A 5xx whose body merely mentions 'not found' or '404' must NOT classify
+    as not-found -- otherwise create_new would mint a duplicate item."""
+    assert (
+        publish._is_not_found(
+            Exception("Other HTTP error: 503: upstream service not found")
+        )
+        is False
+    )
+    assert (
+        publish._is_not_found(Exception("Other HTTP error: 500: route /v/404 failed"))
+        is False
+    )
+    assert publish._is_not_found(Exception("Unauthorized access")) is False
+
+
+# ---------------------------------------------------------------------------
+# typed-record key invariant
+# ---------------------------------------------------------------------------
+
+
+def test_typed_records_enforce_key_invariant():
+    """umbrella must be keyless; source/fabric must carry a key (mirrors
+    BuildResult)."""
+    with pytest.raises(ValueError, match="key invariant"):
+        publish.PublishResult(
+            scope="umbrella",
+            key="oops",
+            sb_id="x",
+            mode="create",
+            adopted=False,
+            uploaded=(),
+            skipped=(),
+            orphans=(),
+            orphans_deleted=(),
+            body_patched=(),
+            registry_entry={},
+        )
+    with pytest.raises(ValueError, match="key invariant"):
+        publish.ScopeDiff(
+            scope="fabric", key=None, sb_id=None, local="missing", remote="missing"
+        )

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -1,0 +1,159 @@
+"""Offline pre-flight + happy-path tests for release.publish.
+
+Pre-flight gates must each fail loudly *before* anything is published; the
+happy paths cover create and update for the umbrella, a source child, and a
+fabric child against an in-memory ScienceBase (the :class:`FakeSbSession`).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from nhf_spatial_targets.release import publish, registry
+from nhf_spatial_targets.release.checksums import ChecksumMismatch
+from tests.conftest import FakeSbSession, build_release_project, make_sb_client
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+COMMUNITY = "COMMUNITY"  # the ScienceBase folder that hosts the release
+
+
+def _registry(tmp_path):
+    return tmp_path / "release_registry.yml"
+
+
+def _seed_umbrella(reg, sb_id="UMB"):
+    registry.put_umbrella(
+        sb_id=sb_id,
+        version="1.0",
+        published_utc="2026-01-01T00:00:00+00:00",
+        title="Umbrella",
+        path=reg,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight gates (each fatal, before any publish)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_missing_manifest_is_fatal(tmp_path):
+    project = build_release_project(tmp_path, with_manifest=False)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    with pytest.raises(publish.PreflightError, match="manifest.json"):
+        publish.publish_fabric_child(
+            project, make_sb_client(FakeSbSession()), registry_path=reg, now=NOW
+        )
+
+
+def test_preflight_empty_authors_is_fatal(tmp_path):
+    project = build_release_project(tmp_path, authors=[])
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    with pytest.raises(publish.PreflightError, match="authors"):
+        publish.publish_fabric_child(
+            project, make_sb_client(FakeSbSession()), registry_path=reg, now=NOW
+        )
+
+
+def test_preflight_missing_umbrella_sb_id_is_fatal(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)  # no umbrella recorded
+    with pytest.raises(publish.PreflightError, match="umbrella"):
+        publish.publish_fabric_child(
+            project, make_sb_client(FakeSbSession()), registry_path=reg, now=NOW
+        )
+
+
+def test_checksum_drift_is_fatal(tmp_path, monkeypatch):
+    """A staged file edited since build fails the verify_csv gate loudly."""
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+
+    def _raise(_stage_dir):
+        raise ChecksumMismatch("staged file drifted from checksums.csv")
+
+    monkeypatch.setattr(publish, "verify_csv", _raise)
+    with pytest.raises(ChecksumMismatch, match="drifted"):
+        publish.publish_fabric_child(
+            project, make_sb_client(FakeSbSession()), registry_path=reg, now=NOW
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path create + update
+# ---------------------------------------------------------------------------
+
+
+def test_umbrella_create_records_registry(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    session = FakeSbSession()
+
+    result = publish.publish_umbrella(
+        project,
+        make_sb_client(session),
+        parent_id=COMMUNITY,
+        registry_path=reg,
+        now=NOW,
+    )
+    assert result.mode == "create"
+    assert result.scope == "umbrella"
+    assert result.key is None
+    # Metadata-only: README/FGDC/ISO + integrity uploaded, no NetCDF data.
+    assert "README.md" in result.uploaded
+    assert not any(name.endswith(".nc") for name in result.uploaded)
+
+    umbrella = registry.get_umbrella(reg)
+    assert umbrella["sb_id"] == result.sb_id
+    assert umbrella["version"] == "1.0"
+    assert umbrella["title"]
+    # The created item lives under the supplied community folder.
+    assert session.items[result.sb_id]["parentId"] == COMMUNITY
+
+
+def test_source_child_create_records_registry(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+
+    result = publish.publish_source_child(
+        project, make_sb_client(session), "era5_land", registry_path=reg, now=NOW
+    )
+    assert result.mode == "create"
+    assert result.scope == "source" and result.key == "era5_land"
+    # The consolidated NetCDFs are the source child's data payload.
+    assert "era5_land_daily_1980.nc" in result.uploaded
+    assert "era5_land_monthly_1980.nc" in result.uploaded
+
+    entry = registry.get_source("era5_land", reg)
+    assert entry["sb_id"] == result.sb_id
+    assert entry["file_count"] == len(result.uploaded) + len(result.skipped)
+    assert entry["total_bytes"] > 0
+
+
+def test_fabric_create_then_update_patches_changed_body(tmp_path):
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    client = make_sb_client(session)
+
+    first = publish.publish_fabric_child(project, client, registry_path=reg, now=NOW)
+    assert first.mode == "create"
+    assert first.body_patched == ()  # create patches nothing
+
+    # No-op update: nothing patched, the unchanged body matches the remote.
+    second = publish.publish_fabric_child(project, client, registry_path=reg, now=NOW)
+    assert second.mode == "update"
+    assert second.body_patched == ()
+
+    # A drifted remote body is patched back to the rendered abstract on update.
+    session.items[first.sb_id]["body"] = "STALE DESCRIPTION"
+    third = publish.publish_fabric_child(project, client, registry_path=reg, now=NOW)
+    assert "body" in third.body_patched
+    assert session.items[first.sb_id]["body"] != "STALE DESCRIPTION"

--- a/tests/test_release_sb_client_offline.py
+++ b/tests/test_release_sb_client_offline.py
@@ -25,6 +25,7 @@ import pytest
 import requests
 
 from nhf_spatial_targets.release import sb_client
+from nhf_spatial_targets.release._models import ReleaseError
 from nhf_spatial_targets.release.sb_client import (
     SbClient,
     SbClientError,
@@ -423,3 +424,29 @@ def test_from_token_factory_dispatches(monkeypatch) -> None:
 
     assert client.session is fake
     fake.add_token.assert_called_once_with("token-json")
+
+
+# ---------------------------------------------------------------------------
+# delete_file + the ReleaseError base
+# ---------------------------------------------------------------------------
+
+
+def test_delete_file_fetches_item_then_dispatches(client_factory) -> None:
+    """delete_file gets the item, then calls session.delete_file(name, item)."""
+    session = MagicMock()
+    item = {"id": "child1", "files": [{"name": "orphan.nc"}]}
+    session.get_item.return_value = item
+    session.delete_file.return_value = {"id": "child1", "files": []}
+    client = client_factory(session)
+
+    result = client.delete_file("child1", "orphan.nc")
+
+    session.get_item.assert_called_once_with("child1")
+    session.delete_file.assert_called_once_with("orphan.nc", item)
+    assert result == {"id": "child1", "files": []}
+
+
+def test_sb_client_error_is_a_release_error() -> None:
+    """SbClientError is catchable as the release-layer base ReleaseError."""
+    assert issubclass(SbClientError, ReleaseError)
+    assert isinstance(SbClientError("x"), ReleaseError)


### PR DESCRIPTION
Closes #273. Part of the ScienceBase data-release effort; the publish/dry-run orchestration that composes the **PR-E1 (#270)** offline build with the **PR-E2 (#272)** registry + `sb_client` primitives. Offline-testable end to end; the CLI is **PR-F** and credentials + live integration tests + docs are **PR-G**.

## Summary

- **`release/publish.py`** — `publish_umbrella` / `publish_source_child` / `publish_fabric_child`. Each runs cheap fail-fast pre-flight, the idempotent build, the `verify_csv` checksum gate, then reconciles registry *intent* vs ScienceBase *reality* per the plan's matrix: a recorded `sb_id` is fetched (404 ⇒ `StaleRegistryError`, fatal unless `create_new`); otherwise an exact-title child is sought under the parent — one adopts (update + writes `sb_id`), zero creates, many is fatal. Create uploads all; update patches only changed item-body fields, skips per-file when the remote MD5 already matches, and warns about (or, with `delete_orphans`, deletes) remote files no longer staged. Returns a typed `PublishResult`.
- **`release/publish.py::diff_local_vs_remote`** — the read-only intent-vs-reality diff (lives here because it needs SB queries; PR-E2 deferred it). Returns typed `ScopeDiff` (local: built/stale/missing × remote: present/drift/missing). Consumed by dry-run and the future `status` CLI.
- **`release/dry_run.py`** — builds (idempotent), validates each `fgdc.xml` with `mp` (warn-only if absent), and does a read-only SB parity check. Prints a Rich table and returns a structured `DryRunReport`. **No ScienceBase writes.**

## Decisions (documented in module docstrings)

- **MD5 vs SHA-256 (per the plan, option (a)).** ScienceBase records per-file checksums as **MD5** (sciencebasepy 2.0.22 `_replace_file`), and `upload_file(skip_if_sha256_matches=...)` does value-equality against the remote `checksum.value`. The skip fast-path therefore computes the **local MD5** and passes that: a genuine content match skips, any mismatch re-uploads (an MD5 can never equal a SHA-256, so the comparison is honest either way). This keeps the "what checksum does SB use" knowledge in the orchestration layer rather than re-touching the merged PR-E2 primitive.
- **Flat SB namespace guard.** Staged trees are nested but a ScienceBase item's `files` are flat-by-basename; `_payload_files` raises on a basename collision rather than silently overwriting.
- **`manifest_sha256`** recorded in the registry is the SHA-256 of the staged `SHA256SUMS` — a single fingerprint of the whole payload, uniform across source (no `manifest.json`) and fabric children.
- **`--create-umbrella`** for a child is a CLI-level composition (PR-F) of `publish_umbrella` + child; the library keeps the gate single-purpose (a missing umbrella `sb_id` is fatal).

## Roadmap fold-ins from PR-E2 (#272)

- Stale-registry message on `get_item` 404 → `StaleRegistryError` (escape: `create_new`).
- `find_child` enumeration-failure context wrapped at the publish boundary.
- Typed records at the orchestration boundary (`PublishResult`, `ScopeDiff`).
- `ReleaseError` base (in `_models`) so `SbClientError` + the new `PreflightError`/`StaleRegistryError` catch uniformly.

## Supporting changes

- `sb_client.delete_file(sb_id, name)` (orphan removal; thin wrapper over `SbSession.delete_file`).
- `defaults.require_populated_release_defaults` / `missing_release_defaults` — publish-time "fully populated" gate; the loader stays shape-only.
- Shared `FakeSbSession` + `build_release_project` factory in `tests/conftest.py`.

## Out of scope (later PRs)

`release/cli.py` (PR-F); `materialize_sciencebase_token` + `.credentials.yml` `sciencebase:` block + `@pytest.mark.integration` live tests + docs (PR-G). No XSD validation.

## Test plan

- [x] `pixi run -e dev fmt` + `lint` clean
- [x] Targeted offline suite green (74 tests): `test_release_idempotency` (full create-vs-update matrix, per-file skip/replace, orphan warn vs delete, flock sibling-preservation), `test_release_publish` (4 pre-flight gates + happy-path create/update/body-patch for umbrella/source/fabric), `test_release_dry_run` (would-create/exists/drift, mp warn/err, no-SB-writes, Rich render), plus `delete_file` / `ReleaseError` / populated-check coverage
- [ ] Full suite on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)