### PR TITLE
feature(#237): ua_swe threshold provenance + publish gate (PR-B2)

### DIFF
--- a/docs/architecture/transformation-pipeline.md
+++ b/docs/architecture/transformation-pipeline.md
@@ -255,6 +255,68 @@ targets/sca.py
     └─ Write CF-compliant per-HRU per-day NetCDF.
 ```
 
+## Worked example: ua_swe `snow_covered_fraction` (the canonical gotcha)
+
+`ua_swe` (UA daily 4-km SWE + snow depth, source `ua_swe`) derives a
+*second* SCA signal: a per-HRU snow-covered fraction from a per-pixel
+binary `snow_depth > depth_threshold_mm`. It is the cleanest illustration
+of why a threshold must precede aggregation, because the threshold is a
+**tunable parameter** and the pre/post answers diverge sharply.
+
+```
+aggregate/ua_swe.py      pre_aggregate_hook = make_pre_aggregate_hook(threshold)
+    ├─ scf = (snow_depth > depth_threshold_mm).astype(float)
+    │        .where(snow_depth.notnull())     ← re-NaN fill pixels (load-bearing)
+    └─ Stamp depth_threshold_mm on scf.attrs. swe / snow_depth untouched.
+
+aggregate/ua_swe.py      stat_method = "masked_mean"
+    └─ NaN (off-CONUS / fill) pixels excluded; without this, NaN > t = False
+       would inject phantom 0.0 and dilute border HRUs.
+
+aggregate/ua_swe.py      post_aggregate_hook = make_post_aggregate_hook(threshold)
+    └─ Re-assert CF attrs + the depth_threshold_mm stamp (synthesized-var
+       attrs don't reliably survive gdptools).
+
+→ <project>/data/aggregated/ua_swe/ua_swe_<year>_agg.nc
+   carries: swe (kg m-2 ≡ mm), snow_depth (mm),
+            snow_covered_fraction ∈ [0,1], attr depth_threshold_mm
+```
+
+**Worked example (threshold = 1 mm).** An HRU split 40% deep snow / 60%
+bare ground (depths 200 mm and 0 mm):
+
+- Pre-aggregation binary (the right answer): pixels → `[1, 0]`,
+  area-weighted → `snow_covered_fraction = 0.40`. ✅ 40% of the HRU is
+  snow-covered.
+- Post-aggregation binary (the wrong answer): area-weight depth first →
+  HRU-mean depth = `0.4 × 200 = 80 mm`, then `80 > 1` → `1.0`. ❌ The whole
+  HRU reads as 100% snow-covered. `mean(d > t) ≠ mean(d) > t`.
+
+**Threshold-baking + re-aggregation coupling.** Because the threshold is
+applied *inside* the pre-aggregation nonlinearity, the value that defined
+`snow_covered_fraction` is **baked into the agg NC** — it is not a knob a
+downstream target can re-tune. Three consequences, all enforced:
+
+1. The threshold is **stamped** on `snow_covered_fraction.attrs["depth_threshold_mm"]`
+   (PR-B), so the agg NC self-documents the value that produced it.
+2. The deterministic `rebuild-manifest` projection **lifts that stamp into
+   the aggregate step's `params`** (read from the NC attr, never config — the
+   rebuild is a pure function of disk), so it flows into `manifest.json` and
+   the released FGDC/ISO process steps automatically (PR-B2).
+3. Changing `targets.snow_covered_area.depth_threshold_mm` **invalidates the
+   agg NC, not just the target** — the operator must re-aggregate `ua_swe`.
+   A publish-time staleness gate
+   (`release/publish.py:_preflight_ua_swe_threshold_current`, the agg-layer
+   analogue of the `config.effective.yml` staleness gate) refuses to publish
+   when the stamped threshold ≠ the config-resolved threshold, closing the
+   "edited config, forgot to re-aggregate" footgun (PR-B2).
+
+Contrast with `mod10c1`'s `ci_threshold` (0.70), which does *not* force a
+re-aggregation: that threshold gates the **already-aggregated HRU-mean CI** —
+a post-aggregation operation on a linear quantity — so it can live as a
+target-stage knob. Same word "threshold," opposite stage, dictated entirely
+by where the nonlinearity sits.
+
 ## Decision flow for a new source
 
 When you add a new source that needs transformations, ask in order:

--- a/docs/data_release/usgs-process.md
+++ b/docs/data_release/usgs-process.md
@@ -67,7 +67,7 @@ At minimum:
 | Purpose | Per-item template |
 | Bounding coordinates | Umbrella: union of children. Source child: `catalog/sources.yml[<key>].access.bbox_nwse`. Fabric child: `<project>/fabric.json.bbox` |
 | Time period | Umbrella: union of children. Source child: `catalog/sources.yml[<key>].period`. Fabric child: union of enabled-target periods |
-| Lineage / Process steps | `<project>/manifest.json.steps[]` (currently empty — PR-B instruments this) |
+| Lineage / Process steps | `<project>/manifest.json.steps[]`, rendered by `release/mcf.py:_step_description` — including each step's resolved `params` (e.g. the ua_swe aggregate step's `depth_threshold_mm`, see below) |
 | Entity / Attribute | Per-NC variable: from `catalog/sources.yml[<key>].variables[].{name,long_name,cf_units,cell_methods}`; per-target: from `catalog/variables.yml[<target>]` |
 | Keywords (theme) | `release_defaults.yml.keywords.{umbrella,source,fabric}` + per-target CF standard_names |
 | Point of contact | `release_defaults.yml.contacts.point_of_contact` (overridable per project) |
@@ -78,6 +78,24 @@ At minimum:
 Validate FGDC XML with the [USGS Metadata Parser](https://geology.usgs.gov/tools/metadata/tools/doc/mp.html)
 before upload. Our `release/validate_xml.py` shells out to `mp` if it's on
 PATH and reports warn-only if not.
+
+**Aggregate-step parameters travel into the metadata.** When an aggregate
+step is defined by a tunable parameter, that parameter is captured in the
+manifest step's `params` and surfaced in the FGDC/ISO process steps. The
+first instance is the **SCA depth threshold**: `ua_swe`'s
+`snow_covered_fraction` is a per-pixel `snow_depth > depth_threshold_mm`
+binary evaluated *before* aggregation (a nonlinearity — see
+[transformation-pipeline.md](../architecture/transformation-pipeline.md#worked-example-ua_swe-snow_covered_fraction-the-canonical-gotcha)),
+so the threshold is baked into the aggregated NC and stamped on the variable.
+The deterministic `rebuild-manifest` projection lifts that stamp into the
+aggregate step's `params` (read from the NC attr, never config), and
+`release/mcf.py` renders it into the process-step description. Because the
+threshold is baked at aggregation time, editing
+`targets.snow_covered_area.depth_threshold_mm` without re-aggregating `ua_swe`
+is a release-blocking error: the publish preflight
+`_preflight_ua_swe_threshold_current` refuses to publish a `snow_covered_fraction`
+whose stamped threshold no longer matches config (the agg-layer analogue of
+the `config.effective.yml` staleness gate).
 
 ## File and data requirements
 

--- a/src/nhf_spatial_targets/rebuild_manifest.py
+++ b/src/nhf_spatial_targets/rebuild_manifest.py
@@ -275,6 +275,74 @@ def _target_nc_params(nc: Path) -> dict:
     return params
 
 
+# Aggregate steps with an aggregate-affecting, pre-aggregation-baked tunable
+# (issue #237 PR-B2). Currently ua_swe only: its ``snow_covered_fraction`` is a
+# per-pixel binary ``snow_depth > depth_threshold_mm`` evaluated PRE-aggregation
+# (a nonlinearity that does not commute with the area-weighted mean), so the
+# threshold that defined the fraction is baked into the agg NC and must travel
+# with it as provenance. The general pattern -- an aggregate-affecting parameter
+# stamped on its derived variable, lifted here into that aggregate step's
+# ``params`` -- widens this map when a second such source lands.
+_UA_SWE_KEY = "ua_swe"
+_SCF_VAR = "snow_covered_fraction"
+_DEPTH_THRESHOLD_ATTR = "depth_threshold_mm"
+
+
+def read_scf_threshold_stamp(nc: Path) -> float | None:
+    """Return the ``depth_threshold_mm`` stamped on ``snow_covered_fraction``.
+
+    Reads the pixel depth threshold (mm) baked into a ua_swe aggregated NC's
+    ``snow_covered_fraction`` variable attrs (stamped by ``aggregate/ua_swe.py``
+    pre/post-aggregation). Returns ``None`` when the variable or attr is absent
+    (a pre-PR-B agg NC), or when the file cannot be opened (corrupt/truncated) --
+    a WARNING is logged in the latter case. The caller decides what ``None``
+    means: the projection omits the param (best-effort, never fatal), the publish
+    staleness gate treats it as un-verifiable provenance and refuses to ship.
+    """
+    try:
+        import xarray as xr
+
+        with xr.open_dataset(nc) as ds:
+            if _SCF_VAR not in ds.variables:
+                return None
+            value = ds[_SCF_VAR].attrs.get(_DEPTH_THRESHOLD_ATTR)
+            if value is None:
+                return None
+            # numpy scalar -> plain float for JSON stability + exact compares.
+            return float(value.item() if hasattr(value, "item") else value)
+    except Exception as exc:
+        logger.warning(
+            "rebuild-manifest: could not read %s.%s from %s (%s); the ua_swe "
+            "aggregate step's threshold param will be omitted.",
+            _SCF_VAR,
+            _DEPTH_THRESHOLD_ATTR,
+            nc,
+            exc,
+        )
+        return None
+
+
+def _aggregate_nc_params(source_key: str, ncs: list[Path]) -> dict:
+    """Lift aggregate-baked derived-variable attrs into the aggregate step params.
+
+    Currently ua_swe-specific: reads the ``depth_threshold_mm`` stamp from the
+    deterministically-first agg NC that carries it (``ncs`` is pre-sorted) into
+    ``params``. Read from the NC attr, **not** config -- the rebuild is a pure
+    function of disk and must stay deterministic; config could have drifted from
+    what actually defined the on-disk fraction (the publish staleness gate is the
+    place that catches that drift). A missing var/attr yields ``{}``: the param
+    is provenance-enriching, not gating, so the projection never fails on its
+    absence.
+    """
+    if source_key != _UA_SWE_KEY:
+        return {}
+    for nc in ncs:
+        stamp = read_scf_threshold_stamp(nc)
+        if stamp is not None:
+            return {_DEPTH_THRESHOLD_ATTR: stamp}
+    return {}
+
+
 def synthesize_steps(
     *,
     datastore: Path,
@@ -328,14 +396,20 @@ def synthesize_steps(
     # aggregate: every data/aggregated/<key>/ dir (incl. derived variants).
     aggregated_root = project_dir / "data" / "aggregated"
     for source_dir in _sorted_source_dirs(aggregated_root):
+        ncs = _ncs_in(source_dir)
         outputs = _guarded_output_entries(
-            _ncs_in(source_dir),
+            ncs,
             compute_sha256=compute_sha256,
             source_key=source_dir.name,
         )
         if not outputs:
             continue
-        _record(kind="aggregate", source_key=source_dir.name, outputs=outputs)
+        _record(
+            kind="aggregate",
+            source_key=source_dir.name,
+            outputs=outputs,
+            params=_aggregate_nc_params(source_dir.name, ncs),
+        )
 
     # target: one per targets/*.nc (one-level glob; never per-year intermediates).
     targets_dir = project_dir / "targets"

--- a/src/nhf_spatial_targets/rebuild_manifest.py
+++ b/src/nhf_spatial_targets/rebuild_manifest.py
@@ -293,33 +293,65 @@ def read_scf_threshold_stamp(nc: Path) -> float | None:
 
     Reads the pixel depth threshold (mm) baked into a ua_swe aggregated NC's
     ``snow_covered_fraction`` variable attrs (stamped by ``aggregate/ua_swe.py``
-    pre/post-aggregation). Returns ``None`` when the variable or attr is absent
-    (a pre-PR-B agg NC), or when the file cannot be opened (corrupt/truncated) --
-    a WARNING is logged in the latter case. The caller decides what ``None``
-    means: the projection omits the param (best-effort, never fatal), the publish
-    staleness gate treats it as un-verifiable provenance and refuses to ship.
-    """
-    try:
-        import xarray as xr
+    pre/post-aggregation).
 
-        with xr.open_dataset(nc) as ds:
-            if _SCF_VAR not in ds.variables:
-                return None
-            value = ds[_SCF_VAR].attrs.get(_DEPTH_THRESHOLD_ATTR)
-            if value is None:
-                return None
-            # numpy scalar -> plain float for JSON stability + exact compares.
-            return float(value.item() if hasattr(value, "item") else value)
+    Returns ``None`` only for a *genuinely absent* stamp -- the variable or attr
+    is missing, or the file is a non-NetCDF placeholder (no NetCDF/HDF5 magic).
+    The caller decides what that ``None`` means: the projection omits the param
+    (best-effort, never fatal), the publish staleness gate treats it as
+    un-verifiable provenance and refuses to ship.
+
+    **Raises** ``ValueError`` for a *corrupt* stamp, mirroring
+    :func:`_target_nc_params` (issue #283): a file that carries NetCDF/HDF5 magic
+    but cannot be opened (truncated/corrupt), or a ``depth_threshold_mm`` attr
+    that is present but not a float scalar. Both are conflated with "absent" only
+    if we degrade silently -- which would let a broken agg NC ship with its
+    threshold provenance quietly dropped from the manifest. Failing loud is the
+    only safe behaviour for a file that claims to be NetCDF. (The publish flow
+    catches this ``ValueError`` at the ``_preflight_provenance_complete`` boundary
+    -- which runs the projection first -- exactly as it does for a corrupt target
+    NC, so the downstream threshold gate never sees a corrupt file.)
+    """
+    import xarray as xr
+
+    try:
+        ds = xr.open_dataset(nc)
     except Exception as exc:
+        if _looks_like_netcdf(nc):
+            raise ValueError(
+                f"ua_swe agg NC {nc} carries NetCDF/HDF5 magic but could not be "
+                f"opened ({exc}); it appears truncated or corrupt. Refusing to "
+                f"silently omit its {_DEPTH_THRESHOLD_ATTR} provenance. "
+                f"Re-aggregate ua_swe, then rebuild-manifest."
+            ) from exc
         logger.warning(
-            "rebuild-manifest: could not read %s.%s from %s (%s); the ua_swe "
-            "aggregate step's threshold param will be omitted.",
-            _SCF_VAR,
-            _DEPTH_THRESHOLD_ATTR,
+            "rebuild-manifest: %s is unreadable and carries no NetCDF/HDF5 magic "
+            "(%s); treating it as a non-NetCDF placeholder, so the ua_swe "
+            "aggregate step's %s param is omitted.",
             nc,
             exc,
+            _DEPTH_THRESHOLD_ATTR,
         )
         return None
+    with ds:
+        if _SCF_VAR not in ds.variables:
+            return None
+        value = ds[_SCF_VAR].attrs.get(_DEPTH_THRESHOLD_ATTR)
+        if value is None:
+            return None
+        # numpy scalar -> plain float for JSON stability + exact compares. A
+        # present-but-malformed value (non-numeric string, multi-element array)
+        # is a corrupt stamp, NOT an absent one -- raise rather than mis-report
+        # it downstream as "no stamp".
+        raw = value.item() if hasattr(value, "item") else value
+        try:
+            return float(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{nc}: {_SCF_VAR}.{_DEPTH_THRESHOLD_ATTR} is present but not a "
+                f"float scalar ({raw!r}); refusing to treat a malformed stamp as "
+                f"absent provenance. Re-aggregate ua_swe, then rebuild-manifest."
+            ) from exc
 
 
 def _aggregate_nc_params(source_key: str, ncs: list[Path]) -> dict:

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -729,6 +729,104 @@ def _preflight_config_product_consistency(project: Project) -> None:
         )
 
 
+def _preflight_ua_swe_threshold_current(project: Project) -> None:
+    """Verify the ua_swe agg NC's baked depth threshold matches config intent.
+
+    The **aggregate-layer analogue** of :func:`_preflight_effective_config_current`.
+    ua_swe's ``snow_covered_fraction`` is a per-pixel binary
+    ``snow_depth > depth_threshold_mm`` evaluated PRE-aggregation -- a
+    nonlinearity that does not commute with the area-weighted mean -- so the
+    threshold is *baked into the agg NC*, not a downstream knob. If an operator
+    edits ``targets.snow_covered_area.depth_threshold_mm`` without re-aggregating
+    ua_swe, the published fraction (and the manifest aggregate-step / FGDC / ISO
+    provenance lifted from its stamp) would describe a threshold the data was NOT
+    built with.
+
+    Verify-don't-mutate, and **unconditionally fatal** (no
+    ``allow_incomplete_sources`` override), parity with the config-staleness gate:
+    shipping a fraction whose stamped threshold contradicts config is a
+    correctness error, not an incompleteness. The fix is to re-aggregate ua_swe
+    (and re-run ``validate`` / ``rebuild-manifest``) so the bake, config, and
+    provenance realign.
+
+    No-op when the project never aggregated ua_swe (not every fabric uses it):
+    an absent ``data/aggregated/ua_swe/`` dir or no NCs there -> return.
+
+    This is the **first** instance of an aggregate-affecting config param; it is
+    specced narrowly for ua_swe, but the pattern -- a pre-aggregation-baked
+    tunable whose stamp must match config at publish -- generalizes to any future
+    such source.
+
+    Stale / un-verifiable (any of) -> :class:`PreflightError`:
+
+    - an agg NC carries no ``snow_covered_fraction`` ``depth_threshold_mm`` stamp
+      (a pre-PR-B build) or is unreadable -- provenance that cannot be verified,
+    - a stamped threshold != the config-resolved
+      ``targets.snow_covered_area.depth_threshold_mm`` (default
+      :data:`~nhf_spatial_targets.aggregate.ua_swe.DEFAULT_DEPTH_THRESHOLD_MM`).
+    """
+    import math
+
+    from nhf_spatial_targets.aggregate.ua_swe import DEFAULT_DEPTH_THRESHOLD_MM
+    from nhf_spatial_targets.rebuild_manifest import (
+        _UA_SWE_KEY,
+        read_scf_threshold_stamp,
+    )
+
+    ua_swe_dir = project.aggregated_dir() / _UA_SWE_KEY
+    if not ua_swe_dir.is_dir():
+        return
+    ncs = sorted(p for p in ua_swe_dir.rglob("*.nc") if p.is_file())
+    if not ncs:
+        return
+
+    # Read the resolved threshold from the (already staleness-gated)
+    # config.effective.yml, the canonical resolved intent -- consistent with the
+    # triangle gate. The default mirrors aggregate/ua_swe._resolve_depth_threshold_mm
+    # so an unset key compares equal to a stamped default-built fraction.
+    eff_path = project.workdir / "config.effective.yml"
+    try:
+        effective = yaml.safe_load(eff_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        # _preflight_effective_config_current runs first and already turns an
+        # absent/unparseable effective config into a clean PreflightError; guard
+        # here too so a call-order change can't crash this gate.
+        raise PreflightError(
+            f"config.effective.yml at {eff_path} is unreadable for the ua_swe "
+            f"depth-threshold check: {exc}"
+        ) from exc
+    sca_cfg = (effective.get("targets") or {}).get("snow_covered_area") or {}
+    configured = float(sca_cfg.get("depth_threshold_mm", DEFAULT_DEPTH_THRESHOLD_MM))
+
+    fix = (
+        f"re-aggregate ua_swe (and re-run 'nhf-targets validate -d "
+        f"{project.workdir}' / rebuild-manifest) so the baked fraction, config, "
+        f"and published provenance realign"
+    )
+    problems: list[str] = []
+    for nc in ncs:
+        stamped = read_scf_threshold_stamp(nc)
+        if stamped is None:
+            problems.append(
+                f"{nc.name} carries no snow_covered_fraction "
+                f"depth_threshold_mm stamp (a pre-PR-B build) or is unreadable; "
+                f"its threshold provenance cannot be verified"
+            )
+        elif not math.isclose(stamped, configured, rel_tol=1e-9, abs_tol=1e-12):
+            problems.append(
+                f"{nc.name} was built with depth_threshold_mm={stamped} but "
+                f"config resolves to {configured}"
+            )
+
+    if problems:
+        joined = "\n  - ".join(problems)
+        raise PreflightError(
+            "publish pre-flight: the ua_swe snow_covered_fraction was aggregated "
+            "with a depth threshold that no longer matches config "
+            f"(targets.snow_covered_area.depth_threshold_mm) -- {fix}:\n  - {joined}"
+        )
+
+
 def _preflight_common(
     project: Project, *, allow_incomplete_sources: bool = False
 ) -> None:
@@ -788,6 +886,15 @@ def _preflight_common(
     # param disagreement is a correctness inconsistency that must never ship,
     # so allow_incomplete_sources does not reach it.
     _preflight_config_product_consistency(project)
+
+    # The aggregate-layer staleness gate (verify-don't-mutate, unconditionally
+    # fatal -- no override): ua_swe's snow_covered_fraction bakes a pre-aggregation
+    # depth threshold into the agg NC, so an operator who edits the config
+    # threshold without re-aggregating would ship a fraction whose stamped
+    # provenance contradicts config. No-op for projects that never aggregated
+    # ua_swe. Runs after the config-staleness gate so config.effective.yml is
+    # known current.
+    _preflight_ua_swe_threshold_current(project)
 
 
 def _require_umbrella_sb_id(registry_path: Path | None) -> str:

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -760,10 +760,17 @@ def _preflight_ua_swe_threshold_current(project: Project) -> None:
     Stale / un-verifiable (any of) -> :class:`PreflightError`:
 
     - an agg NC carries no ``snow_covered_fraction`` ``depth_threshold_mm`` stamp
-      (a pre-PR-B build) or is unreadable -- provenance that cannot be verified,
+      (aggregated before depth-threshold stamping existed) -- provenance that
+      cannot be verified,
     - a stamped threshold != the config-resolved
-      ``targets.snow_covered_area.depth_threshold_mm`` (default
+      ``targets.snow_covered_area.depth_threshold_mm`` (read from the
+      staleness-gated ``config.effective.yml``; default
       :data:`~nhf_spatial_targets.aggregate.ua_swe.DEFAULT_DEPTH_THRESHOLD_MM`).
+
+    A *corrupt* agg NC (NetCDF magic but unopenable, or a malformed stamp) raises
+    from :func:`read_scf_threshold_stamp` and is caught earlier, at the
+    ``_preflight_provenance_complete`` projection boundary -- so this gate only
+    ever sees a healthy or genuinely-unstamped file.
     """
     import math
 
@@ -809,8 +816,8 @@ def _preflight_ua_swe_threshold_current(project: Project) -> None:
         if stamped is None:
             problems.append(
                 f"{nc.name} carries no snow_covered_fraction "
-                f"depth_threshold_mm stamp (a pre-PR-B build) or is unreadable; "
-                f"its threshold provenance cannot be verified"
+                f"depth_threshold_mm stamp (aggregated before depth-threshold "
+                f"stamping was added); its threshold provenance cannot be verified"
             )
         elif not math.isclose(stamped, configured, rel_tol=1e-9, abs_tol=1e-12):
             problems.append(

--- a/tests/test_rebuild_manifest.py
+++ b/tests/test_rebuild_manifest.py
@@ -599,3 +599,121 @@ def test_rebuild_skips_vanished_file_without_aborting(tmp_path, monkeypatch, cap
     names = [Path(o["path"]).name for o in agg[0]["outputs"]]
     assert names == ["merra2_2001_agg.nc"]
     assert any("merra2_2000_agg.nc" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# PR-B2 (#237): ua_swe depth-threshold provenance lifted into aggregate params
+# ---------------------------------------------------------------------------
+
+import numpy as np  # noqa: E402
+import xarray as xr  # noqa: E402
+
+
+def _write_ua_swe_agg_nc(path: Path, *, threshold: float | None, with_scf: bool = True):
+    """Write a synthetic ua_swe aggregated NC.
+
+    When ``with_scf`` is True, includes a ``snow_covered_fraction`` variable; the
+    ``depth_threshold_mm`` attr is stamped only when ``threshold`` is not None
+    (mirrors the pre/post-aggregate stamp in ``aggregate/ua_swe.py``). ``swe`` is
+    always present as a genuine raw variable.
+    """
+    hrus = [1, 2, 3]
+    ds = xr.Dataset(
+        {
+            "swe": (("nhm_id",), np.array([10.0, 20.0, 30.0], dtype="float64")),
+            **(
+                {"snow_covered_fraction": (("nhm_id",), np.array([0.0, 0.5, 1.0]))}
+                if with_scf
+                else {}
+            ),
+        },
+        coords={"nhm_id": hrus},
+    )
+    if with_scf and threshold is not None:
+        ds["snow_covered_fraction"].attrs["depth_threshold_mm"] = float(threshold)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+
+
+def test_read_scf_threshold_stamp_reads_attr(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    _write_ua_swe_agg_nc(nc, threshold=5.0)
+    assert read_scf_threshold_stamp(nc) == 5.0
+
+
+def test_read_scf_threshold_stamp_absent_attr_is_none(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    _write_ua_swe_agg_nc(nc, threshold=None)  # scf var, but no stamp
+    assert read_scf_threshold_stamp(nc) is None
+
+
+def test_read_scf_threshold_stamp_no_scf_var_is_none(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    _write_ua_swe_agg_nc(nc, threshold=None, with_scf=False)
+    assert read_scf_threshold_stamp(nc) is None
+
+
+def test_read_scf_threshold_stamp_unreadable_is_none(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    nc.write_bytes(b"not a netcdf")
+    assert read_scf_threshold_stamp(nc) is None  # warns + degrades, never raises
+
+
+def test_aggregate_nc_params_only_for_ua_swe(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import _aggregate_nc_params
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    _write_ua_swe_agg_nc(nc, threshold=2.5)
+    # Non-ua_swe key: never lifts a param, even from a stamped NC.
+    assert _aggregate_nc_params("merra2", [nc]) == {}
+    # ua_swe: lifts the stamped threshold.
+    assert _aggregate_nc_params("ua_swe", [nc]) == {"depth_threshold_mm": 2.5}
+
+
+def test_aggregate_nc_params_reads_first_stamped_deterministically(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import _aggregate_nc_params
+
+    # ncs are pre-sorted by the caller; the first carrying a stamp wins.
+    first = tmp_path / "ua_swe_1982_agg.nc"
+    second = tmp_path / "ua_swe_1983_agg.nc"
+    _write_ua_swe_agg_nc(first, threshold=1.0)
+    _write_ua_swe_agg_nc(second, threshold=1.0)
+    assert _aggregate_nc_params("ua_swe", [first, second]) == {
+        "depth_threshold_mm": 1.0
+    }
+
+
+def test_aggregate_nc_params_empty_when_no_stamp(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import _aggregate_nc_params
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    _write_ua_swe_agg_nc(nc, threshold=None)
+    assert _aggregate_nc_params("ua_swe", [nc]) == {}
+
+
+def test_synthesize_steps_lifts_ua_swe_threshold_param(tmp_path):
+    from nhf_spatial_targets.rebuild_manifest import synthesize_steps
+
+    (tmp_path / "datastore").mkdir()
+    proj = tmp_path / "proj"
+    agg = proj / "data" / "aggregated" / "ua_swe"
+    _write_ua_swe_agg_nc(agg / "ua_swe_1982_agg.nc", threshold=3.0)
+    (proj / "fabric.json").write_text("{}")
+
+    steps = synthesize_steps(
+        datastore=tmp_path / "datastore",
+        project_dir=proj,
+        compute_sha256=False,
+    )
+    agg_steps = [s for s in steps if s["kind"] == "aggregate"]
+    assert len(agg_steps) == 1
+    assert agg_steps[0]["source_key"] == "ua_swe"
+    assert agg_steps[0]["params"] == {"depth_threshold_mm": 3.0}

--- a/tests/test_rebuild_manifest.py
+++ b/tests/test_rebuild_manifest.py
@@ -659,12 +659,42 @@ def test_read_scf_threshold_stamp_no_scf_var_is_none(tmp_path):
     assert read_scf_threshold_stamp(nc) is None
 
 
-def test_read_scf_threshold_stamp_unreadable_is_none(tmp_path):
+def test_read_scf_threshold_stamp_non_netcdf_placeholder_is_none(tmp_path):
     from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
 
     nc = tmp_path / "ua_swe_1982_agg.nc"
-    nc.write_bytes(b"not a netcdf")
+    nc.write_bytes(b"not a netcdf")  # no NetCDF/HDF5 magic -> placeholder
     assert read_scf_threshold_stamp(nc) is None  # warns + degrades, never raises
+
+
+def test_read_scf_threshold_stamp_corrupt_netcdf_magic_raises(tmp_path):
+    """A file that CLAIMS to be NetCDF (HDF5 magic) but cannot be opened is a
+    corrupt artifact, not an absent stamp -> raise (issue #283 precedent), so a
+    broken agg NC cannot ship with its threshold provenance silently dropped."""
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    # HDF5 magic header + garbage body: _looks_like_netcdf() is True, but
+    # xarray cannot open it.
+    nc.write_bytes(b"\x89HDF\r\n\x1a\n" + b"\x00garbage")
+    with pytest.raises(ValueError, match="truncated or corrupt"):
+        read_scf_threshold_stamp(nc)
+
+
+def test_read_scf_threshold_stamp_malformed_attr_raises(tmp_path):
+    """A depth_threshold_mm attr that is present but not a float scalar (a
+    non-numeric string) is a corrupt stamp, not an absent one -> raise."""
+    from nhf_spatial_targets.rebuild_manifest import read_scf_threshold_stamp
+
+    nc = tmp_path / "ua_swe_1982_agg.nc"
+    ds = xr.Dataset(
+        {"snow_covered_fraction": (("nhm_id",), np.array([0.0, 0.5, 1.0]))},
+        coords={"nhm_id": [1, 2, 3]},
+    )
+    ds["snow_covered_fraction"].attrs["depth_threshold_mm"] = "not-a-number"
+    ds.to_netcdf(nc)
+    with pytest.raises(ValueError, match="not a float scalar"):
+        read_scf_threshold_stamp(nc)
 
 
 def test_aggregate_nc_params_only_for_ua_swe(tmp_path):
@@ -682,12 +712,27 @@ def test_aggregate_nc_params_reads_first_stamped_deterministically(tmp_path):
     from nhf_spatial_targets.rebuild_manifest import _aggregate_nc_params
 
     # ncs are pre-sorted by the caller; the first carrying a stamp wins.
+    # Distinct values so this genuinely proves "first", not "any".
     first = tmp_path / "ua_swe_1982_agg.nc"
     second = tmp_path / "ua_swe_1983_agg.nc"
     _write_ua_swe_agg_nc(first, threshold=1.0)
-    _write_ua_swe_agg_nc(second, threshold=1.0)
+    _write_ua_swe_agg_nc(second, threshold=2.0)
     assert _aggregate_nc_params("ua_swe", [first, second]) == {
         "depth_threshold_mm": 1.0
+    }
+
+
+def test_aggregate_nc_params_skips_unstamped_first(tmp_path):
+    """When the first NC has no stamp, the loop continues to the next NC that
+    does (read_scf_threshold_stamp returns None on the unstamped one)."""
+    from nhf_spatial_targets.rebuild_manifest import _aggregate_nc_params
+
+    first = tmp_path / "ua_swe_1982_agg.nc"
+    second = tmp_path / "ua_swe_1983_agg.nc"
+    _write_ua_swe_agg_nc(first, threshold=None)  # scf var, no stamp
+    _write_ua_swe_agg_nc(second, threshold=2.0)
+    assert _aggregate_nc_params("ua_swe", [first, second]) == {
+        "depth_threshold_mm": 2.0
     }
 
 

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -891,10 +891,56 @@ def test_ua_swe_threshold_default_mismatch_is_fatal(tmp_path):
 
 
 def test_ua_swe_threshold_missing_stamp_is_fatal(tmp_path):
-    """A ua_swe agg NC with no depth_threshold_mm stamp (a pre-PR-B build) is
-    un-verifiable provenance -> fatal, not a silent pass."""
+    """A ua_swe agg NC with no depth_threshold_mm stamp (aggregated before
+    stamping existed) is un-verifiable provenance -> fatal, not a silent pass."""
     project = build_release_project(tmp_path)
     _write_ua_swe_agg_nc(project, threshold=None)  # scf var, no stamp
     _set_config_threshold(project, 1.0)
     with pytest.raises(publish.PreflightError, match="carries no"):
         publish._preflight_ua_swe_threshold_current(project)
+
+
+def test_ua_swe_threshold_isclose_tolerates_float_noise(tmp_path):
+    """The gate compares with math.isclose, so a threshold differing only by
+    floating-point noise passes -- a regression to bare `==` would fail here."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=1.0)
+    # Equal under isclose (rel_tol 1e-9) but NOT under ==.
+    _set_config_threshold(project, 1.0000000001)
+    publish._preflight_ua_swe_threshold_current(project)  # does not raise
+
+
+def test_ua_swe_threshold_effective_config_unreadable_is_fatal(tmp_path):
+    """An unreadable config.effective.yml when the gate runs -> clean
+    PreflightError (defensive; the effective-config staleness gate normally
+    catches this first, but a call-order change must not crash this gate)."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=1.0)
+    eff = project.workdir / "config.effective.yml"
+    eff.chmod(0o644)
+    eff.write_text("{ : : not valid yaml")
+    with pytest.raises(publish.PreflightError, match="unreadable"):
+        publish._preflight_ua_swe_threshold_current(project)
+
+
+def test_ua_swe_threshold_mismatch_blocks_real_publish(tmp_path):
+    """End-to-end: a stale ua_swe depth threshold aborts a real publish_*()
+    through _preflight_common BEFORE any ScienceBase mutation -- proving the gate
+    is wired in, not just callable in isolation."""
+    from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
+
+    project = build_release_project(tmp_path)
+    reg = _registry(tmp_path)
+    _seed_umbrella(reg)
+    session = FakeSbSession()
+    _write_ua_swe_agg_nc(project, threshold=1.0)
+    # Rebuild so the on-disk manifest carries the ua_swe aggregate step (the
+    # provenance / drift gates pass); config.yml is untouched so the
+    # effective-config staleness gate also passes.
+    rebuild_manifest(project)
+    _set_config_threshold(project, 25.0)  # edited threshold, didn't re-aggregate
+    with pytest.raises(publish.PreflightError, match="no longer matches config"):
+        publish.publish_fabric_child(
+            project, make_sb_client(session), registry_path=reg, now=NOW
+        )
+    assert session.created == []  # nothing published -- gate fired fail-fast

--- a/tests/test_release_publish.py
+++ b/tests/test_release_publish.py
@@ -791,3 +791,110 @@ def test_typed_records_enforce_key_invariant():
         publish.ScopeDiff(
             scope="fabric", key=None, sb_id=None, local="missing", remote="missing"
         )
+
+
+# ---------------------------------------------------------------------------
+# ua_swe depth-threshold staleness gate (verify-don't-mutate) -- PR-B2 / #237
+# ---------------------------------------------------------------------------
+
+import numpy as np  # noqa: E402
+import xarray as xr  # noqa: E402
+import yaml as _yaml  # noqa: E402
+
+
+def _write_ua_swe_agg_nc(
+    project, *, threshold, with_scf=True, name="ua_swe_1982_agg.nc"
+):
+    """Write a ua_swe aggregated NC under the project's aggregated dir.
+
+    ``threshold`` None + ``with_scf`` True -> snow_covered_fraction present but
+    unstamped (un-verifiable provenance). ``with_scf`` False -> no scf var.
+    """
+    nc = project.aggregated_dir() / "ua_swe" / name
+    nc.parent.mkdir(parents=True, exist_ok=True)
+    data = {"swe": (("nhm_id",), np.array([10.0, 20.0, 30.0]))}
+    if with_scf:
+        data["snow_covered_fraction"] = (("nhm_id",), np.array([0.0, 0.5, 1.0]))
+    ds = xr.Dataset(data, coords={"nhm_id": [1, 2, 3]})
+    if with_scf and threshold is not None:
+        ds["snow_covered_fraction"].attrs["depth_threshold_mm"] = float(threshold)
+    ds.to_netcdf(nc)
+    return nc
+
+
+def _set_config_threshold(project, threshold):
+    """Inject targets.snow_covered_area.depth_threshold_mm into config.effective.yml.
+
+    Edits the (read-only) effective config in place. ``threshold`` None leaves the
+    key unset so the gate exercises its DEFAULT_DEPTH_THRESHOLD_MM fallback.
+    """
+    eff = project.workdir / "config.effective.yml"
+    eff.chmod(0o644)
+    body = _yaml.safe_load(eff.read_text()) or {}
+    if threshold is not None:
+        body.setdefault("targets", {}).setdefault("snow_covered_area", {})[
+            "depth_threshold_mm"
+        ] = threshold
+    eff.write_text(_yaml.safe_dump(body))
+
+
+def test_ua_swe_threshold_noop_when_not_aggregated(tmp_path):
+    """A project that never aggregated ua_swe (no agg dir) clears the gate."""
+    project = build_release_project(tmp_path)
+    publish._preflight_ua_swe_threshold_current(project)  # does not raise
+
+
+def test_ua_swe_threshold_noop_when_dir_empty(tmp_path):
+    """A ua_swe agg dir with no NCs is a no-op (nothing to verify)."""
+    project = build_release_project(tmp_path)
+    (project.aggregated_dir() / "ua_swe").mkdir(parents=True)
+    publish._preflight_ua_swe_threshold_current(project)  # does not raise
+
+
+def test_ua_swe_threshold_match_passes(tmp_path):
+    """Stamped threshold == config threshold clears the gate."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=5.0)
+    _set_config_threshold(project, 5.0)
+    publish._preflight_ua_swe_threshold_current(project)  # does not raise
+
+
+def test_ua_swe_threshold_default_fallback_passes(tmp_path):
+    """Config unset + a fraction baked at the module default (1.0 mm) passes:
+    the gate's fallback mirrors aggregate/ua_swe._resolve_depth_threshold_mm."""
+    from nhf_spatial_targets.aggregate.ua_swe import DEFAULT_DEPTH_THRESHOLD_MM
+
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=DEFAULT_DEPTH_THRESHOLD_MM)
+    _set_config_threshold(project, None)  # key unset -> default
+    publish._preflight_ua_swe_threshold_current(project)  # does not raise
+
+
+def test_ua_swe_threshold_mismatch_is_fatal(tmp_path):
+    """Editing the config threshold without re-aggregating -> fatal: the agg NC's
+    stamped threshold no longer matches config (the agg-layer fossil)."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=1.0)
+    _set_config_threshold(project, 25.0)
+    with pytest.raises(publish.PreflightError, match="depth_threshold_mm=1.0"):
+        publish._preflight_ua_swe_threshold_current(project)
+
+
+def test_ua_swe_threshold_default_mismatch_is_fatal(tmp_path):
+    """Config unset (resolves to default 1.0) but the fraction was baked at a
+    non-default threshold -> fatal."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=10.0)
+    _set_config_threshold(project, None)
+    with pytest.raises(publish.PreflightError, match="depth_threshold_mm=10.0"):
+        publish._preflight_ua_swe_threshold_current(project)
+
+
+def test_ua_swe_threshold_missing_stamp_is_fatal(tmp_path):
+    """A ua_swe agg NC with no depth_threshold_mm stamp (a pre-PR-B build) is
+    un-verifiable provenance -> fatal, not a silent pass."""
+    project = build_release_project(tmp_path)
+    _write_ua_swe_agg_nc(project, threshold=None)  # scf var, no stamp
+    _set_config_threshold(project, 1.0)
+    with pytest.raises(publish.PreflightError, match="carries no"):
+        publish._preflight_ua_swe_threshold_current(project)


### PR DESCRIPTION
Part of #237 (PR-B2 of the ua_swe wiring chain A2 → B → **B2** → C → D). Builds on PR-B (#303), which stamped `depth_threshold_mm` on `snow_covered_fraction`.

## Why

ua_swe's `snow_covered_fraction` is a per-pixel `snow_depth > depth_threshold_mm` binary evaluated **pre-aggregation** — a nonlinearity that does not commute with the area-weighted mean (`mean(d > t) ≠ mean(d) > t`). So the threshold is *baked into* the aggregated NC; it is not a knob a downstream target can re-tune. A published `snow_covered_fraction` is meaningless without the threshold that defined it, and an operator who edits the threshold without re-aggregating would ship a fraction whose provenance contradicts config. PR-B2 makes the baked threshold **travel into the release metadata** and **gates a stale bake at publish**.

## What this adds

- **Projection lift** (`rebuild_manifest.py`) — `read_scf_threshold_stamp` + `_aggregate_nc_params` read `snow_covered_fraction.attrs["depth_threshold_mm"]` from the ua_swe agg NC into that **aggregate step's `params`**. Read from the **NC attr, not config**: the rebuild is a pure function of disk and must stay deterministic (config could have drifted — the publish gate catches that). Best-effort: a missing/unreadable stamp omits the param, never fails the projection (mirrors `_target_nc_params`).
- **FGDC/ISO** — `release/mcf.py:_step_description` already renders step `params` into the process steps, so the threshold appears in released FGDC/ISO with **no template change** (verified, no code change).
- **Publish staleness gate** (`release/publish.py`) — `_preflight_ua_swe_threshold_current`, the **aggregate-layer analogue** of `_preflight_effective_config_current`. Unconditionally fatal (no `allow_incomplete_sources` override): refuses to publish when the agg NC's stamped threshold ≠ the config-resolved `targets.snow_covered_area.depth_threshold_mm` (default `1.0`), or when an existing ua_swe agg NC carries no stamp. **No-op** for projects that never aggregated ua_swe. First instance of an aggregate-affecting config param; specced narrowly for ua_swe but the general pattern is named in the code.
- **Tests** — projection lift + reader degradation (`test_rebuild_manifest.py`); match / mismatch / default-fallback / missing-stamp / no-op gate paths (`test_release_publish.py`).
- **Docs** — the `snow_covered_fraction` 40%→100% worked example as the canonical pre/post-aggregation gotcha + the threshold-baking / re-aggregation coupling (`transformation-pipeline.md`); release-metadata note (`usgs-process.md`).

## Design notes (for review)

- **One reader, split semantics.** `read_scf_threshold_stamp` returns `float | None`; the projection treats `None` as "omit param" (best-effort), the publish gate treats `None` (missing stamp *or* corrupt NC) as "un-verifiable provenance → refuse." Mirrors the existing `_target_nc_params` projection-vs-triangle-gate split.
- **Gate reads `config.effective.yml`,** the already-staleness-gated resolved intent (the gate runs after `_preflight_effective_config_current`), consistent with the config↔product triangle gate. Default fallback mirrors `aggregate/ua_swe._resolve_depth_threshold_mm` so an unset key compares equal to a default-built fraction.

## Testing note

Per this HPC's discipline the full pytest suite was not run locally (login-node collection of the heavy release/rebuild test modules exceeds the time budget); fmt + lint pass, and the new projection + gate logic was exercised inline against real NetCDFs (all paths green). **CI runs the full suite.**

## Out of scope (later PRs)

- PR-C: `ua_swe` as a SWE target source.
- PR-D: SCA multi-source refactor + the `depth_threshold_mm` config-schema stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)