### PR TITLE
docs(#237): ua_swe wiring design spec + PR-A2 plan

### DIFF
--- a/docs/superpowers/plans/2026-06-09-ua-swe-pr-a2-consolidate-rewindow.md
+++ b/docs/superpowers/plans/2026-06-09-ua-swe-pr-a2-consolidate-rewindow.md
@@ -1,0 +1,618 @@
+# ua_swe PR-A2 — Re-window Consolidator to Calendar Years — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ua_swe`'s consolidator emit per-**calendar-year** NetCDFs (`ua_swe_daily_<year>.nc`) instead of per-water-year ones, so the shared calendar-year aggregation driver stops crashing on the overlapping-year collision.
+
+**Architecture:** Port the Margulis pattern (`fetch/margulis_wus_sr.py:consolidate_calendar_year_margulis_wus_sr`). Calendar year *X* is assembled from the Jan–Sep portion of WY *X* joined with the Oct–Dec portion of WY *X+1*. Extract the existing per-WY decode+reproject body into a reusable helper, then build calendar-year consolidation on top. Re-shard the fetch worker loop by calendar year (each worker downloads the two adjacent WY raws it needs, idempotently) so multi-worker SLURM runs have both raws on disk before consolidating. Drop partial edge years (1981, 2023) via a `FileNotFoundError` boundary rule.
+
+**Tech Stack:** xarray, rioxarray (EPSG:4269→5070 reproject), pandas time decode, pytest. All commands via `pixi`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-ua-swe-wiring-design.md` (PR-A2 section).
+
+**Branch:** `feature/237-ua-swe-pr-a2-consolidate-rewindow` (off `main`). Per project norms, develop in a worktree; run `pixi install -e dev` once after creating it.
+
+---
+
+## File Structure
+
+- **Modify** `src/nhf_spatial_targets/fetch/ua_swe.py`
+  - Extract `_reproject_wy_to_dataset(wy, raw_path) -> xr.Dataset` from the body of `consolidate_water_year_ua_swe` (decode + sentinel-check + per-day reproject + rename → reprojected `swe`/`snow_depth` dataset, **pre-CF**).
+  - Add `_calendar_year_slice(ds, calendar_year) -> xr.Dataset`.
+  - Add `consolidate_calendar_year_ua_swe(calendar_year, raw_dir, daily_dir) -> Path`.
+  - Replace `consolidate_water_year_ua_swe` (callers move to the CY function).
+  - Add `_CONSOLIDATED_FILENAME_TEMPLATE = "ua_swe_daily_{year}.nc"` (replaces the `WY{wy}` template).
+  - Re-shard `fetch_ua_swe`: assign **calendar years** to workers; per CY download WY *X* and *X+1* raws, then consolidate.
+  - Rewrite `_update_manifest` records to be keyed by `calendar_year` (not `water_year`).
+  - Rename `_assign_worker_water_years` → `_assign_worker_calendar_years` (same round-robin body).
+- **Modify** `tests/test_ua_swe.py` — add calendar-year consolidation tests; update WY-assuming tests.
+- **Modify** `catalog/sources.yml` — `ua_swe.access.notes` filename description.
+- **Modify** `notebooks/consolidated/inspect_consolidated_swe.ipynb` and `inspect_consolidated_snow_covered_area.ipynb` — fix hardcoded `ua_swe_daily_WY{...}.nc` paths.
+- **Create** `docs/sources/ua_swe.md`; **Modify** `docs/sources/index.md`.
+
+---
+
+## Task 1: Extract `_reproject_wy_to_dataset` helper (pure refactor)
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/ua_swe.py`
+- Test: `tests/test_ua_swe.py`
+
+- [ ] **Step 1: Write a characterization test for the helper**
+
+Add to `tests/test_ua_swe.py` (reuse the existing synthetic-raw-NC fixture; if the file already builds a fake raw WY NC for `consolidate_water_year_ua_swe`, factor that into a `_make_raw_wy_nc(tmp_path, wy, n_days=...)` helper and call it here):
+
+```python
+def test_reproject_wy_to_dataset_shape_and_vars(tmp_path):
+    from nhf_spatial_targets.fetch.ua_swe import _reproject_wy_to_dataset
+
+    raw = _make_raw_wy_nc(tmp_path, wy=2000, n_days=366)  # WY2000 = Oct1999-Sep2000
+    ds = _reproject_wy_to_dataset(2000, raw)
+
+    assert set(ds.data_vars) == {"swe", "snow_depth"}
+    assert ds["swe"].dims == ("time", "y", "x")
+    # EPSG:5070 projected coords are metres, monotonic.
+    assert "x" in ds.coords and "y" in ds.coords
+    assert ds.sizes["time"] == 366
+    # First timestamp is Oct 1 of the prior calendar year.
+    assert pd.Timestamp(ds["time"].values[0]) == pd.Timestamp("1999-10-01")
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py::test_reproject_wy_to_dataset_shape_and_vars -v`
+Expected: FAIL with `ImportError`/`AttributeError: _reproject_wy_to_dataset`.
+
+- [ ] **Step 3: Extract the helper**
+
+In `fetch/ua_swe.py`, cut the body of `consolidate_water_year_ua_swe` from the `ds_raw = xr.open_dataset(...)` line through the construction of `ds_reproj` (the `try/finally` block that decodes time, runs the sentinel `< -1.0` guard, does the per-day reproject, and builds `ds_reproj`) into a new module-level function. It returns the reprojected, renamed, **pre-CF** dataset:
+
+```python
+def _reproject_wy_to_dataset(wy: int, raw_path: Path) -> xr.Dataset:
+    """Decode + pre-project one raw WY NC to an EPSG:5070 (time, y, x) dataset.
+
+    Returns a dataset with ``swe`` / ``snow_depth`` (float32, native units),
+    a decoded daily ``time`` axis (Oct 1 of WY-1 .. Sep 30 of WY), and
+    projected ``y`` / ``x`` metre coords. CF metadata is NOT applied here —
+    the caller applies it once after stitching (see
+    :func:`consolidate_calendar_year_ua_swe`).
+    """
+    if not raw_path.exists():
+        raise FileNotFoundError(f"ua_swe raw NC not found: {raw_path}")
+    ds_raw = xr.open_dataset(raw_path, decode_times=False)
+    try:
+        # ... existing time-decode, sentinel-check, per-day reproject body ...
+        # (verbatim from the old consolidate_water_year_ua_swe), ending with:
+        ds_reproj = xr.Dataset(
+            {
+                dst_name: xr.concat(days, dim="time")
+                for dst_name, days in reprojected_per_var.items()
+            }
+        )
+    finally:
+        ds_raw.close()
+    return ds_reproj
+```
+
+Leave `consolidate_water_year_ua_swe` temporarily calling the helper (it is removed in Task 3) so the suite stays green:
+
+```python
+def consolidate_water_year_ua_swe(wy: int, raw_path: Path, daily_dir: Path) -> Path:
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    out_path = daily_dir / f"ua_swe_daily_WY{wy}.nc"
+    if out_path.exists() and out_path.stat().st_mtime >= raw_path.stat().st_mtime:
+        return out_path
+    ds_reproj = _reproject_wy_to_dataset(wy, raw_path)
+    ds_out = apply_cf_metadata(ds_reproj, _SOURCE_KEY, time_step="daily",
+                               coord_type="projected")
+    _atomic_write_dataset(ds_out, out_path, encoding=_build_consolidated_encoding(ds_out))
+    return out_path
+```
+
+- [ ] **Step 4: Run the helper test + the existing WY-consolidate tests**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -k "reproject or consolidate" -v`
+Expected: PASS (helper test + any existing `consolidate_water_year` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/ua_swe.py tests/test_ua_swe.py
+pixi run git commit -m "refactor(#237): extract _reproject_wy_to_dataset from ua_swe consolidator"
+```
+
+---
+
+## Task 2: `_calendar_year_slice` + `consolidate_calendar_year_ua_swe`
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/ua_swe.py`
+- Test: `tests/test_ua_swe.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_consolidate_calendar_year_spans_jan_to_dec(tmp_path):
+    from nhf_spatial_targets.fetch.ua_swe import consolidate_calendar_year_ua_swe
+
+    raw_dir = tmp_path / "raw"; raw_dir.mkdir()
+    daily = tmp_path / "daily"
+    _make_raw_wy_nc(raw_dir, wy=2000)   # Oct1999-Sep2000  -> file 4km_SWE_Depth_WY2000_v01.nc
+    _make_raw_wy_nc(raw_dir, wy=2001)   # Oct2000-Sep2001  -> file 4km_SWE_Depth_WY2001_v01.nc
+
+    out = consolidate_calendar_year_ua_swe(2000, raw_dir, daily)
+
+    assert out.name == "ua_swe_daily_2000.nc"
+    ds = xr.open_dataset(out)
+    t = pd.DatetimeIndex(ds["time"].values)
+    assert t.min() == pd.Timestamp("2000-01-01")
+    assert t.max() == pd.Timestamp("2000-12-31")
+    # No duplicate / gap across the Sep30 -> Oct1 seam.
+    assert t.is_monotonic_increasing and t.is_unique
+    assert (t[1:] - t[:-1]).max() == pd.Timedelta(days=1)
+    ds.close()
+
+
+def test_consolidate_calendar_year_boundary_raises(tmp_path):
+    from nhf_spatial_targets.fetch.ua_swe import consolidate_calendar_year_ua_swe
+
+    raw_dir = tmp_path / "raw"; raw_dir.mkdir()
+    daily = tmp_path / "daily"
+    _make_raw_wy_nc(raw_dir, wy=2023)   # only WY2023; WY2024 (for Oct-Dec 2023) absent
+    with pytest.raises(FileNotFoundError):
+        consolidate_calendar_year_ua_swe(2023, raw_dir, daily)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -k "calendar_year" -v`
+Expected: FAIL with `AttributeError: consolidate_calendar_year_ua_swe`.
+
+- [ ] **Step 3: Implement the slice helper + CY consolidator**
+
+```python
+def _calendar_year_slice(ds: xr.Dataset, calendar_year: int) -> xr.Dataset:
+    """Slice a decoded WY dataset to whichever portion overlaps the calendar year."""
+    return ds.sel(
+        time=slice(
+            pd.Timestamp(f"{calendar_year}-01-01"),
+            pd.Timestamp(f"{calendar_year}-12-31"),
+        )
+    )
+
+
+def consolidate_calendar_year_ua_swe(
+    calendar_year: int, raw_dir: Path, daily_dir: Path
+) -> Path:
+    """Re-window two adjacent WY raws into one CF-1.6 calendar-year NC.
+
+    Calendar year *X* = [Jan 1 – Sep 30 of X] from WY *X*
+    (``4km_SWE_Depth_WY{X}_v01.nc``, which runs Oct *X-1* – Sep *X*)
+    joined with [Oct 1 – Dec 31 of X] from WY *X+1*. Both raws must be
+    present; a missing WY *X+1* (the archive boundary, e.g. CY 2023)
+    raises ``FileNotFoundError`` and the caller skips the partial edge.
+
+    Mirrors ``fetch/margulis_wus_sr.py:consolidate_calendar_year_margulis_wus_sr``.
+    Output: ``<daily_dir>/ua_swe_daily_<calendar_year>.nc`` (EPSG:5070).
+    mtime-idempotent against both contributing raws.
+    """
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    out_path = daily_dir / _CONSOLIDATED_FILENAME_TEMPLATE.format(year=calendar_year)
+
+    raw_x = raw_dir / _WY_FILENAME_TEMPLATE.format(wy=calendar_year)
+    raw_x1 = raw_dir / _WY_FILENAME_TEMPLATE.format(wy=calendar_year + 1)
+    for p in (raw_x, raw_x1):
+        if not p.exists():
+            raise FileNotFoundError(
+                f"ua_swe: calendar year {calendar_year} needs both "
+                f"{raw_x.name} and {raw_x1.name}; missing {p.name}. "
+                f"(Archive-boundary calendar years are dropped.)"
+            )
+
+    newest_raw = max(raw_x.stat().st_mtime, raw_x1.stat().st_mtime)
+    if out_path.exists() and out_path.stat().st_mtime >= newest_raw:
+        logger.info(
+            "ua_swe: CY %d already consolidated and current (%s); skipping.",
+            calendar_year, out_path.name,
+        )
+        return out_path
+
+    ds_x = _reproject_wy_to_dataset(calendar_year, raw_x)
+    ds_x1 = _reproject_wy_to_dataset(calendar_year + 1, raw_x1)
+    try:
+        jan_sep = _calendar_year_slice(ds_x, calendar_year)    # Jan1 .. Sep30
+        oct_dec = _calendar_year_slice(ds_x1, calendar_year)   # Oct1 .. Dec31
+        ds_cy = xr.concat([jan_sep, oct_dec], dim="time").sortby("time")
+    finally:
+        ds_x.close()
+        ds_x1.close()
+
+    ds_out = apply_cf_metadata(
+        ds_cy, _SOURCE_KEY, time_step="daily", coord_type="projected"
+    )
+    _atomic_write_dataset(
+        ds_out, out_path, encoding=_build_consolidated_encoding(ds_out)
+    )
+    return out_path
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -k "calendar_year" -v`
+Expected: PASS (both new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/ua_swe.py tests/test_ua_swe.py
+pixi run git commit -m "feat(#237): add calendar-year ua_swe consolidator (Margulis-style re-window)"
+```
+
+---
+
+## Task 3: Swap the filename template + remove the WY consolidator
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/ua_swe.py`
+
+- [ ] **Step 1: Update the constant**
+
+Replace:
+
+```python
+_CONSOLIDATED_FILENAME_TEMPLATE = "ua_swe_daily_WY{wy}.nc"
+```
+
+with:
+
+```python
+_CONSOLIDATED_FILENAME_TEMPLATE = "ua_swe_daily_{year}.nc"
+```
+
+- [ ] **Step 2: Remove `consolidate_water_year_ua_swe`**
+
+Delete the function (its only remaining caller, `fetch_ua_swe`, is rewired in Task 4). Keep `_reproject_wy_to_dataset`, `_build_consolidated_encoding`, `_atomic_write_dataset`.
+
+- [ ] **Step 3: Delete/replace the now-obsolete WY-consolidate tests**
+
+Remove any `tests/test_ua_swe.py` test that calls `consolidate_water_year_ua_swe` or asserts a `ua_swe_daily_WY*.nc` filename (the calendar-year tests from Task 2 supersede them).
+
+- [ ] **Step 4: Run the module's tests**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -v`
+Expected: PASS, no reference to the removed function.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/ua_swe.py tests/test_ua_swe.py
+pixi run git commit -m "refactor(#237): drop per-WY ua_swe consolidator + WY filename template"
+```
+
+---
+
+## Task 4: Re-shard `fetch_ua_swe` by calendar year
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/ua_swe.py`
+- Test: `tests/test_ua_swe.py`
+
+**Why:** Consolidating CY *X* needs WY *X* and *X+1* raws on disk. Sharding by WY across SLURM-array workers cannot guarantee both adjacent raws land in one worker. Shard by **calendar year** instead: each worker downloads the (idempotent, shared) two WY raws for each CY it owns, then consolidates. Redundant boundary-WY downloads stat-check as `already_present`.
+
+- [ ] **Step 1: Write the failing orchestration test**
+
+```python
+def test_fetch_ua_swe_consolidates_by_calendar_year(tmp_path, monkeypatch):
+    # Stub the network: _download_file writes a synthetic raw WY NC and
+    # returns "downloaded". Patch _earthaccess_session to a dummy.
+    import nhf_spatial_targets.fetch.ua_swe as m
+
+    def fake_download(session, url, out_path, **kw):
+        wy = int(re.search(r"WY(\d{4})", url).group(1))
+        _write_raw_wy_nc(out_path, wy)   # same body as _make_raw_wy_nc, given a path
+        return "downloaded"
+
+    monkeypatch.setattr(m, "_download_file", fake_download)
+    monkeypatch.setattr(m, "_earthaccess_session", lambda: object())
+    ws = _make_project(tmp_path)         # existing project fixture used elsewhere
+
+    result = m.fetch_ua_swe(ws.workdir, "2000/2001")
+
+    daily = ws.raw_dir("ua_swe") / "daily"
+    assert (daily / "ua_swe_daily_2000.nc").exists()
+    assert (daily / "ua_swe_daily_2001.nc").exists()
+    # Records are keyed by calendar year now.
+    assert {r["calendar_year"] for r in result["calendar_years"]} == {2000, 2001}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py::test_fetch_ua_swe_consolidates_by_calendar_year -v`
+Expected: FAIL (`KeyError: 'calendar_years'` or missing CY files).
+
+- [ ] **Step 3: Rewire the worker loop**
+
+In `fetch_ua_swe`, after the publisher-window validation:
+
+```python
+    # Full calendar years require WY X (Jan-Sep) AND WY X+1 (Oct-Dec).
+    # Drop edge calendar years whose WY X+1 is unpublished.
+    publishable_cys = [
+        cy for cy in requested_cys if (cy + 1) <= publisher_wy_hi and cy >= publisher_wy_lo - 1
+    ]
+    assigned_cys = _assign_worker_calendar_years(
+        publishable_cys, worker_index, n_workers
+    )
+```
+
+Then replace the per-WY download+consolidate loop with a per-CY loop. For each assigned CY, download WY *X* and *X+1* (idempotent), then consolidate:
+
+```python
+    cy_records: list[dict] = []
+    for cy in assigned_cys:
+        wy_status: dict[int, str] = {}
+        for wy in (cy, cy + 1):
+            url = _wy_url(archive_url, wy)
+            raw_path = raw_dir / _WY_FILENAME_TEMPLATE.format(wy=wy)
+            wy_status[wy] = _download_file(session, url, raw_path)
+        rec: dict = {
+            "calendar_year": cy,
+            "water_years": [cy, cy + 1],
+            "wy_status": wy_status,
+            "downloaded_utc": now_utc,
+        }
+        if all(s in ("downloaded", "already_present") for s in wy_status.values()):
+            try:
+                daily_path = consolidate_calendar_year_ua_swe(cy, raw_dir, daily_dir)
+                rec["daily_path"] = str(daily_path)
+                rec["consolidated_utc"] = datetime.now(timezone.utc).isoformat()
+            except (FileNotFoundError, ValueError, OSError, RuntimeError) as exc:
+                logger.warning("ua_swe: CY %d consolidation failed: %s", cy, exc)
+                rec["consolidate_error"] = str(exc)
+        else:
+            logger.warning(
+                "ua_swe: CY %d skipped — WY download status %s", cy, wy_status
+            )
+        cy_records.append(rec)
+
+    _update_manifest(workdir, period, meta, cy_records, archive_url, mask_record)
+    return {
+        "source_key": _SOURCE_KEY,
+        "period": period,
+        "archive_url": archive_url,
+        "worker_index": worker_index,
+        "n_workers": n_workers,
+        "calendar_years": cy_records,
+    }
+```
+
+Rename `_assign_worker_water_years` → `_assign_worker_calendar_years` (body unchanged — round-robin slice `items[worker_index::n_workers]`). Remove the old WY-assignment + early-return block that returned `{"water_years": []}`; the per-CY loop with an empty `assigned_cys` returns naturally with `cy_records == []`.
+
+- [ ] **Step 4: Run the orchestration test + module suite**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/ua_swe.py tests/test_ua_swe.py
+pixi run git commit -m "feat(#237): shard ua_swe fetch by calendar year; consolidate per-CY"
+```
+
+---
+
+## Task 5: Manifest records keyed by calendar year
+
+**Files:**
+- Modify: `src/nhf_spatial_targets/fetch/ua_swe.py` (`_update_manifest`)
+- Test: `tests/test_ua_swe.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_manifest_records_calendar_years(tmp_path, monkeypatch):
+    import nhf_spatial_targets.fetch.ua_swe as m
+    # (reuse fake_download / project fixture from Task 4)
+    ...
+    m.fetch_ua_swe(ws.workdir, "2000/2000")
+    manifest = json.loads(ws.manifest_path.read_text())
+    entry = manifest["sources"]["ua_swe"]
+    assert "calendar_years" in entry
+    assert entry["calendar_years"][0]["calendar_year"] == 2000
+    # consolidate step output is the CY NC.
+    steps = [s for s in manifest["steps"] if s["source_key"] == "ua_swe"]
+    assert any("ua_swe_daily_2000.nc" in o["path"]
+               for s in steps for o in s["outputs"])
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py::test_manifest_records_calendar_years -v`
+Expected: FAIL (`water_years` key, not `calendar_years`).
+
+- [ ] **Step 3: Update `_update_manifest`**
+
+Change the signature param `wy_records` → `cy_records`, and inside `_do_update`:
+
+```python
+        existing_by_cy = {
+            int(y["calendar_year"]): y for y in entry.get("calendar_years", [])
+        }
+        for rec in cy_records:
+            existing_by_cy[int(rec["calendar_year"])] = rec
+        merged_cys = [existing_by_cy[c] for c in sorted(existing_by_cy)]
+        ...
+        entry.update({
+            ...
+            "calendar_years": merged_cys,   # replaces "water_years"
+            ...
+        })
+        ...
+        step_outputs = [
+            output_file_entry(Path(rec["daily_path"]))
+            for rec in cy_records
+            if rec.get("daily_path") and Path(rec["daily_path"]).exists()
+        ]
+        manifest["steps"].append(build_step_record(
+            kind="consolidate",
+            source_key=_SOURCE_KEY,
+            outputs=step_outputs,
+            params={
+                "period": period,
+                "calendar_years": [int(r["calendar_year"]) for r in cy_records],
+                "archive_url": archive_url,
+            },
+            command=f"fetch {_SOURCE_KEY.replace('_', '-')}",
+        ))
+```
+
+Update the trailing log line to `[r["calendar_year"] for r in cy_records]`.
+
+- [ ] **Step 4: Run the test + module suite**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nhf_spatial_targets/fetch/ua_swe.py tests/test_ua_swe.py
+pixi run git commit -m "feat(#237): ua_swe manifest records keyed by calendar year"
+```
+
+---
+
+## Task 6: Catalog notes — describe calendar-year layout
+
+**Files:**
+- Modify: `catalog/sources.yml` (`ua_swe.access.notes`)
+- Test: `tests/test_catalog.py` (load smoke-test must stay green)
+
+- [ ] **Step 1: Edit the note**
+
+In the `ua_swe.access.notes` block, change the sentence describing one NetCDF per water year named `ua_swe_daily_WY<YYYY>.nc` to: consolidated to one NetCDF **per calendar year** named `ua_swe_daily_<YYYY>.nc`, assembled from the Jan–Sep portion of WY *X* and the Oct–Dec portion of WY *X+1* (mirrors `margulis_wus_sr`). Note full coverage is CY 1982–2022 (partial edge years dropped). Leave the raw archive description (`4km_SWE_Depth_WY<YYYY>_v01.nc`) unchanged — the raws are still per-WY.
+
+- [ ] **Step 2: Run catalog tests**
+
+Run: `pixi run -e dev pytest tests/test_catalog.py -v`
+Expected: PASS (YAML still parses; `ua_swe` still resolves).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add catalog/sources.yml
+pixi run git commit -m "docs(#237): ua_swe catalog notes describe calendar-year consolidation"
+```
+
+---
+
+## Task 7: Fix the breaking notebook paths
+
+**Files:**
+- Modify: `notebooks/consolidated/inspect_consolidated_swe.ipynb`
+- Modify: `notebooks/consolidated/inspect_consolidated_snow_covered_area.ipynb` (only if it carries the same hardcode)
+
+- [ ] **Step 1: Find the hardcoded WY paths**
+
+Run: `grep -n "ua_swe_daily_WY" notebooks/consolidated/*.ipynb`
+Expected: the SWE notebook registry entry `DATASTORE / "ua_swe" / "daily" / f"ua_swe_daily_WY{TARGET_YEAR}.nc"` plus a markdown cell describing WY filenames.
+
+- [ ] **Step 2: Edit the registry + markdown**
+
+Change the path to `f"ua_swe_daily_{TARGET_YEAR}.nc"`. Update the markdown bullet that says the consolidated layout is per-water-year (`ua_swe_daily_WY<YYYY>.nc`, "for March 2010 the WY2010 file…") to per-calendar-year (`ua_swe_daily_<YYYY>.nc`, "the CY2010 file holds Jan–Dec 2010"). Repeat in the SCA notebook only if `grep` found it there.
+
+- [ ] **Step 3: Sanity check (no execution required)**
+
+Run: `grep -c "ua_swe_daily_WY" notebooks/consolidated/*.ipynb`
+Expected: `0` in every file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add notebooks/consolidated/inspect_consolidated_swe.ipynb
+# add the SCA notebook too iff it was edited
+pixi run git commit -m "docs(#237): point consolidated SWE notebook at calendar-year ua_swe NCs"
+```
+
+---
+
+## Task 8: Add the `docs/sources/ua_swe.md` source page
+
+**Files:**
+- Create: `docs/sources/ua_swe.md`
+- Modify: `docs/sources/index.md`
+
+- [ ] **Step 1: Read the template**
+
+Run: `sed -n '1,60p' docs/sources/margulis_wus_sr.md` and `grep -n "margulis\|snodas" docs/sources/index.md` to match the existing per-source page structure and the index-row format.
+
+- [ ] **Step 2: Write `docs/sources/ua_swe.md`**
+
+Follow the `margulis_wus_sr.md` section layout. Cover: NSIDC-0719 (UA Daily 4-km Gridded SWE & Snow Depth), DOI `10.5067/0GGPB220EX6A`, CONUS, native NAD83 (EPSG:4269) ~4 km, **pre-projected to EPSG:5070 at consolidate time**, variables `swe` (kg m⁻²) / `snow_depth` (mm), the **calendar-year** consolidated layout (`ua_swe_daily_<year>.nc`, full coverage 1982–2022, assembled from two adjacent WY raws), its role as a 5th SWE source and 2nd SCA source, and the `snow_covered_fraction` depth-derived SCA proxy with its `depth_threshold_mm` knob (note: changing the threshold requires re-running `agg ua-swe`).
+
+- [ ] **Step 3: Add the index row**
+
+Add a `ua_swe` row to `docs/sources/index.md` matching the column layout of the existing `snodas` / `margulis_wus_sr` rows.
+
+- [ ] **Step 4: Link check**
+
+Run: `grep -n "ua_swe\|NSIDC-0719" docs/sources/index.md`
+Expected: the new row present and pointing at `ua_swe.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/sources/ua_swe.md docs/sources/index.md
+pixi run git commit -m "docs(#237): add ua_swe source page + index row"
+```
+
+---
+
+## Task 9: Full targeted verification + PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Run the touched-module tests**
+
+Run: `pixi run -e dev pytest tests/test_ua_swe.py tests/test_catalog.py -v`
+Expected: PASS.
+
+- [ ] **Step 2: Lint + format**
+
+Run: `pixi run -e dev fmt && pixi run -e dev lint`
+Expected: clean (no diffs from fmt; lint passes).
+
+- [ ] **Step 3: Push + open PR (let CI run the full suite — per the caldera test policy, do not run the whole pytest locally)**
+
+```bash
+git push -u origin feature/237-ua-swe-pr-a2-consolidate-rewindow
+gh pr create --title "feat(#237): re-window ua_swe consolidator to calendar years (PR-A2)" \
+  --body "$(cat <<'BODY'
+Re-windows ua_swe consolidation from per-water-year to per-calendar-year
+NCs (`ua_swe_daily_<year>.nc`), matching the Margulis pattern, so the
+shared calendar-year aggregation driver stops crashing on the
+overlapping-year collision. Shards the fetch by calendar year. Drops
+partial edge years (full coverage 1982–2022). Fixes the breaking WY path
+in the consolidated SWE notebook and adds the ua_swe source doc.
+
+Part of #237 (PR-A2). Unblocks PR-B (aggregate).
+BODY
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+Run: `gh pr checks --watch`
+Expected: green. Address failures before requesting review.
+
+- [ ] **Step 5: Check off PR-A2 in #237** once merged.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** PR-A2 section items — new CY consolidator (T2), boundary-drop rule (T2/T4), fetch orchestration (T4), manifest CY records (T5), catalog notes (T6), breaking notebook fix (T7), `docs/sources/ua_swe.md` (T8) — all mapped.
+- **Type/name consistency:** `_reproject_wy_to_dataset`, `_calendar_year_slice`, `consolidate_calendar_year_ua_swe`, `_assign_worker_calendar_years`, record key `calendar_year`, manifest key `calendar_years`, filename `ua_swe_daily_{year}.nc` used consistently across tasks.
+- **Fixtures:** Tasks assume a `_make_raw_wy_nc(dir_or_path, wy, n_days=...)` synthetic-raw helper and a project fixture (`_make_project`). Task 1 Step 1 factors these from the existing `tests/test_ua_swe.py` setup; if the existing tests use different names, reuse those rather than inventing new ones.
+- **Out of scope (later PRs):** aggregate adapter (PR-B), threshold provenance (PR-B2), SWE shim (PR-C), SCA refactor (PR-D).

--- a/docs/superpowers/specs/2026-06-09-ua-swe-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-09-ua-swe-wiring-design.md
@@ -1,0 +1,425 @@
+# Design: finish wiring `ua_swe` (consolidate fix + aggregate + SWE + SCA)
+
+**Date:** 2026-06-09
+**Umbrella issue:** #237 (reopened — PR-A landed as #238; A2/B/B2/C/D outstanding)
+**Author:** Richard McDonald / Claude
+
+## Problem
+
+NSIDC-0719 (University of Arizona Daily 4-km Gridded SWE & Snow Depth,
+`ua_swe`) landed its catalog entry + fetch module in PR-A (#238). The
+aggregate layer, the SWE-target wiring, and the SCA multi-source refactor
+were sliced as PR-B/C/D in #237 but never implemented; #237 was closed
+when PR-A merged, so there is currently no open issue tracking the
+remaining work. This spec finishes the source end-to-end across both
+targets it feeds (SWE and SCA).
+
+During design we found a blocking defect: `ua_swe`'s PR-A consolidator
+emits **per-water-year** NCs (`ua_swe_daily_WY<YYYY>.nc`), but the shared
+aggregation driver enumerates work by **calendar year** and hard-raises
+when a calendar year appears in two files (`enumerate_years`,
+`aggregate/_driver.py:307`). Adjacent water years share a calendar year
+(WY2000 = Oct 1999–Sep 2000 and WY2001 = Oct 2000–Sep 2001 both contain
+CY 2000), so `agg ua-swe` would crash before aggregating anything.
+
+The repo already solved this for its **other** water-year source. Margulis
+WUS-SR raw granules are per-water-year, but
+`consolidate_calendar_year_margulis_wus_sr`
+(`fetch/margulis_wus_sr.py`) re-windows them to calendar-year NCs
+(`margulis_wus_sr_daily_<year>.nc`) at consolidate time, so the aggregator
+never sees a water year. `ua_swe`'s consolidator simply didn't follow that
+precedent. **Fix: convert at the earliest step** — re-window `ua_swe` to
+calendar-year consolidated NCs, leaving the generic aggregate and target
+workflows untouched.
+
+Delivered as four stacked, independently reviewable PRs (A2 → B → C → D).
+
+## Locked decisions (planning Q&A, 2026-06-09)
+
+1. **WY→CY remapping lives at consolidate** (PR-A2), matching Margulis. No
+   change to the aggregate driver or the target builders; the science is
+   identical (the SWE/SCA combine is per-(HRU, day) — file windowing never
+   touches daily values), so the calendar-year-uniform path is preferred.
+2. **PR-D forced-zero (Jul/Aug):** configurable via new
+   `snow_covered_area.forced_zero_combined`, **default `true`** — both
+   sources forced to `(0, 0)` in July/August, faithful to
+   `PRMSobjfun.f90:calcSCA`. `false` applies the forced-zero mask to the
+   MOD10C1 contribution only, letting ua_swe's independent summer alpine
+   signal reach the combined upper bound.
+3. **PR-D zero-width bounds:** configurable via new
+   `snow_covered_area.min_sources_for_bound`, **default `1`** — a cell gets
+   a bound whenever ≥1 source is finite, so ua_swe alone yields a
+   degenerate `[v, v]` point target in low-CI cells. `2` requires both
+   sources, so every bound has non-zero width.
+4. **Tracking:** reopen #237, keep its checklist, check off A2/B/B2/C/D as
+   each PR lands.
+
+---
+
+## PR-A2 — re-window `ua_swe` consolidator to calendar years
+
+**Confidence: high.** Direct port of the Margulis pattern; *simpler*
+because `ua_swe` raw files are flat per-WY NCs (no tile mosaic).
+
+### New consolidator
+
+Replace `consolidate_water_year_ua_swe(wy, raw_path, daily_dir)` with
+`consolidate_calendar_year_ua_swe(calendar_year, raw_dir, daily_dir)`:
+
+- Calendar year *X* = `[Jan 1 – Sep 30 of X]` from WY *X* raw
+  (`4km_SWE_Depth_WY{X}_v01.nc`, which runs Oct *X-1* – Sep *X*) joined
+  with `[Oct 1 – Dec 31 of X]` from WY *X+1* raw
+  (`4km_SWE_Depth_WY{X+1}_v01.nc`).
+- Keep PR-A's existing per-WY decode + EPSG:5070 reprojection + CF logic;
+  factor the "open one raw WY → decoded (time, y, x) Dataset" step into a
+  helper, then `_calendar_year_slice` each and `xr.concat` along time.
+- Output `<datastore>/ua_swe/daily/ua_swe_daily_<year>.nc` (calendar year,
+  matching `margulis_wus_sr_daily_<year>.nc` and `snodas_daily_<year>.nc`).
+- mtime idempotency + atomic temp-file rename, as today.
+
+### Boundary years
+
+Full calendar coverage is **1982–2022**. CY 1981 (only Oct–Dec, from
+WY1982) and CY 2023 (only Jan–Sep, from WY2023 — WY2024 doesn't exist)
+are partial. Follow Margulis: a calendar year missing its WY *X+1* raw
+**raises `FileNotFoundError`** and is skipped, so only full calendar years
+are emitted. The SWE/SCA target `period` is set within 1982–2022; partial
+edges contribute nothing and the multi-source combine covers them via
+other sources.
+
+### Fetch orchestration
+
+Today the worker loop consolidates per-WY inline after each download. New:
+download the needed WYs first (the fetch already resolves a requested CY to
+WY *X* **and** *X+1* via `_calendar_years_to_water_years`), then
+consolidate per calendar year once both adjacent WY raws are present —
+mirroring Margulis's "consolidate synchronously after each year's
+downloads complete." Raw WY NCs stay under `ua_swe/raw/` (re-consolidation
+needs no re-download).
+
+### Manifest + catalog
+
+- Update the `ua_swe` manifest writer to record **calendar-year**
+  consolidated outputs (raw provenance may still note the contributing
+  WYs). Mirror Margulis's record shape.
+- Update the `catalog/sources.yml[ua_swe]` `access.notes` that describe
+  the consolidated layout as `ua_swe_daily_WY<YYYY>.nc` → `..._<year>.nc`.
+
+### Tests
+
+`tests/test_ua_swe.py` (existing): assert (a) CY X output spans Jan 1 –
+Dec 31 with days drawn from both WY raws, (b) the Sep 30 → Oct 1 seam has
+no gap or duplicate, (c) a boundary CY missing WY *X+1* raises, (d)
+CF-1.6 attrs on output, (e) EPSG:5070 coords preserved.
+
+### Docs + notebooks (PR-A2)
+
+- **Breaking:** `notebooks/consolidated/inspect_consolidated_swe.ipynb`
+  hardcodes `ua_swe_daily_WY{TARGET_YEAR}.nc` (registry entry) and a
+  markdown note describing WY filenames — both must change to the
+  calendar-year `ua_swe_daily_{TARGET_YEAR}.nc`. Check
+  `inspect_consolidated_snow_covered_area.ipynb` for the same hardcode.
+- Add `docs/sources/ua_swe.md` (per-source page; none exists — model on
+  `docs/sources/margulis_wus_sr.md`/`snodas.md`) and the
+  `docs/sources/index.md` row. Describe the calendar-year consolidated
+  layout, not WY.
+
+---
+
+## PR-B — `aggregate/ua_swe.py` + inspect notebook
+
+**Confidence: high.** With PR-A2 done, consolidated NCs are calendar-year,
+so the generic driver just works — no WY handling anywhere. Templated on
+`aggregate/snodas.py` (pre-projected CONUS SWE) + `aggregate/mod10c1.py`
+(binary pre-aggregate hook).
+
+### Adapter
+
+```
+ADAPTER = SourceAdapter(
+    source_key="ua_swe",
+    output_cadence="daily",
+    output_name="ua_swe_agg.nc",
+    variables=("swe", "snow_depth", "snow_covered_fraction"),
+    source_crs="EPSG:5070",          # pre-projected at consolidate; matches WEIGHT_GEN_CRS
+    files_glob="daily/ua_swe_daily_*.nc",   # calendar-year files (post-A2)
+    pre_aggregate_hook=<binary-derivation closure>,
+    stat_method="masked_mean",       # CONUS-masked product; same rationale as SNODAS #151
+)
+```
+
+### Pre-aggregate hook — derivation, and why it must precede aggregation
+
+The hook derives a third variable that does not exist in the consolidated
+NC:
+
+```
+scf = (snow_depth > depth_threshold_mm).astype(float).where(snow_depth.notnull())
+```
+
+**Why pre-aggregation — the nonlinearity.** Area-weighted mean is linear;
+a threshold is nonlinear; the two do not commute:
+`mean(depth > t) ≠ mean(depth) > t`. Worked example — one HRU over 10
+equal-area pixels, 4 with 50 mm snow, 6 bare:
+
+- **Pre-aggregation (what we do):** per pixel `depth > 1mm` →
+  `[1,1,1,1,0,0,0,0,0,0]` → area-mean = **0.40**. Correctly "40% of the
+  HRU is snow-covered."
+- **Post-aggregation (the trap):** HRU-mean depth = `(4·50)/10` = 20 mm,
+  then `20 > 1` = **1.0**. Claims the *whole* HRU is covered when only 40%
+  is.
+
+Fractional snow-covered area is *definitionally* a count-of-snowy-pixels-
+before-averaging quantity, so the binary lives in the hook, never in
+`targets/sca.py`. This is the worked case behind CLAUDE.md's
+transformation policy.
+
+**Why `.where(snow_depth.notnull())` is load-bearing.** In xarray
+`NaN > 1.0` is `False`, so a naive `.astype(float)` silently turns every
+fill / off-CONUS / ocean pixel into a hard `0.0` — a real "no snow" vote
+that dilutes the fraction for any HRU touching the CONUS boundary or an
+internal gap. The `.where(...notnull())` re-NaNs those pixels so they are
+*excluded*, which pairs with `stat_method="masked_mean"` (averages only
+finite survivors; NaN only when the whole HRU is unobserved). This is the
+**opposite** NaN policy from `mod10c1.py`'s `valid_mask`, which
+*deliberately* lets unobserved pixels become `0.0` because its derived
+`valid_area_fraction` means "fraction of HRU with usable observations" —
+there unobserved *should* count as zero. Same mechanical shape
+(binary → float → area-mean), opposite intent: copying mod10c1's hook
+verbatim yields a subtly wrong SCA fraction along every coastline. `swe`
+and `snow_depth` pass through with native names/units (`kg m-2`, `mm`); no
+rescale at agg time.
+
+### Threshold coupling (architectural wrinkle — documented loudly)
+
+`depth_threshold_mm` is *conceptually* an SCA-target knob, so it lives in
+config under `snow_covered_area`. But the binary it controls must be
+evaluated on the pixel grid (above), so the threshold is applied at
+**aggregate** time and its result is **baked into the aggregated NC**.
+`aggregate_ua_swe(...)` reads `snow_covered_area.depth_threshold_mm`
+(default `1.0`), binds it into the hook via closure (the hook signature
+has no `project`, so the module-level `ADAPTER` is parameterized per run),
+and stamps it as an attr on `snow_covered_fraction`. Three consequences:
+
+1. The **aggregate stage reads a target-stage config key** — a deliberate
+   crossing of the otherwise target-agnostic agg/target boundary.
+2. **Changing the threshold invalidates the agg NC, not just the target.**
+   Bump 1 → 5 mm and `snow_covered_fraction` on disk is stale; the
+   operator must re-run `agg ua-swe` (only the derived var rots;
+   `swe`/`snow_depth` are untouched). The stamped attr makes the staleness
+   *detectable* rather than silent (see release section).
+3. It is an **inherent trade**, not a wart: you cannot have both a
+   config-tunable fractional-SCA threshold *and* a threshold-independent
+   agg NC, because the tunable parameter sits inside the nonlinearity that
+   must precede aggregation.
+
+**The mod10c1 asymmetry a reviewer will ask about.** mod10c1 also bakes a
+pixel decision (CI > 70) into its agg NC, yet its configurable
+`ci_threshold` (0.70) does *not* force a re-agg. Why? Because mod10c1's
+tunable threshold gates the **already-aggregated HRU-mean CI** — a linear
+quantity safe to gate post-aggregation — whereas ua_swe's tunable
+threshold defines the **binary that must precede** aggregation. Same word
+"threshold," different stage, dictated by where the nonlinearity sits.
+Rejected alternatives: *aggregate depth only, threshold at target stage*
+(the 40%→100% wrong answer); *hardcode the threshold like mod10c1's 70*
+(loses the configurability #237 wants — 1 vs 5 vs 25 mm is a real
+shallow-snow sensitivity knob).
+
+### Tests + notebook
+
+`tests/test_ua_swe_aggregate.py`: assert (a) an all-NaN-depth HRU yields
+NaN `snow_covered_fraction` (not 0), (b) a half-snow HRU yields ~0.5, (c)
+threshold attr stamped, (d) CF-1.6 attr set on output.
+
+### Docs + notebooks (PR-B)
+
+- Add `notebooks/aggregated/inspect_aggregated_ua_swe.ipynb` (per-source
+  HRU aggregate; one `datasets={}` registry entry per the pattern).
+- Add ua_swe to the multi-source aggregated notebooks it feeds:
+  `notebooks/aggregated/inspect_aggregated_swe.ipynb` and
+  `inspect_aggregated_snow_covered_area.ipynb` (registry entry each).
+- Add the `agg ua-swe` line to CLAUDE.md's aggregation command list.
+
+---
+
+## PR-B2 — threshold provenance + operator documentation
+
+**Confidence: medium.** Depends on PR-B's stamped attr. The baked
+`depth_threshold_mm` is provenance: a published `snow_covered_fraction` is
+meaningless without the threshold that defined it. It must flow into the
+release artifact, the publish gate must refuse a stale fraction, and the
+pre/post-aggregation rationale must be documented where operators look.
+
+### Release provenance — the threshold travels with the data
+
+The release pipeline already has the seams:
+
+1. **Stamp → attr.** (Done in PR-B: `depth_threshold_mm` on
+   `snow_covered_fraction` in the agg NC.)
+2. **Projection lifts attr → step params.** Extend the generic
+   `rebuild_manifest` projection to read
+   `snow_covered_fraction.attrs["depth_threshold_mm"]` from the ua_swe agg
+   NC into that aggregate step's `params` dict (`release/lineage.py` steps
+   already carry `params`, e.g. `batch_size`). Read from the **NC attr,
+   not config** — the rebuild is a pure function of disk and must stay
+   deterministic; config could have drifted. Add the case to
+   `tests/test_rebuild_manifest.py` (per CLAUDE.md's "new on-disk layout →
+   extend the projection + test").
+3. **Params → FGDC/ISO automatically.** `release/mcf.py:237-240` already
+   renders step `params` into the metadata (`params: depth_threshold_mm=1.0,
+   ...`), so once (2) lands the threshold appears in the released FGDC/ISO
+   with no metadata-template change.
+4. **Publish staleness gate.** Add a preflight (sibling to
+   `_preflight_effective_config_current`) that refuses to publish when the
+   agg NC's stamped `depth_threshold_mm` ≠ the project config's
+   `snow_covered_area.depth_threshold_mm` — i.e. the operator edited the
+   threshold without re-aggregating. It is the agg-layer analogue of the
+   config-staleness gate and closes the same "edited config, forgot to
+   re-run" footgun for this baked param. (First instance of an
+   agg-affecting config param; spec it narrowly for ua_swe but name the
+   general pattern in the code comment.) Add a `tests/test_release_*`
+   case covering the mismatch-rejects / match-passes paths.
+
+### Operator documentation — make the coupling impossible to miss
+
+- `docs/architecture/transformation-pipeline.md`: add the
+  `snow_covered_fraction` worked example (40%→100%) as the canonical
+  illustration of the pre/post-aggregation gotcha, and document the
+  threshold-baking + re-agg coupling.
+- `docs/data_release/usgs-process.md`: note that the SCA depth threshold is
+  captured in the release manifest step params and surfaced in FGDC/ISO.
+- (`docs/sources/ua_swe.md` is owned by PR-A2 and the `depth_threshold_mm`
+  config-stub warning by PR-D; both cross-reference this coupling.)
+
+---
+
+## PR-C — SWE target
+
+**Confidence: high.** One shim. `ua_swe.swe` is `kg m-2 ≡ mm`,
+identity-to-mm like daymet/snodas.
+
+- Add to `targets/swe.py:SHIMS`:
+  `SourceShim(source_key="ua_swe", aggregated_var="swe",
+  description="UA SWE (kg/m² ≡ mm, daily)", to_common_units=ua_swe_to_mm,
+  expected_cf_units="kg m-2")`.
+- Add `ua_swe_to_mm` (identity, sets `units="mm"`).
+- Add `ua_swe` to `defaults.py:snow_water_equivalent.sources` and
+  `variables.yml:snow_water_equivalent.sources` + `range_notes`.
+- Flows through `multi_source_nanminmax` untouched. Update docstrings
+  4→5 sources and the period-intersection note: ua_swe (1982–2022 full CY)
+  widens the pre-2003 bound — the original motivation for the source.
+- Not fabric-scoped (CONUS) → contributes on every fabric.
+- `tests/test_swe.py`: assert ua_swe participates in the min/max envelope
+  and the n_sources count.
+
+### Docs + notebooks (PR-C)
+
+- `notebooks/targets/inspect_target_swe.ipynb`: bump "up to four sources"
+  → five and the `n_sources` legend `0..4` → `0..5`; add ua_swe to the
+  per-source aggregate cross-references.
+- `notebooks/consolidated/inspect_consolidated_swe.ipynb`: ua_swe is
+  already in the registry (path fixed in PR-A2) — verify its description
+  lists it as a SWE-bound contributor, not just an SCA proxy.
+- README Implementation Status / Calibration Targets: list ua_swe as a
+  SWE source (5-source bound; 1982–2022).
+
+---
+
+## PR-D — SCA multi-source refactor
+
+**Confidence: medium.** `targets/sca.py` today hardcodes `_MOD10C1_KEY`
+and **asserts** `sources == [mod10c1_v061]`. This is a refactor of working,
+implemented code (the calcSCA formula is live — CLAUDE.md's "sca is a stub"
+comment is stale and will be corrected here).
+
+### Per-source interval registry
+
+Each source produces a per-(HRU, day) interval; combine NaN-aware:
+
+- **mod10c1** → CI-bounded `[ci·sca, ci·sca + (1−ci)]` where
+  `ci ≥ ci_threshold`, else NaN (today's formula, unchanged).
+- **ua_swe** → degenerate `[v, v]`, `v = snow_covered_fraction` (a 0–1 HRU
+  fraction from PR-B's agg NC). No CI gate — ua_swe is physical.
+- **combine:** `lower = nanmin(intervals)`, `upper = nanmax(intervals)`.
+
+### Forced-zero (Jul/Aug) — config-gated `forced_zero_combined` (default `true`)
+
+- `true`: existing behaviour — driver's `forced_zero_months` /
+  `forced_zero_validity_var` zeros the **combined** bound in Jul/Aug.
+- `false`: zero the **mod10c1 contribution only** before the combine (in
+  the loader), leaving driver-level forced-zero off, so ua_swe's summer
+  alpine fraction survives into the combined upper bound.
+
+### Zero-width bounds — config-gated `min_sources_for_bound` (default `1`)
+
+- `1`: bound wherever ≥1 source finite (degenerate `[v,v]` allowed).
+- `2`: mask the combined bound to NaN where per-cell source count `< 2`
+  (threshold on the existing `n_sources` diagnostic), guaranteeing width.
+
+### Config schema additions (4-point checklist ×3)
+
+`snow_covered_area` gains `depth_threshold_mm` (1.0; consumed at **agg**),
+`forced_zero_combined` (true), `min_sources_for_bound` (1). For each:
+update `init_run.py:_CONFIG_TEMPLATE`, `config/pipeline.yml`,
+`tests/test_init_run.py`, `upgrade_config.py:OPTIONAL_CONFIG_FEATURES`.
+`sources` default becomes `["mod10c1_v061", "ua_swe"]`.
+
+### Builder validation
+
+Replace the `sources == [mod10c1_v061]` assertion with: every source has a
+registered interval loader; `ci_threshold ∈ [0,1]`; `min_sources_for_bound
+∈ {1, 2}`; `depth_threshold_mm > 0`.
+
+### Tests
+
+`tests/test_sca.py`: (a) mod10c1-only path unchanged (regression), (b)
+two-source combine widens the bound, (c) `forced_zero_combined=false`
+preserves a synthetic July ua_swe fraction, (d) `min_sources_for_bound=2`
+NaNs a single-source cell, (e) ua_swe-only low-CI cell yields `[v,v]`
+under default config.
+
+### Docs + notebooks (PR-D)
+
+- `notebooks/targets/inspect_target_sca.ipynb`: update from single-source
+  MOD10C1 to the two-source combine; document the `forced_zero_combined` /
+  `min_sources_for_bound` options and their effect on the bound.
+- `notebooks/consolidated/inspect_consolidated_snow_covered_area.ipynb`
+  and `inspect_aggregated_snow_covered_area.ipynb`: ensure ua_swe's
+  `snow_covered_fraction` is shown alongside MOD10C1.
+- CLAUDE.md: correct the stale "sca is a stub pending #210" comment
+  (line ~22) — the calcSCA formula is implemented; this PR makes it
+  multi-source.
+- README + `docs/references/tm6b10-summary.md`: note SCA is now a
+  two-source bound (MOD10C1 CI-interval ∪ ua_swe depth-derived fraction).
+- `docs/references/known-gaps-resolved.md`: record the ua_swe SCA
+  second-source closure.
+
+---
+
+## Out of scope
+
+- Re-unifying SCA with the generic year-chunked driver (#230) — already
+  done; `sca.py` is `year_chunked=True` today.
+- Margulis / other SWE-source behaviour (its CY consolidation is the
+  template we copy, not something we change).
+- Any change to `ua_swe`'s download path or archive URLs (PR-A, merged).
+
+## Build order
+
+PR-A2 (consolidate re-window + tests) → PR-B (agg + binary hook +
+threshold attr + per-source notebook) → PR-B2 (manifest-projection lift +
+publish staleness gate + transformation-pipeline.md + usgs-process.md) →
+PR-C (one shim + config/catalog + tests) → PR-D (sca refactor + config
+schema ×3 + tests). Each rebased on the prior, squash-merged, checked off
+in #237.
+
+The four PRs are a **dependency chain** (PR-B reads PR-A2's calendar-year
+NCs; PR-D reads PR-B's `snow_covered_fraction`), so they cannot be
+developed in parallel. Worktrees are still worth using for **isolation +
+review pipelining**: develop each PR in its own git worktree branched off
+the previous PR's branch, so the next slice can start while the prior is
+in review without disturbing the main checkout. Per project norms, run
+`pixi install -e dev` once in each fresh worktree (per-dir `.pixi`) before
+committing, and rename the auto-named branch to the
+`feature/237-...` convention. The within-PR docs/notebook edits are small
+enough that they ride with their code PR rather than a separate worktree.


### PR DESCRIPTION
Lands the planning artifacts for the ua_swe wiring effort (umbrella #237) on main:

- `docs/superpowers/specs/2026-06-09-ua-swe-wiring-design.md` — the brainstormed design spec, covering all remaining slices (PR-A2/B/B2/C/D): the WY→CY consolidate fix, the aggregate adapter + binary `snow_covered_fraction` hook, the threshold-provenance/publish-gate work, the SWE shim, and the SCA multi-source refactor.
- `docs/superpowers/plans/2026-06-09-ua-swe-pr-a2-consolidate-rewindow.md` — the PR-A2 implementation plan (now complete via #297).

Docs-only. Puts the spec on main so the follow-on PRs (PR-B aggregate, etc.) can reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)