### PR TITLE
PR-3: completeness gate at publish (verify-don't-mutate) + stage_fabric_child hardening (#279)

### DIFF
--- a/src/nhf_spatial_targets/cli/release.py
+++ b/src/nhf_spatial_targets/cli/release.py
@@ -441,6 +441,18 @@ def publish(
             help="Delete remote files no longer in the staged payload.",
         ),
     ] = False,
+    allow_incomplete_sources: Annotated[
+        bool,
+        Parameter(
+            name=["--allow-incomplete-sources"],
+            help=(
+                "Override the manifest completeness gate: publish even if the "
+                "manifest under-reports sources or drifts from the projection "
+                "(logged warning). Schema/fabric/steps checks stay fatal. "
+                "Prefer 'nhf-targets rebuild-manifest' instead."
+            ),
+        ),
+    ] = False,
     parent_id: Annotated[
         str | None,
         Parameter(
@@ -497,6 +509,7 @@ def publish(
                     parent_id=parent_id,  # guarded above
                     create_new=create_new,
                     delete_orphans=delete_orphans,
+                    allow_incomplete_sources=allow_incomplete_sources,
                 )
             )
         if scope == "umbrella":
@@ -507,6 +520,7 @@ def publish(
                     parent_id=parent_id,  # guarded above
                     create_new=create_new,
                     delete_orphans=delete_orphans,
+                    allow_incomplete_sources=allow_incomplete_sources,
                 )
             )
         elif scope == "source":
@@ -517,6 +531,7 @@ def publish(
                     source_key,  # guarded above
                     create_new=create_new,
                     delete_orphans=delete_orphans,
+                    allow_incomplete_sources=allow_incomplete_sources,
                 )
             )
         else:  # fabric
@@ -526,6 +541,7 @@ def publish(
                     client,
                     create_new=create_new,
                     delete_orphans=delete_orphans,
+                    allow_incomplete_sources=allow_incomplete_sources,
                 )
             )
     except Exception as exc:  # noqa: BLE001 -- surface any publish failure cleanly

--- a/src/nhf_spatial_targets/release/payload.py
+++ b/src/nhf_spatial_targets/release/payload.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from nhf_spatial_targets import catalog
 from nhf_spatial_targets.release._models import (
     FabricChildPlan,
+    ReleaseError,
     ReleasePayload,
     SourceChildPlan,
     UmbrellaPlan,
@@ -188,8 +189,13 @@ def stage_fabric_child(project: Project, *, copy: bool = False) -> FabricChildPl
 
     _link_or_copy(plan.fabric_gpkg, plan.stage_dir / "fabric.gpkg", copy=copy)
 
-    if plan.manifest_src.exists():
-        _copy_file(plan.manifest_src, plan.stage_dir / "manifest.json")
+    if not plan.manifest_src.exists():
+        raise ReleaseError(
+            f"Cannot stage fabric child: manifest.json missing at "
+            f"{plan.manifest_src}. Run 'nhf-targets validate' then "
+            f"'nhf-targets rebuild-manifest' for this project before publishing."
+        )
+    _copy_file(plan.manifest_src, plan.stage_dir / "manifest.json")
 
     aggregated_root = project.aggregated_dir()
     for src in plan.aggregated_files:

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -356,7 +356,9 @@ def _preflight_provenance_complete(
 
     Always-fatal (a manifest this broken cannot be published at all):
 
-    - ``manifest_schema_version`` behind :data:`CURRENT_MANIFEST_SCHEMA_VERSION`,
+    - ``manifest_schema_version`` not equal to
+      :data:`CURRENT_MANIFEST_SCHEMA_VERSION` (behind, or an unexpected future
+      version -- either way the shape can't be trusted),
     - no ``fabric`` block,
     - empty ``steps[]`` (no lineage).
 
@@ -467,7 +469,12 @@ def _preflight_provenance_complete(
 def _preflight_common(
     project: Project, *, allow_incomplete_sources: bool = False
 ) -> None:
-    """Fatal, cheap, fail-fast checks shared by every publish scope.
+    """Fatal, fail-fast checks shared by every publish scope.
+
+    The early checks are constant-time, but the provenance gate (last) walks
+    the datastore / ``data/aggregated/`` / ``targets/`` trees to project the
+    manifest, so this is not constant-time overall -- it is still fail-fast
+    (runs before any build / upload).
 
     Credential resolvability is intentionally *not* checked here: PR-E3 assumes
     a ready, injected client (the credential/session wiring is PR-G).

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -57,6 +57,7 @@ content or the file set changes.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -64,6 +65,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+from nhf_spatial_targets import catalog
 from nhf_spatial_targets.release import registry
 from nhf_spatial_targets.release._models import ReleaseError
 from nhf_spatial_targets.release.build import (
@@ -77,7 +79,11 @@ from nhf_spatial_targets.release.defaults import (
     load_release_defaults,
     require_populated_release_defaults,
 )
-from nhf_spatial_targets.release.lineage import read_manifest, sha256_file
+from nhf_spatial_targets.release.lineage import (
+    CURRENT_MANIFEST_SCHEMA_VERSION,
+    read_manifest,
+    sha256_file,
+)
 from nhf_spatial_targets.release.payload import resolve_fabric_label, sources_used
 from nhf_spatial_targets.release.sb_client import SbClient, SbClientError
 from nhf_spatial_targets.workspace import Project
@@ -317,7 +323,150 @@ def _item_body(mcf: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _preflight_common(project: Project) -> None:
+def _drift_fingerprint(manifest: dict) -> str:
+    """JSON-normalized (sorted-key) fingerprint of a manifest's derived catalog.
+
+    Publish compares only the *derived* catalog (``sources`` + ``steps``)
+    between the on-disk manifest and the deterministic projection -- identity
+    fields (``created_utc``, ``fabric`` authorship) are read-merged by the
+    rebuild and are not drift. ``sort_keys`` makes the comparison insensitive
+    to dict-key ordering; the projection already emits steps in a deterministic
+    order, so a byte-equal fingerprint means no drift.
+    """
+    return json.dumps(
+        {
+            "sources": manifest.get("sources") or {},
+            "steps": manifest.get("steps") or [],
+        },
+        sort_keys=True,
+    )
+
+
+def _preflight_provenance_complete(
+    project: Project, *, allow_incomplete_sources: bool = False
+) -> None:
+    """Verify (don't mutate) that the on-disk manifest is complete + current.
+
+    Runs ``rebuild_manifest`` in ``dry_run`` to obtain the deterministic
+    projection of the on-disk artifacts, reads the on-disk manifest, and
+    refuses to publish unless they agree. Publish stays a pure read-local /
+    write-remote operation: this gate never writes the manifest -- regenerating
+    it is the operator's explicit ``nhf-targets rebuild-manifest`` action, which
+    is what keeps publish idempotent.
+
+    Always-fatal (a manifest this broken cannot be published at all):
+
+    - ``manifest_schema_version`` behind :data:`CURRENT_MANIFEST_SCHEMA_VERSION`,
+    - no ``fabric`` block,
+    - empty ``steps[]`` (no lineage).
+
+    Source-completeness + drift (the deliberate
+    ``allow_incomplete_sources`` override downgrades these to a logged warning):
+
+    - ``sources[]`` missing an aggregated dir or a consolidated datastore
+      catalog source present on disk (the #277 ∪ #278 union),
+    - a published target NC with no matching ``target`` step,
+    - on-disk ``sources``/``steps`` differing from the projection (drift).
+    """
+    from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
+
+    projection = rebuild_manifest(project, dry_run=True)
+    on_disk = read_manifest(project.manifest_path)
+
+    rebuild_hint = (
+        f"run 'nhf-targets rebuild-manifest -d {project.workdir}' to regenerate "
+        f"manifest.json as a complete projection of the on-disk artifacts, then "
+        f"re-publish"
+    )
+
+    # --- always-fatal structural checks (not bypassable) ---
+    schema = on_disk.get("manifest_schema_version", 0)
+    if schema != CURRENT_MANIFEST_SCHEMA_VERSION:
+        raise PreflightError(
+            f"manifest.json at {project.manifest_path} is schema version "
+            f"{schema}; current is {CURRENT_MANIFEST_SCHEMA_VERSION}. {rebuild_hint}."
+        )
+    if on_disk.get("fabric") is None:
+        raise PreflightError(
+            f"manifest.json at {project.manifest_path} has no fabric block; "
+            f"run 'nhf-targets validate -d {project.workdir}' then {rebuild_hint}."
+        )
+    if not on_disk.get("steps"):
+        raise PreflightError(
+            f"manifest.json at {project.manifest_path} records no steps[] "
+            f"(no lineage); {rebuild_hint}."
+        )
+
+    # --- source-completeness + drift (override-downgradable) ---
+    problems: list[str] = []
+
+    on_disk_sources = set(on_disk.get("sources") or {})
+    catalog_keys = set(catalog.sources())
+    agg_root = project.aggregated_dir()
+    agg_dirs = (
+        {p.name for p in agg_root.iterdir() if p.is_dir()}
+        if agg_root.is_dir()
+        else set()
+    )
+    datastore_used = (
+        {
+            p.name
+            for p in project.datastore.iterdir()
+            if p.is_dir() and p.name in catalog_keys
+        }
+        if project.datastore.is_dir()
+        else set()
+    )
+    missing_sources = sorted((agg_dirs | datastore_used) - on_disk_sources)
+    if missing_sources:
+        problems.append(
+            f"sources[] is missing {missing_sources} (present on disk under "
+            f"data/aggregated/ or the datastore, absent from the manifest)"
+        )
+
+    targets_dir = project.targets_dir()
+    target_ncs = (
+        sorted(p.name for p in targets_dir.glob("*.nc") if p.is_file())
+        if targets_dir.is_dir()
+        else []
+    )
+    target_step_outputs = {
+        Path(out.get("path", "")).name
+        for step in (on_disk.get("steps") or [])
+        if step.get("kind") == "target"
+        for out in (step.get("outputs") or [])
+    }
+    missing_targets = sorted(set(target_ncs) - target_step_outputs)
+    if missing_targets:
+        problems.append(
+            f"published target NC(s) {missing_targets} have no matching 'target' step"
+        )
+
+    if _drift_fingerprint(on_disk) != _drift_fingerprint(projection):
+        problems.append(
+            "sources[]/steps[] differ from the deterministic rebuild-manifest "
+            "projection (drift)"
+        )
+
+    if problems:
+        message = (
+            f"publish pre-flight: manifest.json at {project.manifest_path} is "
+            f"incomplete or stale:\n  - "
+            + "\n  - ".join(problems)
+            + f"\nTo fix, {rebuild_hint}."
+        )
+        if allow_incomplete_sources:
+            logger.warning(
+                "%s\nProceeding anyway because --allow-incomplete-sources was set.",
+                message,
+            )
+            return
+        raise PreflightError(message)
+
+
+def _preflight_common(
+    project: Project, *, allow_incomplete_sources: bool = False
+) -> None:
     """Fatal, cheap, fail-fast checks shared by every publish scope.
 
     Credential resolvability is intentionally *not* checked here: PR-E3 assumes
@@ -347,6 +496,13 @@ def _preflight_common(project: Project) -> None:
             "config.yml release.authors is empty; add at least one author "
             "(given/family) before publishing."
         )
+
+    # The provenance completeness gate (verify-don't-mutate): every publish
+    # scope is gated, so a child can never ship an under-reported or stale
+    # manifest. The override is the deliberate, logged escape hatch.
+    _preflight_provenance_complete(
+        project, allow_incomplete_sources=allow_incomplete_sources
+    )
 
 
 def _require_umbrella_sb_id(registry_path: Path | None) -> str:
@@ -637,6 +793,7 @@ def publish_umbrella(
     parent_id: str,
     create_new: bool = False,
     delete_orphans: bool = False,
+    allow_incomplete_sources: bool = False,
     now: datetime | None = None,
     registry_path: Path | None = None,
 ) -> PublishResult:
@@ -647,7 +804,7 @@ def publish_umbrella(
     identification.doi), so an operator-set ``config.release.doi`` flows into
     the registry on the next publish.
     """
-    _preflight_common(project)
+    _preflight_common(project, allow_incomplete_sources=allow_incomplete_sources)
     build_result = build_umbrella(project, now=now)
     verify_csv(build_result.stage_dir)
     return _reconcile_and_publish(
@@ -670,6 +827,7 @@ def publish_source_child(
     *,
     create_new: bool = False,
     delete_orphans: bool = False,
+    allow_incomplete_sources: bool = False,
     now: datetime | None = None,
     registry_path: Path | None = None,
 ) -> PublishResult:
@@ -678,7 +836,7 @@ def publish_source_child(
     Parented under the umbrella item recorded in the registry (a missing
     umbrella sb_id is a fatal pre-flight error).
     """
-    _preflight_common(project)
+    _preflight_common(project, allow_incomplete_sources=allow_incomplete_sources)
     parent_id = _require_umbrella_sb_id(registry_path)
     build_result = build_source_child(project, source_key, now=now)
     verify_csv(build_result.stage_dir)
@@ -701,6 +859,7 @@ def publish_fabric_child(
     *,
     create_new: bool = False,
     delete_orphans: bool = False,
+    allow_incomplete_sources: bool = False,
     now: datetime | None = None,
     registry_path: Path | None = None,
 ) -> PublishResult:
@@ -710,7 +869,7 @@ def publish_fabric_child(
     umbrella sb_id is a fatal pre-flight error). The registry key is the
     resolved fabric label.
     """
-    _preflight_common(project)
+    _preflight_common(project, allow_incomplete_sources=allow_incomplete_sources)
     parent_id = _require_umbrella_sb_id(registry_path)
     build_result = build_fabric_child(project, now=now)
     verify_csv(build_result.stage_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,28 +147,6 @@ def build_release_project(
     _touch(datastore / "era5_land" / "monthly" / "era5_land_monthly_1980.nc", b"m-1980")
     _touch(datastore / "daymet" / "daymet_consolidated.nc", b"should-not-stage")
 
-    if with_manifest:
-        (workdir / "manifest.json").write_text(
-            json.dumps(
-                {
-                    "sources": {"era5_land": {}, "watergap22d": {}},
-                    "steps": [
-                        {
-                            "kind": "aggregate",
-                            "source_key": "era5_land",
-                            "timestamp_utc": "2026-01-02T03:04:05+00:00",
-                            "software_version": "0.7.0",
-                            "tool": "nhf-targets",
-                            "command": "agg era5-land",
-                            "inputs": [],
-                            "outputs": [],
-                            "params": {"method": "area_weighted"},
-                        }
-                    ],
-                }
-            )
-        )
-
     config = {
         "fabric": {"path": str(fabric_file), "id_col": "nhm_id"},
         "release": {
@@ -188,13 +166,35 @@ def build_release_project(
         "bbox": {"minx": -125.0, "miny": 24.0, "maxx": -66.0, "maxy": 53.0},
         "hru_count": 4242,
     }
-    return Project(
+    project = Project(
         workdir=workdir,
         datastore=datastore,
         config=config,
         fabric=fabric,
         dir_mode=None,
     )
+    if with_manifest:
+        # A release-ready fixture carries a COMPLETE manifest: seed the fabric
+        # authorship block (as ``validate`` would) then project the on-disk
+        # datastore / aggregated / targets artifacts into sources[]/steps[] via
+        # ``rebuild_manifest``, so the PR-3 publish completeness gate clears for
+        # the happy paths. Tests that need an incomplete/stale manifest mutate
+        # disk (add a source dir) or the manifest after this call.
+        from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
+        from nhf_spatial_targets.release.lineage import (
+            _new_manifest_skeleton,
+            atomic_write_manifest,
+        )
+
+        skeleton = _new_manifest_skeleton()
+        skeleton["fabric"] = {
+            "path": str(fabric_file),
+            "id_col": "nhm_id",
+            "hru_count": 4242,
+        }
+        atomic_write_manifest(project.manifest_path, skeleton)
+        rebuild_manifest(project, dry_run=False)
+    return project
 
 
 def _md5_file(filename: str) -> str:

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -449,15 +449,19 @@ def test_corrupt_manifest_is_a_loud_failure(tmp_path):
         build.build_fabric_child(project, now=NOW)
 
 
-def test_missing_manifest_builds_without_snapshot(tmp_path):
-    """An absent manifest.json is legitimate: the build succeeds and the
-    fabric stage simply carries no manifest snapshot (and never lists one)."""
+def test_missing_manifest_is_a_hard_error(tmp_path):
+    """An absent manifest.json is fatal at staging (PR-3, #279).
+
+    Staging must never emit a fabric child with no provenance snapshot, so
+    ``stage_fabric_child`` (reached via ``build_fabric_child``) raises rather
+    than silently skipping the copy. The operator runs validate /
+    rebuild-manifest first."""
+    from nhf_spatial_targets.release._models import ReleaseError
+
     project = _build_project(tmp_path)
     project.manifest_path.unlink()
-    result = build.build_fabric_child(project, now=NOW)
-    assert not (result.stage_dir / "manifest.json").exists()
-    assert "manifest.json" not in _download_names(result.mcf)
-    verify_csv(result.stage_dir)
+    with pytest.raises(ReleaseError, match="manifest.json"):
+        build.build_fabric_child(project, now=NOW)
 
 
 def test_staged_data_relpaths_rejects_dangling_symlink(tmp_path):

--- a/tests/test_release_cli.py
+++ b/tests/test_release_cli.py
@@ -249,6 +249,29 @@ def test_publish_fabric_confirm_dispatches_logs_and_reminds(
     assert "release_registry.yml" in capsys.readouterr().out
 
 
+def test_publish_allow_incomplete_sources_threads_to_publisher(tmp_path, monkeypatch):
+    """``--allow-incomplete-sources`` reaches the publisher as the deliberate,
+    logged override of the completeness gate; it defaults to False."""
+    project = build_release_project(tmp_path)
+    client = make_sb_client(FakeSbSession())
+    _patch_seams(monkeypatch, project, client)
+    pub = MagicMock(return_value=_fake_result("fabric", LABEL))
+    monkeypatch.setattr(rel, "publish_fabric_child", pub)
+
+    _run(
+        "release",
+        "publish",
+        "-d",
+        str(project.workdir),
+        "--scope",
+        "fabric",
+        "--confirm",
+        "--allow-incomplete-sources",
+    )
+
+    assert pub.call_args.kwargs["allow_incomplete_sources"] is True
+
+
 def test_publish_source_confirm_requires_source_key(tmp_path, monkeypatch):
     project = build_release_project(tmp_path)
     _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))

--- a/tests/test_release_idempotency.py
+++ b/tests/test_release_idempotency.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
 from nhf_spatial_targets.release import publish, registry
 from nhf_spatial_targets.release.build import build_fabric_child
 from nhf_spatial_targets.release.sb_client import SbClientError
@@ -196,8 +197,12 @@ def test_per_file_skip_then_replace_on_content_change(tmp_path):
     assert "aet_targets.nc" in second.skipped
     sha_before = registry.get_fabric(LABEL, reg)["manifest_sha256"]
 
-    # Change one source file's content -> only that file re-uploads.
+    # Change one source file's content -> only that file re-uploads. Editing a
+    # published artifact drifts the manifest projection, so the operator must
+    # re-run rebuild-manifest before publishing (the PR-3 verify-don't-mutate
+    # gate would otherwise refuse) -- mirror that explicit step here.
     (project.workdir / "targets" / "runoff_targets.nc").write_bytes(b"runoff-v2")
+    rebuild_manifest(project, dry_run=False)
     third = _publish(project, session, reg)
     assert "runoff_targets.nc" in third.uploaded
     assert "aet_targets.nc" in third.skipped

--- a/tests/test_release_payload.py
+++ b/tests/test_release_payload.py
@@ -10,7 +10,11 @@ import pytest
 
 from nhf_spatial_targets import catalog
 from nhf_spatial_targets.release import payload
-from nhf_spatial_targets.release._models import DistributionKind, SourceChildPlan
+from nhf_spatial_targets.release._models import (
+    DistributionKind,
+    ReleaseError,
+    SourceChildPlan,
+)
 from nhf_spatial_targets.release.checksums import compute_checksums, verify_csv
 from nhf_spatial_targets.workspace import Project
 
@@ -107,6 +111,19 @@ def test_manifest_is_copied_not_symlinked(tmp_path):
     assert staged.exists()
     assert not staged.is_symlink()  # snapshot copy, never a link
     assert staged.read_bytes() == project.manifest_path.read_bytes()
+
+
+def test_stage_fabric_child_missing_manifest_is_hard_error(tmp_path):
+    """A fabric child must never stage without its provenance snapshot.
+
+    The earlier ``if manifest_src.exists()`` soft skip would emit a child with
+    no manifest at all; PR-3 makes that a hard error so staging fails loudly
+    and the operator runs validate / rebuild-manifest first.
+    """
+    project = _build_project(tmp_path)
+    project.manifest_path.unlink()
+    with pytest.raises(ReleaseError, match="manifest.json"):
+        payload.stage_fabric_child(project, copy=True)
 
 
 def test_watergap22d_excluded_from_fabric(tmp_path):

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -7,6 +7,8 @@ fabric child against an in-memory ScienceBase (the :class:`FakeSbSession`).
 
 from __future__ import annotations
 
+import json
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -85,6 +87,67 @@ def test_checksum_drift_is_fatal(tmp_path, monkeypatch):
         publish.publish_fabric_child(
             project, make_sb_client(FakeSbSession()), registry_path=reg, now=NOW
         )
+
+
+# ---------------------------------------------------------------------------
+# Provenance completeness gate (verify-don't-mutate) -- PR-3 / #279
+# ---------------------------------------------------------------------------
+
+
+def test_complete_manifest_passes(tmp_path):
+    """A release-ready project (complete, rebuilt manifest) clears the gate."""
+    project = build_release_project(tmp_path)
+    publish._preflight_provenance_complete(project)  # does not raise
+
+
+def test_under_report_aggregate_raises(tmp_path):
+    """An aggregated source dir on disk but absent from the manifest is a
+    fatal under-report (the #277 case)."""
+    project = build_release_project(tmp_path)
+    new_agg = project.aggregated_dir() / "gldas_noah_v21_monthly"
+    new_agg.mkdir(parents=True)
+    (new_agg / "gldas_noah_v21_monthly_2000_agg.nc").write_bytes(b"g")
+    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+        publish._preflight_provenance_complete(project)
+
+
+def test_under_report_consolidate_raises(tmp_path):
+    """A consolidated datastore source on disk but absent from the manifest is
+    a fatal under-report (the #278 case)."""
+    project = build_release_project(tmp_path)
+    new_src = project.datastore / "merra2" / "monthly"
+    new_src.mkdir(parents=True)
+    (new_src / "merra2_2000.nc").write_bytes(b"m")
+    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+        publish._preflight_provenance_complete(project)
+
+
+def test_drift_between_disk_and_projection_refuses(tmp_path):
+    """An on-disk manifest whose steps[] differ from the deterministic
+    projection (here: a phantom extra step) is refused as drift, even though
+    every source is still present."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    manifest["steps"].append(
+        {"kind": "aggregate", "source_key": "ghost", "outputs": []}
+    )
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+        publish._preflight_provenance_complete(project)
+
+
+def test_allow_incomplete_sources_bypasses(tmp_path, caplog):
+    """``allow_incomplete_sources`` downgrades the source/drift failure to a
+    logged warning instead of raising; structural checks still apply."""
+    project = build_release_project(tmp_path)
+    new_agg = project.aggregated_dir() / "gldas_noah_v21_monthly"
+    new_agg.mkdir(parents=True)
+    (new_agg / "gldas_noah_v21_monthly_2000_agg.nc").write_bytes(b"g")
+    with caplog.at_level(logging.WARNING):
+        publish._preflight_provenance_complete(
+            project, allow_incomplete_sources=True
+        )  # does not raise
+    assert any("allow-incomplete-sources" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 import requests
 
+from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
 from nhf_spatial_targets.release import publish, registry
 from nhf_spatial_targets.release._models import FileEntry, ReleaseError
 from nhf_spatial_targets.release.build import BuildResult
@@ -107,7 +108,9 @@ def test_under_report_aggregate_raises(tmp_path):
     new_agg = project.aggregated_dir() / "gldas_noah_v21_monthly"
     new_agg.mkdir(parents=True)
     (new_agg / "gldas_noah_v21_monthly_2000_agg.nc").write_bytes(b"g")
-    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+    # Match the source name (not the universal rebuild-manifest hint) so this
+    # genuinely pins the aggregate-dir arm rather than any PreflightError.
+    with pytest.raises(publish.PreflightError, match="gldas_noah_v21_monthly"):
         publish._preflight_provenance_complete(project)
 
 
@@ -118,7 +121,8 @@ def test_under_report_consolidate_raises(tmp_path):
     new_src = project.datastore / "merra2" / "monthly"
     new_src.mkdir(parents=True)
     (new_src / "merra2_2000.nc").write_bytes(b"m")
-    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+    # Match the source name so this pins the datastore arm specifically.
+    with pytest.raises(publish.PreflightError, match="merra2"):
         publish._preflight_provenance_complete(project)
 
 
@@ -132,13 +136,25 @@ def test_drift_between_disk_and_projection_refuses(tmp_path):
         {"kind": "aggregate", "source_key": "ghost", "outputs": []}
     )
     project.manifest_path.write_text(json.dumps(manifest))
-    with pytest.raises(publish.PreflightError, match="rebuild-manifest"):
+    with pytest.raises(publish.PreflightError, match="drift"):
+        publish._preflight_provenance_complete(project)
+
+
+def test_published_target_without_step_raises(tmp_path):
+    """A target NC on disk with no matching ``target`` step in the manifest is
+    a fatal completeness failure (Pillar 3 assertion (e))."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    manifest["steps"] = [s for s in manifest["steps"] if s.get("kind") != "target"]
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="no matching 'target' step"):
         publish._preflight_provenance_complete(project)
 
 
 def test_allow_incomplete_sources_bypasses(tmp_path, caplog):
     """``allow_incomplete_sources`` downgrades the source/drift failure to a
-    logged warning instead of raising; structural checks still apply."""
+    logged warning instead of raising; the warning carries the problem detail
+    (here: the under-reported source name), not just the override literal."""
     project = build_release_project(tmp_path)
     new_agg = project.aggregated_dir() / "gldas_noah_v21_monthly"
     new_agg.mkdir(parents=True)
@@ -147,7 +163,64 @@ def test_allow_incomplete_sources_bypasses(tmp_path, caplog):
         publish._preflight_provenance_complete(
             project, allow_incomplete_sources=True
         )  # does not raise
-    assert any("allow-incomplete-sources" in r.message for r in caplog.records)
+    warnings = "\n".join(r.message for r in caplog.records)
+    assert "allow-incomplete-sources" in warnings
+    assert "gldas_noah_v21_monthly" in warnings  # the downgraded problem is shown
+
+
+# --- always-fatal structural checks: fatal AND not bypassable by the override ---
+
+
+def test_schema_behind_is_fatal_even_with_override(tmp_path):
+    """A behind/unexpected manifest_schema_version is fatal and cannot be
+    waved through by --allow-incomplete-sources."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    manifest["manifest_schema_version"] = 0
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="schema version"):
+        publish._preflight_provenance_complete(project, allow_incomplete_sources=True)
+
+
+def test_missing_fabric_is_fatal_even_with_override(tmp_path):
+    """A manifest with no fabric block is fatal and not bypassable."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    manifest["fabric"] = None
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="no fabric block"):
+        publish._preflight_provenance_complete(project, allow_incomplete_sources=True)
+
+
+def test_empty_steps_is_fatal_even_with_override(tmp_path):
+    """An empty steps[] (no lineage) is fatal and not bypassable."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    manifest["steps"] = []
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="no lineage"):
+        publish._preflight_provenance_complete(project, allow_incomplete_sources=True)
+
+
+def test_live_captured_manifest_refused_then_passes_after_rebuild(tmp_path):
+    """The intended verify-don't-mutate workflow: a live-captured manifest
+    carries richer metadata than the deterministic projection (real command /
+    timestamp / params / sha256, no ``provenance`` tag), so it is refused as
+    drift even with no source/file divergence. Running rebuild-manifest
+    regenerates it as the projection, after which the gate passes -- so the
+    *published* manifest is always the deterministic projection (Pillar 6)."""
+    project = build_release_project(tmp_path)
+    manifest = json.loads(project.manifest_path.read_text())
+    # A command string the projection would never emit (it uses
+    # "rebuild-manifest:<kind>"); pure capture-vs-rebuild drift, no missing
+    # source or target.
+    manifest["steps"][0]["command"] = "agg era5-land"
+    project.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(publish.PreflightError, match="drift"):
+        publish._preflight_provenance_complete(project)
+
+    rebuild_manifest(project, dry_run=False)  # operator's explicit action
+    publish._preflight_provenance_complete(project)  # now passes
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Third slice of #279 (durable manifest & config artifacts). PR-2 (#281, rebuild-manifest) is merged, so this targets **main**. Implements the spec's Pillar 3 + Pillar 4 (locked decisions C/D) and the plan's PR-3 Tasks 3.1–3.2. References #279 — `Closes` rides on the final PR in the chain.

## Task 3.1 — completeness gate at publish (verify-don't-mutate)
New `release/publish.py::_preflight_provenance_complete(project, *, allow_incomplete_sources=False)`:
- Runs `rebuild_manifest(project, dry_run=True)` for the deterministic projection and reads the on-disk manifest via `lineage.read_manifest`.
- **Always-fatal** (not bypassable): `manifest_schema_version` behind current, missing `fabric` block, empty `steps[]`.
- **Source-completeness + drift** (override-downgradable): `sources[]` missing an aggregated dir or a consolidated datastore catalog source (the #277 ∪ #278 union); a published target NC with no matching `target` step; on-disk `sources`/`steps` differing from the projection (JSON-normalized comparison).
- Any failure → `PreflightError` telling the operator to run `rebuild-manifest`.
- Wired into `_preflight_common`, so **every** publish scope (umbrella/source/fabric) is gated.
- **Verify-don't-mutate:** the gate never writes the manifest — regenerating it is the operator's explicit `rebuild-manifest` action, which is what keeps publish idempotent. No fabric registry.
- `--allow-incomplete-sources` CLI flag threaded through `publish_umbrella/source/fabric` as the deliberate, logged override (schema/fabric/steps stay fatal).

## Task 3.2 — `stage_fabric_child` hardening
Replaced the silent `if manifest_src.exists()` skip in `release/payload.py` with a hard `ReleaseError` so staging can never emit a fabric child with no provenance snapshot.

## Tests (mirror the spec's PR-3 list)
- `tests/test_release_publish.py`: under-report aggregate → raise; under-report consolidate → raise; disk≠projection drift → refuse; `allow_incomplete_sources` bypass warns-not-raises; complete manifest passes.
- `tests/test_release_payload.py`: missing manifest → hard error.
- Fixture/contract updates: `build_release_project` now writes a **complete** (rebuilt) manifest so a release-ready fixture is genuinely release-ready; the per-file skip/replace idempotency test re-runs `rebuild-manifest` after editing an artifact (mirrors the operator workflow the gate enforces); `test_release_build.py`'s missing-manifest test now asserts the hard error (its old "absent manifest is legitimate" premise is reversed by the spec).

Local: `fmt` + `lint` clean; full `tests/test_release_*` suite green (112 passed) + targeted PR-3 modules (40 passed). CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)