### PR TITLE
fix(#283): corrupt published target NC must fail the publish gate

### DIFF
--- a/src/nhf_spatial_targets/rebuild_manifest.py
+++ b/src/nhf_spatial_targets/rebuild_manifest.py
@@ -184,15 +184,47 @@ def _ncs_in(source_dir: Path) -> list[Path]:
     return sorted((p for p in source_dir.rglob("*.nc") if p.is_file()), key=str)
 
 
+# Leading magic bytes that identify a file as NetCDF/HDF5. Used to tell a
+# genuine-but-corrupt published target NC (must fail loudly -- issue #283) from
+# a benign non-NetCDF placeholder (target writer hasn't persisted attrs yet, or
+# a fixture wrote plain bytes -> degrade to {}).
+#   - HDF5 (NetCDF4):       \x89 H D F \r \n \x1a \n
+#   - classic NetCDF-1:     C D F \x01
+#   - 64-bit-offset NC-2:   C D F \x02
+#   - CDF-5:                C D F \x05
+_NETCDF_MAGIC: tuple[bytes, ...] = (
+    b"\x89HDF\r\n\x1a\n",
+    b"CDF\x01",
+    b"CDF\x02",
+    b"CDF\x05",
+)
+
+
+def _looks_like_netcdf(nc: Path) -> bool:
+    """Return True if *nc*'s leading bytes carry NetCDF/HDF5 magic."""
+    try:
+        head = nc.read_bytes()[:8]
+    except OSError:
+        return False
+    return any(head.startswith(m) for m in _NETCDF_MAGIC)
+
+
 def _target_nc_params(nc: Path) -> dict:
     """Best-effort read of resolved-target attrs (``period``, ``sources``).
 
     Reads the ``period`` / ``sources`` global attrs when present. Target
     writers may not yet persist the full resolved param set, so a missing attr
-    -- or a non-NetCDF placeholder file -- simply yields ``{}``; the read is
-    never fatal to the projection. A present-but-unreadable NC (a truncated or
-    corrupt *published* target) is logged at WARNING so the lost resolved-param
-    provenance is at least visible, rather than vanishing silently.
+    -- or a non-NetCDF placeholder file (no NetCDF/HDF5 magic) -- simply yields
+    ``{}`` with a WARNING; that read is never fatal to the projection.
+
+    A file that **does** carry NetCDF/HDF5 magic but cannot be opened is a
+    truncated or corrupt *published* target, and this **raises** ``ValueError``
+    (issue #283). Returning ``{}`` there would let the publish completeness gate
+    green-light a broken artifact: the projection still records the ``target``
+    step (built from the file's existence; only its params go empty), so both
+    the "matching target step" and the drift checks pass and a corrupt NC could
+    ship into a DOI. Failing loudly is the only safe behaviour for a file that
+    claims to be NetCDF.
     """
     params: dict = {}
     try:
@@ -205,11 +237,18 @@ def _target_nc_params(nc: Path) -> dict:
                     # numpy scalars / arrays -> plain Python for JSON stability.
                     params[attr] = value.tolist() if hasattr(value, "tolist") else value
     except Exception as exc:
+        if _looks_like_netcdf(nc):
+            raise ValueError(
+                f"target NC {nc} carries NetCDF/HDF5 magic but could not be "
+                f"opened ({exc}); it appears truncated or corrupt. Refusing to "
+                f"project an empty-params target step over a broken published "
+                f"artifact. Re-run the target build, then rebuild-manifest."
+            ) from exc
         logger.warning(
             "rebuild-manifest: could not read resolved-target attrs from %s "
-            "(%s); the target step's params will be empty. If this is a "
-            "published target NC and not a placeholder, it may be truncated "
-            "or corrupt.",
+            "(%s); the target step's params will be empty. The file carries no "
+            "NetCDF/HDF5 magic, so it is treated as a non-NetCDF placeholder "
+            "rather than a corrupt published target.",
             nc,
             exc,
         )

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -374,7 +374,14 @@ def _preflight_provenance_complete(
     """
     from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
 
-    projection = rebuild_manifest(project, dry_run=True)
+    # A corrupt/truncated published target NC makes the projection raise
+    # (issue #283). Surface it as a fatal PreflightError -- it is a genuine
+    # read failure, NOT a source/drift problem, so it must never be downgraded
+    # by allow_incomplete_sources below.
+    try:
+        projection = rebuild_manifest(project, dry_run=True)
+    except ValueError as exc:
+        raise PreflightError(f"publish pre-flight: {exc}") from exc
     on_disk = read_manifest(project.manifest_path)
 
     rebuild_hint = (

--- a/tests/test_rebuild_manifest.py
+++ b/tests/test_rebuild_manifest.py
@@ -452,11 +452,12 @@ def test_target_nc_params_reads_real_attrs(tmp_path):
     json.dumps(m)
 
 
-def test_target_nc_params_warns_on_unreadable(tmp_path, caplog):
-    """A present-but-unreadable target NC yields {} AND logs a warning.
+def test_target_nc_params_placeholder_is_benign(tmp_path, caplog):
+    """A non-NetCDF placeholder (no NetCDF/HDF5 magic) yields {} AND warns.
 
-    Silent {} would lose resolved-param provenance from a corrupt published
-    NC with no trace; the warning is the operator's only signal.
+    Target writers may not yet persist resolved-param attrs, and many fixtures
+    write plain-text placeholder bytes; such a file is NOT a corrupt published
+    artifact -- it degrades to empty params with a warning, never fatally.
     """
     import logging
 
@@ -467,6 +468,29 @@ def test_target_nc_params_warns_on_unreadable(tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         assert _target_nc_params(bad) == {}
     assert any("aet_targets.nc" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "magic",
+    [
+        b"\x89HDF\r\n\x1a\n",  # HDF5 (NetCDF4) magic
+        b"CDF\x01",  # classic NetCDF-1 magic
+        b"CDF\x02",  # 64-bit-offset NetCDF-2 magic
+    ],
+)
+def test_target_nc_params_corrupt_netcdf_is_fatal(tmp_path, magic):
+    """A file carrying NetCDF/HDF5 magic but unopenable is a corrupt published
+    artifact -- it must RAISE (issue #283), not degrade to {}. Otherwise the
+    publish gate green-lights a truncated/corrupt target NC: the projection
+    still records the target step (built from the file's existence), only its
+    params go empty, so both the 'matching step' and the drift checks pass.
+    """
+    from nhf_spatial_targets.rebuild_manifest import _target_nc_params
+
+    corrupt = tmp_path / "aet_targets.nc"
+    corrupt.write_bytes(magic + b"\x00truncated-garbage")
+    with pytest.raises(ValueError, match="truncated or corrupt"):
+        _target_nc_params(corrupt)
 
 
 def test_rebuild_aggregated_dir_wins_union(tmp_path):

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -151,6 +151,33 @@ def test_published_target_without_step_raises(tmp_path):
         publish._preflight_provenance_complete(project)
 
 
+def test_corrupt_published_target_nc_is_fatal(tmp_path):
+    """A corrupt/truncated published target NC must fail the gate, not slip it
+    with only a WARNING (issue #283).
+
+    A file carrying NetCDF/HDF5 magic but unopenable used to leave the target
+    step's params empty while the step itself (built from file existence) still
+    matched -- so both the 'matching target step' and drift checks passed and a
+    broken artifact could ship into a DOI. The projection read must now raise.
+    """
+    project = build_release_project(tmp_path)
+    target_nc = project.targets_dir() / "aet_targets.nc"
+    # HDF5 (NetCDF4) magic + garbage: claims to be a NetCDF, won't open.
+    target_nc.write_bytes(b"\x89HDF\r\n\x1a\n" + b"\x00corrupt")
+    with pytest.raises(publish.PreflightError, match="truncated or corrupt"):
+        publish._preflight_provenance_complete(project)
+
+
+def test_corrupt_published_target_nc_fatal_even_with_override(tmp_path):
+    """The corrupt-NC failure is a true read error, not a source/drift problem,
+    so --allow-incomplete-sources must NOT wave it through (issue #283)."""
+    project = build_release_project(tmp_path)
+    target_nc = project.targets_dir() / "aet_targets.nc"
+    target_nc.write_bytes(b"\x89HDF\r\n\x1a\n" + b"\x00corrupt")
+    with pytest.raises(publish.PreflightError, match="truncated or corrupt"):
+        publish._preflight_provenance_complete(project, allow_incomplete_sources=True)
+
+
 def test_allow_incomplete_sources_bypasses(tmp_path, caplog):
     """``allow_incomplete_sources`` downgrades the source/drift failure to a
     logged warning instead of raising; the warning carries the problem detail


### PR DESCRIPTION
Closes #283.

Surfaced by the PR-3 (#282, #279) review. `rebuild_manifest._target_nc_params` caught a broad `Exception` and returned `{}` for any unreadable `targets/*.nc`. For a **corrupt/truncated *published*** NC that was a hole the PR-3 publish gate could not see: the deterministic projection still records the `target` step (built from the file's existence — only its params go empty), so the gate's "every published target NC has a matching `target` step" check **and** the on-disk-vs-projection drift check both pass. A broken artifact could ship into a DOI with only a WARNING.

## Fix
Discriminate by **NetCDF/HDF5 magic bytes**:
- a **non-NetCDF placeholder** (no magic — the target writer hasn't persisted resolved-param attrs yet, or a fixture wrote plain bytes) still degrades to `{}` with a WARNING (the benign case PR-2 intended);
- a file that **does** carry NetCDF/HDF5 magic but won't open raises `ValueError` ("truncated or corrupt").

`_preflight_provenance_complete` wraps the `rebuild_manifest` call and converts that `ValueError` into a fatal `PreflightError`. Because it is a genuine **read failure** (not a source/drift problem), it sits *before* the override logic and `--allow-incomplete-sources` cannot downgrade it.

Magic covered: HDF5 (`\x89HDF\r\n\x1a\n`, NetCDF4), classic NetCDF-1 (`CDF\x01`), 64-bit-offset NetCDF-2 (`CDF\x02`), CDF-5 (`CDF\x05`).

## Tests
- `tests/test_rebuild_manifest.py`: placeholder stays benign (`{}` + warning); corrupt-NetCDF (HDF5 + CDF1/2 magic) raises `ValueError`.
- `tests/test_release_publish.py`: a corrupt published target NC fails `_preflight_provenance_complete` with `PreflightError`, **including** under `--allow-incomplete-sources` (proving it is not downgradable).

Local: `fmt` clean, `lint` "All checks passed!", `pytest tests/test_rebuild_manifest.py tests/test_release_publish.py` = **70 passed**. Full suite on CI.

This is a standalone correctness fix in already-merged #279 code (PR-2 origin), not part of the PR-6/PR-7 chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)