### PR TITLE
chore: wire ua_swe into the fetch + agg ops harness (pixi + SLURM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,28 @@ All work follows issue-branch-PR flow:
 - Rebase feature branches against origin/main before opening PRs.
 - Before every commit, run: `git branch --show-current` (must not be main/master), `git status` (review untracked), `git diff --cached --stat` (review staged). Stage files explicitly by path — never use `git add -A` or `git add .`.
 
+### Documentation Sync Gate (every PR)
+
+Before opening or finalizing **any** PR, scan whether the change has drifted
+the docs and forward-facing documentation, and update them in the same PR.
+Docs that lag the code are a silent correctness bug — an operator following a
+stale recipe runs the wrong command. Walk this checklist against the diff:
+
+- **CLAUDE.md** — command lists (the `pixi run` / `nhf-targets` examples),
+  section invariants, and any rule the change alters or adds.
+- **README.md** and **`docs/`** — architecture notes, source/target tables,
+  recipes, `docs/sources/<src>.md`, `docs/references/*` (known-gaps, tm6b10,
+  transformation-pipeline, usgs-process).
+- **In-tree operator docs** — SLURM script header comments, `slurm/**/README.md`,
+  config templates (`init_run.py` / `config/pipeline.yml` stubs).
+- **Catalog prose** — `catalog/sources.yml` / `variables.yml` `notes:` /
+  `description:` / `range_notes:` that describe behavior the change touched.
+
+If the change adds/renames a source, target, stage, command, or config key,
+treat the matching doc update as **required**, not optional — the same PR-
+boundary rule as the test-coverage and config-schema checklists. If a scan
+turns up nothing to change, say so explicitly rather than skipping silently.
+
 ## Pre-commit Quality Gate
 
 Before suggesting a commit, always run:

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Array index → source mapping (`slurm/shared/fetch_all.slurm`):
 | 11 | Daymet V4 R1 | 1980/2024 | ORNL DAAC zarr, manual staging |
 | 12 | SNODAS | 2003/2025 | NSIDC G02158 via earthaccess |
 | 13 | Margulis WUS-SR | 1985/2021 | NSIDC-0719 via earthaccess; OR-fabric only |
+| 14 | UA SWE | 1981/2023 | NSIDC-0719 UA Broxton; SWE + SCA source (CY1982–2022 on disk) |
 
 Most fetch routines are network I/O-bound; the general script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. Per-source scripts (`slurm/shared/fetch_era5_land.slurm`, `slurm/shared/fetch_snodas.slurm`, `slurm/project_or/fetch_margulis_wus_sr.slurm`) tune memory and concurrency for their workload — notably SNODAS uses only 8 GB because PR #110's dask-streaming consolidator bounds peak RSS. Override `PROJECT_DIR` and `REPO_DIR` via environment before submission. SLURM directives (`--account`, `--partition`) at the top of each script may need adjustment for your cluster.
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ Each `fetch` command downloads source granules and consolidates them into CF-1.6
 | Daymet V4 R1 | `fetch daymet` | manual staging (ORNL DAAC regional zarrs) | `daymet_{na,hi,pr}.zarr` (verify-only, recorded in manifest) |
 | SNODAS | `fetch snodas` | earthaccess + HTTPS (NSIDC G02158 daily `.tar`) | `snodas_daily_<year>.nc` |
 | Margulis WUS-SR | `fetch margulis-wus-sr` | earthaccess (NSIDC-0719 per-WY per-tile) | raw granules under `raw/<year>/` (consolidation TBD) |
-| **all** | `fetch all` | runs all 14 sources sequentially | — |
+| UA SWE | `fetch ua-swe` | earthaccess (NSIDC-0719 UA Broxton, per-WY 4 km NetCDF) | `ua_swe_daily_<year>.nc` (calendar-year, EPSG:5070) |
+| **all** | `fetch all` | runs all 15 sources sequentially | — |
 
 All fetch commands are **incremental** — periods (or per-year completion records, for sources that track them) already recorded in `manifest.json` are skipped on re-run. `mwbm-climgrid` and `daymet` are verify-only: the operator stages the file(s) manually (see `docs/sources/mwbm_climgrid.md`, `docs/sources/daymet.md`), then the fetch command registers them in the manifest.
 
@@ -289,7 +290,7 @@ fabric-independent (the datastore is shared):
 mkdir -p logs
 export PROJECT_DIR=/path/to/gfv11-targets
 
-# General fetch-all array (14 sources):
+# General fetch-all array (15 sources):
 sbatch slurm/shared/fetch_all.slurm
 
 # Single source by index (e.g. rerun MERRA-2 only):
@@ -388,7 +389,7 @@ sbatch slurm/shared/agg_ssebop.slurm
 PERIOD=2010/2020 sbatch slurm/shared/agg_daymet.slurm
 ```
 
-Array index → source mapping for the `agg_all_<fabric>.slurm` array (14 sources):
+Array index → source mapping for the `agg_all_<fabric>.slurm` array (15 sources):
 
 | Index | Source | Notes |
 |---|---|---|
@@ -406,6 +407,7 @@ Array index → source mapping for the `agg_all_<fabric>.slurm` array (14 source
 | 11 | MWBM ClimGrid | 2.5 arcmin monthly, 4 vars (clipped to 1979/2020 in-script) |
 | 12 | ERA5-Land sd | 0.1° daily snow depth (SWE source) |
 | 13 | Margulis WUS-SR | 90 m daily SWE — OR-only (fabric_scope=[or]); no-op on other fabrics |
+| 14 | UA SWE | 4 km daily SWE + SCA source — EPSG:5070-native (fast weight-gen); aggregates `swe` + depth-thresholded `snow_covered_fraction` (#237) |
 
 All jobs are CPU/memory-bound; the agg array allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. Override `BATCH_SIZE` (default 10000 HRUs/batch, tuned for 128 GB) with `BATCH_SIZE=2500 sbatch slurm/project_<fabric>/agg_all_<fabric>.slurm` if a source OOMs. WGS84-native sources (SNODAS, GLDAS) cost ~5–8× more in weight generation than projected sources (Daymet, MODIS sinusoidal) at comparable resolution — see [`docs/architecture/transformation-pipeline.md`](docs/architecture/transformation-pipeline.md).
 

--- a/docs/references/calibration-target-recipes.md
+++ b/docs/references/calibration-target-recipes.md
@@ -15,8 +15,8 @@ place to look.
 
 Status: most of this is consolidated from the `inspect_consolidated_*`
 notebooks (PR #68) and the catalog corrections that fell out of them.
-Several target builders are still stubs raising `NotImplementedError`;
-the recipes below are guidance for filling them in.
+All six target builders (runoff/aet/rch/som/sca/swe) are now implemented;
+the recipes below document the as-built behavior.
 
 For **which time window each target can be built over**, see
 [`target-period-coverage.md`](target-period-coverage.md) — per-source
@@ -136,7 +136,7 @@ the diff between user config and defaults is logged to stderr.
 
 - **PRMS variable:** `hru_actet`
 - **Sources:** SSEBop `et`, MOD16A2 v061 `ET_500m`, MWBM (Wieczorek et al. 2024) `aet`
-- **Builder:** `src/nhf_spatial_targets/targets/aet.py` (status: stub at last check)
+- **Builder:** `src/nhf_spatial_targets/targets/aet.py` (status: implemented)
 
 **Native-unit conversion to mm/month**
 
@@ -218,7 +218,7 @@ Per-HRU per-month: `lower_bound = min(ssebop, mod16a2, mwbm)`,
 
 - **PRMS variable:** `recharge`
 - **Sources:** Reitz 2017 `total_recharge`, WaterGAP 2.2d `qrdif`, ERA5-Land `ssro`
-- **Builder:** `src/nhf_spatial_targets/targets/rch.py` (status: stub)
+- **Builder:** `src/nhf_spatial_targets/targets/rch.py` (status: implemented)
 - **TM 6-B10 originally used Reitz + WaterGAP 2.2a. We replace 2.2a with 2.2d
   (open-access on PANGAEA) and add ERA5-Land ssro as a third proxy.**
 
@@ -279,7 +279,7 @@ These will diverge in absolute magnitude, especially in arid regions — the per
 - **PRMS variable:** `soil_rechr`
 - **Sources:** MERRA-2 `GWETTOP`, NLDAS-2 NOAH `SoilM_0_10cm`,
   NLDAS-2 MOSAIC `SoilM_0_10cm`, NCEP/NCAR R1 `soilw_0_10cm`
-- **Builder:** `src/nhf_spatial_targets/targets/som.py` (status: stub)
+- **Builder:** `src/nhf_spatial_targets/targets/som.py` (status: implemented)
 
 **Native-unit handling**
 
@@ -358,11 +358,15 @@ combinable with VWC (0.05–0.45 typical) — the constant offset cancels.
 ### 5. Snow-covered area (SCA)
 
 - **PRMS variable:** `snowcov_area`
-- **Sources:** MOD10C1 v061 — `Day_CMG_Snow_Cover` (SCA) and
-  `Day_CMG_Clear_Index` (CI). The consolidated NC also contains
-  `Day_CMG_Cloud_Obscured` (kept for QA cross-checks) and
-  `Snow_Spatial_QA` (categorical 0–4 quality flag, **not the CI**).
-- **Builder:** `src/nhf_spatial_targets/targets/sca.py` (status: stub)
+- **Sources:** two, combined NaN-aware (#237).
+  1. MOD10C1 v061 — `Day_CMG_Snow_Cover` (SCA) and `Day_CMG_Clear_Index` (CI).
+     The consolidated NC also contains `Day_CMG_Cloud_Obscured` (kept for QA
+     cross-checks) and `Snow_Spatial_QA` (categorical 0–4 quality flag, **not
+     the CI**). Yields the CI-bounded interval `[ci·sca, ci·sca + (1−ci)]`
+     where CI ≥ threshold.
+  2. UA SWE (NSIDC-0719) — depth-thresholded `snow_covered_fraction`, a
+     degenerate `[v, v]` interval (no CI gate).
+- **Builder:** `src/nhf_spatial_targets/targets/sca.py` (status: implemented)
 
 **Native-unit handling**
 

--- a/docs/references/pipeline-architecture-reference.md
+++ b/docs/references/pipeline-architecture-reference.md
@@ -462,26 +462,28 @@ multi_source_runoff_bounds(sources):
 ```
 - Output: `lower_bound` and `upper_bound` variables, dims `(time, hru)`, units `cfs`, CF-1.6 attrs
 
-#### AET (`targets/aet.py`) — **STUB**
+#### AET (`targets/aet.py`) — **IMPLEMENTED**
 - Sources: mod16a2_v061, ssebop, mwbm_climgrid
 - Method: multi_source_minmax over absolute mm/month values
 - MOD16A2 8-day → monthly: overlap-weighted sum (`(days_overlap / composite_length) × value`)
 - `sources` override from project config (pending MOD16A2 decision)
 
-#### Recharge (`targets/rch.py`) — **STUB**
+#### Recharge (`targets/rch.py`) — **IMPLEMENTED**
 - Sources: reitz2017, watergap22d, era5_land (ssro)
 - Each source normalized 0–1 over 2000–2009 before min/max
 - Annual output
 
-#### Soil Moisture (`targets/som.py`) — **STUB**
+#### Soil Moisture (`targets/som.py`) — **IMPLEMENTED**
 - Sources: merra2, ncep_ncar, nldas_mosaic, nldas_noah
 - Monthly: normalize per calendar month over 1982–2010
 - Annual: normalize over full 1982–2010
 - Two separate output NCs
 
-#### Snow-Covered Area (`targets/sca.py`) — **STUB**
-- Source: mod10c1_v061
-- Read aggregated NC (native 0–100); apply ÷ 100; call `normalize.modis_ci_bounds(sca, ci, 0.70)`
+#### Snow-Covered Area (`targets/sca.py`) — **IMPLEMENTED**
+- Sources: mod10c1_v061 + ua_swe, combined NaN-aware (#237)
+- MOD10C1: read aggregated NC (native 0–100); ÷ 100; CI-bounded interval `[ci·sca, ci·sca + (1−ci)]` where CI ≥ threshold
+- UA SWE: depth-thresholded `snow_covered_fraction`, degenerate `[v, v]` interval
+- Combine: `lower = nanmin`, `upper = nanmax`, `n_sources = Σ finite`
 - Daily output per HRU
 
 ---
@@ -491,7 +493,7 @@ multi_source_runoff_bounds(sources):
 ### Decision 1: Runoff — ERA5 + GLDAS replaces NHM-MWBM (Issue #41)
 - NHM-MWBM was circular (PRMS-derived, used to calibrate PRMS)
 - Two independent reanalysis sources provide better constraint and remove circularity
-- MWBM kept in catalog; not yet consumed by `targets/run.py`
+- MWBM kept in catalog and now consumed by `targets/run.py` (capped at its 2020 publisher end)
 - GLDAS unit trap: `_acc` = mean of 3-hourly accumulations; requires `× 8 × days_in_month`
 
 ### Decision 2: AET — MOD16A2 v061 Inclusion Pending
@@ -564,8 +566,20 @@ multi_source_runoff_bounds(sources):
 
 ## Part 8: Known Open Gaps
 
-1. **SCA CI-bounds formula:** TM 6-B10 describes intent; math in PRMSobjfun.f (not public). `targets/sca.py` is a stub pending resolution.
-2. **AET target builder:** Stub. Awaiting MOD16A2 v061 collaborator decision + MWBM integration.
-3. **Recharge target builder:** Stub. Requires per-source normalization + multi-source min/max.
-4. **Soil moisture target builder:** Stub. Requires per-calendar-month normalization (monthly) + annual normalization.
-5. **MWBM in runoff bounds:** Aggregated but not yet consumed by `targets/run.py`.
+All six target builders (runoff/aet/rch/som/sca/swe) are now implemented; the
+gaps below were the open items at the time this reference was first written and
+are recorded here as resolved. `catalog/sources.yml` `status:`/`notes:` and the
+"Known Gaps" block in `CLAUDE.md` are authoritative for current status.
+
+1. **SCA CI-bounds formula (RESOLVED):** the `calcSCA` math was recovered from
+   `PRMSobjfun.f90` (lines 1052–1061); `targets/sca.py` implements it, extended
+   in #237 to a two-source MOD10C1 + UA SWE NaN-aware bound.
+2. **AET target builder (RESOLVED):** `targets/aet.py` implemented (MOD16A2 v061
+   + SSEBop + MWBM).
+3. **Recharge target builder (RESOLVED):** `targets/rch.py` implemented
+   (per-source normalization + multi-source min/max).
+4. **Soil moisture target builder (RESOLVED):** `targets/som.py` implemented
+   (per-calendar-month + annual normalization).
+5. **MWBM in runoff bounds (RESOLVED):** `targets/run.py` consumes
+   `mwbm_climgrid` (capped at 2020 — the publisher's end; see the
+   gfv2/OR source-selection notes).

--- a/docs/references/pipeline-architecture-reference.md
+++ b/docs/references/pipeline-architecture-reference.md
@@ -171,9 +171,9 @@ source unit gotchas), see `calibration-target-recipes.md`.
 3. MWBM `runoff` already mm/month
 4. Per HRU per month: `(mm × 1e-3 / days_in_month) × hru_area_m2` → m³/day
 5. m³/day → cfs via `× 35.3146667 / 86400.0`
-6. `lower_bound = min(era5_cfs, gldas_cfs)`, `upper_bound = max(era5_cfs, gldas_cfs)`
+6. NaN-aware over the configured sources (era5_cfs, gldas_cfs, mwbm_cfs): `lower_bound = nanmin`, `upper_bound = nanmax`, plus an `n_sources` diagnostic (`multi_source_nanminmax`)
 
-**Note:** mwbm_climgrid declared as third source but `targets/run.py` currently consumes only ERA5 and GLDAS; mwbm aggregated to disk but not yet folded into bounds.
+**Note:** `targets/run.py` consumes all three runoff sources (ERA5-Land, GLDAS, MWBM ClimGrid). MWBM ends at its 2020 publisher cap, so it contributes to bounds only through 2020 (`n_sources` drops from 3 to 2 thereafter).
 
 #### AET (aet / hru_actet)
 

--- a/docs/references/prmsobjfun-summary.md
+++ b/docs/references/prmsobjfun-summary.md
@@ -188,9 +188,9 @@ The bound is then `(LOWER, UPPER)` per HRU/day where CI passed the gate;
 days where CI ≤ 70 are dropped from the RMSE denominator (`n` only
 increments for valid days).
 
-**Implication for this pipeline:** `targets/sca.py` is currently a stub
-because the formula was thought unrecoverable. It isn't. The implementation
-is roughly:
+**Implication for this pipeline:** `targets/sca.py` now implements this
+formula (the stub is gone — #237 extended it to a two-source MOD10C1 + UA SWE
+bound). The MOD10C1 interval is roughly:
 
 ```python
 def build_sca_target(mod10c1_aggregated_nc, ci_threshold=0.70):
@@ -265,8 +265,8 @@ PRMS objfun.
 
 ## Things this file makes us reconsider
 
-- **SCA is buildable now.** `targets/sca.py` can stop being a stub. Worth
-  a small follow-up issue.
+- **SCA is built.** `targets/sca.py` implements this formula (#237), extended
+  to a two-source MOD10C1 + UA SWE NaN-aware bound.
 - **Bound-collapse to a point estimate is well-defined, not a bug.** When
   the operator sees `upper == lower` in a deck figure, the question is
   whether the resulting point-estimate constraint is *informative* — not

--- a/docs/references/processing-steps-reference.md
+++ b/docs/references/processing-steps-reference.md
@@ -102,7 +102,7 @@ over absolute mm/month values (no normalization); converted to cfs before writin
 **Combination rule:** per-HRU per-month `lower = min(sources)`, `upper = max(sources)` over absolute mm/month (no normalization; inter-source spread is the calibration bound)
 **Output period:** 2000–2010 (TM 6-B10 default; user-configurable)
 **Sources:** SSEBop `et`, MWBM ClimGrid `aet`, MOD16A2 v061 `ET_500m` — all three
-**Builder:** `targets/aet.py` (stub — `NotImplementedError`)
+**Builder:** `targets/aet.py`
 
 ---
 
@@ -176,7 +176,7 @@ over absolute mm/month values (no normalization); converted to cfs before writin
 **PRMS variable:** `recharge`
 **Combination rule:** each source normalized 0–1 over 2000–2009 independently per HRU, then `lower = min(normalized)`, `upper = max(normalized)` per year
 **Output period:** annual, 2000–2009 (normalization window matches calibration window)
-**Builder:** `targets/rch.py` (stub — `NotImplementedError`)
+**Builder:** `targets/rch.py`
 
 **Normalization rationale:** sources measure conceptually different fluxes (empirical regression vs process model vs soil drainage proxy); absolute magnitudes diverge substantially especially in arid regions. Optimizer targets relative year-to-year change, making normalization tractable and making absolute differences irrelevant.
 
@@ -249,7 +249,7 @@ over absolute mm/month values (no normalization); converted to cfs before writin
 **Two outputs required:**
 - **Monthly:** normalize per calendar month (all Januaries together, all Februaries together, etc.) over 1982–2010 — confirmed in TM 6-B10 Appendix 1
 - **Annual:** normalize over full 1982–2010 period
-**Builder:** `targets/som.py` (stub — `NotImplementedError`)
+**Builder:** `targets/som.py`
 
 **Normalization rationale:** sources use fundamentally different physical quantities (plant-available wetness, volumetric water content, mass per area); per-source 0–1 normalization cancels constant offsets and makes GWETTOP (0–1 dimensionless) combinable with VWC (0.05–0.45 m³/m³) and kg/m² (0–40 kg/m²).
 
@@ -344,12 +344,12 @@ over absolute mm/month values (no normalization); converted to cfs before writin
 ## 5. Snow-Covered Area (`snowcov_area`)
 
 **PRMS variable:** `snowcov_area`
-**Single source:** MOD10C1 v061 only
-**Combination rule:** CI-based bounds from daily SCA and associated Clear_Index per HRU
+**Sources:** MOD10C1 v061 (CI-bounded) + UA SWE (depth-thresholded `snow_covered_fraction`), combined NaN-aware (#237)
+**Combination rule:** per-source interval registry → `lower = nanmin`, `upper = nanmax`, `n_sources = Σ finite`; MOD10C1 → `[ci·sca, ci·sca + (1−ci)]` where CI ≥ threshold; UA SWE → degenerate `[v, v]`
 **Output:** daily, per-HRU, fraction [0, 1]
-**Output period:** 2000–2010 (user-configurable)
-**Builder:** `targets/sca.py` (stub — `NotImplementedError`)
-**Open gap:** exact bounds formula not published; PRMSobjfun.f not publicly available
+**Output period:** user-configurable (recorded in target metadata + manifest)
+**Builder:** `targets/sca.py`
+**Bounds formula:** recovered from `PRMSobjfun.f90` `calcSCA` (lines 1052–1061); the earlier "not publicly available" gap is closed
 
 ---
 

--- a/docs/references/target-period-coverage.md
+++ b/docs/references/target-period-coverage.md
@@ -119,12 +119,19 @@ NOAH/MOSAIC).
 | Source | Coverage |
 |---|---|
 | mod10c1_v061 | 2000–2025 |
-| **Intersection** | **2000–2025** (26 years × 365 days ≈ 9498 daily timesteps) |
+| ua_swe | 1982–2022 |
+| **Union** (default `min_sources_for_bound: 1`) | **1982–2025** — a bound is defined wherever ≥1 source is finite |
+| Two-source overlap (`n_sources == 2`) | 2000–2022 |
 
-Single-source target — intersection equals coverage. Builder is
-currently a stub (CI-bounds formula gap per [CLAUDE.md](../conventions.md)
-Known Gaps); period extends easily once the placeholder formula
-lands.
+Two-source NaN-aware bound (#237): unlike the min/max-intersection
+targets above, SCA combines sources with `lower = nanmin`,
+`upper = nanmax`, so coverage is the **union**, not the intersection —
+the bound is well-defined whenever either source has data. ua_swe
+(depth-thresholded `snow_covered_fraction`) extends coverage back to
+1982; mod10c1 (CI-bounded) carries it to 2025. Setting
+`min_sources_for_bound: 2` narrows the bound to the 2000–2022 overlap.
+The `calcSCA` CI-bounds formula gap is closed (recovered from
+`PRMSobjfun.f90`); the builder is implemented.
 
 ### Snow water equivalent (`targets/swe.py`) — pending
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -184,6 +184,7 @@ fetch-mwbm-climgrid = { cmd = "nhf-targets fetch mwbm-climgrid", description = "
 fetch-daymet = { cmd = "nhf-targets fetch daymet", description = "Register operator-staged Daymet V4 R1 regional zarr stores (verify-only)" }
 fetch-snodas = { cmd = "nhf-targets fetch snodas", description = "Download SNODAS daily SWE granules from NSIDC (G02158) via earthaccess" }
 fetch-margulis-wus-sr = { cmd = "nhf-targets fetch margulis-wus-sr", description = "Download Margulis Western US Snow Reanalysis (NSIDC-0719) via earthaccess" }
+fetch-ua-swe = { cmd = "nhf-targets fetch ua-swe", description = "Download UA daily 4-km SWE/snow-depth (NSIDC-0719) + consolidate to calendar-year NCs" }
 fetch-all = { cmd = "nhf-targets fetch all", description = "Download all source datasets sequentially" }
 
 # Aggregation
@@ -203,6 +204,7 @@ agg-snodas       = { cmd = "nhf-targets agg snodas",       description = "Aggreg
 agg-mwbm-climgrid = { cmd = "nhf-targets agg mwbm-climgrid", description = "Aggregate USGS MWBM (ClimGrid-forced) monthly outputs to HRU fabric" }
 agg-era5-land-sd = { cmd = "nhf-targets agg era5-land-sd", description = "Aggregate ERA5-Land daily snow depth water equivalent to HRU fabric" }
 agg-margulis-wus-sr = { cmd = "nhf-targets agg margulis-wus-sr", description = "Aggregate Margulis WUS-SR daily SWE to HRU fabric (OR fabric only)" }
+agg-ua-swe       = { cmd = "nhf-targets agg ua-swe",       description = "Aggregate UA daily SWE + depth-derived snow_covered_fraction to HRU fabric (SWE + SCA source)" }
 agg-all          = { cmd = "nhf-targets agg all",          description = "Aggregate all tier-1/2 sources to HRU fabric sequentially" }
 
 # Catalog inspection

--- a/slurm/project_gfv2/agg_all_gfv2.slurm
+++ b/slurm/project_gfv2/agg_all_gfv2.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=nhf-agg-gfv2
 #SBATCH --account=impd
 #SBATCH --partition=cpu
-#SBATCH --array=0-13
+#SBATCH --array=0-14
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G

--- a/slurm/project_or/README.md
+++ b/slurm/project_or/README.md
@@ -12,14 +12,14 @@ cd <repo root>
 mkdir -p logs
 OR=/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets
 
-# 1. Aggregate the 14 array sources (incl. Margulis WUS-SR, OR-only SWE).
+# 1. Aggregate the 15 array sources (incl. Margulis WUS-SR OR-only SWE + UA SWE).
 sbatch slurm/project_or/agg_all_or.slurm
 
 # 2. Aggregate the two companion sources the array excludes.
 PROJECT_DIR=$OR sbatch slurm/shared/agg_ssebop.slurm
 PROJECT_DIR=$OR sbatch slurm/shared/agg_daymet.slurm   # edit --region (na) inside if needed
 
-# 3. Build the 5 implemented targets (runoff/aet/rch/som/swe; sca self-skips).
+# 3. Build all six implemented targets (runoff/aet/rch/som/sca/swe).
 #    Submit after the aggregations above have completed.
 sbatch slurm/project_or/run_or.slurm
 

--- a/slurm/project_or/agg_all_or.slurm
+++ b/slurm/project_or/agg_all_or.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=nhf-agg-or
 #SBATCH --account=impd
 #SBATCH --partition=cpu
-#SBATCH --array=0-13
+#SBATCH --array=0-14
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G

--- a/slurm/project_or/run_or.slurm
+++ b/slurm/project_or/run_or.slurm
@@ -14,10 +14,11 @@
 # Oregon" entry point. Thin wrapper over the shared target dispatch; only
 # PROJECT_DIR differs from slurm/project_gfv2/run_gfv2.slurm.
 #
-# Builds the 5 implemented targets (runoff/aet/rch/som/swe). Index 4 (run-sca)
-# is a stub: it raises NotImplementedError, which the CLI catches and logs as
-# "skipping", so the array completes without a failure. SWE picks up the OR-only
-# Margulis WUS-SR source via fabric_scope.
+# Builds all six implemented targets (runoff/aet/rch/som/sca/swe). Index 4
+# (run-sca) is the two-source MOD10C1 + UA SWE bound (#237). A target whose
+# configured sources are not yet aggregated self-skips (logged "skipping") so
+# the array completes without a failure. SWE picks up the OR-only Margulis
+# WUS-SR source via fabric_scope.
 #
 # Prerequisites (see slurm/project_or/README.md for the full order):
 #   agg_all_or.slurm + slurm/shared/agg_ssebop.slurm + slurm/shared/agg_daymet.slurm (--region na) done.

--- a/slurm/project_or/run_or.slurm
+++ b/slurm/project_or/run_or.slurm
@@ -15,9 +15,10 @@
 # PROJECT_DIR differs from slurm/project_gfv2/run_gfv2.slurm.
 #
 # Builds all six implemented targets (runoff/aet/rch/som/sca/swe). Index 4
-# (run-sca) is the two-source MOD10C1 + UA SWE bound (#237). A target whose
-# configured sources are not yet aggregated self-skips (logged "skipping") so
-# the array completes without a failure. SWE picks up the OR-only Margulis
+# (run-sca) is the two-source MOD10C1 + UA SWE bound (#237). Each target
+# requires its configured sources to be aggregated FIRST: missing sources fail
+# the array task with FileNotFoundError (exit 1) — they do NOT self-skip, so run
+# the agg array to completion before this one. SWE picks up the OR-only Margulis
 # WUS-SR source via fabric_scope.
 #
 # Prerequisites (see slurm/project_or/README.md for the full order):

--- a/slurm/shared/agg_all.body.sh
+++ b/slurm/shared/agg_all.body.sh
@@ -39,6 +39,7 @@ AGG_TASKS=(
     "agg-mwbm-climgrid" # 11 — USGS MWBM (ClimGrid) (2.5 arcmin monthly, 4 vars)
     "agg-era5-land-sd"  # 12 — ERA5-Land sd   (0.1° daily snow depth, SWE source)
     "agg-margulis-wus-sr" # 13 — Margulis WUS-SR (90 m daily SWE, OR-only SWE source)
+    "agg-ua-swe"        # 14 — UA SWE NSIDC-0719 (4 km daily, EPSG:5070; SWE + SCA source)
 )
 
 # Optional --period override per task. Empty string means "no clip"; the
@@ -60,6 +61,7 @@ AGG_PERIODS=(
     "1979/2020"     # 11 mwbm-climgrid (publisher: 1895-2020; clip to NHM window, drop spinup)
     ""              # 12 era5-land-sd
     ""              # 13 margulis-wus-sr (1985-2020 on disk; clip via --period if desired)
+    ""              # 14 ua-swe (CY1982-2022 on disk; clip via --period if desired)
 )
 
 if ((SLURM_ARRAY_TASK_ID < 0 || SLURM_ARRAY_TASK_ID >= ${#AGG_TASKS[@]})); then

--- a/slurm/shared/agg_ua_swe.slurm
+++ b/slurm/shared/agg_ua_swe.slurm
@@ -1,0 +1,105 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-agg-ua-swe
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --array=0-3          # 4 workers — adjust with N_WORKERS below
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=128G           # Per-worker peak ≈ one batch's weight-gen +
+                             # one batch's aggregation working set. 128G
+                             # matches the proven --mem in agg_all_<fabric>.slurm
+                             # and agg_snodas.slurm; UA SWE is 4 km (coarser
+                             # than SNODAS ~1 km) so the per-batch pixel set is
+                             # smaller, but keep 128G for headroom on the CONUS
+                             # fabric. Per CLAUDE.md memory: prefer SLURM --mem
+                             # bumps over in-code memory refactors.
+#SBATCH --time=16:00:00      # 41 calendar years (1982-2022) / 4 workers ≈ 10-11
+                             # years per worker. UA SWE is pre-projected to
+                             # EPSG:5070 (matches WEIGHT_GEN_CRS), so weight-gen
+                             # skips the source-grid reproject and is fast (the
+                             # ~5-8x tax that hits WGS84-native sources does not
+                             # apply). 16 hrs is generous headroom.
+#SBATCH --output=logs/agg_ua_swe_%a_%A.out
+#SBATCH --error=logs/agg_ua_swe_%a_%A.err
+
+# NHF Spatial Targets — parallel UA SWE (NSIDC-0719) aggregation (year-sharded).
+#
+# Each array task processes a non-overlapping ROUND-ROBIN slice of the
+# calendar years on disk under <datastore>/ua_swe/daily/ (ua_swe_daily_<YYYY>.nc,
+# CY1982-2022, EPSG:5070), writes per-year aggregated NCs to
+# <project>/data/aggregated/ua_swe/, and merges its slice into manifest.json
+# under an advisory flock so parallel workers can't lose each other's
+# provenance entries.
+#
+# This aggregates THREE variables to the fabric: `swe` (a SWE-target source)
+# and the depth-thresholded `snow_covered_fraction` (the second SCA-target
+# source, #237), plus `snow_depth`. The snow_covered_fraction binary is derived
+# PRE-aggregation in aggregate/ua_swe.py's pre-aggregate hook; the
+# `snow_covered_area.depth_threshold_mm` config value (default 1.0 mm) is read
+# at agg time and stamped on the output (changing it requires re-aggregating).
+#
+# Weight CSVs are computed by EACH worker on its first year and reused across
+# that worker's remaining years; the atomic temp+rename in
+# compute_or_load_weights handles the cross-worker race (last-writer-wins is
+# correct because the content is deterministic). Weight cache invalidation
+# includes source CRS in the SHA-256 fingerprint, so an EPSG mismatch can't
+# silently reuse a stale cache.
+#
+# Year sharding is round-robin (same as agg_snodas.slurm): worker 0 takes years
+# [0::N], worker 1 takes [1::N], etc. — keeps load balanced when per-year cost
+# is uneven.
+#
+# PREREQUISITE: the consolidated NCs must be CALENDAR year
+# (ua_swe_daily_<YYYY>.nc), written by PR-A2's consolidator. A datastore that
+# still holds the pre-A2 water-year files (ua_swe_daily_WY<YYYY>.nc) must be
+# re-consolidated first (rm the WY files, re-run `nhf-targets fetch ua-swe` —
+# raw under <datastore>/ua_swe/raw/ is cached, so no re-download).
+#
+# Usage:
+#   mkdir -p logs
+#   export PROJECT_DIR=/path/to/your/project
+#   sbatch slurm/shared/agg_ua_swe.slurm
+#
+# To change the number of workers (must edit BOTH --array and N_WORKERS):
+#   Edit  --array=0-2  and  N_WORKERS=3  below for 3 workers, etc.
+#
+# To resume after a partial run — just re-submit; no other flags needed.
+# Per-year aggregated NCs already on disk are skipped by the aggregator's
+# existence check; weight CSVs already on disk pass the fingerprint check and
+# are reused; the flock-protected manifest merge makes a re-run additive.
+#
+# To restrict to a subset of years:
+#   PERIOD=2000/2010 sbatch slurm/shared/agg_ua_swe.slurm
+
+set -euo pipefail
+
+# Flush Python stdout per-line so SLURM logs update in real time.
+export PYTHONUNBUFFERED=1
+
+# Must match the --array upper bound + 1 (i.e. --array=0-3 → N_WORKERS=4).
+N_WORKERS=4
+
+REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets}"
+PROJECT_DIR="${PROJECT_DIR:?set PROJECT_DIR to the target project dir, e.g. PROJECT_DIR=/caldera/.../gfv2-spatial-targets}"
+PERIOD="${PERIOD:-}"
+
+echo "=== UA SWE agg: worker ${SLURM_ARRAY_TASK_ID}/${N_WORKERS} ==="
+echo "=== Project: ${PROJECT_DIR} ==="
+echo "=== Period:  ${PERIOD:-<all years on disk>} ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+cd "${REPO_DIR}" || { echo "ERROR: REPO_DIR=${REPO_DIR} not found" >&2; exit 1; }
+
+EXTRA_ARGS=()
+if [ -n "${PERIOD}" ]; then
+    EXTRA_ARGS+=("--period" "${PERIOD}")
+fi
+
+pixi run agg-ua-swe -- \
+    --project-dir   "${PROJECT_DIR}" \
+    --worker-index  "${SLURM_ARRAY_TASK_ID}" \
+    --n-workers     "${N_WORKERS}" \
+    ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+
+echo "=== Done: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/slurm/shared/fetch_all.slurm
+++ b/slurm/shared/fetch_all.slurm
@@ -2,7 +2,7 @@
 #SBATCH --job-name=nhf-fetch
 #SBATCH --account=impd
 #SBATCH --partition=cpu
-#SBATCH --array=0-13
+#SBATCH --array=0-14
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
@@ -80,6 +80,7 @@ FETCH_TASKS=(
     "fetch-daymet"         # 11 — 1980–2024 at 1 km, daily (ORNL DAAC zarr, MANUAL STAGING; see docs/sources/daymet.md)
     "fetch-snodas"         # 12 — 2003–present at 1 km, daily (NSIDC G02158 via earthaccess)
     "fetch-margulis-wus-sr" # 13 — 1985–2021 at 90 m, daily (NSIDC-0719 via earthaccess) — Oregon-fabric only
+    "fetch-ua-swe"         # 14 — 1982–2022 at 4 km, daily (NSIDC-0719 UA Broxton; SWE + SCA source)
 )
 
 # Map array index → fetch period (YYYY/YYYY)
@@ -101,6 +102,7 @@ FETCH_PERIODS=(
     "1980/2024"   # 11 daymet      (publisher ends 2024; V4 R1)
     "2003/2025"   # 12 snodas      (daily archive starts 2003-09-30)
     "1985/2021"   # 13 margulis-wus-sr (water years 1985-2021)
+    "1981/2023"   # 14 ua-swe      (calendar-year range; resolves WY1982-2023 raws)
 )
 
 TASK="${FETCH_TASKS[$SLURM_ARRAY_TASK_ID]}"

--- a/slurm/shared/fetch_ua_swe.slurm
+++ b/slurm/shared/fetch_ua_swe.slurm
@@ -1,0 +1,82 @@
+#!/bin/bash
+#SBATCH --job-name=nhf-ua-swe
+#SBATCH --account=impd
+#SBATCH --partition=cpu
+#SBATCH --array=0-3          # 4 workers — adjust with N_WORKERS below
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=64G            # Unlike the SNODAS streaming consolidator, the UA
+                             # SWE consolidator windows two adjacent water-year
+                             # rasters into one calendar year AND pre-projects to
+                             # EPSG:5070, so peak RSS is higher. 64G is the proven
+                             # value from the original per-project run; per
+                             # CLAUDE.md memory, prefer a --mem bump over an
+                             # in-code memory refactor.
+#SBATCH --time=6:00:00       # Full archive (42 water years, ~90 MB raw each) ≈
+                             # ~1.5 h wall-clock across 4 workers per the original
+                             # run; 6 h is headroom. A re-consolidate (raw already
+                             # under ua_swe/raw/) skips all downloads and is faster.
+#SBATCH --output=logs/ua_swe_%a_%A.out
+#SBATCH --error=logs/ua_swe_%a_%A.err
+
+# NHF Spatial Targets — parallel UA SWE fetch + consolidate (NSIDC-0719).
+#
+# Each array task downloads a non-overlapping ROUND-ROBIN slice of the published
+# water-year rasters (4km_SWE_Depth_WY<YYYY>_v01.nc) to <datastore>/ua_swe/raw/,
+# then consolidates each CALENDAR year — [Jan 1–Sep 30] from WY X plus
+# [Oct 1–Dec 31] from WY X+1 — and pre-projects it to EPSG:5070, writing
+# <datastore>/ua_swe/daily/ua_swe_daily_<YYYY>.nc (CY1982-2022). Workers merge
+# into manifest.json under an advisory flock so concurrent provenance writes
+# can't clobber each other.
+#
+# RE-CONSOLIDATE (no re-download): the raw water-year files under
+# <datastore>/ua_swe/raw/ are preserved and cached. To rebuild the consolidated
+# calendar-year NCs — e.g. a datastore that still holds the pre-A2 water-year
+# outputs (ua_swe_daily_WY<YYYY>.nc) — delete the daily NCs and resubmit; the
+# per-file already-present check keeps HTTP traffic to zero and consolidation
+# runs alone:
+#   rm <datastore>/ua_swe/daily/ua_swe_daily_*.nc
+#   PROJECT_DIR=... sbatch slurm/shared/fetch_ua_swe.slurm
+#
+# Usage:
+#   mkdir -p logs
+#   export PROJECT_DIR=/path/to/your/project
+#   sbatch slurm/shared/fetch_ua_swe.slurm
+#
+# To change the number of workers (must edit BOTH --array and N_WORKERS):
+#   Edit  --array=0-2  and  N_WORKERS=3  below for 3 workers, etc.
+#
+# To resume after a partial run — just re-submit; no other flags needed.
+# Completed years are detected from manifest.json + on-disk file presence.
+#
+# To fetch a subset of years only (calendar-year range resolves the WY files
+# needed):
+#   PERIOD=2000/2010 sbatch slurm/shared/fetch_ua_swe.slurm
+
+set -euo pipefail
+
+# Flush Python stdout per-line so slurm logs update in real time.
+export PYTHONUNBUFFERED=1
+
+# Must match the --array upper bound + 1 (i.e. --array=0-3 → N_WORKERS=4).
+N_WORKERS=4
+
+REPO_DIR="${REPO_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/nhf-spatial-targets}"
+PROJECT_DIR="${PROJECT_DIR:?set PROJECT_DIR to the target project dir, e.g. PROJECT_DIR=/caldera/.../gfv2-spatial-targets}"
+PERIOD="${PERIOD:-1981/2023}"
+
+echo "=== UA SWE fetch: worker ${SLURM_ARRAY_TASK_ID}/${N_WORKERS} ==="
+echo "=== Period:  ${PERIOD} ==="
+echo "=== Project: ${PROJECT_DIR} ==="
+echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== Host:    $(hostname) ==="
+
+cd "${REPO_DIR}" || { echo "ERROR: REPO_DIR=${REPO_DIR} not found" >&2; exit 1; }
+
+pixi run fetch-ua-swe -- \
+    --project-dir "${PROJECT_DIR}" \
+    --period       "${PERIOD}" \
+    --worker-index "${SLURM_ARRAY_TASK_ID}" \
+    --n-workers    "${N_WORKERS}"
+
+echo "=== Done: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/slurm/shared/run_all.body.sh
+++ b/slurm/shared/run_all.body.sh
@@ -9,9 +9,12 @@
 #
 # All six targets are implemented (runoff/aet/rch/som/sca/swe). SCA is the
 # two-source NaN-aware bound from MOD10C1 (calcSCA CI-interval) + UA SWE
-# (depth-thresholded snow_covered_fraction), #237. A target whose configured
-# sources have not been aggregated yet self-skips (the CLI logs "skipping")
-# rather than failing the array.
+# (depth-thresholded snow_covered_fraction), #237. Each target requires its
+# configured sources to be aggregated FIRST: a target whose sources are not yet
+# on disk fails its array task with FileNotFoundError (exit 1) — it does NOT
+# self-skip. Run the agg array to completion before this one. (The CLI only
+# logs "skipping" for a builder that raises NotImplementedError; no target does
+# anymore, so in practice nothing self-skips.)
 
 # Flush Python stdout per-line so slurm logs update in real time.
 export PYTHONUNBUFFERED=1

--- a/slurm/shared/run_all.body.sh
+++ b/slurm/shared/run_all.body.sh
@@ -7,10 +7,11 @@
 # depends on its source aggregations being complete (run the agg array first);
 # targets are otherwise independent and run concurrently on separate nodes.
 #
-# SCA (targets/sca.py) is still a stub: it raises NotImplementedError, which the
-# CLI catches and logs as "skipping" (cli.py), so the array does not fail on it.
-# runoff/aet/rch/som/swe are implemented. When the SCA builder lands, the skip
-# becomes a real build with no script change.
+# All six targets are implemented (runoff/aet/rch/som/sca/swe). SCA is the
+# two-source NaN-aware bound from MOD10C1 (calcSCA CI-interval) + UA SWE
+# (depth-thresholded snow_covered_fraction), #237. A target whose configured
+# sources have not been aggregated yet self-skips (the CLI logs "skipping")
+# rather than failing the array.
 
 # Flush Python stdout per-line so slurm logs update in real time.
 export PYTHONUNBUFFERED=1
@@ -26,7 +27,7 @@ RUN_TASKS=(
     "run-aet"      # 1 — AET (MOD16A2, SSEBop[, MWBM])
     "run-rch"      # 2 — Recharge (Reitz 2017, ERA5-Land[, WaterGAP])
     "run-som"      # 3 — Soil moisture (MERRA-2, NLDAS-MOSAIC, NLDAS-NOAH)
-    "run-sca"      # 4 — SCA (stub: skips via NotImplementedError)
+    "run-sca"      # 4 — SCA (MOD10C1 CI-bounds + UA SWE depth-threshold, #237)
     "run-swe"      # 5 — SWE (Daymet, SNODAS, ERA5-Land[, Margulis on OR])
 )
 


### PR DESCRIPTION
## Why

The #237 ua_swe chain wired `ua_swe` fully into the CLI — `nhf-targets fetch ua-swe` and `nhf-targets agg ua-swe` both support `--worker-index` / `--n-workers` / `--period` like their snodas siblings — but ua_swe never got the **pixi-task and SLURM wrappers** every other source has. So there was no `pixi run agg-ua-swe`, no shared fetch/agg batch scripts, and ua_swe was missing from the `fetch-all` / `agg-all` SLURM arrays. The fetch script even lived in a **project directory** (`gfv2-spatial-targets/run_fetch_ua_swe.sbatch`) with a hardcoded gfv2 `PROJECT_DIR`, instead of the repo with the other (fabric-independent) fetch scripts. This PR closes the whole ops gap — **no Python changes**.

## What

**pixi tasks** (`pixi.toml`)
- `fetch-ua-swe`, `agg-ua-swe` (mirror `fetch-snodas` / `agg-snodas`).

**Standalone SLURM scripts** (`slurm/shared/`, year-sharded arrays, `PROJECT_DIR`-driven)
- `fetch_ua_swe.slurm` *(new)* — relocates the project-local script into the repo. 64G (the consolidator windows two water years into one calendar year + pre-projects to EPSG:5070 — heavier than SNODAS's streaming consolidator; 64G is the proven per-project value). Header documents the **raw-is-cached re-consolidate** path (`rm` daily NCs + resubmit → no re-download) — exactly the pre-A2 water-year → calendar-year migration operators hit.
- `agg_ua_swe.slurm` *(new)* — modeled on `agg_snodas.slurm`; ua_swe is pre-projected EPSG:5070 (matches `WEIGHT_GEN_CRS`), so the 128G / 4-worker / fast-weight-gen profile applies. Documents the calendar-year prerequisite.

**`*_all` arrays**
- `fetch_all.slurm`: add `fetch-ua-swe` as index **14** (+ period `1981/2023`); `--array=0-13` → `0-14`.
- `agg_all.body.sh`: add `agg-ua-swe` as index **14**; `agg_all_{gfv2,or}.slurm` `--array=0-13` → `0-14`.

## Follow-up for the operator
The project-local `gfv2-spatial-targets/run_fetch_ua_swe.sbatch` is now superseded and can be deleted.

## Verification
- `pixi task list` shows `fetch-ua-swe` + `agg-ua-swe`.
- `bash -n` clean on all new/edited shell scripts; `FETCH_TASKS`/`FETCH_PERIODS` both 15 entries, `AGG_TASKS` 15 entries (0–14).
- New scripts match their sibling exec-bit convention (agg `0755`, fetch `0664`).
- `fmt` + `lint` clean (no Python touched).

## Usage
```bash
export PROJECT_DIR=/caldera/.../gfv2-spatial-targets
# re-consolidate ua_swe (raw cached):
rm $DATASTORE/ua_swe/daily/ua_swe_daily_*.nc
sbatch slurm/shared/fetch_ua_swe.slurm
# aggregate:
sbatch slurm/shared/agg_ua_swe.slurm
# or as part of the full arrays (now 0-14):
sbatch slurm/shared/fetch_all.slurm
sbatch slurm/project_gfv2/agg_all_gfv2.slurm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)