### PR TITLE
feature(release): phase-level INFO progress logging for release build (#295)

### DIFF
--- a/src/nhf_spatial_targets/release/build.py
+++ b/src/nhf_spatial_targets/release/build.py
@@ -52,6 +52,7 @@ Distribution-list decision:
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime
@@ -66,6 +67,8 @@ from nhf_spatial_targets.release._models import (
 )
 from nhf_spatial_targets.release.defaults import load_release_defaults
 from nhf_spatial_targets.workspace import Project
+
+logger = logging.getLogger(__name__)
 
 # release build --scope choices; "fabric" is the default (one fabric child).
 BuildScope = Literal["fabric", "sources", "all"]
@@ -181,6 +184,9 @@ def _render_metadata(stage_dir: Path, mcf_dict: dict, *, kind: ItemKind) -> None
     A pure function of *mcf_dict* (every date is already baked into the MCF),
     so re-rendering an unchanged MCF rewrites byte-identical files.
     """
+    # The CPU-bound pygeometa/template render is the slow step of a build;
+    # announce it so an operator does not read the pause as a hang (#295).
+    logger.info("rendering metadata (fgdc/iso/readme) for %s %r", kind, stage_dir.name)
     (stage_dir / "fgdc.xml").write_text(fgdc.render_fgdc(mcf_dict, kind=kind))
     (stage_dir / "iso.xml").write_text(iso.render_iso(mcf_dict))
     (stage_dir / "README.md").write_text(readme.render_readme(mcf_dict, kind=kind))
@@ -198,6 +204,13 @@ def _finish(
     """
     _render_metadata(stage_dir, mcf_dict, kind=kind)
     entries = checksums.compute_checksums(stage_dir)
+    logger.info(
+        "staged %s %r: %d file(s) -> %s",
+        kind,
+        key or stage_dir.name,
+        len(entries),
+        stage_dir,
+    )
     return BuildResult(
         kind=kind, key=key, stage_dir=stage_dir, mcf=mcf_dict, entries=tuple(entries)
     )
@@ -244,6 +257,7 @@ def build_source_child(
     The distribution list is the staged NetCDFs; see the module docstring for
     why README / checksums are not enumerated there for source children.
     """
+    logger.info("staging source child %r", key)
     defaults = load_release_defaults()
     manifest = _load_manifest(project)
     plan = payload.stage_source_child(project, key, copy=copy)
@@ -267,6 +281,7 @@ def build_fabric_child(
     list is every staged downloadable artifact (the metadata records aside);
     see the module docstring.
     """
+    logger.info("staging fabric child %r", payload.resolve_fabric_label(project))
     defaults = load_release_defaults()
     manifest = _load_manifest(project)
     plan = payload.stage_fabric_child(project, copy=copy)
@@ -301,6 +316,7 @@ def build_umbrella(
     refresh live in the publish/registry layer, not here; any operator-set DOI
     is read from ``config.release.doi`` here.
     """
+    logger.info("staging umbrella")
     defaults = load_release_defaults()
     release_cfg = _release_cfg(project)
     if children is None:

--- a/src/nhf_spatial_targets/release/payload.py
+++ b/src/nhf_spatial_targets/release/payload.py
@@ -93,6 +93,7 @@ def _link_or_copy(src: Path, dest: Path, *, copy: bool) -> None:
         shutil.copy2(src, dest)
     else:
         os.symlink(os.path.abspath(src), dest)
+    logger.debug("%s %s -> %s", "copied" if copy else "linked", src, dest)
 
 
 def _copy_file(src: Path, dest: Path) -> None:
@@ -101,6 +102,7 @@ def _copy_file(src: Path, dest: Path) -> None:
     if dest.is_symlink() or dest.exists():
         dest.unlink()
     shutil.copy2(src, dest)
+    logger.debug("copied %s -> %s", src, dest)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_build.py
+++ b/tests/test_release_build.py
@@ -426,6 +426,62 @@ def test_build_all_unknown_scope_raises(tmp_path):
         build.build_all(project, scope="bogus", now=NOW)  # type: ignore[arg-type]
 
 
+# ---------------------------------------------------------------------------
+# progress logging (#295): phase-level INFO + meaningful -v/DEBUG
+# ---------------------------------------------------------------------------
+
+_BUILD_LOGGER = "nhf_spatial_targets.release.build"
+_PAYLOAD_LOGGER = "nhf_spatial_targets.release.payload"
+
+
+def test_fabric_build_emits_phase_info_lines(tmp_path, caplog):
+    """At INFO the build narrates its phases instead of running silent (#295)."""
+    project = _build_project(tmp_path)
+    with caplog.at_level("INFO", logger=_BUILD_LOGGER):
+        build.build_fabric_child(project, now=NOW)
+    messages = [r.getMessage() for r in caplog.records]
+    # entry line names the item, render line names the slow metadata step,
+    # completion line reports the file count + destination.
+    assert any("staging fabric child 'gfv_test'" in m for m in messages)
+    assert any("rendering metadata (fgdc/iso/readme) for fabric" in m for m in messages)
+    assert any(m.startswith("staged fabric 'gfv_test':") for m in messages)
+
+
+def test_build_is_quiet_at_warning_level(tmp_path, caplog):
+    """The phase lines are INFO, so a default WARNING console stays uncluttered."""
+    project = _build_project(tmp_path)
+    with caplog.at_level("WARNING", logger=_BUILD_LOGGER):
+        build.build_fabric_child(project, now=NOW)
+    assert [r for r in caplog.records if r.levelname == "INFO"] == []
+
+
+def test_verbose_debug_surfaces_per_file_staging(tmp_path, caplog):
+    """`-v`/DEBUG surfaces per-file staging in payload -- previously a no-op (#295).
+
+    The build path had zero debug calls, so ``--verbose`` produced nothing extra
+    for ``release build``. The payload write chokepoints now emit one debug line
+    per staged file.
+    """
+    project = _build_project(tmp_path)
+    with caplog.at_level("DEBUG", logger=_PAYLOAD_LOGGER):
+        build.build_fabric_child(project, now=NOW)
+    debug_msgs = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    # fabric.gpkg is symlinked; manifest.json is copied -- both chokepoints fire.
+    assert any("-> " in m and "fabric.gpkg" in m for m in debug_msgs)
+    assert any(m.startswith("copied") and "manifest.json" in m for m in debug_msgs)
+
+
+def test_build_all_narrates_each_child(tmp_path, caplog):
+    """scope=all emits a staging line per child kind (source + umbrella too)."""
+    project = _build_project(tmp_path)
+    with caplog.at_level("INFO", logger=_BUILD_LOGGER):
+        build.build_all(project, scope="all", now=NOW)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("staging fabric child" in m for m in messages)
+    assert any("staging source child 'era5_land'" in m for m in messages)
+    assert any(m == "staging umbrella" for m in messages)
+
+
 def test_build_all_scope_all_matches_payload_sources_used(tmp_path):
     """The dispatcher is catalog/manifest-driven: the source children it builds
     are exactly payload.sources_used (no hard-coded list)."""


### PR DESCRIPTION
Closes #295. Observability follow-up surfaced while smoke-testing the local publish after #293.

## Problem

The `release build` path ran **silent** from start to its end-of-run Rich summary. The whole pipeline (`build.py` + `payload.py` + metadata writers) had exactly **one** log call — the #260 warning. A real build stages dozens of symlinks and renders three pygeometa docs per item with no feedback, which reads as a hang on caldera's filesystem (observed directly). Separately, the global `-v/--verbose` flag was a **no-op** for build because the path had zero debug calls.

## Change

Phase-level INFO at the seams the code already has:

- `build_{fabric,source}_child` / `build_umbrella` — `staging <kind> child …` on entry (first feedback arrives immediately).
- `_render_metadata` — `rendering metadata (fgdc/iso/readme) for …`, naming the CPU-bound step operators actually wait on.
- `_finish` — `staged <kind> <label>: N file(s) -> <dir>` on completion, mirroring the end summary but streamed per item.

And `-v` is now meaningful: the payload write chokepoints (`_link_or_copy` / `_copy_file`) emit one `logger.debug` line per staged file.

**Non-goal (kept as scoped in #295):** no per-file INFO — the end summary already gives per-item counts; per-file detail stays behind `-v`/DEBUG. The end-of-run Rich summary is unchanged.

## Tests (`tests/test_release_build.py`)

- INFO phase lines emitted by `build_fabric_child` (entry / render / completion).
- WARNING-level run stays free of INFO (phase lines don't clutter the default console).
- DEBUG surfaces per-file staging (`fabric.gpkg` symlink + `manifest.json` copy) — pins the `-v`-now-works fix.
- `build_all(scope="all")` narrates each child kind (fabric + source + umbrella).

`pixi run -e dev fmt && lint` clean; `tests/test_release_build.py tests/test_release_payload.py` → 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)