### PR TITLE
PR-5: config.yml catalog-key validation + upgrade-config extension (#279)

### DIFF
--- a/src/nhf_spatial_targets/cli/run.py
+++ b/src/nhf_spatial_targets/cli/run.py
@@ -326,7 +326,11 @@ def upgrade_config_cmd(
     from rich.console import Console
     from rich.table import Table
 
-    from nhf_spatial_targets.upgrade_config import check_drift
+    from nhf_spatial_targets.upgrade_config import (
+        check_available_sources,
+        check_drift,
+        check_missing_targets,
+    )
 
     console = Console()
     if not workdir.exists():
@@ -334,34 +338,64 @@ def upgrade_config_cmd(
         sys.exit(2)
     try:
         missing = check_drift(workdir)
+        missing_targets = check_missing_targets(workdir)
+        available = check_available_sources(workdir)
     except FileNotFoundError as e:
         print(f"upgrade-config failed: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # --- Optional-feature stubs (the only signal that drives the exit code) ---
     if not missing:
         console.print(
             "[bold green]Project config is in sync with the latest "
             "optional-feature stubs in the init template.[/bold green]"
         )
-        return
+    else:
+        table = Table(title="Optional features missing from this project's config.yml")
+        table.add_column("feature", style="bold")
+        table.add_column("added")
+        table.add_column("why")
+        for feat in missing:
+            table.add_row(feat.name, feat.added, feat.why)
+        console.print(table)
 
-    table = Table(title="Optional features missing from this project's config.yml")
-    table.add_column("feature", style="bold")
-    table.add_column("added")
-    table.add_column("why")
-    for feat in missing:
-        table.add_row(feat.name, feat.added, feat.why)
-    console.print(table)
+        console.print(
+            "\nPaste each block below into config.yml (or see "
+            "src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE for context). "
+            "This command never edits your file.\n"
+        )
+        for feat in missing:
+            console.print(f"[bold]# --- {feat.name} ---[/bold]")
+            console.print(feat.block)
 
-    console.print(
-        "\nPaste each block below into config.yml (or see "
-        "src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE for context). "
-        "This command never edits your file.\n"
-    )
-    for feat in missing:
-        console.print(f"[bold]# --- {feat.name} ---[/bold]")
-        console.print(feat.block)
-    sys.exit(1)
+    # --- Whole-target additions (report-only hint; issue #279, PR-5) ---
+    if missing_targets:
+        ttable = Table(
+            title="Targets in the defaults schema absent from your config.yml"
+        )
+        ttable.add_column("target", style="bold")
+        ttable.add_column("note")
+        for tname in missing_targets:
+            ttable.add_row(
+                tname,
+                "in defaults; add a targets: entry to build it on this fabric",
+            )
+        console.print(ttable)
+
+    # --- Newly-available catalog sources (report-only hint; issue #279, PR-5) ---
+    if available:
+        stable = Table(title="Catalog sources available but not in targets.*.sources[]")
+        stable.add_column("target", style="bold")
+        stable.add_column("available source(s)")
+        for tname, srcs in available.items():
+            stable.add_row(tname, ", ".join(srcs))
+        console.print(stable)
+
+    # Exit code stays driven solely by optional-feature drift, preserving the
+    # report-only contract; the whole-target and new-source tables above are
+    # informational hints and never, on their own, fail the command.
+    if missing:
+        sys.exit(1)
 
 
 def upgrade_manifest_cmd(

--- a/src/nhf_spatial_targets/cli/run.py
+++ b/src/nhf_spatial_targets/cli/run.py
@@ -343,6 +343,13 @@ def upgrade_config_cmd(
     except FileNotFoundError as e:
         print(f"upgrade-config failed: {e}", file=sys.stderr)
         sys.exit(1)
+    except yaml.YAMLError as e:
+        # check_missing_targets / check_available_sources parse config.yml
+        # (check_drift was text-only). A malformed config must fail with an
+        # actionable message, not a raw traceback -- this command exists to
+        # help the operator fix config drift.
+        print(f"upgrade-config failed to parse config.yml: {e}", file=sys.stderr)
+        sys.exit(1)
 
     # --- Optional-feature stubs (the only signal that drives the exit code) ---
     if not missing:

--- a/src/nhf_spatial_targets/upgrade_config.py
+++ b/src/nhf_spatial_targets/upgrade_config.py
@@ -173,12 +173,13 @@ def check_drift(project_dir: Path) -> list[OptionalConfigFeature]:
 #     operator has not pinned in targets.<t>.sources[].
 
 # Config target key -> catalog/variables.yml top-level key. Currently identity
-# for all six targets: the config schema (defaults.py "targets") and the
-# variable registry (variables.yml) both use the long names (recharge,
-# soil_moisture, snow_covered_area, ...). The rch/som/sca/swe divergence lives
-# only in the targets/ builder module names, NOT in these keys. Kept explicit
-# so a future rename of either side is a one-line change here rather than a
-# silent mis-map; consistency is asserted by
+# for every target: the config schema (defaults.py "targets") and the variable
+# registry (variables.yml) both use the long names (recharge, soil_moisture,
+# snow_covered_area, ...). The rch/som/sca/swe divergence lives only in the
+# targets/ builder module names, NOT in these keys. Kept explicit so a future
+# rename of either side is a one-line change here rather than a silent mis-map;
+# consistency (coverage of DEFAULTS["targets"] + each value resolving in
+# variables()) is asserted by
 # tests/test_upgrade_config.py::test_target_to_variable_mapping_is_consistent.
 _TARGET_TO_VARIABLE: dict[str, str] = {
     "runoff": "runoff",
@@ -236,6 +237,12 @@ def check_available_sources(project_dir: Path) -> dict[str, list[str]]:
     defaults and so cannot fossilize against a newly-added catalog source, so
     reporting them would be noise.
 
+    Eligibility is taken **verbatim** from ``variables.yml`` with no
+    ``superseded_by`` filtering (unlike the loud check in ``validate``). This is
+    correct today because the per-variable ``sources`` lists name only current
+    keys; if a superseded key ever lands in one, this hint would suggest adding
+    a dead source — fix the catalog, not this function.
+
     Raises
     ------
     FileNotFoundError
@@ -253,6 +260,9 @@ def check_available_sources(project_dir: Path) -> dict[str, list[str]]:
         configured = tgt_cfg.get("sources")
         if not isinstance(configured, list):
             continue  # on defaults for sources -> nothing pinned to drift
+        # _TARGET_TO_VARIABLE values are guaranteed to resolve in variables()
+        # by test_target_to_variable_mapping_is_consistent; the guard is purely
+        # defensive against an unsynced future edit.
         var_def = all_vars.get(var_key)
         if var_def is None:
             continue

--- a/src/nhf_spatial_targets/upgrade_config.py
+++ b/src/nhf_spatial_targets/upgrade_config.py
@@ -22,6 +22,10 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
+from nhf_spatial_targets.defaults import DEFAULTS
+
 
 @dataclass(frozen=True)
 class OptionalConfigFeature:
@@ -156,3 +160,104 @@ def check_drift(project_dir: Path) -> list[OptionalConfigFeature]:
     return [
         feat for feat in OPTIONAL_CONFIG_FEATURES if not re.search(feat.detect, text)
     ]
+
+
+# ---------------------------------------------------------------------------
+# Whole-target + new-source hints (issue #279, PR-5)
+# ---------------------------------------------------------------------------
+#
+# Beyond the enumerated optional params above, upgrade-config also surfaces two
+# coarser-grained drifts, both report-only:
+#   - a whole target in the defaults schema that the operator's config omits;
+#   - a catalog source eligible for a target (per variables.yml) that the
+#     operator has not pinned in targets.<t>.sources[].
+
+# Config target key -> catalog/variables.yml top-level key. Currently identity
+# for all six targets: the config schema (defaults.py "targets") and the
+# variable registry (variables.yml) both use the long names (recharge,
+# soil_moisture, snow_covered_area, ...). The rch/som/sca/swe divergence lives
+# only in the targets/ builder module names, NOT in these keys. Kept explicit
+# so a future rename of either side is a one-line change here rather than a
+# silent mis-map; consistency is asserted by
+# tests/test_upgrade_config.py::test_target_to_variable_mapping_is_consistent.
+_TARGET_TO_VARIABLE: dict[str, str] = {
+    "runoff": "runoff",
+    "aet": "aet",
+    "recharge": "recharge",
+    "soil_moisture": "soil_moisture",
+    "snow_covered_area": "snow_covered_area",
+    "snow_water_equivalent": "snow_water_equivalent",
+}
+
+
+def _load_user_targets(project_dir: Path) -> dict:
+    """Return the operator's literal ``targets:`` mapping from config.yml.
+
+    Reads the on-disk config verbatim (NOT merged with defaults) so the report
+    reflects what the operator actually wrote. Returns ``{}`` when there is no
+    ``targets:`` mapping. Raises ``FileNotFoundError`` if config.yml is absent
+    (mirrors :func:`check_drift`).
+    """
+    cfg_path = Path(project_dir) / "config.yml"
+    raw = yaml.safe_load(cfg_path.read_text())  # raises FileNotFoundError
+    if not isinstance(raw, dict):
+        return {}
+    targets = raw.get("targets")
+    return targets if isinstance(targets, dict) else {}
+
+
+def check_missing_targets(project_dir: Path) -> list[str]:
+    """Return target keys in the defaults schema absent from the operator config.
+
+    A whole target present in :data:`~nhf_spatial_targets.defaults.DEFAULTS`
+    but missing from the operator's ``config.yml`` ``targets:`` mapping is a
+    report-only hint — the operator may want to add and configure it. Order
+    follows the defaults schema for stable output.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``<project_dir>/config.yml`` does not exist.
+    """
+    user_targets = _load_user_targets(project_dir)
+    return [t for t in DEFAULTS["targets"] if t not in user_targets]
+
+
+def check_available_sources(project_dir: Path) -> dict[str, list[str]]:
+    """Return, per target, eligible catalog sources not pinned in the config.
+
+    For each target where the operator pinned an explicit ``sources:`` list,
+    report the catalog sources that ``catalog/variables.yml`` lists as eligible
+    for that target's variable but which are absent from the operator's list —
+    i.e. "a catalog source is available for target X that you are not using."
+    A report-only hint, never a failure.
+
+    Targets without an explicit ``sources:`` list are skipped: they track the
+    defaults and so cannot fossilize against a newly-added catalog source, so
+    reporting them would be noise.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``<project_dir>/config.yml`` does not exist.
+    """
+    from nhf_spatial_targets.catalog import variables
+
+    user_targets = _load_user_targets(project_dir)
+    all_vars = variables()
+    out: dict[str, list[str]] = {}
+    for tgt_name, var_key in _TARGET_TO_VARIABLE.items():
+        tgt_cfg = user_targets.get(tgt_name)
+        if not isinstance(tgt_cfg, dict):
+            continue
+        configured = tgt_cfg.get("sources")
+        if not isinstance(configured, list):
+            continue  # on defaults for sources -> nothing pinned to drift
+        var_def = all_vars.get(var_key)
+        if var_def is None:
+            continue
+        eligible = var_def.get("sources") or []
+        missing = [s for s in eligible if s not in configured]
+        if missing:
+            out[tgt_name] = missing
+    return out

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -442,8 +442,11 @@ def _check_catalog_consistency(config: dict) -> None:
        source from a ``multi_source_minmax`` bound — a silent under-build. The
        superseded arm reads the replacement straight off the catalog entry
        (``source[...]["superseded_by"]``) so the hint always names the right
-       successor. Disabled targets are validated too: a dangling key is a
-       config error regardless of whether the target runs this time.
+       successor. Because validation runs on the *merged* config, every target
+       is checked against its effective ``sources[]`` — including targets the
+       operator disabled or omitted entirely (which inherit the default
+       sources): a dangling key is a config error regardless of whether the
+       target runs this time.
     """
     from nhf_spatial_targets.catalog import sources, variables
 
@@ -463,7 +466,21 @@ def _check_catalog_consistency(config: dict) -> None:
     for tgt_name, tgt in (config.get("targets") or {}).items():
         if not isinstance(tgt, dict):
             continue
-        for key in tgt.get("sources") or []:
+        raw_sources = tgt.get("sources")
+        if raw_sources is None:
+            continue
+        # A scalar `sources: ssebop` (the common "forgot the list" YAML typo)
+        # would otherwise iterate characters -- failing loud but pointing at a
+        # phantom one-letter source, and silently passing if a one-character
+        # catalog key ever existed. Reject the wrong shape with a message that
+        # names the real mistake.
+        if not isinstance(raw_sources, list):
+            raise ValueError(
+                f"Target '{tgt_name}' config.yml 'sources' must be a YAML list "
+                f"(e.g. 'sources: [ssebop]'); got "
+                f"{type(raw_sources).__name__}: {raw_sources!r}."
+            )
+        for key in raw_sources:
             if key not in all_sources:
                 raise ValueError(
                     f"Target '{tgt_name}' config.yml sources[] references "

--- a/src/nhf_spatial_targets/validate.py
+++ b/src/nhf_spatial_targets/validate.py
@@ -236,8 +236,8 @@ def validate_workspace(workdir: Path) -> None:
     dir_mode = int(dir_mode_str, 8) if dir_mode_str else None
     _ensure_datastore(datastore, dir_mode)
 
-    # 7. Catalog consistency
-    _check_catalog_consistency()
+    # 7. Catalog consistency (catalog-internal + config targets.*.sources[])
+    _check_catalog_consistency(config)
 
     # Write outputs
     _write_fabric_json(workdir, fabric_meta)
@@ -427,16 +427,55 @@ def _ensure_datastore(datastore: Path, dir_mode: int | None) -> None:
         make_dir(datastore / key, dir_mode=dir_mode)
 
 
-def _check_catalog_consistency() -> None:
+def _check_catalog_consistency(config: dict) -> None:
+    """Validate catalog cross-references and config-declared source keys.
+
+    Two loud checks, each raising ``ValueError`` (which fails ``validate``):
+
+    1. **Catalog-internal:** every source listed under a variable in
+       ``catalog/variables.yml`` must exist in ``catalog/sources.yml``.
+    2. **Config intent (issue #279):** every key in the merged config's
+       ``targets.*.sources[]`` must be a *current* catalog source — present in
+       ``sources.yml`` **and** not carrying ``superseded_by``. A renamed or
+       superseded key (``merra_land`` -> ``merra2``,
+       ``watergap22a`` -> ``watergap22d``) would otherwise silently drop that
+       source from a ``multi_source_minmax`` bound — a silent under-build. The
+       superseded arm reads the replacement straight off the catalog entry
+       (``source[...]["superseded_by"]``) so the hint always names the right
+       successor. Disabled targets are validated too: a dangling key is a
+       config error regardless of whether the target runs this time.
+    """
     from nhf_spatial_targets.catalog import sources, variables
 
-    src_keys = set(sources().keys())
+    all_sources = sources()
+    src_keys = set(all_sources)
+
+    # 1. Catalog-internal cross-references: variables.yml -> sources.yml.
     for var_name, var_def in variables().items():
         for src in var_def.get("sources", []):
             if src not in src_keys:
                 raise ValueError(
                     f"Variable '{var_name}' references source '{src}' "
                     f"which does not exist in catalog/sources.yml"
+                )
+
+    # 2. Config intent: targets.*.sources[] must be current catalog sources.
+    for tgt_name, tgt in (config.get("targets") or {}).items():
+        if not isinstance(tgt, dict):
+            continue
+        for key in tgt.get("sources") or []:
+            if key not in all_sources:
+                raise ValueError(
+                    f"Target '{tgt_name}' config.yml sources[] references "
+                    f"'{key}', which is absent from catalog/sources.yml. "
+                    f"Check the source key against catalog/sources.yml."
+                )
+            superseded_by = all_sources[key].get("superseded_by")
+            if superseded_by is not None:
+                raise ValueError(
+                    f"Target '{tgt_name}' config.yml sources[] references "
+                    f"'{key}', which is superseded in catalog/sources.yml. "
+                    f"Did you mean '{superseded_by}' (superseded_by)?"
                 )
 
 

--- a/tests/test_upgrade_config.py
+++ b/tests/test_upgrade_config.py
@@ -228,9 +228,12 @@ def test_check_available_sources_lists_omitted_eligible(tmp_path):
 
     _config_with_targets(tmp_path)
     available = check_available_sources(tmp_path)
-    # aet pins only mod16a2_v061; ssebop is eligible per variables.yml.
-    assert "aet" in available
-    assert "ssebop" in available["aet"]
+    # aet eligible per variables.yml = [mod16a2_v061, ssebop, mwbm_climgrid];
+    # config pins only mod16a2_v061, so BOTH remaining eligible sources are
+    # reported, in the eligible-list (defaults-schema) order. Exact-equality
+    # locks the documented order-preserving contract and catches a partial
+    # omission (e.g. dropping mwbm_climgrid).
+    assert available["aet"] == ["ssebop", "mwbm_climgrid"]
     # The pinned key is not reported as "available" (already in use).
     assert "mod16a2_v061" not in available["aet"]
 
@@ -270,3 +273,32 @@ def test_cli_never_mutates_config(tmp_path):
     with pytest.raises(SystemExit):
         app(["upgrade-config", "--project-dir", str(tmp_path)])
     assert cfg.read_bytes() == before
+
+
+def test_cli_exits_one_when_config_missing_in_existing_dir(tmp_path, capsys):
+    """An existing project dir with no config.yml routes through the new check
+    calls and must exit 1 (FileNotFoundError), not 2 (which is dir-not-found)."""
+    from nhf_spatial_targets.cli import app
+
+    tmp_path.mkdir(parents=True, exist_ok=True)  # dir exists; config.yml absent
+    with pytest.raises(SystemExit) as exc:
+        app(["upgrade-config", "--project-dir", str(tmp_path)])
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "upgrade-config failed" in err
+
+
+def test_cli_exits_one_on_malformed_config(tmp_path, capsys):
+    """A syntactically malformed config.yml fails with an actionable message,
+    not a raw YAMLError traceback (the new checks parse YAML; check_drift did
+    not, so this is a guarded regression)."""
+    from nhf_spatial_targets.cli import app
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    # Unclosed bracket -> yaml.ParserError (a yaml.YAMLError subclass).
+    (tmp_path / "config.yml").write_text("targets: [unclosed\n")
+    with pytest.raises(SystemExit) as exc:
+        app(["upgrade-config", "--project-dir", str(tmp_path)])
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "parse config.yml" in err

--- a/tests/test_upgrade_config.py
+++ b/tests/test_upgrade_config.py
@@ -158,3 +158,115 @@ def test_cli_exits_two_when_project_missing(tmp_path, capsys):
     assert exc.value.code == 2
     err = capsys.readouterr().err
     assert "not found" in err.lower()
+
+
+# --- whole-target + new-source hints (issue #279, PR-5) ----------------------
+#
+# upgrade-config is extended beyond the enumerated optional params to surface
+# (a) whole targets present in the defaults schema but absent from the
+# operator's config.yml, and (b) catalog sources eligible for a target (per
+# variables.yml) but not pinned in the operator's targets.<t>.sources[]. Both
+# are report-only hints: they print but never mutate config.yml and never
+# change the exit-code contract (exit driven solely by optional-feature drift).
+
+
+def _config_with_targets(project_dir: Path) -> Path:
+    """Write a config with five of six targets; aet pins a partial sources[].
+
+    Omits ``snow_water_equivalent`` entirely (a missing-target case) and pins
+    ``aet.sources`` to a single key (an available-sources case: ssebop +
+    mwbm_climgrid are eligible but not listed).
+    """
+    project_dir.mkdir(parents=True, exist_ok=True)
+    text = (
+        "fabric:\n"
+        "  path: /x.gpkg\n"
+        "  id_col: nhm_id\n"
+        "datastore: /x\n"
+        "targets:\n"
+        "  runoff:\n"
+        '    period: "2000/2010"\n'
+        "  aet:\n"
+        "    sources:\n"
+        "      - mod16a2_v061\n"
+        '    period: "2000/2010"\n'
+        "  recharge:\n"
+        '    period: "2000/2010"\n'
+        "  soil_moisture:\n"
+        '    period: "2000/2010"\n'
+        "  snow_covered_area:\n"
+        '    period: "2000/2010"\n'
+    )
+    p = project_dir / "config.yml"
+    p.write_text(text)
+    return p
+
+
+def test_check_missing_targets_reports_absent_target(tmp_path):
+    from nhf_spatial_targets.upgrade_config import check_missing_targets
+
+    _config_with_targets(tmp_path)
+    missing = check_missing_targets(tmp_path)
+    # snow_water_equivalent is in the defaults schema but absent from config.
+    assert "snow_water_equivalent" in missing
+    # Targets that ARE present are not reported.
+    assert "aet" not in missing
+    assert "runoff" not in missing
+
+
+def test_check_missing_targets_reports_all_when_no_targets_block(tmp_path):
+    from nhf_spatial_targets.upgrade_config import check_missing_targets
+    from nhf_spatial_targets.defaults import DEFAULTS
+
+    _write_minimal_config(tmp_path)  # no targets: mapping
+    missing = check_missing_targets(tmp_path)
+    assert set(missing) == set(DEFAULTS["targets"])
+
+
+def test_check_available_sources_lists_omitted_eligible(tmp_path):
+    from nhf_spatial_targets.upgrade_config import check_available_sources
+
+    _config_with_targets(tmp_path)
+    available = check_available_sources(tmp_path)
+    # aet pins only mod16a2_v061; ssebop is eligible per variables.yml.
+    assert "aet" in available
+    assert "ssebop" in available["aet"]
+    # The pinned key is not reported as "available" (already in use).
+    assert "mod16a2_v061" not in available["aet"]
+
+
+def test_check_available_sources_skips_unpinned_targets(tmp_path):
+    """Targets without an explicit sources[] track defaults and so cannot
+    fossilize — they are not reported (avoids noise)."""
+    from nhf_spatial_targets.upgrade_config import check_available_sources
+
+    _config_with_targets(tmp_path)
+    available = check_available_sources(tmp_path)
+    # runoff has a period but no explicit sources[] -> on defaults -> skipped.
+    assert "runoff" not in available
+
+
+def test_target_to_variable_mapping_is_consistent():
+    """The explicit config-target -> variables.yml-key map must cover exactly
+    the defaults targets and point at real variable definitions (guards the
+    reconciliation against future renames)."""
+    from nhf_spatial_targets.catalog import variables
+    from nhf_spatial_targets.defaults import DEFAULTS
+    from nhf_spatial_targets.upgrade_config import _TARGET_TO_VARIABLE
+
+    assert set(_TARGET_TO_VARIABLE) == set(DEFAULTS["targets"])
+    all_vars = variables()
+    for var_key in _TARGET_TO_VARIABLE.values():
+        assert var_key in all_vars
+
+
+def test_cli_never_mutates_config(tmp_path):
+    """upgrade-config (with the new hints) is report-only: config.yml is
+    byte-identical before and after the command runs."""
+    from nhf_spatial_targets.cli import app
+
+    cfg = _config_with_targets(tmp_path)
+    before = cfg.read_bytes()
+    with pytest.raises(SystemExit):
+        app(["upgrade-config", "--project-dir", str(tmp_path)])
+    assert cfg.read_bytes() == before

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -687,11 +687,37 @@ def test_write_manifest_preserves_identity_on_rerun(tmp_path):
 
 
 def test_check_catalog_consistency_rejects_superseded_target_source():
-    """A superseded key fails with a hint naming the superseded_by replacement."""
+    """A superseded key fails with a hint naming both the offending key and the
+    superseded_by replacement."""
     from nhf_spatial_targets.validate import _check_catalog_consistency
 
     cfg = {"targets": {"aet": {"sources": ["merra_land"]}}}
-    with pytest.raises(ValueError, match="merra2"):
+    with pytest.raises(ValueError, match="merra_land.*merra2"):
+        _check_catalog_consistency(cfg)
+
+
+def test_check_catalog_consistency_checks_non_first_target():
+    """A dangling key in a non-first target is still caught (the loop validates
+    every target, not just the first)."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {
+        "targets": {
+            "aet": {"sources": ["mod16a2_v061", "ssebop"]},  # clean
+            "runoff": {"sources": ["watergap22a"]},  # superseded, second
+        }
+    }
+    with pytest.raises(ValueError, match="watergap22a.*watergap22d"):
+        _check_catalog_consistency(cfg)
+
+
+def test_check_catalog_consistency_rejects_scalar_sources():
+    """A scalar `sources: ssebop` (forgot the list) fails loud with a message
+    naming the real mistake, not a phantom one-letter source."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {"targets": {"aet": {"sources": "ssebop"}}}
+    with pytest.raises(ValueError, match="must be a YAML list"):
         _check_catalog_consistency(cfg)
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -673,3 +673,126 @@ def test_write_manifest_preserves_identity_on_rerun(tmp_path):
     assert second["created_utc"] == first["created_utc"]  # never re-minted
     assert "era5_land" in second["sources"]  # preserved
     assert len(second["steps"]) == 1  # preserved
+
+
+# ---------------------------------------------------------------------------
+# Catalog-key validation of config.targets.*.sources[] (issue #279, PR-5)
+#
+# validate must fail loudly when a target's configured source key is not a
+# *current* catalog source: either absent from sources.yml entirely (typo /
+# removed) or present but carrying superseded_by (merra_land -> merra2,
+# watergap22a -> watergap22d). A superseded key would otherwise silently drop
+# that source from a multi_source_minmax bound -- a silent under-build.
+# ---------------------------------------------------------------------------
+
+
+def test_check_catalog_consistency_rejects_superseded_target_source():
+    """A superseded key fails with a hint naming the superseded_by replacement."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {"targets": {"aet": {"sources": ["merra_land"]}}}
+    with pytest.raises(ValueError, match="merra2"):
+        _check_catalog_consistency(cfg)
+
+
+def test_check_catalog_consistency_rejects_absent_target_source():
+    """A truly-absent key (typo) fails loudly, naming the offending key."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {"targets": {"aet": {"sources": ["merra_lnd"]}}}
+    with pytest.raises(ValueError, match="merra_lnd"):
+        _check_catalog_consistency(cfg)
+
+
+def test_check_catalog_consistency_accepts_current_target_sources():
+    """All-current catalog source keys validate clean (no raise)."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {"targets": {"aet": {"sources": ["mod16a2_v061", "ssebop"]}}}
+    _check_catalog_consistency(cfg)  # must not raise
+
+
+def test_check_catalog_consistency_validates_disabled_targets():
+    """A dangling key is a config error even when the target is disabled."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    cfg = {"targets": {"aet": {"enabled": False, "sources": ["merra_land"]}}}
+    with pytest.raises(ValueError, match="merra2"):
+        _check_catalog_consistency(cfg)
+
+
+def test_check_catalog_consistency_still_checks_variables_to_sources():
+    """The existing variables.yml -> sources.yml check stays intact: a config
+    with no targets still validates the catalog-internal cross-references and
+    passes (the shipped catalog is consistent)."""
+    from nhf_spatial_targets.validate import _check_catalog_consistency
+
+    _check_catalog_consistency({})  # no targets key -> only the variables check
+
+
+def test_validate_superseded_target_source_fails_with_hint(
+    tmp_path, minimal_fabric, no_system_cred_checks
+):
+    """End-to-end: validate_workspace threads the merged config into the
+    catalog check and fails on a superseded target source, naming merra2."""
+    _write_config(
+        tmp_path,
+        overrides={
+            "fabric": {"path": str(minimal_fabric), "id_col": "nhm_id"},
+            "datastore": str(tmp_path / "datastore"),
+            "targets": {
+                "aet": {
+                    "sources": ["merra_land"],
+                    "period": "2000-01-01/2010-12-31",
+                }
+            },
+        },
+    )
+    _write_credentials(tmp_path)
+    with pytest.raises(ValueError, match="merra2"):
+        validate_workspace(tmp_path)
+
+
+def test_validate_absent_target_source_fails_loudly(
+    tmp_path, minimal_fabric, no_system_cred_checks
+):
+    """End-to-end: a typo'd (absent) target source fails validate loudly."""
+    _write_config(
+        tmp_path,
+        overrides={
+            "fabric": {"path": str(minimal_fabric), "id_col": "nhm_id"},
+            "datastore": str(tmp_path / "datastore"),
+            "targets": {
+                "aet": {
+                    "sources": ["merra_lnd"],
+                    "period": "2000-01-01/2010-12-31",
+                }
+            },
+        },
+    )
+    _write_credentials(tmp_path)
+    with pytest.raises(ValueError, match="merra_lnd"):
+        validate_workspace(tmp_path)
+
+
+def test_validate_current_target_sources_pass(
+    tmp_path, minimal_fabric, no_system_cred_checks
+):
+    """End-to-end: all-current target sources let validate complete and write
+    its output artifacts."""
+    _write_config(
+        tmp_path,
+        overrides={
+            "fabric": {"path": str(minimal_fabric), "id_col": "nhm_id"},
+            "datastore": str(tmp_path / "datastore"),
+            "targets": {
+                "aet": {
+                    "sources": ["mod16a2_v061", "ssebop"],
+                    "period": "2000-01-01/2010-12-31",
+                }
+            },
+        },
+    )
+    _write_credentials(tmp_path)
+    validate_workspace(tmp_path)  # must not raise
+    assert (tmp_path / "fabric.json").exists()


### PR DESCRIPTION
Fifth slice of #279 (durable manifest & config artifacts). Base = \`main\` (PR-1/2/3/4 merged via #280/#281/#282/#284). Implements **Pillar 5 bullets 2–3** of the design spec — the *Intent* durability rule "validated against the catalog so dangling refs fail loudly."

## Task 5.1 — Loud catalog-key validation of \`targets.*.sources[]\`
\`validate._check_catalog_consistency\` now takes the merged config and validates every \`targets.*.sources[]\` key against the catalog (via the \`catalog\` interface — no direct YAML reads):

- a key **absent** from \`sources.yml\` (typo / removed) → loud \`ValueError\` naming the offending key;
- a key **present but superseded** (carries \`superseded_by\`) → loud \`ValueError\` with a hint naming the replacement, read straight off the catalog entry (e.g. \`merra_land\` → "Did you mean 'merra2' (superseded_by)?").

This closes the **silent under-build**: a renamed/superseded source key (\`merra_land\`→\`merra2\`, \`watergap22a\`→\`watergap22d\`) silently dropped that source from a \`multi_source_minmax\` bound with no error. Disabled targets are validated too (a dangling key is a config error regardless of whether the target runs). The existing \`variables.yml\`→\`sources.yml\` check is retained. The call site (\`validate_workspace\` step 7) threads the merged \`config\` in.

## Task 5.2 — \`upgrade-config\` whole-target + new-source hints (report-only)
Two new report-only checks beyond the enumerated \`OPTIONAL_CONFIG_FEATURES\`:

- \`check_missing_targets(project_dir)\` — targets in \`DEFAULTS["targets"]\` absent from the operator's \`config.yml\` \`targets:\` mapping;
- \`check_available_sources(project_dir)\` — per target the operator has **pinned** an explicit \`sources:\` list, catalog sources eligible per \`variables.yml\` but not in that list (targets on defaults are skipped — they can't fossilize against a new catalog source).

An explicit \`_TARGET_TO_VARIABLE\` map reconciles config-target keys to \`variables.yml\` keys (identity for all six today, but pinned so a future rename of either side is a one-line change; asserted by a test). \`upgrade_config_cmd\` renders both as new Rich tables; the **exit code stays driven solely by optional-feature drift** (exit 0 in sync / 1 on drift), preserving the report-only, never-mutates contract.

## Notes
- These tasks add detection/validation **code**, not a new operator config key, so the CLAUDE.md four-point "Config schema additions" checklist does **not** apply.
- Not "Closes #279" — PR-6 (CLAUDE.md section) and PR-7 (triangle) remain; the final PR in the chain carries the close.

## Tests (local: \`fmt\` clean, \`lint\` "All checks passed!", \`pytest tests/test_validate.py tests/test_upgrade_config.py\` = **57 passed**)
- \`tests/test_validate.py\`: superseded key → hint naming \`merra2\`; absent typo'd key → loud fail; all-current keys → pass; disabled-target validation; variables→sources check retained (+ end-to-end \`validate_workspace\` wiring).
- \`tests/test_upgrade_config.py\`: missing \`snow_water_equivalent\` reported; \`aet.sources\` omitting \`ssebop\` listed; unpinned targets skipped; mapping consistency; command never mutates \`config.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)