### PR TITLE
docs: strip residual PR-A..G + "This PR" task-decay markers (#254, #256)

### DIFF
--- a/src/nhf_spatial_targets/aggregate/daymet.py
+++ b/src/nhf_spatial_targets/aggregate/daymet.py
@@ -9,7 +9,7 @@ so the standard ``SourceAdapter`` / ``aggregate_source`` driver
 follow the ssebop precedent: a custom year loop that reuses the
 driver's weight-cache, gdptools, atomic-write, and manifest helpers.
 
-This PR supports the NA region only. ``--region hi`` / ``--region pr``
+Only the NA region is supported; ``--region hi`` / ``--region pr``
 raise ``NotImplementedError`` until a fabric that needs them lands
 (tracked under issue #101).
 """

--- a/src/nhf_spatial_targets/cli/release.py
+++ b/src/nhf_spatial_targets/cli/release.py
@@ -8,15 +8,15 @@ own -- every subcommand resolves a :class:`~nhf_spatial_targets.workspace.Projec
 (and, where ScienceBase is touched, an
 :class:`~nhf_spatial_targets.release.sb_client.SbClient`) and dispatches.
 
-Two seams are deliberately small so PR-G can fill them in without touching the
-subcommand bodies:
+Two seams are deliberately small so the pending credential/session wiring can
+fill them in without touching the subcommand bodies:
 
 - :func:`_load_project` wraps :func:`nhf_spatial_targets.workspace.load` (a test
   seam; the dispatch tests patch it to return a synthetic project).
-- :func:`_resolve_client` builds the live ``SbClient``. **For PR-F** it resolves
-  a Keycloak token from an explicit ``--token`` or the ``SB_TOKEN`` environment
-  variable via :meth:`SbClient.from_token`. The ``.credentials.yml``
-  ``sciencebase:`` block + ``materialize_sciencebase_token`` wiring is PR-G; a
+- :func:`_resolve_client` builds the live ``SbClient``. It resolves a Keycloak
+  token from an explicit ``--token`` or the ``SB_TOKEN`` environment variable
+  via :meth:`SbClient.from_token`. The ``.credentials.yml`` ``sciencebase:``
+  block + ``materialize_sciencebase_token`` wiring is not yet implemented; a
   clear "no credentials found" error fires until then.
 
 The umbrella's ScienceBase parent (community / folder id) is supplied with the
@@ -24,7 +24,7 @@ The umbrella's ScienceBase parent (community / folder id) is supplied with the
 shared across every project publishing to the same umbrella, it is needed only
 for the rare ``publish --scope umbrella`` / ``--create-umbrella`` path, and a
 per-project config key would both duplicate it and pre-commit a schema before
-PR-G clarifies where ScienceBase deployment settings live.
+the deployment-settings location is decided.
 """
 
 from __future__ import annotations
@@ -70,7 +70,7 @@ _TOKEN_PARAM = Parameter(
     name=["--token"],
     help=(
         "ScienceBase Keycloak token JSON. Falls back to the SB_TOKEN "
-        "environment variable. (.credentials.yml wiring is PR-G.)"
+        "environment variable. (.credentials.yml wiring is not yet implemented.)"
     ),
 )
 _ENV_PARAM = Parameter(
@@ -99,7 +99,7 @@ and `ipds_number` in `release.yml` (this directory) before publishing.
 
 
 # ---------------------------------------------------------------------------
-# Errors + seams (the two PR-G fills in)
+# Errors + seams (the two the pending credential wiring fills in)
 # ---------------------------------------------------------------------------
 
 
@@ -121,9 +121,9 @@ def _load_project(workdir: Path) -> Project:
 def _resolve_client(*, token: str | None = None, env: str | None = None) -> SbClient:
     """Construct an :class:`SbClient` for live ScienceBase operations.
 
-    **PR-F seam.** Resolves a Keycloak token from *token* (the ``--token`` flag)
-    or, failing that, the ``SB_TOKEN`` environment variable, and builds the
-    client via :meth:`SbClient.from_token`. PR-G extends this to read the
+    Resolves a Keycloak token from *token* (the ``--token`` flag) or, failing
+    that, the ``SB_TOKEN`` environment variable, and builds the client via
+    :meth:`SbClient.from_token`. A later phase extends this to read the
     ``sciencebase:`` block from ``.credentials.yml`` (via
     ``materialize_sciencebase_token``); until then a token must be supplied.
 
@@ -141,7 +141,7 @@ def _resolve_client(*, token: str | None = None, env: str | None = None) -> SbCl
         raise ReleaseCliError(
             "no ScienceBase credentials found: pass --token or set the SB_TOKEN "
             "environment variable. (Reading the `sciencebase:` block from "
-            ".credentials.yml lands in PR-G.)"
+            ".credentials.yml is not yet implemented.)"
         )
     try:
         return SbClient.from_token(resolved, env=env)

--- a/src/nhf_spatial_targets/release/build.py
+++ b/src/nhf_spatial_targets/release/build.py
@@ -9,8 +9,10 @@ self-contained release payload on disk under
 ``<project>/release/build/<scope>/``.
 
 It is **entirely offline**: no ScienceBase client, registry, or network I/O.
-Publishing, the registry, and dry-run are a later phase (PR-E2); the CLI that
-drives this is PR-F. The build is **catalog- + manifest-driven**: source
+Publishing, the registry, and dry-run live in separate modules
+(:mod:`~nhf_spatial_targets.release.publish` /
+:mod:`~nhf_spatial_targets.release.registry`); the CLI that drives this is
+:mod:`~nhf_spatial_targets.cli.release`. The build is **catalog- + manifest-driven**: source
 children flow from :func:`payload.sources_used` (the intersection of
 :func:`catalog.publishable_sources` with the sources the project actually
 aggregated on disk) and fabric participation from the project ``manifest.json``
@@ -38,7 +40,7 @@ Distribution-list decision:
     - **Fabric child:** ``fabric.gpkg`` + every aggregated NC + every target NC
       + ``manifest.json`` + ``README.md`` + ``checksums.csv`` + ``SHA256SUMS``.
       This matches the fgdc-field-map's "every staged file" intent.
-    - **Source child:** the staged consolidated NetCDFs only. The PR-D1
+    - **Source child:** the staged consolidated NetCDFs only. The
       source-distribution builder labels every listed entry "Consolidated
       CF-1.6 NetCDF.", so listing README / checksums there would mislabel them;
       those files are still staged and checksummed, just not enumerated in
@@ -296,8 +298,8 @@ def build_umbrella(
     when ``None`` (a standalone umbrella build), the fabric + source child MCFs
     are rebuilt locally -- a local build unions exactly the children this
     project would produce. The registry-driven cross-project union and DOI
-    refresh are a later phase (PR-E2); any operator-set DOI is read from
-    ``config.release.doi`` here.
+    refresh live in the publish/registry layer, not here; any operator-set DOI
+    is read from ``config.release.doi`` here.
     """
     defaults = load_release_defaults()
     release_cfg = _release_cfg(project)

--- a/src/nhf_spatial_targets/release/mcf.py
+++ b/src/nhf_spatial_targets/release/mcf.py
@@ -270,8 +270,9 @@ def build_source_mcf(
     period, bbox, variables) and ``release`` block, plus repo-level
     ``defaults``. ``manifest`` (loaded ``manifest.json``) supplies the
     process steps filtered to ``source_key``. ``distribution_files`` are the
-    staged consolidated NetCDF filenames (passed by PR-E; ``None`` pre-build
-    yields only the upstream landing entry). ``metadata_only`` sources
+    staged consolidated NetCDF filenames (passed by the build orchestrator;
+    ``None`` pre-build yields only the upstream landing entry).
+    ``metadata_only`` sources
     (e.g. daymet) carry only the upstream landing entry regardless.
 
     Parameters
@@ -282,7 +283,8 @@ def build_source_mcf(
         Validated ``catalog/release_defaults.yml`` mapping.
     manifest, distribution_files, identifier, now
         See module docstring. ``identifier`` overrides the deterministic
-        ``urn:usgs:nhf-release:source:<key>`` (PR-E passes the ScienceBase id).
+        ``urn:usgs:nhf-release:source:<key>`` (the build orchestrator passes
+        the ScienceBase id).
     """
     src = catalog.source(source_key)
     release = catalog.release_block(source_key)
@@ -447,7 +449,8 @@ def build_fabric_mcf(
     ``manifest['sources']`` intersected with
     :func:`catalog.publishable_sources` (catalog/manifest-driven, never a
     hard-coded list). ``doi`` is the umbrella DOI children share (``None``
-    pre-mint); ``distribution_files`` are the staged file names (PR-E).
+    pre-mint); ``distribution_files`` are the staged file names (supplied by
+    the build orchestrator).
     """
     release_cfg = config.get("release") or {}
     fab_defaults = defaults.get("fabric", {})

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -8,7 +8,8 @@ umbrella / source-child / fabric-child item and records the result.
 
 **Dependency injection.** Every ``publish_*`` takes an already-constructed
 :class:`~nhf_spatial_targets.release.sb_client.SbClient`. Resolving credentials
-and building a real session is PR-G's job; here the client is assumed ready, so
+and building a real session is handled by the (not-yet-implemented) credential
+wiring; here the client is assumed ready, so
 the whole module is offline-testable against a mock client (the mock patterns
 in ``tests/test_release_sb_client_offline.py``).
 
@@ -38,7 +39,7 @@ comparison is honest in both directions: an MD5 hex string (32 chars) can
 never equal a SHA-256 (64 chars), so if a remote file ever records a SHA-256
 the local MD5 simply won't match and the file re-uploads -- correct, just not
 skipped. We pass MD5 through the (SHA-256-named) parameter rather than
-extending the merged PR-E2 primitive: the "what checksum does ScienceBase
+extending the ``SbClient`` upload primitive: the "what checksum does ScienceBase
 actually use" knowledge belongs in this orchestration layer.
 
 **Flat ScienceBase namespace.** A staged payload is a nested tree
@@ -161,7 +162,7 @@ class PublishResult:
     def __post_init__(self) -> None:
         # The umbrella is keyless; source/fabric children always carry a key.
         # Same invariant BuildResult guards -- enforced here so a future second
-        # producer (the PR-F CLI / status command) can't construct a mismatch.
+        # producer (the CLI / status command) can't construct a mismatch.
         if (self.scope == "umbrella") != (self.key is None):
             raise ValueError(
                 f"{self.scope!r} key invariant violated: umbrella must have "
@@ -738,8 +739,9 @@ def _preflight_common(
     manifest, so this is not constant-time overall -- it is still fail-fast
     (runs before any build / upload).
 
-    Credential resolvability is intentionally *not* checked here: PR-E3 assumes
-    a ready, injected client (the credential/session wiring is PR-G).
+    Credential resolvability is intentionally *not* checked here: the publish
+    orchestration assumes a ready, injected client (the credential/session
+    wiring is not yet implemented).
     """
     manifest_path = project.manifest_path
     if not manifest_path.exists():
@@ -792,7 +794,7 @@ def _require_umbrella_sb_id(registry_path: Path | None) -> str:
     """Return the umbrella sb_id or raise -- a child can't be parented without it.
 
     The plan's ``--create-umbrella`` affordance (publish the umbrella and a
-    child in one invocation) is a CLI-level composition (PR-F) of
+    child in one invocation) is a CLI-level composition of
     :func:`publish_umbrella` then a child publish; the library keeps the gate
     single-purpose so a child never silently lands under a missing parent.
     """
@@ -1170,7 +1172,7 @@ def publish_fabric_child(
 
 
 # ---------------------------------------------------------------------------
-# Read-only diff (intent vs reality) -- used by dry-run and status (PR-F)
+# Read-only diff (intent vs reality) -- used by dry-run and status
 # ---------------------------------------------------------------------------
 
 DiffScope = Literal["umbrella", "sources", "fabric", "all"]

--- a/src/nhf_spatial_targets/release/registry.py
+++ b/src/nhf_spatial_targets/release/registry.py
@@ -4,7 +4,7 @@ The registry is the **source of truth for what we intend to have published**
 to ScienceBase: the umbrella DOI parent, one entry per consolidated-source
 child, and one entry per fabric child. ScienceBase itself remains the source
 of truth for *what actually exists*; reconciling the two (``diff_local_vs_remote``)
-needs live SB queries and lives in the publish/status layer (PR-E3), not here.
+needs live SB queries and lives in the publish/status layer, not here.
 This module stays pure-local.
 
 Two invariants drive the implementation:

--- a/src/nhf_spatial_targets/release/sb_client.py
+++ b/src/nhf_spatial_targets/release/sb_client.py
@@ -1,7 +1,7 @@
 """Thin, retrying wrapper over :class:`sciencebasepy.SbSession`.
 
 This is the only place the rest of the release tooling touches ScienceBase.
-It exposes the handful of operations the publish orchestration (PR-E3) needs
+It exposes the handful of operations the publish orchestration needs
 -- authenticate, look up / create / update an item, find a child by title,
 upload a file with a skip-if-unchanged fast path -- and wraps each underlying
 call in exponential-backoff retry for transient HTTP failures (429 + 5xx) and
@@ -113,7 +113,7 @@ def remote_file_checksum(item: dict | None, filename: str) -> str | None:
     ``SbSession._replace_file``), so a SHA-256 passed to
     :meth:`SbClient.upload_file`'s ``skip_if_sha256_matches`` only matches once
     a SHA-256 is recorded on the remote file -- a responsibility of the publish
-    orchestration (PR-E3). When the recorded checksum is an MD5 that can't
+    orchestration. When the recorded checksum is an MD5 that can't
     match a SHA-256, the file simply re-uploads: correct, just not skipped.
     """
     if not item:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def make_minimal_project(tmp_path, fabric_path: str | None = None):
 
 
 # ---------------------------------------------------------------------------
-# Release publish/dry-run test helpers (PR-E3)
+# Release publish/dry-run test helpers
 # ---------------------------------------------------------------------------
 
 # A populated author list satisfies the publish pre-flight; tests pass

--- a/tests/test_fetch_consolidate_step_outputs.py
+++ b/tests/test_fetch_consolidate_step_outputs.py
@@ -12,7 +12,7 @@ Issue #263: the step-output builders probed a fixed key tuple
 (``consolidated_nc`` / ``consolidated_path`` / ``path``) that never included
 ``daily_path``, so ``step["outputs"]`` came out empty and the consolidate steps
 carried no output sha256 -- undercutting the release checksum/provenance
-feature (PR-C #258).
+feature (#258).
 
 These tests drive each module's ``_update_manifest`` directly with records
 shaped like the live loop produces. They pin its read-and-checksum contract:

--- a/tests/test_release_cli.py
+++ b/tests/test_release_cli.py
@@ -1,4 +1,4 @@
-"""Offline tests for the ``nhf-targets release`` CLI sub-app (PR-F).
+"""Offline tests for the ``nhf-targets release`` CLI sub-app.
 
 These exercise the CLI *wiring* only: help + argument parsing for all seven
 subcommands, the local artifacts ``init`` / ``build`` / ``manifest`` produce,
@@ -7,7 +7,8 @@ and -- for the ScienceBase-touching subcommands -- that the right
 dispatched with the right scope and flags. ScienceBase is never hit: the
 client seam (:func:`cli.release._resolve_client`) and the project loader
 (:func:`cli.release._load_project`) are patched, and the orchestrators are
-patched with recorders. Live ScienceBase verification is PR-G.
+patched with recorders. Live ScienceBase verification is deferred to the
+credential/session-wiring phase (not yet implemented).
 """
 
 from __future__ import annotations

--- a/tests/test_release_mcf.py
+++ b/tests/test_release_mcf.py
@@ -11,7 +11,7 @@ an exhaustive registry: adding a new catalog source must not require
 touching them. Spot-check tests assert the load-bearing invariants
 (bbox conversion, publishability filtering, metadata-only handling) so the
 intent is visible without diffing the large golden dicts, and an
-``ISO19139`` render smoke-test protects the shape the PR-D2 emitter consumes.
+``ISO19139`` render smoke-test protects the shape the ISO emitter consumes.
 """
 
 from __future__ import annotations
@@ -34,7 +34,8 @@ FX = Path(__file__).parent / "fixtures" / "release"
 # Injected so metadata.datestamp / dates are byte-stable in the golden.
 NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
 
-# Canned staged-file lists (PR-E supplies these from the payload stager).
+# Canned staged-file lists (the build orchestrator supplies these from the
+# payload stager).
 SRC_FILES = {
     "era5_land": [
         "monthly/era5_land_monthly_2003.nc",
@@ -165,7 +166,7 @@ def test_source_without_bbox_is_none(defaults, manifest):
     """A source with no access.bbox_nwse gets an honest None MCF bbox.
 
     merra2 is global and subsets at aggregation time, so the catalog carries
-    no bbox for it. (SNODAS used to be the example here, but PR-D2 gave it a
+    no bbox for it. (SNODAS used to be the example here, but it was given a
     catalog CONUS bbox so its FGDC <bounding> is valid; the code-side None
     path is also covered by test_fabric_bbox_absent_is_none.)
     """
@@ -232,7 +233,7 @@ def test_umbrella_unions_child_extents(config, fabric, defaults, manifest):
 
 @pytest.mark.parametrize("kind", ["era5_land", "snodas", "daymet"])
 def test_source_mcf_renders_to_iso(kind, defaults, manifest):
-    """The MCF shape is consumable by the PR-D2 ISO emitter (smoke)."""
+    """The MCF shape is consumable by the ISO emitter (smoke)."""
     built = mcf.build_source_mcf(kind, defaults=defaults, manifest=manifest, now=NOW)
     xml = ISO19139OutputSchema().write(built)
     assert xml.lstrip().startswith("<?xml")


### PR DESCRIPTION
Closes #254
Closes #256

## What

Sweeps `src/` and `tests/` for the release-stack **PR-phase markers** the per-PR cleanups missed, plus the pre-`PR-X`-convention **"This PR"** marker in `aggregate/daymet.py`. Each reference is replaced with a description of *what* the code does or *why*, neutral of the PR sequence (CLAUDE.md's "don't reference the current task" rule).

## Why now

- **#256** named one site: `aggregate/daymet.py:12` ("This PR supports the NA region only"). Fixed with the issue's suggested wording; the kept WHY is "until a fabric that needs them lands" (issue #101).
- **#254** named `catalog.py`, but that site was **already swept by #255**. #254 also asked to grep the rest of `src/` for residual `PR-[A-G]` markers — that surfaced ~31 references across the `release/` stack that landed *after* #254 was filed. This PR completes that broader sweep.

## How each class was handled

| Marker class | Treatment |
|---|---|
| **Decayed** (`PR-A`..`PR-F` — those PRs are now in git history) | Replaced with the module / orchestrator they refer to (e.g. "passed by `PR-E`" → "passed by the build orchestrator"). |
| **Live seams** (`PR-G` — credential/session wiring, `materialize_sciencebase_token`, not yet implemented) | Rephrased to describe the *pending wiring*, neutral of the PR letter. No dedicated tracking issue exists, so no `#` substituted. |

## Scope / safety

- **Docstring + comment only.** No code paths, signatures, or test logic touched.
- `grep -rnE 'PR-[A-G]' src/ tests/` → **zero hits**; `grep -rn 'This PR' src/` → **zero hits**.
- `pixi run -e dev fmt` + `lint` clean; pre-commit passed.
- **Out of scope** (per #254): the release PR plan file and PR/commit messages, which legitimately reference the PR-A..G phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)