### PR TITLE
perf(catalog): memoize _load — stop re-parsing catalog YAMLs per call (#291)

### DIFF
--- a/src/nhf_spatial_targets/catalog.py
+++ b/src/nhf_spatial_targets/catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
@@ -9,8 +10,20 @@ import yaml
 _CATALOG_DIR = Path(__file__).parent.parent.parent / "catalog"
 
 
+@lru_cache(maxsize=None)
 def _load(filename: str) -> dict:
-    """Load a YAML catalog file and return its contents."""
+    """Load a YAML catalog file and return its contents.
+
+    Memoized per filename: the catalog YAMLs (the 1045-line ``sources.yml``,
+    ``variables.yml``, ...) are static, read-only reference data within a
+    process, but every ``sources()`` / ``source()`` / ``variables()`` call used
+    to re-parse the whole file with PyYAML's pure-Python scanner. That cost
+    dominated the release test suite (issue #291) and the live pipeline (which
+    reads the catalog repeatedly per fetch/aggregate/target). Callers must treat
+    the returned dict as read-only (none mutate it today); use
+    ``_load.cache_clear()`` if a test rewrites a catalog file on disk and needs
+    a fresh parse.
+    """
     path = _CATALOG_DIR / filename
     if not path.exists():
         raise FileNotFoundError(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -635,3 +635,41 @@ def test_release_registry_yml_loads_as_valid_yaml():
     assert data["umbrella"] is None
     assert data["consolidated_sources"] == {}
     assert data["fabrics"] == {}
+
+
+# --- _load caching (issue #291) -------------------------------------------
+
+
+def test_load_is_memoized_returns_same_object():
+    """catalog._load caches per filename so the 1045-line sources.yml is parsed
+    once per process, not re-scanned on every sources()/source()/variables()
+    call. Same filename -> identical object (cache hit)."""
+    from nhf_spatial_targets import catalog as cat
+
+    cat._load.cache_clear()
+    first = cat._load("sources.yml")
+    second = cat._load("sources.yml")
+    assert first is second  # cache hit, not a re-parse
+
+
+def test_load_cache_clear_forces_reparse():
+    """cache_clear() is the escape hatch: after it, _load re-reads (a fresh
+    object), so tests that rewrite a catalog file on disk can opt out."""
+    from nhf_spatial_targets import catalog as cat
+
+    first = cat._load("sources.yml")
+    cat._load.cache_clear()
+    third = cat._load("sources.yml")
+    assert first is not third  # re-parsed after clear
+    assert first == third  # same content
+
+
+def test_load_caches_per_filename():
+    """Different filenames get independent cache entries (no cross-contamination)."""
+    from nhf_spatial_targets import catalog as cat
+
+    s = cat._load("sources.yml")
+    v = cat._load("variables.yml")
+    assert s is not v
+    assert s is cat._load("sources.yml")
+    assert v is cat._load("variables.yml")


### PR DESCRIPTION
Closes #291. Follow-up to #289/#290 (CI parallelization).

## Finding
Profiling the `test_release_*` long pole showed the dominant cost is **YAML parsing, not metadata rendering**: ~30s cumulative in `yaml.scanner`/`reader` for one release test (4.9M `forward()` calls, 18.9M `peek()`).

Root cause: **`catalog._load` was uncached** — every `sources()`/`source()`/`variables()` call re-parsed the **1045-line `sources.yml`** with PyYAML's pure-Python scanner. The release build/publish/FGDC path hits those accessors many times per op, ×~3 publishes per test, ×308 release tests.

## Fix
`@lru_cache` on `_load` (keyed by filename). The catalog YAMLs are static, read-only reference data within a process.

**Safety:** no caller mutates the returned dict (`release_block()`'s `.update` is on a fresh `dict(_RELEASE_DEFAULTS)` copy); tests monkeypatch at the `catalog.source` function level, not `_load`. `_load.cache_clear()` added as the escape hatch (covered by a test).

## Payoff
Worst release test locally: **17.6s → 12.7s**. The cache benefits **nearly the whole suite** (almost every test touches the catalog) and the **live pipeline** (every fetch/aggregate/target/validate reads the catalog repeatedly), so the aggregate CI win exceeds any single-test delta. Full-suite wall-clock + the `--durations=25` profile (added in #290) will show on this PR's CI run.

## Tests
3 new in `tests/test_catalog.py`: `_load` is memoized (same object on repeat), `cache_clear()` forces a re-parse, per-filename cache isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)