### PR TITLE
PR-F: release CLI surface (nhf-targets release …)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -205,6 +205,16 @@ agg-all          = { cmd = "nhf-targets agg all",          description = "Aggreg
 catalog-sources   = { cmd = "nhf-targets catalog sources" }
 catalog-variables = { cmd = "nhf-targets catalog variables" }
 
+# ScienceBase data release (PR-F). Pass --project-dir (and publish flags) as
+# extra args, e.g.  pixi run release-build -- --project-dir /data/nhf-runs/gfv2
+release-init      = { cmd = "nhf-targets release init",      description = "Scaffold a project's ScienceBase release directory" }
+release-build     = { cmd = "nhf-targets release build",     description = "Build the ScienceBase release payload on disk (offline)" }
+release-manifest  = { cmd = "nhf-targets release manifest",  description = "Recompute checksums for staged release items" }
+release-dry-run   = { cmd = "nhf-targets release dry-run",   description = "Preview a ScienceBase release (read-only)" }
+release-publish   = { cmd = "nhf-targets release publish",   description = "Publish the release to ScienceBase (idempotent)" }
+release-status    = { cmd = "nhf-targets release status",    description = "Diff release intent vs ScienceBase" }
+release-auth-test = { cmd = "nhf-targets release auth-test", description = "Check ScienceBase authentication" }
+
 # Development
 test  = { cmd = "pytest tests/ -v -m 'not integration'", description = "Run test suite (excludes integration)" }
 test-quiet = { cmd = "pytest tests/ -q -m 'not integration'", description = "Run test suite quietly (for pre-commit hooks)" }

--- a/src/nhf_spatial_targets/cli/__init__.py
+++ b/src/nhf_spatial_targets/cli/__init__.py
@@ -71,6 +71,7 @@ def launcher(
 from nhf_spatial_targets.cli.agg import agg_app  # noqa: E402
 from nhf_spatial_targets.cli.catalog import catalog_app  # noqa: E402
 from nhf_spatial_targets.cli.fetch import fetch_app  # noqa: E402
+from nhf_spatial_targets.cli.release import release_app  # noqa: E402
 from nhf_spatial_targets.cli.run import (  # noqa: E402
     _dispatch,
     init,
@@ -86,6 +87,7 @@ from nhf_spatial_targets.cli.run import (  # noqa: E402
 app.command(fetch_app)
 app.command(agg_app)
 app.command(catalog_app)
+app.command(release_app)
 _register_run_commands(app)
 
 

--- a/src/nhf_spatial_targets/cli/release.py
+++ b/src/nhf_spatial_targets/cli/release.py
@@ -33,7 +33,7 @@ import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
 from cyclopts import App, Parameter
 
@@ -143,7 +143,15 @@ def _resolve_client(*, token: str | None = None, env: str | None = None) -> SbCl
             "environment variable. (Reading the `sciencebase:` block from "
             ".credentials.yml lands in PR-G.)"
         )
-    return SbClient.from_token(resolved, env=env)
+    try:
+        return SbClient.from_token(resolved, env=env)
+    except Exception as exc:  # noqa: BLE001 -- a mangled token must read cleanly
+        # from_token parses the token JSON (sciencebasepy add_token); a
+        # copy-paste-mangled --token / SB_TOKEN raises JSONDecodeError / KeyError
+        # here. Surface it as the same clean CLI error the no-token case uses.
+        raise ReleaseCliError(
+            f"could not authenticate to ScienceBase with the provided token: {exc}"
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +159,7 @@ def _resolve_client(*, token: str | None = None, env: str | None = None) -> SbCl
 # ---------------------------------------------------------------------------
 
 
-def _fail(message: str, code: int) -> None:
+def _fail(message: str, code: int) -> NoReturn:
     """Print *message* to stderr and exit with *code* (never returns)."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(code)
@@ -165,7 +173,6 @@ def _load_project_or_exit(workdir: Path) -> Project:
         return _load_project(workdir)
     except (FileNotFoundError, ValueError) as exc:
         _fail(str(exc), 1)
-        raise  # unreachable; satisfies the type checker that this returns Project
 
 
 def _resolve_client_or_exit(*, token: str | None, env: str | None) -> SbClient:
@@ -174,7 +181,24 @@ def _resolve_client_or_exit(*, token: str | None, env: str | None) -> SbClient:
         return _resolve_client(token=token, env=env)
     except ReleaseCliError as exc:
         _fail(str(exc), 1)
-        raise  # unreachable; satisfies the type checker
+
+
+def _run_client_op(label: str, fn, *args, **kwargs):
+    """Run a ScienceBase orchestrator call, converting any failure to a clean exit.
+
+    The read-only commands (``dry-run`` / ``status``) and the publish no-confirm
+    preview call into the release library, which raises typed errors
+    (``PreflightError`` / ``StaleRegistryError`` / ``SbClientError``) and lets
+    transport errors propagate. Surfacing those as the module's ``Error: …`` +
+    exit 1 convention -- with the traceback in the log -- keeps a failed preview
+    or status check from dumping a raw traceback at the operator, matching the
+    confirmed-publish path.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except Exception as exc:  # noqa: BLE001 -- top-level CLI: any failure -> clean exit
+        _logger.exception("release %s failed", label)
+        _fail(f"{label} failed: {exc}", 1)
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +364,7 @@ def dry_run_cmd(
     """
     project = _load_project_or_exit(workdir)
     client = _resolve_client_or_exit(token=token, env=env)
-    dry_run(project, client, scope=scope)
+    _run_client_op("dry-run", dry_run, project, client, scope=scope)
 
 
 @release_app.command(name="status")
@@ -359,7 +383,7 @@ def status(
 
     project = _load_project_or_exit(workdir)
     client = _resolve_client_or_exit(token=token, env=env)
-    diffs = diff_local_vs_remote(project, client, scope=scope)
+    diffs = _run_client_op("status", diff_local_vs_remote, project, client, scope=scope)
 
     table = Table(title="ScienceBase release status")
     table.add_column("scope")
@@ -440,7 +464,9 @@ def publish(
     if not confirm:
         # Preview only -- the dry run builds + mp-validates locally and queries
         # ScienceBase read-only. See _PUBLISH_PREVIEW_SCOPE for the mapping.
-        dry_run(project, client, scope=_PUBLISH_PREVIEW_SCOPE[scope])
+        _run_client_op(
+            "dry-run", dry_run, project, client, scope=_PUBLISH_PREVIEW_SCOPE[scope]
+        )
         target = (
             scope if scope != "source" else f"source/{source_key or '<source-key>'}"
         )
@@ -527,6 +553,7 @@ def auth_test(
     try:
         client.ping()
     except Exception as exc:  # noqa: BLE001 -- a failed ping is the answer here
+        _logger.exception("release auth-test ping failed")
         _fail(f"ScienceBase ping failed: {exc}", 1)
     who = client.whoami()
     Console().print(

--- a/src/nhf_spatial_targets/cli/release.py
+++ b/src/nhf_spatial_targets/cli/release.py
@@ -1,0 +1,595 @@
+"""``nhf-targets release`` sub-app: build and publish the ScienceBase release.
+
+This module is the **CLI surface** over the offline build orchestrator
+(:mod:`nhf_spatial_targets.release.build`) and the idempotent publish / dry-run
+orchestration (:mod:`nhf_spatial_targets.release.publish` /
+:mod:`~nhf_spatial_targets.release.dry_run`). It adds no release logic of its
+own -- every subcommand resolves a :class:`~nhf_spatial_targets.workspace.Project`
+(and, where ScienceBase is touched, an
+:class:`~nhf_spatial_targets.release.sb_client.SbClient`) and dispatches.
+
+Two seams are deliberately small so PR-G can fill them in without touching the
+subcommand bodies:
+
+- :func:`_load_project` wraps :func:`nhf_spatial_targets.workspace.load` (a test
+  seam; the dispatch tests patch it to return a synthetic project).
+- :func:`_resolve_client` builds the live ``SbClient``. **For PR-F** it resolves
+  a Keycloak token from an explicit ``--token`` or the ``SB_TOKEN`` environment
+  variable via :meth:`SbClient.from_token`. The ``.credentials.yml``
+  ``sciencebase:`` block + ``materialize_sciencebase_token`` wiring is PR-G; a
+  clear "no credentials found" error fires until then.
+
+The umbrella's ScienceBase parent (community / folder id) is supplied with the
+``--parent-id`` flag rather than a config key: it is a deployment-level value
+shared across every project publishing to the same umbrella, it is needed only
+for the rare ``publish --scope umbrella`` / ``--create-umbrella`` path, and a
+per-project config key would both duplicate it and pre-commit a schema before
+PR-G clarifies where ScienceBase deployment settings live.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Literal
+
+from cyclopts import App, Parameter
+
+from nhf_spatial_targets.release.build import build_all
+from nhf_spatial_targets.release.checksums import compute_checksums
+from nhf_spatial_targets.release.config import scaffold_release_yml
+from nhf_spatial_targets.release.dry_run import dry_run
+from nhf_spatial_targets.release.publish import (
+    PublishResult,
+    diff_local_vs_remote,
+    publish_fabric_child,
+    publish_source_child,
+    publish_umbrella,
+)
+
+if TYPE_CHECKING:
+    from nhf_spatial_targets.release.sb_client import SbClient
+    from nhf_spatial_targets.workspace import Project
+
+_logger = logging.getLogger(__name__)
+
+release_app = App(
+    name="release",
+    help="Build, validate, and publish the ScienceBase data release.",
+)
+
+# --project-dir is shared by every subcommand except auth-test (which needs only
+# credentials). The default lives on each signature so the type checker sees it.
+_PROJECT_DIR_PARAM = Parameter(
+    name=["--project-dir", "-d"],
+    help="Project created by 'nhf-targets init'.",
+)
+_TOKEN_PARAM = Parameter(
+    name=["--token"],
+    help=(
+        "ScienceBase Keycloak token JSON. Falls back to the SB_TOKEN "
+        "environment variable. (.credentials.yml wiring is PR-G.)"
+    ),
+)
+_ENV_PARAM = Parameter(
+    name=["--env"],
+    help="ScienceBase environment (e.g. 'beta'); default is production.",
+)
+
+# A publish --scope maps to the dry_run build scope used for its no-confirm
+# preview. dry_run has no single-source or umbrella-only scope, so a 'source'
+# preview shows every source child and an 'umbrella' preview shows everything
+# (the umbrella's metadata unions its children, so 'all' is the faithful
+# preview). --confirm then publishes only the requested scope.
+_PUBLISH_PREVIEW_SCOPE: dict[str, Literal["fabric", "sources", "all"]] = {
+    "fabric": "fabric",
+    "source": "sources",
+    "umbrella": "all",
+}
+
+_README_NOTES_PLACEHOLDER = """\
+# Release abstract notes
+
+Text added here is appended to the fabric child's abstract by the release
+metadata builders. Leave empty to use the catalog defaults. Fill `authors`
+and `ipds_number` in `release.yml` (this directory) before publishing.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Errors + seams (the two PR-G fills in)
+# ---------------------------------------------------------------------------
+
+
+class ReleaseCliError(Exception):
+    """A CLI-level precondition failed (e.g. no credentials, missing flag)."""
+
+
+def _load_project(workdir: Path) -> Project:
+    """Load a project from disk.
+
+    A thin wrapper over :func:`nhf_spatial_targets.workspace.load` so the
+    dispatch tests can patch one name to inject a synthetic project.
+    """
+    from nhf_spatial_targets.workspace import load as load_project
+
+    return load_project(workdir)
+
+
+def _resolve_client(*, token: str | None = None, env: str | None = None) -> SbClient:
+    """Construct an :class:`SbClient` for live ScienceBase operations.
+
+    **PR-F seam.** Resolves a Keycloak token from *token* (the ``--token`` flag)
+    or, failing that, the ``SB_TOKEN`` environment variable, and builds the
+    client via :meth:`SbClient.from_token`. PR-G extends this to read the
+    ``sciencebase:`` block from ``.credentials.yml`` (via
+    ``materialize_sciencebase_token``); until then a token must be supplied.
+
+    Raises
+    ------
+    ReleaseCliError
+        No token was provided and ``SB_TOKEN`` is unset.
+    """
+    import os
+
+    from nhf_spatial_targets.release.sb_client import SbClient
+
+    resolved = token or os.environ.get("SB_TOKEN")
+    if not resolved:
+        raise ReleaseCliError(
+            "no ScienceBase credentials found: pass --token or set the SB_TOKEN "
+            "environment variable. (Reading the `sciencebase:` block from "
+            ".credentials.yml lands in PR-G.)"
+        )
+    return SbClient.from_token(resolved, env=env)
+
+
+# ---------------------------------------------------------------------------
+# Small exit helpers (mirror the run.py / agg.py conventions)
+# ---------------------------------------------------------------------------
+
+
+def _fail(message: str, code: int) -> None:
+    """Print *message* to stderr and exit with *code* (never returns)."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _load_project_or_exit(workdir: Path) -> Project:
+    """Resolve the project, exiting 2 (missing dir) / 1 (bad config) on failure."""
+    if not workdir.exists():
+        _fail(f"Project not found: {workdir}", 2)
+    try:
+        return _load_project(workdir)
+    except (FileNotFoundError, ValueError) as exc:
+        _fail(str(exc), 1)
+        raise  # unreachable; satisfies the type checker that this returns Project
+
+
+def _resolve_client_or_exit(*, token: str | None, env: str | None) -> SbClient:
+    """Construct the client, exiting 1 with a clear message when it can't."""
+    try:
+        return _resolve_client(token=token, env=env)
+    except ReleaseCliError as exc:
+        _fail(str(exc), 1)
+        raise  # unreachable; satisfies the type checker
+
+
+# ---------------------------------------------------------------------------
+# Subcommands -- local / offline
+# ---------------------------------------------------------------------------
+
+
+@release_app.command(name="init")
+def init(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+):
+    """Scaffold the per-project release directory.
+
+    Writes ``<project>/release/release.yml`` (operator fills authors +
+    ipds_number), the empty ``release/build/`` staging dir, and a
+    ``release/README.notes.md`` placeholder. Local only; never clobbers an
+    existing ``release.yml``.
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.text import Text
+
+    if not workdir.exists():
+        _fail(f"Project not found: {workdir}", 2)
+
+    release_dir = workdir / "release"
+    yml_path = scaffold_release_yml(release_dir)
+    (release_dir / "build").mkdir(parents=True, exist_ok=True)
+    notes_path = release_dir / "README.notes.md"
+    if not notes_path.exists():
+        notes_path.write_text(_README_NOTES_PLACEHOLDER)
+
+    msg = Text()
+    msg.append("Release scaffold created:\n", style="bold green")
+    msg.append(f"  {release_dir}\n\n")
+    msg.append("Next steps:\n", style="bold")
+    msg.append(f"  1. Edit  {yml_path}  (authors, ipds_number)\n")
+    msg.append(f"  2. Run   nhf-targets release build --project-dir {workdir}\n")
+    Console().print(Panel(msg, title="nhf-targets release init", border_style="green"))
+
+
+@release_app.command(name="build")
+def build(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    scope: Annotated[
+        Literal["fabric", "sources", "all"],
+        Parameter(
+            name=["--scope"],
+            help="fabric child (default), all source children, or all + umbrella.",
+        ),
+    ] = "fabric",
+    copy: Annotated[
+        bool,
+        Parameter(
+            name=["--copy"],
+            help="Copy staged files instead of symlinking (no-symlink filesystems).",
+        ),
+    ] = False,
+):
+    """Build a complete release payload on disk under ``release/build/``.
+
+    Stages files (symlink by default), renders FGDC / ISO / README, and writes
+    checksums for each item the *scope* selects. Entirely offline.
+    """
+    from rich.console import Console
+
+    project = _load_project_or_exit(workdir)
+    try:
+        results = build_all(project, scope=scope, copy=copy)
+    except (FileNotFoundError, ValueError, NotADirectoryError, OSError) as exc:
+        _fail(str(exc), 1)
+
+    console = Console()
+    console.print(f"[bold green]Built {len(results)} release item(s):[/bold green]")
+    for result in results:
+        label = result.kind if result.key is None else f"{result.kind}/{result.key}"
+        console.print(f"  {label}: {len(result.entries)} file(s) -> {result.stage_dir}")
+
+
+@release_app.command(name="manifest")
+def manifest(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    scope: Annotated[
+        Literal["fabric", "sources", "all"],
+        Parameter(
+            name=["--scope"],
+            help="Which already-staged items to re-checksum (default: fabric).",
+        ),
+    ] = "fabric",
+):
+    """Recompute ``checksums.csv`` + ``SHA256SUMS`` for staged items.
+
+    Re-runs the checksum pass over the staged directories already on disk (no
+    XML re-render, no client). Use after editing a file that is already staged.
+    """
+    from rich.console import Console
+
+    if not workdir.exists():
+        _fail(f"Project not found: {workdir}", 2)
+
+    stage_dirs = _staged_dirs(workdir / "release" / "build", scope)
+    if not stage_dirs:
+        _fail(
+            f"no staged items found under {workdir / 'release' / 'build'} for scope "
+            f"'{scope}'; run 'nhf-targets release build' first.",
+            1,
+        )
+
+    console = Console()
+    try:
+        for stage_dir in stage_dirs:
+            entries = compute_checksums(stage_dir)
+            console.print(
+                f"  {stage_dir.relative_to(workdir)}: re-checksummed "
+                f"{len(entries)} file(s)"
+            )
+    except (FileNotFoundError, NotADirectoryError, OSError) as exc:
+        _fail(str(exc), 1)
+    console.print("[bold green]Checksums recomputed.[/bold green]")
+
+
+def _staged_dirs(build_root: Path, scope: str) -> list[Path]:
+    """Existing staged item directories under *build_root* for *scope*.
+
+    Discovered by globbing what is on disk (not by re-deriving the catalog's
+    source / fabric set), so ``manifest`` re-checksums exactly what ``build``
+    left behind.
+    """
+    dirs: list[Path] = []
+    if scope in ("fabric", "all"):
+        fabric_root = build_root / "fabric"
+        if fabric_root.is_dir():
+            dirs += sorted(p for p in fabric_root.iterdir() if p.is_dir())
+    if scope in ("sources", "all"):
+        sources_root = build_root / "sources"
+        if sources_root.is_dir():
+            dirs += sorted(p for p in sources_root.iterdir() if p.is_dir())
+    if scope == "all":
+        umbrella = build_root / "umbrella"
+        if umbrella.is_dir():
+            dirs.append(umbrella)
+    return dirs
+
+
+# ---------------------------------------------------------------------------
+# Subcommands -- ScienceBase (need an SbClient)
+# ---------------------------------------------------------------------------
+
+
+@release_app.command(name="dry-run")
+def dry_run_cmd(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    scope: Annotated[
+        Literal["fabric", "sources", "all"],
+        Parameter(name=["--scope"], help="fabric (default), sources, or all."),
+    ] = "fabric",
+    token: Annotated[str | None, _TOKEN_PARAM] = None,
+    env: Annotated[str | None, _ENV_PARAM] = None,
+):
+    """Preview a release: build, mp-validate, and read-only-diff ScienceBase.
+
+    Writes nothing to ScienceBase. Prints the dry-run summary table.
+    """
+    project = _load_project_or_exit(workdir)
+    client = _resolve_client_or_exit(token=token, env=env)
+    dry_run(project, client, scope=scope)
+
+
+@release_app.command(name="status")
+def status(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    scope: Annotated[
+        Literal["umbrella", "sources", "fabric", "all"],
+        Parameter(name=["--scope"], help="Which scope(s) to diff (default: all)."),
+    ] = "all",
+    token: Annotated[str | None, _TOKEN_PARAM] = None,
+    env: Annotated[str | None, _ENV_PARAM] = None,
+):
+    """Read-only intent-vs-reality diff of the registry against ScienceBase."""
+    from rich.console import Console
+    from rich.table import Table
+
+    project = _load_project_or_exit(workdir)
+    client = _resolve_client_or_exit(token=token, env=env)
+    diffs = diff_local_vs_remote(project, client, scope=scope)
+
+    table = Table(title="ScienceBase release status")
+    table.add_column("scope")
+    table.add_column("ScienceBase id")
+    table.add_column("local")
+    table.add_column("remote")
+    table.add_column("detail")
+    for diff in diffs:
+        label = diff.scope if diff.key is None else f"{diff.scope}/{diff.key}"
+        table.add_row(
+            label, diff.sb_id or "-", diff.local, diff.remote, diff.detail or ""
+        )
+    Console().print(table)
+
+
+@release_app.command(name="publish")
+def publish(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    scope: Annotated[
+        Literal["umbrella", "source", "fabric"],
+        Parameter(name=["--scope"], help="What to publish (default: fabric)."),
+    ] = "fabric",
+    source_key: Annotated[
+        str | None,
+        Parameter(
+            name=["--source-key"],
+            help="Source key to publish; required with --scope source --confirm.",
+        ),
+    ] = None,
+    confirm: Annotated[
+        bool,
+        Parameter(
+            name=["--confirm"],
+            help="Actually publish. Without it, this is a dry-run preview.",
+        ),
+    ] = False,
+    create_umbrella: Annotated[
+        bool,
+        Parameter(
+            name=["--create-umbrella"],
+            help="Publish the umbrella first, then the child (needs --parent-id).",
+        ),
+    ] = False,
+    create_new: Annotated[
+        bool,
+        Parameter(
+            name=["--create-new"],
+            help="If the registry sb_id is gone on ScienceBase, mint a fresh item.",
+        ),
+    ] = False,
+    delete_orphans: Annotated[
+        bool,
+        Parameter(
+            name=["--delete-orphans"],
+            help="Delete remote files no longer in the staged payload.",
+        ),
+    ] = False,
+    parent_id: Annotated[
+        str | None,
+        Parameter(
+            name=["--parent-id"],
+            help="ScienceBase community/folder id hosting the umbrella.",
+        ),
+    ] = None,
+    token: Annotated[str | None, _TOKEN_PARAM] = None,
+    env: Annotated[str | None, _ENV_PARAM] = None,
+):
+    """Publish one scope to ScienceBase (idempotent create-vs-update).
+
+    Without ``--confirm`` this previews via a dry run and writes nothing. With
+    ``--confirm`` it dispatches to the matching ``publish_*`` orchestrator,
+    writes a ``release/last_publish_<scope>_<key>.log``, and prints the
+    registry-commit reminder.
+    """
+    project = _load_project_or_exit(workdir)
+    client = _resolve_client_or_exit(token=token, env=env)
+
+    if not confirm:
+        # Preview only -- the dry run builds + mp-validates locally and queries
+        # ScienceBase read-only. See _PUBLISH_PREVIEW_SCOPE for the mapping.
+        dry_run(project, client, scope=_PUBLISH_PREVIEW_SCOPE[scope])
+        target = (
+            scope if scope != "source" else f"source/{source_key or '<source-key>'}"
+        )
+        from rich.console import Console
+
+        Console().print(
+            f"[yellow]Dry run only.[/yellow] Re-run with --confirm to publish {target}."
+        )
+        return
+
+    # --- confirmed publish ---
+    if scope == "source" and not source_key:
+        _fail("--scope source --confirm requires --source-key.", 2)
+    if (scope == "umbrella" or create_umbrella) and not parent_id:
+        _fail(
+            "publishing the umbrella requires --parent-id (the ScienceBase "
+            "community/folder id).",
+            2,
+        )
+
+    try:
+        results: list[PublishResult] = []
+        if create_umbrella and scope != "umbrella":
+            results.append(
+                publish_umbrella(
+                    project,
+                    client,
+                    parent_id=parent_id,  # guarded above
+                    create_new=create_new,
+                    delete_orphans=delete_orphans,
+                )
+            )
+        if scope == "umbrella":
+            results.append(
+                publish_umbrella(
+                    project,
+                    client,
+                    parent_id=parent_id,  # guarded above
+                    create_new=create_new,
+                    delete_orphans=delete_orphans,
+                )
+            )
+        elif scope == "source":
+            results.append(
+                publish_source_child(
+                    project,
+                    client,
+                    source_key,  # guarded above
+                    create_new=create_new,
+                    delete_orphans=delete_orphans,
+                )
+            )
+        else:  # fabric
+            results.append(
+                publish_fabric_child(
+                    project,
+                    client,
+                    create_new=create_new,
+                    delete_orphans=delete_orphans,
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 -- surface any publish failure cleanly
+        _logger.exception("release publish failed")
+        _fail(f"publish failed: {exc}", 1)
+
+    log_path = _write_publish_log(project, scope, results)
+    _print_publish_summary(results, log_path)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands -- credentials liveness
+# ---------------------------------------------------------------------------
+
+
+@release_app.command(name="auth-test")
+def auth_test(
+    token: Annotated[str | None, _TOKEN_PARAM] = None,
+    env: Annotated[str | None, _ENV_PARAM] = None,
+):
+    """Construct a client, ping ScienceBase, and print the session identity."""
+    from rich.console import Console
+
+    client = _resolve_client_or_exit(token=token, env=env)
+    try:
+        client.ping()
+    except Exception as exc:  # noqa: BLE001 -- a failed ping is the answer here
+        _fail(f"ScienceBase ping failed: {exc}", 1)
+    who = client.whoami()
+    Console().print(
+        f"[bold green]ScienceBase OK[/bold green] "
+        f"user={who.get('username') or '<unknown>'} "
+        f"logged_in={who.get('logged_in')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Publish logging / summary
+# ---------------------------------------------------------------------------
+
+
+def _summarize_result(result: PublishResult) -> str:
+    """One-line human summary of a published item."""
+    label = result.scope if result.key is None else f"{result.scope}/{result.key}"
+    return (
+        f"[{label}] mode={result.mode} sb_id={result.sb_id} "
+        f"adopted={result.adopted} uploaded={len(result.uploaded)} "
+        f"skipped={len(result.skipped)} orphans={len(result.orphans)} "
+        f"orphans_deleted={len(result.orphans_deleted)} "
+        f"body_patched={','.join(result.body_patched) or '-'}"
+    )
+
+
+def _write_publish_log(
+    project: Project, scope: str, results: list[PublishResult]
+) -> Path:
+    """Write a publish log named for the command's scope; return its path.
+
+    The log is named after the primary (last) result -- the child for a
+    ``--create-umbrella`` + child run, the single item otherwise -- and records
+    every item this invocation published.
+    """
+    primary = results[-1]
+    key_token = primary.key if primary.key is not None else primary.scope
+    safe_key = key_token.replace("/", "_")
+    project.release_dir.mkdir(parents=True, exist_ok=True)
+    log_path = project.release_dir / f"last_publish_{scope}_{safe_key}.log"
+    lines = [
+        "ScienceBase release publish log",
+        f"written_utc: {datetime.now(timezone.utc).isoformat()}",
+        f"project: {project.workdir}",
+        "",
+    ]
+    lines += [_summarize_result(r) for r in results]
+    lines.append("")
+    lines.append("Reminder: commit the registry so other operators see this publish:")
+    lines.append("  git add catalog/release_registry.yml && git commit")
+    log_path.write_text("\n".join(lines) + "\n")
+    return log_path
+
+
+def _print_publish_summary(results: list[PublishResult], log_path: Path) -> None:
+    from rich.console import Console
+
+    console = Console()
+    console.print("[bold green]Published:[/bold green]")
+    for result in results:
+        console.print(f"  {_summarize_result(result)}")
+    console.print(f"\nLog: {log_path}")
+    console.print(
+        "\n[bold]Commit the registry so other operators see this publish:[/bold]\n"
+        "  git add catalog/release_registry.yml && git commit"
+    )

--- a/tests/test_release_cli.py
+++ b/tests/test_release_cli.py
@@ -367,6 +367,54 @@ def test_publish_create_umbrella_composes_umbrella_then_child(tmp_path, monkeypa
     assert f"[fabric/{LABEL}]" in log_text
 
 
+@pytest.mark.parametrize(
+    "publish_scope,preview_scope",
+    [("source", "sources"), ("umbrella", "all"), ("fabric", "fabric")],
+)
+def test_publish_without_confirm_previews_mapped_scope(
+    tmp_path, monkeypatch, publish_scope, preview_scope
+):
+    """The publish-scope -> dry-run-scope preview mapping (_PUBLISH_PREVIEW_SCOPE):
+    a no-confirm publish runs dry_run with the mapped build scope, never the raw
+    publish scope (umbrella/source are not valid dry_run scopes)."""
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    recorder = MagicMock()
+    monkeypatch.setattr(rel, "dry_run", recorder)
+
+    _run("release", "publish", "-d", str(project.workdir), "--scope", publish_scope)
+
+    recorder.assert_called_once()
+    assert recorder.call_args.kwargs["scope"] == preview_scope
+
+
+def test_publish_create_umbrella_confirm_requires_parent_id(tmp_path, monkeypatch):
+    """The --create-umbrella arm of the parent-id guard (not just --scope umbrella)."""
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    monkeypatch.setattr(rel, "publish_umbrella", MagicMock())
+    monkeypatch.setattr(rel, "publish_fabric_child", MagicMock())
+
+    _expect_exit(
+        2,
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "fabric",
+        "--confirm",
+        "--create-umbrella",
+    )
+
+
+@pytest.mark.parametrize("sub", ["build", "dry-run", "status"])
+def test_project_command_missing_dir_exits_2(tmp_path, sub):
+    """build / dry-run / status all route through _load_project_or_exit, which
+    exits 2 before any client work when --project-dir does not exist."""
+    _expect_exit(2, "release", sub, "-d", str(tmp_path / "nope"))
+
+
 # ---------------------------------------------------------------------------
 # auth-test + the client seam
 # ---------------------------------------------------------------------------
@@ -385,4 +433,11 @@ def test_auth_test_without_credentials_exits_1(monkeypatch):
     # Exercise the real _resolve_client no-credentials branch + exit wrapper
     # (no SB_TOKEN, no --token). Must not import sciencebasepy.
     monkeypatch.delenv("SB_TOKEN", raising=False)
+    _expect_exit(1, "release", "auth-test")
+
+
+def test_auth_test_ping_failure_exits_1(monkeypatch):
+    client = MagicMock()
+    client.ping.side_effect = RuntimeError("ScienceBase unreachable")
+    monkeypatch.setattr(rel, "_resolve_client", lambda **kwargs: client)
     _expect_exit(1, "release", "auth-test")

--- a/tests/test_release_cli.py
+++ b/tests/test_release_cli.py
@@ -1,0 +1,388 @@
+"""Offline tests for the ``nhf-targets release`` CLI sub-app (PR-F).
+
+These exercise the CLI *wiring* only: help + argument parsing for all seven
+subcommands, the local artifacts ``init`` / ``build`` / ``manifest`` produce,
+and -- for the ScienceBase-touching subcommands -- that the right
+``publish_*`` / ``dry_run`` / ``diff_local_vs_remote`` orchestrator is
+dispatched with the right scope and flags. ScienceBase is never hit: the
+client seam (:func:`cli.release._resolve_client`) and the project loader
+(:func:`cli.release._load_project`) are patched, and the orchestrators are
+patched with recorders. Live ScienceBase verification is PR-G.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import nhf_spatial_targets.cli.release as rel
+from nhf_spatial_targets.cli import app
+from nhf_spatial_targets.release.build import build_all
+from nhf_spatial_targets.release.publish import PublishResult
+from tests.conftest import FakeSbSession, build_release_project, make_sb_client
+
+SUBCOMMANDS = ("init", "build", "manifest", "dry-run", "publish", "status", "auth-test")
+LABEL = "gfv_test"  # build_release_project's default fabric label
+
+# Files every finished stage carries (from build._finish / checksums).
+_STAGE_FILES = ("fgdc.xml", "iso.xml", "README.md", "checksums.csv", "SHA256SUMS")
+
+
+# ---------------------------------------------------------------------------
+# Invocation helpers (cyclopts raises SystemExit(0) on success)
+# ---------------------------------------------------------------------------
+
+
+def _run(*tokens: str) -> None:
+    """Invoke the app, swallowing the SystemExit(0) cyclopts raises on success."""
+    try:
+        app(list(tokens), exit_on_error=False)
+    except SystemExit as exc:
+        if exc.code not in (None, 0):
+            raise
+
+
+def _expect_exit(code: int, *tokens: str) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        app(list(tokens), exit_on_error=False)
+    assert excinfo.value.code == code
+
+
+def _fake_result(scope: str, key: str | None) -> PublishResult:
+    """A minimal valid PublishResult for a patched publish_* recorder."""
+    return PublishResult(
+        scope=scope,  # type: ignore[arg-type]
+        key=key,
+        sb_id="SB1",
+        mode="create",
+        adopted=False,
+        uploaded=("data.nc",),
+        skipped=(),
+        orphans=(),
+        orphans_deleted=(),
+        body_patched=(),
+        registry_entry={},
+    )
+
+
+def _patch_seams(monkeypatch, project, client):
+    """Patch the project loader + client seam to the given offline doubles."""
+    monkeypatch.setattr(rel, "_load_project", lambda workdir: project)
+    monkeypatch.setattr(rel, "_resolve_client", lambda **kwargs: client)
+
+
+# ---------------------------------------------------------------------------
+# Help + arg parsing for all seven subcommands
+# ---------------------------------------------------------------------------
+
+
+def test_release_help_lists_subcommands(capsys):
+    _run("release", "--help")
+    out = capsys.readouterr().out
+    for name in SUBCOMMANDS:
+        assert name in out
+
+
+@pytest.mark.parametrize("sub", SUBCOMMANDS)
+def test_each_subcommand_help_parses(sub):
+    # --help parses the subcommand's option spec and exits 0; a parse error
+    # would raise a non-zero SystemExit (or a cyclopts error) instead.
+    _run("release", sub, "--help")
+
+
+# ---------------------------------------------------------------------------
+# init / build / manifest -- local artifacts (offline)
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_local_artifacts(tmp_path):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _run("release", "init", "--project-dir", str(proj))
+
+    assert (proj / "release" / "release.yml").is_file()
+    assert (proj / "release" / "build").is_dir()
+    assert (proj / "release" / "README.notes.md").is_file()
+
+
+def test_init_missing_project_dir_exits_2(tmp_path):
+    _expect_exit(2, "release", "init", "-d", str(tmp_path / "nope"))
+
+
+def test_build_creates_stage_artifacts(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    monkeypatch.setattr(rel, "_load_project", lambda workdir: project)
+
+    _run("release", "build", "-d", str(project.workdir), "--scope", "fabric")
+
+    stage = project.release_build_dir / "fabric" / LABEL
+    for name in _STAGE_FILES:
+        assert (stage / name).is_file(), f"missing {name}"
+
+
+def test_manifest_recomputes_checksums(tmp_path):
+    project = build_release_project(tmp_path)
+    # Stage fabric + source + umbrella items on disk first.
+    build_all(project, scope="all")
+
+    fabric_csv = project.release_build_dir / "fabric" / LABEL / "checksums.csv"
+    assert fabric_csv.is_file()
+    fabric_csv.unlink()  # simulate a removed/edited integrity file
+
+    _run("release", "manifest", "-d", str(project.workdir), "--scope", "all")
+
+    assert fabric_csv.is_file()  # regenerated
+    # Every staged item now carries both integrity files.
+    for sub in (project.release_build_dir).rglob("SHA256SUMS"):
+        assert sub.is_file()
+
+
+def test_manifest_no_staged_items_exits_1(tmp_path):
+    proj = tmp_path / "proj"
+    (proj / "release" / "build").mkdir(parents=True)
+    _expect_exit(1, "release", "manifest", "-d", str(proj))
+
+
+# ---------------------------------------------------------------------------
+# dry-run / status -- dispatch with the right scope (read-only)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_dispatches_with_scope(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    client = make_sb_client(FakeSbSession())
+    _patch_seams(monkeypatch, project, client)
+    recorder = MagicMock()
+    monkeypatch.setattr(rel, "dry_run", recorder)
+
+    _run("release", "dry-run", "-d", str(project.workdir), "--scope", "sources")
+
+    recorder.assert_called_once()
+    assert recorder.call_args.args[0] is project
+    assert recorder.call_args.args[1] is client
+    assert recorder.call_args.kwargs["scope"] == "sources"
+
+
+def test_dry_run_default_scope_is_fabric(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    recorder = MagicMock()
+    monkeypatch.setattr(rel, "dry_run", recorder)
+
+    _run("release", "dry-run", "-d", str(project.workdir))
+
+    assert recorder.call_args.kwargs["scope"] == "fabric"
+
+
+def test_status_dispatches_diff_with_scope(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    client = make_sb_client(FakeSbSession())
+    _patch_seams(monkeypatch, project, client)
+    recorder = MagicMock(return_value=[])
+    monkeypatch.setattr(rel, "diff_local_vs_remote", recorder)
+
+    _run("release", "status", "-d", str(project.workdir), "--scope", "all")
+
+    recorder.assert_called_once()
+    assert recorder.call_args.args[0] is project
+    assert recorder.call_args.kwargs["scope"] == "all"
+
+
+# ---------------------------------------------------------------------------
+# publish -- without --confirm is a dry run; never mutates ScienceBase
+# ---------------------------------------------------------------------------
+
+
+def test_publish_without_confirm_does_not_publish(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    session = FakeSbSession()
+    _patch_seams(monkeypatch, project, make_sb_client(session))
+    # dry_run runs for real (read-only); the publish orchestrator must NOT.
+    pub = MagicMock()
+    monkeypatch.setattr(rel, "publish_fabric_child", pub)
+
+    _run("release", "publish", "-d", str(project.workdir), "--scope", "fabric")
+
+    pub.assert_not_called()
+    assert session.created == []
+    assert session.updated == []
+    assert session.uploaded == []
+    assert session.deleted == []
+    assert not list(project.release_dir.glob("last_publish_*.log"))
+
+
+# ---------------------------------------------------------------------------
+# publish --confirm -- dispatch, log, and registry-commit reminder
+# ---------------------------------------------------------------------------
+
+
+def test_publish_fabric_confirm_dispatches_logs_and_reminds(
+    tmp_path, monkeypatch, capsys
+):
+    project = build_release_project(tmp_path)
+    client = make_sb_client(FakeSbSession())
+    _patch_seams(monkeypatch, project, client)
+    pub = MagicMock(return_value=_fake_result("fabric", LABEL))
+    monkeypatch.setattr(rel, "publish_fabric_child", pub)
+
+    _run(
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "fabric",
+        "--confirm",
+        "--delete-orphans",
+    )
+
+    pub.assert_called_once()
+    assert pub.call_args.args[0] is project
+    assert pub.call_args.args[1] is client
+    assert pub.call_args.kwargs["delete_orphans"] is True
+    assert pub.call_args.kwargs["create_new"] is False
+
+    log_path = project.release_dir / f"last_publish_fabric_{LABEL}.log"
+    assert log_path.is_file()
+    assert "release_registry.yml" in log_path.read_text()
+    assert "release_registry.yml" in capsys.readouterr().out
+
+
+def test_publish_source_confirm_requires_source_key(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    monkeypatch.setattr(rel, "publish_source_child", MagicMock())
+
+    _expect_exit(
+        2,
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "source",
+        "--confirm",
+    )
+
+
+def test_publish_source_confirm_dispatches_with_key(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    pub = MagicMock(return_value=_fake_result("source", "era5_land"))
+    monkeypatch.setattr(rel, "publish_source_child", pub)
+
+    _run(
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "source",
+        "--source-key",
+        "era5_land",
+        "--confirm",
+    )
+
+    pub.assert_called_once()
+    assert pub.call_args.args[2] == "era5_land"
+    assert (project.release_dir / "last_publish_source_era5_land.log").is_file()
+
+
+def test_publish_umbrella_confirm_requires_parent_id(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    monkeypatch.setattr(rel, "publish_umbrella", MagicMock())
+
+    _expect_exit(
+        2,
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "umbrella",
+        "--confirm",
+    )
+
+
+def test_publish_umbrella_confirm_dispatches_with_parent_id(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    pub = MagicMock(return_value=_fake_result("umbrella", None))
+    monkeypatch.setattr(rel, "publish_umbrella", pub)
+
+    _run(
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "umbrella",
+        "--confirm",
+        "--parent-id",
+        "COMM123",
+    )
+
+    pub.assert_called_once()
+    assert pub.call_args.kwargs["parent_id"] == "COMM123"
+    assert (project.release_dir / "last_publish_umbrella_umbrella.log").is_file()
+
+
+def test_publish_create_umbrella_composes_umbrella_then_child(tmp_path, monkeypatch):
+    project = build_release_project(tmp_path)
+    _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
+    calls: list[str] = []
+    umb = MagicMock(
+        side_effect=lambda *a, **k: (
+            (calls.append("umbrella")) or _fake_result("umbrella", None)
+        )
+    )
+    fab = MagicMock(
+        side_effect=lambda *a, **k: (
+            (calls.append("fabric")) or _fake_result("fabric", LABEL)
+        )
+    )
+    monkeypatch.setattr(rel, "publish_umbrella", umb)
+    monkeypatch.setattr(rel, "publish_fabric_child", fab)
+
+    _run(
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "fabric",
+        "--confirm",
+        "--create-umbrella",
+        "--parent-id",
+        "COMM123",
+    )
+
+    umb.assert_called_once()
+    fab.assert_called_once()
+    assert calls == ["umbrella", "fabric"]  # umbrella published first
+    log_text = (project.release_dir / f"last_publish_fabric_{LABEL}.log").read_text()
+    assert "[umbrella]" in log_text
+    assert f"[fabric/{LABEL}]" in log_text
+
+
+# ---------------------------------------------------------------------------
+# auth-test + the client seam
+# ---------------------------------------------------------------------------
+
+
+def test_auth_test_pings_and_prints_identity(monkeypatch, capsys):
+    client = make_sb_client(FakeSbSession())
+    monkeypatch.setattr(rel, "_resolve_client", lambda **kwargs: client)
+
+    _run("release", "auth-test")
+
+    assert "logged_in=True" in capsys.readouterr().out
+
+
+def test_auth_test_without_credentials_exits_1(monkeypatch):
+    # Exercise the real _resolve_client no-credentials branch + exit wrapper
+    # (no SB_TOKEN, no --token). Must not import sciencebasepy.
+    monkeypatch.delenv("SB_TOKEN", raising=False)
+    _expect_exit(1, "release", "auth-test")


### PR DESCRIPTION
## Summary
- Wires the offline build (PR-E1) + idempotent publish/dry-run (PR-E3) orchestration onto the root `nhf-targets` cyclopts CLI as a `release` sub-app with seven subcommands: `init`, `build`, `manifest`, `dry-run`, `publish`, `status`, `auth-test`.
- Adds `src/nhf_spatial_targets/cli/release.py`, registers `release_app` in `cli/__init__.py`, and adds `release-*` task aliases in `pixi.toml`.
- Adds `tests/test_release_cli.py` (offline only).

Closes #275. Follows PR-E3 (#274).

## Decisions (documented in the module docstring)
1. **Client construction seam.** `_resolve_client(token, env)` builds the `SbClient` from an explicit `--token` or the `SB_TOKEN` env var via `SbClient.from_token`. The `.credentials.yml` `sciencebase:` integration is explicitly **deferred to PR-G** — a clear "no credentials found; pass --token or set SB_TOKEN" error fires until then. It is the single seam PR-G fills in. `_load_project` is a matching seam over `workspace.load` (patched in the dispatch tests).
2. **Umbrella parent id → `--parent-id` flag (no new config key).** The ScienceBase community/folder id is a deployment-level value shared across every project publishing to one umbrella, needed only for the rare `publish --scope umbrella` / `--create-umbrella` path. A per-project config key would duplicate it and pre-commit a schema before PR-G clarifies where ScienceBase deployment settings live. Flag-only is the minimal, reversible choice for PR-F.

## Subcommand behavior
- `init` — `scaffold_release_yml` + `release/build/` + `release/README.notes.md` placeholder. Local only.
- `build [--scope fabric|sources|all] [--copy]` — `build.build_all`. Offline.
- `manifest [--scope]` — re-runs `compute_checksums` over the staged dirs found on disk (no XML re-render).
- `dry-run [--scope]` — `dry_run.dry_run(project, client, scope=…)`. Read-only.
- `publish [--scope umbrella|source|fabric] [--source-key] [--confirm] [--create-umbrella] [--create-new] [--delete-orphans] [--parent-id]` — without `--confirm` previews via dry-run (publish-scope → dry-run build-scope mapping documented); with `--confirm` dispatches to the matching `publish_*`, writes `release/last_publish_<scope>_<key>.log`, and prints the `git add catalog/release_registry.yml && git commit` reminder. `--create-umbrella` composes `publish_umbrella` then the child.
- `status [--scope]` — `diff_local_vs_remote` Rich table. Read-only.
- `auth-test` — construct client, ping, print whoami.

## Out of scope (PR-G)
`.credentials.yml` `sciencebase:` block + `materialize_sciencebase_token` (the `_resolve_client` seam stubs this), `@pytest.mark.integration` live tests, `docs/release/*.md`, XSD validation.

## Test plan
- [x] `pixi run -e dev fmt` + `lint` clean
- [x] `tests/test_release_cli.py` — 25 passed (help + arg parsing for all 7 subcommands; init/build/manifest local artifacts; dry-run/status/publish dispatch via mock `SbClient`; publish-without---confirm makes no ScienceBase mutations and writes no log; `--confirm` dispatches + writes the log + prints the registry reminder)
- [x] `tests/test_cli.py` + `tests/test_cli_agg.py` — 59 passed (no regression from the new eager `release_app` import)
- [x] `nhf-targets release --help` and `release init` smoke-tested via the real entry point
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)