### PR TITLE
fix(release): harden publishability filter + pin liability publish gate (#260, #268)

### DIFF
--- a/src/nhf_spatial_targets/release/payload.py
+++ b/src/nhf_spatial_targets/release/payload.py
@@ -33,6 +33,7 @@ build orchestrator.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -46,6 +47,8 @@ from nhf_spatial_targets.release._models import (
     UmbrellaPlan,
 )
 from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_fabric_label(project: Project) -> str:
@@ -124,11 +127,26 @@ def sources_used(project: Project) -> list[str]:
 def plan_fabric_child(project: Project) -> FabricChildPlan:
     """Build the :class:`FabricChildPlan` for *project* without staging."""
     aggregated_root = project.aggregated_dir()
+    all_keys = set(catalog.sources())
     aggregated: list[Path] = []
     if aggregated_root.exists():
         for source_dir in sorted(p for p in aggregated_root.iterdir() if p.is_dir()):
-            if not _publishable_agg_dir(source_dir.name):
+            name = source_dir.name
+            if not _publishable_agg_dir(name):
                 continue
+            if name not in all_keys:
+                # Admitted via the derived-variant branch (no catalog key), so
+                # the legal-hold filter never saw it. Names match catalog keys
+                # in the normal pipeline, so this fires only on a typo or a
+                # hand-created dir -- surface it in case it hides held-back
+                # content (e.g. a stray ``watergap_22d``). See issue #260.
+                logger.warning(
+                    "admitting derived-variant aggregated dir %r into the "
+                    "fabric child (no catalog key, so the publishability "
+                    "filter did not gate it); confirm it is not held-back "
+                    "content",
+                    name,
+                )
             aggregated.extend(_nc_files(source_dir))
 
     label = resolve_fabric_label(project)

--- a/tests/test_release_defaults.py
+++ b/tests/test_release_defaults.py
@@ -107,3 +107,22 @@ def test_single_blank_leaf_is_reported(tmp_path):
     assert missing == ["umbrella.title_template"]
     with pytest.raises(ValueError, match="umbrella.title_template"):
         require_populated_release_defaults(data)
+
+
+def test_blank_liability_statement_blocks_publish(tmp_path):
+    """A blanked ``distribution.liability_statement`` fails the publish gate.
+
+    Issue #268: FGDC emits a mandatory ``<distliab>`` straight from this field,
+    and ``mp`` rejects an empty one. The gate lives at publish time -- the path
+    is in ``REQUIRED_POPULATED_PATHS`` (added by #274), so an operator who
+    blanks the statement is stopped before any invalid FGDC can ship, rather
+    than at config-load (``validate_release_defaults`` stays shape-only so the
+    scaffold can still build/dry-run). This pins that behavior.
+    """
+    assert "distribution.liability_statement" in REQUIRED_POPULATED_PATHS
+    data = load_release_defaults()
+    data["distribution"] = dict(data["distribution"])
+    data["distribution"]["liability_statement"] = "   \n  "  # whitespace only
+    assert missing_release_defaults(data) == ["distribution.liability_statement"]
+    with pytest.raises(ValueError, match="distribution.liability_statement"):
+        require_populated_release_defaults(data)

--- a/tests/test_release_payload.py
+++ b/tests/test_release_payload.py
@@ -143,6 +143,31 @@ def test_era5_land_sd_variant_kept_in_fabric(tmp_path):
     assert sd.is_symlink()
 
 
+def test_derived_variant_admission_is_warned(tmp_path, caplog):
+    """A non-catalog-key aggregated dir ships, but the admit is logged.
+
+    The legal-hold filter is an exact catalog-key match, so an unknown name
+    (typo / hand-created dir) falls into the derived-variant branch and ships
+    unconditionally. Issue #260: emit a warning so a stray held-back dir is
+    visible in the build log rather than leaking silently.
+    """
+    project = _build_project(tmp_path)
+    with caplog.at_level("WARNING", logger="nhf_spatial_targets.release.payload"):
+        payload.plan_fabric_child(project)
+    warned_names = {r.args[0] for r in caplog.records if r.args}
+    assert "era5_land_sd" in warned_names
+
+
+def test_catalog_key_admission_is_not_warned(tmp_path, caplog):
+    """Publishable catalog-key dirs ship through the gated branch silently."""
+    project = _build_project(tmp_path)
+    with caplog.at_level("WARNING", logger="nhf_spatial_targets.release.payload"):
+        payload.plan_fabric_child(project)
+    warned_names = {r.args[0] for r in caplog.records if r.args}
+    assert "era5_land" not in warned_names
+    assert "daymet" not in warned_names
+
+
 def test_daymet_aggregated_kept_in_fabric(tmp_path):
     """daymet is metadata_only as a source child, but its aggregated NCs
     still ship in fabric children (they are derived products)."""


### PR DESCRIPTION
Two small orphan-hardening items from prior PR reviews, bundled into one PR (both are tiny, both live in `release/`).

## #260 — warn on admitting an unknown derived-variant aggregated dir (PR #258 H4)

`_publishable_agg_dir` gates aggregated subdirs by **exact catalog-key match**: a known key must be publishable (correctly excludes `watergap22d` legal-hold + superseded keys), but a name that *isn't* a catalog key (a derived variant like `era5_land_sd`) is admitted unconditionally. A typo or hand-created dir (`watergap_22d`, `watergap22d_v2`, a scratch copy) falls into that branch and ships silently.

**Fix (issue's recommended Option 1):** emit a `logger.warning` at the admit site in `plan_fabric_child` when a non-catalog-key dir is admitted, so a stray held-back dir is visible in the build / dry-run log. `_publishable_agg_dir` stays a pure predicate; the warn lives in the loop where catalog-key membership is known.

## #268 — liability_statement / FGDC `<distliab>` (PR-D2 #267)

The concern: a blanked `distribution.liability_statement` would render an empty FGDC `<distliab>`, which `mp` rejects.

**Finding:** this is **already closed at publish time**. `distribution.liability_statement` was added to `REQUIRED_POPULATED_PATHS` in #274 (PR-E3, *after* #268 was filed), so `require_populated_release_defaults` (publish pre-flight) refuses to publish a blanked statement before any invalid FGDC can ship.

The issue asked to enforce it in `validate_release_defaults` (config-load). That function is **deliberately shape-only** — the committed scaffold ships empty sections and operators build/dry-run against them; the populated-gate is the publish-time check. Moving one of ~21 populated-paths into the load-time shape check would carve a single field out of that contract. Instead this PR **pins the existing publish-gate behavior with a regression test** and documents the resolution. (Decision confirmed with the maintainer.)

## Changes

- `release/payload.py` — module logger + `logger.warning` on derived-variant admission.
- `tests/test_release_payload.py` — assert the warning fires for `era5_land_sd` and **not** for real catalog keys (`era5_land`, `daymet`).
- `tests/test_release_defaults.py` — assert a blanked `liability_statement` is reported by `missing_release_defaults` and raises in `require_populated_release_defaults`.

`pixi run -e dev fmt && lint` clean; `tests/test_release_payload.py tests/test_release_defaults.py` → 37 passed.

Closes #260
Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)