### PR TITLE
ci(#289): parallelize pytest with xdist (+ thread caps, --durations)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -968,6 +968,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
@@ -1169,6 +1170,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.12-hc97d973_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -1366,6 +1368,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
@@ -1563,6 +1566,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.12-h20e6be0_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -1758,6 +1762,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ecmwf-datastores-client-0.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
@@ -1938,6 +1943,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.12-h09917c8_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
@@ -7191,6 +7197,17 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21333
   timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+  sha256: 1acc6a420efc5b64c384c1f35f49129966f8a12c93b4bb2bdc30079e5dc9d8a8
+  md5: a57b4be42619213a94f31d2c69c5dda7
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/execnet?source=hash-mapping
+  size: 39499
+  timestamp: 1762974150770
 - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
   sha256: 210c8165a58fdbf16e626aac93cc4c14dbd551a01d1516be5ecad795d2422cad
   md5: ff9efb7f7469aed3c4a8106ffa29593c
@@ -17618,6 +17635,21 @@ packages:
   - pkg:pypi/pytest-cov?source=hash-mapping
   size: 29016
   timestamp: 1757612051022
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+  sha256: b7b58a5be090883198411337b99afb6404127809c3d1c9f96e99b59f36177a96
+  md5: 8375cfbda7c57fbceeda18229be10417
+  depends:
+  - execnet >=2.1
+  - pytest >=7.0.0
+  - python >=3.9
+  constrains:
+  - psutil >=3.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest-xdist?source=hash-mapping
+  size: 39300
+  timestamp: 1751452761594
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.12-hc97d973_100_cp313.conda
   build_number: 100
   sha256: 8a08fe5b7cb5a28aa44e2994d18dbf77f443956990753a4ca8173153ffb6eb56

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,6 +55,10 @@ jinja2 = ">=3.1"
 [feature.dev.dependencies]
 pytest = ">=8.0"
 pytest-cov = ">=5.0"
+# pytest-xdist: parallelize the ~1.5k-test suite across CI cores (-n auto).
+# The suite is overwhelmingly independent tmp_path tests, so workers don't
+# contend; ~halves CI wall-clock (issue #289).
+pytest-xdist = ">=3.5"
 ruff = ">=0.4"
 mypy = ">=1.10"
 ipykernel = ">=6.0"
@@ -216,8 +220,13 @@ release-status    = { cmd = "nhf-targets release status",    description = "Diff
 release-auth-test = { cmd = "nhf-targets release auth-test", description = "Check ScienceBase authentication" }
 
 # Development
-test  = { cmd = "pytest tests/ -v -m 'not integration'", description = "Run test suite (excludes integration)" }
-test-quiet = { cmd = "pytest tests/ -q -m 'not integration'", description = "Run test suite quietly (for pre-commit hooks)" }
+# xdist runs N worker processes; without capping BLAS/OMP thread pools each
+# worker would spawn one-thread-per-core (on a 128-thread HPC login node that
+# is N*128 threads -> pthread_create exhaustion). Pin every math backend to a
+# single thread so the only parallelism is across xdist workers. Safe on CI
+# (ubuntu-latest = 4 workers) and on caldera. (issue #289)
+test  = { cmd = "pytest tests/ -n auto --durations=25 -m 'not integration'", description = "Run test suite in parallel (xdist; excludes integration)", env = { OMP_NUM_THREADS = "1", OPENBLAS_NUM_THREADS = "1", MKL_NUM_THREADS = "1", NUMEXPR_NUM_THREADS = "1", VECLIB_MAXIMUM_THREADS = "1" } }
+test-quiet = { cmd = "pytest tests/ -n auto -q -m 'not integration'", description = "Run test suite quietly in parallel (for pre-commit hooks)", env = { OMP_NUM_THREADS = "1", OPENBLAS_NUM_THREADS = "1", MKL_NUM_THREADS = "1", NUMEXPR_NUM_THREADS = "1", VECLIB_MAXIMUM_THREADS = "1" } }
 test-integration = { cmd = "pytest tests/ -v -m integration", description = "Run integration tests only (requires credentials/network)" }
 lint  = { cmd = "ruff check src/ tests/", description = "Lint source" }
 fmt   = { cmd = "ruff format src/ tests/", description = "Format source" }


### PR DESCRIPTION
Closes #289.

The ~1583-test non-integration suite ran **serially** in CI (>7 min). This runs it under **pytest-xdist**.

## Changes
- Add `pytest-xdist` to the dev env (`pixi.toml` + lock).
- `test` / `test-quiet` pixi tasks run `-n auto` (ubuntu-latest CI = 4 vCPU → 4 workers). **`ci.yml` is unchanged** — it calls `pixi run -e dev test`, so the task edit flows through automatically.
- `test` adds `--durations=25`: this PR's CI log will surface the slowest tests (profile + speedup in one shot). Hypothesis: the year-chunked SCA/SWE target builds dominate.
- Drop `-v` (noisy and serializes output under xdist).
- **Thread caps** (`OMP/OPENBLAS/MKL/NUMEXPR/VECLIB_NUM_THREADS=1`) in the task env. Without them each xdist worker spawns one BLAS thread per core; on a 128-thread HPC login node `-n auto` = 64 workers × 128 threads → `pthread_create` exhaustion. Single-threaded BLAS makes worker-level the only parallelism — safe on CI **and** caldera (this was a real failure I hit validating locally).

## Validation
Local full suite is not run on the contended HPC box (per project convention). Validated xdist mechanics with `tests/test_release_publish.py -n 4` + thread caps → **50 passed, 4 workers, no BLAS/execnet errors**. The full-suite wall-clock and the `--durations=25` profile will appear on this PR's CI run.

## Follow-up (only if the profile justifies it)
If a few year-chunked builds remain the long pole after parallelization, a later change can `@pytest.mark.slow` them into a secondary job or shrink multi-year fixtures to single-month (same code path). Not done pre-emptively — the durations output decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)