### PR TITLE
docs(#312): public-API evaluation + Tier-1 doc-sync fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,9 +319,11 @@ The pipeline separates **projects** (fabric-specific) from the **datastore** (sh
 6. `nhf-targets agg ssebop --project-dir <project-dir>` aggregates remote data to fabric
 7. `nhf-targets run --project-dir <project-dir>` builds calibration targets
 
-- `nhf-targets reconcile-manifest --project-dir <dir>` backfills `manifest.json`
-  from consolidated NCs already in a shared datastore (new project against an
-  existing datastore). Gap-fill only; see `docs/architecture/reconcile-manifest.md`.
+- `nhf-targets rebuild-manifest --project-dir <dir>` regenerates `manifest.json`
+  as a deterministic projection of (on-disk artifacts × catalog × `fabric.json`).
+  This subsumes the former `reconcile-manifest` (removed in #279); it also covers
+  the gap-fill case of a new project pointed at an existing shared datastore. See
+  `docs/architecture/reconcile-manifest.md` for the tombstone/redirect note.
 
 **Key paths:**
 - `<project>/config.yml` — project configuration (fabric, datastore, targets, dir_mode)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ pixi run fetch-mod10c1         -- --project-dir /data/gfv11-targets --period 200
 pixi run fetch-mwbm-climgrid   -- --project-dir /data/gfv11-targets               # manual stage required
 pixi run fetch-daymet          -- --project-dir /data/gfv11-targets               # manual stage required
 pixi run fetch-snodas          -- --project-dir /data/gfv11-targets --period 2003/2024
+pixi run fetch-ua-swe          -- --project-dir /data/gfv11-targets --period 1981/2023  # SWE + SCA source
 pixi run fetch-margulis-wus-sr -- --project-dir /data/gfv11-targets --period 1985/2021  # OR fabric only
 
 # 7. Aggregate sources to the HRU fabric
@@ -271,7 +272,15 @@ SLURM scripts live under `slurm/`: fabric-independent ones in `slurm/shared/`,
 fabric-specific wrappers in `slurm/project_<fabric>/`. Fetch is
 fabric-independent (the datastore is shared):
 
-- [`slurm/shared/fetch_all.slurm`](slurm/shared/fetch_all.slurm) — 14-element array, one task per source (general case)
+> **On the USGS `caldera` cluster, every `sbatch` must specify `--account=impd`.**
+> The `default` account has `MaxSubmit=0` and rejects every submission with
+> `AssocMaxSubmitJobLimit`. The committed `slurm/project_*/` scripts already carry
+> `#SBATCH --account=impd`; when submitting a `slurm/shared/*` script (or any script
+> whose header you have edited), pass it explicitly:
+> `sbatch --account=impd slurm/shared/fetch_all.slurm`. On a non-caldera cluster,
+> substitute or drop `--account` as your scheduler requires.
+
+- [`slurm/shared/fetch_all.slurm`](slurm/shared/fetch_all.slurm) — 15-element array (indices 0–14), one task per source (general case)
 - [`slurm/shared/fetch_era5_land.slurm`](slurm/shared/fetch_era5_land.slurm) — sharded array (default 4 workers) for ERA5-Land specifically; respects CDS per-user throttling
 - [`slurm/shared/fetch_snodas.slurm`](slurm/shared/fetch_snodas.slurm) — sharded array (default 4 workers) for SNODAS; per-day idempotent
 - [`slurm/project_or/fetch_margulis_wus_sr.slurm`](slurm/project_or/fetch_margulis_wus_sr.slurm) — single task; Oregon-scoped (raw downloads still datastore-shared), no sharding yet
@@ -326,7 +335,7 @@ Array index → source mapping (`slurm/shared/fetch_all.slurm`):
 | 13 | Margulis WUS-SR | 1985/2021 | NSIDC-0719 via earthaccess; OR-fabric only |
 | 14 | UA SWE | 1981/2023 | NSIDC-0719 UA Broxton; SWE + SCA source (CY1982–2022 on disk) |
 
-Most fetch routines are network I/O-bound; the general script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. Per-source scripts (`slurm/shared/fetch_era5_land.slurm`, `slurm/shared/fetch_snodas.slurm`, `slurm/project_or/fetch_margulis_wus_sr.slurm`) tune memory and concurrency for their workload — notably SNODAS uses only 8 GB because PR #110's dask-streaming consolidator bounds peak RSS. Override `PROJECT_DIR` and `REPO_DIR` via environment before submission. SLURM directives (`--account`, `--partition`) at the top of each script may need adjustment for your cluster.
+Most fetch routines are network I/O-bound; the general script allocates 1 CPU and 128 GB RAM per task with a 24-hour wall-clock limit. Per-source scripts (`slurm/shared/fetch_era5_land.slurm`, `slurm/shared/fetch_snodas.slurm`, `slurm/project_or/fetch_margulis_wus_sr.slurm`) tune memory and concurrency for their workload — notably SNODAS uses only 8 GB because PR #110's dask-streaming consolidator bounds peak RSS. Override `PROJECT_DIR` and `REPO_DIR` via environment before submission. SLURM directives (`--account`, `--partition`) at the top of each script may need adjustment for your cluster — on caldera, `--account=impd` is mandatory (see the callout above).
 
 ### Running Aggregation: PC vs HPC
 
@@ -351,11 +360,11 @@ Each aggregator writes one or more NetCDFs to `<project>/data/aggregated/<source
 
 #### On HPC (SLURM)
 
-The 14-source aggregation array is a per-fabric wrapper that sources a shared
+The 15-source aggregation array is a per-fabric wrapper that sources a shared
 body (`slurm/shared/agg_all.body.sh`); SSEBop and Daymet stay separate (remote
 STAC / region-arg). Only `PROJECT_DIR` differs between fabrics:
 
-- [`slurm/project_gfv2/agg_all_gfv2.slurm`](slurm/project_gfv2/agg_all_gfv2.slurm) / [`slurm/project_or/agg_all_or.slurm`](slurm/project_or/agg_all_or.slurm) — 14-element array for local-NC aggregators
+- [`slurm/project_gfv2/agg_all_gfv2.slurm`](slurm/project_gfv2/agg_all_gfv2.slurm) / [`slurm/project_or/agg_all_or.slurm`](slurm/project_or/agg_all_or.slurm) — 15-element array (indices 0–14) for local-NC aggregators
 - [`slurm/shared/agg_ssebop.slurm`](slurm/shared/agg_ssebop.slurm) — single job for SSEBop (remote STAC)
 - [`slurm/shared/agg_daymet.slurm`](slurm/shared/agg_daymet.slurm) — single job for Daymet (local zarr, per-region)
 - [`slurm/shared/agg_snodas.slurm`](slurm/shared/agg_snodas.slurm) — optional sharded (4-worker) SNODAS aggregator; SNODAS is otherwise array index 10, so use this only to parallelize that one source
@@ -643,8 +652,8 @@ Pixi supports **linux-64**, **osx-arm64**, and **win-64** (see `pixi.toml`).
 | **AET target builder** (multi-source min/max; PR #126/#127) | Done |
 | **Recharge target builder** (`normalized_minmax`, 2-source; PR #133/#134) | Done |
 | **Soil moisture target builder** (`normalized_minmax`, monthly + annual; PR #133/#134) | Done |
-| **SCA target builder** (CI-bounded single-source MOD10C1 v061 per `PRMSobjfun.f90:calcSCA`; PR #210/#212, year-chunk fingerprinting #213/#214, finish workflow #217) | Done |
-| **SWE target builder** (4-source NaN-aware, OR-scoped Margulis via `fabric_scope`; PR #101/#135) | Done |
+| **SCA target builder** (CI-bounded two-source MOD10C1 v061 ∪ UA SWE per `PRMSobjfun.f90:calcSCA`; PR #210/#212, year-chunk fingerprinting #213/#214, finish workflow #217, two-source #237) | Done |
+| **SWE target builder** (4-source gfv2 / 5-source OR NaN-aware, OR-scoped Margulis via `fabric_scope`, UA SWE extending to 1982; PR #101/#135, #237) | Done |
 | Margulis WUS-SR per-WY granule consolidation | Done (PR #101/#135) |
 
 ## Known Gaps

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,12 @@ This pipeline builds the baseline calibration targets documented in [Hay and oth
 | AET | `hru_actet` | MOD16A2 v061 · SSEBop · MWBM ClimGrid | Multi-source min/max | Monthly |
 | Recharge | `recharge` | Reitz 2017 · WaterGAP 2.2d · ERA5-Land | Normalized min/max | Annual |
 | Soil moisture | `soil_rechr` | MERRA-2 · NCEP/NCAR · NLDAS-MOSAIC · NLDAS-NOAH | Normalized min/max per calendar month | Monthly + annual |
-| Snow cover | `snowcov_area` | MOD10C1 v061 | MODIS CI-bounded (CI > 70 %) | Daily |
-| SWE | `pkwater_equiv` | Daymet · SNODAS · ERA5-Land · Margulis WUS-SR¹ | NaN-aware multi-source min/max | Daily |
+| Snow cover | `snowcov_area` | MOD10C1 v061 · UA SWE² | NaN-aware bound: MODIS CI-interval (CI ≥ 70 %) ∪ depth-derived fraction | Daily |
+| SWE | `pkwater_equiv` | Daymet · SNODAS · ERA5-Land · UA SWE² · Margulis WUS-SR¹ | NaN-aware multi-source min/max | Daily |
 
-¹ Margulis Western US Snow Reanalysis (NSIDC-0719) is **fabric-scoped to Oregon** via `catalog/sources.yml → margulis_wus_sr.fabric_scope`. Non-Oregon projects reduce the SWE bound to the remaining three sources at target-build time; raw downloads remain reusable across any project sharing the datastore.
+¹ Margulis Western US Snow Reanalysis (NSIDC-0719) is **fabric-scoped to Oregon** via `catalog/sources.yml → margulis_wus_sr.fabric_scope`. Non-Oregon projects reduce the SWE bound to the remaining four sources (Daymet, SNODAS, ERA5-Land, UA SWE) at target-build time; raw downloads remain reusable across any project sharing the datastore.
+
+² UA Daily 4-km SWE (NSIDC-0719; Broxton, Zeng & Dawson 2019) is CONUS-wide for calendar years 1982–2022 and is the only SWE source reaching before SNODAS's 2003 start. It is a fifth SWE source and the second SCA source (its depth-derived snow-covered fraction extends the CI-bound back to 1982); see [#237](https://github.com/rmcd-mscb/nhf-spatial-targets/issues/237).
 
 ## Where to start
 

--- a/docs/reviews/2026-06-10-public-api-evaluation.md
+++ b/docs/reviews/2026-06-10-public-api-evaluation.md
@@ -159,6 +159,18 @@ recipe):**
     (#8); the `maintenance` sub-app / verb-rename question (#6 + §3 road-not-taken).
     These are breaking or near-breaking; batch them behind a deprecation note.
 
+> **Note on numbering:** the `#N` references in this document are this report's
+> internal *finding* IDs (§2 tables), not GitHub issues. The GitHub tracking
+> numbers are listed below.
+
+**Follow-up tracking.** Tier-1 closed in PR #313 (tracking issue #312). The roadmap
+and CLI-grammar tiers are filed as: operator catch-up guide + maintenance-verb
+wrappers → issue #314; `config/pipeline.yml` reconciliation → issue #315;
+`slurm/project_gfv2/` README + `slurm/shared/` index → issue #316; mkdocs API
+reference + release user docs → issue #317; onboarding required-key markers +
+`validate` NASA-cred note → issue #318; CLI grammar consistency + maintenance-verb
+structure → issue #319.
+
 ---
 
 ## Appendix: one refuted claim

--- a/docs/reviews/2026-06-10-public-api-evaluation.md
+++ b/docs/reviews/2026-06-10-public-api-evaluation.md
@@ -1,0 +1,172 @@
+# Public-API & Operator-Documentation Evaluation — 2026-06-10
+
+**Scope:** the full public-facing surface of `nhf-spatial-targets` as experienced by
+an operator/developer who is *not* the original author — the `nhf-targets` CLI, its
+`pixi run` wrappers, the prose docs that lead a newcomer through (a) standing up a
+**new fabric** and (b) **catching an existing project up** when a new element lands,
+the SLURM harness, the config templates, and the mkdocs site.
+
+**Audience for this document:** the earth-science colleague who may continue
+development of this repository. Findings are evidence-backed (`file:line`) and tiered
+so you can triage.
+
+**Method:** four parallel read-only audits (command surface, new-fabric onboarding,
+existing-project catch-up lifecycle, HPC/config/docs-site), followed by direct
+verification of every BLOCKER-class claim. One claim was **refuted** on verification
+(see [Appendix: refuted claim](#appendix-one-refuted-claim)); it is recorded here so it
+is not "rediscovered" later.
+
+---
+
+## 1. The one root cause
+
+Almost every real problem below is a single pattern wearing different hats:
+
+> **Load-bearing operator knowledge lives in `CLAUDE.md`, `MEMORY.md`, and committed
+> SLURM scripts — not in the artifact the operator actually edits, the page they
+> actually read, or the `--help` they actually scan.**
+
+`CLAUDE.md` is a *developer/agent* guide. A successor scientist running the pipeline
+reads `README.md`, `docs/getting-started.md`, the `config.yml` the template generated,
+and `nhf-targets --help`. Wherever a fact lives only in `CLAUDE.md` (or only in
+project memory, or only baked into a committed `.slurm` file), the operator-facing
+surface has a hole. The fixes are correspondingly cheap: **move the tacit fact to the
+surface the operator touches.**
+
+The design itself is sound. The command surface is near-complete, the
+intent-vs-derived durability split holds in code, the SLURM harness calls only live
+commands, and every current catalog source has a doc page. What's missing is
+*continuity at the seams* — the places where a command was renamed, a source was
+added, or a fact was assumed.
+
+---
+
+## 2. Findings, tiered
+
+### Tier 1 — Fix now (a successor follows a documented recipe and it fails or misleads)
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| 1 | **`CLAUDE.md` documents `reconcile-manifest` as a live command — it was removed.** Folded into `rebuild-manifest`. A successor (or Claude) typing it gets "unknown command." | [CLAUDE.md:322-324](../../CLAUDE.md#L322); refuted-into [cli/run.py:262](../../src/nhf_spatial_targets/cli/run.py#L262) "Subsumes the former 'reconcile-manifest'." The tombstone doc [docs/architecture/reconcile-manifest.md](../architecture/reconcile-manifest.md) is correct; only `CLAUDE.md` is stale. |
+| 2 | **CDS credential template ships the stale `<uid>:<key>` format** against the *new* CDS endpoint, which issues a single Personal Access Token. `materialize_cdsapirc` writes the string verbatim; `validate` only checks file existence, so the failure surfaces as a runtime 401 the operator can't diagnose. | [init_run.py:213-216](../../src/nhf_spatial_targets/init_run.py#L213) — `url: https://cds.climate.copernicus.eu/api` paired with `key: "<uid>:<key>"`. |
+| 3 | **`docs/index.md` SCA + SWE source descriptions are pre-#237 stale.** SCA shown as single-source MOD10C1 (now a two-source MOD10C1 ∪ ua_swe bound); SWE shown as 4 sources / "the remaining three" (ua_swe is a 5th, extending to 1982). The site landing page contradicts `README.md` and the config template. | [docs/index.md:15-18](../index.md#L15) vs [README.md:15-16](../../README.md#L15) and [init_run.py:123-153](../../src/nhf_spatial_targets/init_run.py#L123). |
+| 4 | **`docs/sources/ua_swe.md` is orphaned from the mkdocs nav.** The Sources nav ends at SSEBop (15 pages, no ua_swe), so the page is unreachable and the documented `--strict` build will warn "not in nav." ua_swe is central to both SCA (#237) and SWE. | [mkdocs.yml:113-129](../../mkdocs.yml#L113); page exists at [docs/sources/ua_swe.md](../sources/ua_swe.md). |
+| 5 | **`--account=impd` is mandatory on caldera but absent from operator-facing HPC docs.** The `default` account is rejected with `AssocMaxSubmitJobLimit`. It's baked into the committed `slurm/project_*/` scripts and lives in project memory, but `README.md` tells operators to `sbatch slurm/shared/*.slurm` and only says directives "may need adjustment." A newcomer's every `slurm/shared/*` submission bounces with no explanation. | `README.md` HPC section (~L294, L329); contrast committed `#SBATCH --account=impd` in every `slurm/**/*.slurm`. |
+
+### Tier 2 — Inconsistencies (defensible but will confuse a successor; design-continuity gaps)
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| 6 | **The maintenance verb family doesn't track behavior.** `upgrade-config` and `upgrade-manifest` are **report-only** (they never mutate; `upgrade-manifest` just tells you to run `rebuild-manifest`), while `rebuild-manifest` and `rechunk` mutate. So two `upgrade-*` verbs don't upgrade, and there is **no `rebuild-config`** — the config actuator is `validate`, which a successor cannot predict from the names. | [cli/run.py:445-452](../../src/nhf_spatial_targets/cli/run.py#L445), [upgrade_manifest.py:32-59](../../src/nhf_spatial_targets/upgrade_manifest.py#L32), [cli/run.py:323](../../src/nhf_spatial_targets/cli/run.py#L323). |
+| 7 | **`-d` / `--project-dir` short alias exists on 3 of 5 sub-surfaces.** Root commands and `release` define `-d`; **`fetch` and `agg` do not.** `validate -d X` works; `fetch merra2 -d X` does not. Highest-frequency daily paper-cut. | `-d` at e.g. [cli/run.py:43](../../src/nhf_spatial_targets/cli/run.py#L43); absent in `cli/fetch.py` / `cli/agg.py` (`name=["--project-dir"]` only). |
+| 8 | **`release publish --scope source` (singular) vs `--scope sources` (plural) everywhere else.** `build`/`status`/`dry-run` take `sources`; `publish` takes `source`. Guaranteed paper-cut, undocumented. Same theme: one concept ("a catalog source key") is spelled `--source` (`rechunk`), `--source-key` (`release`), and a positional (`fetch`/`agg`). | `cli/release.py` scope literals (build ~L355 `sources` vs publish ~L406 `source`); [cli/run.py:146](../../src/nhf_spatial_targets/cli/run.py#L146) `--source`. |
+| 9 | **`config/pipeline.yml` has drifted from `init_run.py:_CONFIG_TEMPLATE`.** The reference config is **missing `datastore`, `dir_mode`, `fabric.buffer_deg`** — including the single most important path an operator must set — and differs on per-target `nn_fill` defaults and `aet.sources`. It self-declares "REFERENCE ONLY," but `CLAUDE.md`'s four-point rule mandates the mirror, and an operator reading it as the schema reference is misled. | [config/pipeline.yml:1-3](../../config/pipeline.yml#L1) (reference-only banner); `grep datastore config/pipeline.yml` → none; template keys at [init_run.py:40-44](../../src/nhf_spatial_targets/init_run.py#L40). |
+| 10 | **`validate` unconditionally requires NASA Earthdata creds + `~/.netrc`** (`required` always seeds `["nasa_earthdata"]`), so *every* project — even one whose enabled targets use no NASA source — fails `validate` until Earthdata creds are materialized. Defensible (nearly every target uses a NASA source) but **undocumented**, and the error gives no hint it's a blanket requirement. | [validate.py:388](../../src/nhf_spatial_targets/validate.py#L388) `required: list[str] = ["nasa_earthdata"]`; netrc check fires because `"nasa_earthdata" in required` is always true ([validate.py:420-421](../../src/nhf_spatial_targets/validate.py#L420)). |
+| 11 | **`README.md` Quick-Start fetch list omits `fetch-ua-swe`** (a default source in two enabled targets), and is internally inconsistent on the agg array size ("14" vs "15"). A copy-paste operator never fetches ua_swe, then hits missing aggregated data at `run-sca`/`run-swe`. `getting-started.md` sidesteps this by using `fetch-all`. | `README.md:83-96`; agg count drift `README.md:274,354` ("14") vs `:293` ("15"); array bound is `--array=0-14` = 15 tasks ([slurm/shared/agg_all.body.sh:7](../../slurm/shared/agg_all.body.sh#L7) comment says "14 total"). |
+| 12 | **`README.md` internal SCA drift:** the Calibration-Targets table (top) says two-source; the Implementation-Status row says "single-source MOD10C1." Same #237 refactor, half-applied. | `README.md:15` vs `README.md:646`. |
+| 13 | **SLURM project dirs are not structurally parallel.** `slurm/project_or/` has a `README.md`; `slurm/project_gfv2/` (the default CONUS fabric) does not. `rechunk_*.slurm` exists only for gfv2. A successor running the *default* fabric has no submit-order doc co-located with the scripts. | `ls slurm/project_gfv2/` (no README), vs [slurm/project_or/README.md](../../slurm/project_or/README.md). |
+
+### Tier 3 — Gaps (missing, but no wrong recipe; reduces discoverability for a successor)
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| 14 | **No operator-facing "catch-up an existing project" guide exists.** `CLAUDE.md`'s checklists tell the *developer adding* an element what to change; nothing tells the *operator* the sequence to run afterward (`upgrade-config` → paste stub → `validate`; or add source → `fetch`/`agg` → `rebuild-manifest`; or schema bump → `upgrade-manifest` → `rebuild-manifest`). The `upgrade→edit→validate` ordering is unenforced and ambushes the operator at the publish staleness gate. | No README/getting-started mention of any maintenance verb; gate at `release/publish.py` `_preflight_effective_config_current`. |
+| 15 | **The five maintenance verbs have no `pixi` wrapper and no `--help` grouping.** `upgrade-config`, `upgrade-manifest`, `rebuild-manifest`, `rechunk` (and the removed `reconcile-manifest`) are reachable only as bare `nhf-targets <verb>` — a different invocation pattern than everything else — and are registered flat on the root app with no `group=`, so `--help` intermixes them with build verbs. Effectively hidden. | [cli/run.py:30-36](../../src/nhf_spatial_targets/cli/run.py#L30); `pixi.toml` has no `upgrade-*`/`rebuild-*`/`rechunk` task. |
+| 16 | **`release` family is absent from all user docs** (README/getting-started) despite being seven subcommands and the terminal step of the whole pipeline. Only `pixi.toml` comments mention it. | `pixi.toml:216-222`; no README/getting-started hit. |
+| 17 | **API reference omits the provenance/release/validation subsystem.** `docs/api/` covers the read/aggregate/target hot path but has **no page** for `validate`, `rebuild_manifest`/`lineage`, `upgrade_config`, the `release/` package, `rechunk`, or `fetch/consolidate` (`apply_cf_metadata`, the single CF-1.6 entry point) — exactly the invariant-heavy code `CLAUDE.md` flags as subtle. | `ls docs/api/` — 6 module pages, none for the above. |
+| 18 | **In-file config template doesn't distinguish required from optional keys**, and ships `fabric.path: /path/to/fabric.gpkg` / `datastore: /path/to/datastore` as unmarked placeholders. A newcomer can run `validate` against placeholders and get a bare `FileNotFoundError` with no hint it was an unedited template value. | [init_run.py:17,40](../../src/nhf_spatial_targets/init_run.py#L17); required-key checks in `workspace.py` (`datastore`, `fabric.path`, `fabric.id_col`). |
+| 19 | **`docs/data_release/*.md` (4 pages) are orphaned from mkdocs nav** — the config template points operators to `docs/data_release/` for the release workflow, but the pages aren't reachable from the rendered site and trip `--strict`. | [mkdocs.yml:96-102](../../mkdocs.yml#L96) (not in nav, not in `exclude_docs`). |
+
+### Tier 4 — Polish (low impact; record for completeness)
+
+- **`agg` is the only abbreviated sub-app name** (`fetch`/`catalog`/`release` spelled out). Either alias `aggregate`→`agg` or accept the asymmetry deliberately. ([cli/agg.py:30](../../src/nhf_spatial_targets/cli/agg.py#L30))
+- **`run --target` accepts only the long keys** (`recharge`, not `rch`), but the `pixi run run-rch`/`-som`/`-sca` task *names* use the short nicknames; a user typing `--target rch` gets "Unknown target." Help text doesn't list the accepted vocabulary. ([cli/run.py:47-53](../../src/nhf_spatial_targets/cli/run.py#L47))
+- **App tagline** says `nhf-spatial-targets` while the binary is `nhf-targets`. ([cli/__init__.py:55](../../src/nhf_spatial_targets/cli/__init__.py#L55))
+- **`fetch` redefines `--worker-index`/`--n-workers` without the `-w`/`-n` aliases** that `agg` gives them (via `_params.py`), with divergent help text — two parallel definitions of the same SLURM-array concept.
+- **`validate` refreshes the `fabric` block; `rebuild-manifest` preserves it verbatim** — a `rebuild-manifest` after an un-revalidated fabric change carries a stale fabric block. No correctness bug today (publish re-validates) but a subtle divergence worth a one-line note.
+
+---
+
+## 3. Continuity-of-design assessment
+
+You asked whether the API is **complete**, **consistent**, and shows **continuity of
+design**. Honest scorecard:
+
+- **Complete — yes, with two narrow holes.** Every pipeline stage has a command; every
+  current source has a fetch/agg command, a pixi wrapper, and a doc page. The holes
+  are (a) the maintenance/catch-up verbs are present but undiscoverable (Tier 3
+  #14–15), and (b) the `release` subsystem is undocumented for users (#16) and
+  under-documented in the API reference (#17).
+
+- **Consistent — mostly, fraying at the manifest/config seam.** The build verbs
+  (`fetch`/`agg`/`run`/`catalog`) are clean and parallel. The friction is concentrated
+  in (a) the maintenance-verb naming not tracking mutate-vs-report (#6), (b) the `-d`
+  alias and `--scope source/sources` asymmetries (#7, #8), and (c) the
+  `--source`/`--source-key`/positional three-spelling of one concept (#8). None are
+  fatal; all are the kind of thing that erodes a successor's trust that the surface was
+  designed as a whole.
+
+- **Continuity of design — this is the weakest axis, and it's the one your scenario
+  cares most about.** The breaks are exactly where the codebase *evolved*:
+  `reconcile-manifest` → `rebuild-manifest` (#1), single-source SCA → two-source (#3,
+  #12), the ua_swe #237 addition (#3, #4, #11). Each refactor updated the code and the
+  developer guide but left a stale fingerprint on the operator-facing surface. **The
+  Documentation Sync Gate in `CLAUDE.md` is the right mechanism; it just hasn't been
+  applied to `docs/index.md`, the mkdocs nav, and `config/pipeline.yml` on the last two
+  feature waves.**
+
+**The road not taken / reviewer's question for you:** the deepest structural choice
+here is whether the maintenance verbs (`upgrade-*`, `rebuild-manifest`, `rechunk`)
+should become a `manifest`/`maintenance` **sub-app** (mirroring `fetch`/`agg`/`release`),
+so `nhf-targets maintenance --help` reads as a coherent group and the rename to
+`manifest rebuild` / `manifest upgrade` makes the report-vs-mutate distinction a
+namespace property rather than a verb-mood guess. That's a breaking change to the CLI
+grammar, so it belongs in a deliberate decision, not a doc fixup — flagged here as the
+one architectural lever worth your judgment.
+
+---
+
+## 4. Recommended fix sequence
+
+**Fix-now (same PR, mechanical, no design decisions — closes every Tier-1 wrong
+recipe):**
+1. `CLAUDE.md:322-324` → replace `reconcile-manifest` with `rebuild-manifest` (#1).
+2. `init_run.py` CDS template → single-PAT format + one-line "Personal Access Token"
+   note (#2).
+3. `docs/index.md` → refresh SCA (two-source) and SWE (5-source) descriptions (#3);
+   `README.md:646` SCA row (#12).
+4. `mkdocs.yml` → add `sources/ua_swe.md` and the `data_release/*.md` pages to nav (#4,
+   #19).
+5. `README.md` → add `fetch-ua-swe` to Quick-Start, fix "14"→"15" agg-array prose; same
+   in `slurm/shared/agg_all.body.sh:7` (#11).
+6. `README.md` HPC section → explicit "on caldera, pass `--account=impd`" callout (#5).
+
+**Roadmap (a planned doc PR — net-new operator material):**
+7. Add an **operator catch-up guide** (a `docs/` page or a README section) with the
+   three concrete sequences for new-config-key / new-source / new-manifest-field
+   (#14). Mirror the existing developer checklists.
+8. Add `slurm/project_gfv2/README.md` mirroring `project_or/` (#13).
+9. Reconcile `config/pipeline.yml` with `_CONFIG_TEMPLATE` — at minimum add
+   `datastore`, `dir_mode`, `buffer_deg` (#9). (Or: retire `pipeline.yml` and point the
+   reference at `init_run.py`, if the four-point rule is more cost than value now.)
+10. Extend `docs/api/` to the provenance/release/validation modules (#17); add a `release`
+    section to user docs (#16).
+11. Mark required keys in the in-file config template; flag the `validate`-needs-NASA-creds
+    requirement in getting-started (#10, #18).
+
+**File-issue (CLI-grammar decisions — need your call, don't fix in a doc PR):**
+12. `-d` alias on `fetch`/`agg` (#7); `--scope source`→`sources` on `release publish`
+    (#8); the `maintenance` sub-app / verb-rename question (#6 + §3 road-not-taken).
+    These are breaking or near-breaking; batch them behind a deprecation note.
+
+---
+
+## Appendix: one refuted claim
+
+An earlier pass flagged the `pixi run nhf-targets agg <src> …` form in `CLAUDE.md:29-42`
+as a broken recipe (no `nhf-targets` pixi *task* exists). **Refuted:** `nhf-targets` is
+an installed console script ([pyproject.toml:28](../../pyproject.toml#L28)) and
+`pixi run <cmd>` executes any binary in the environment, not only named tasks — so the
+form runs. It is merely a *style* inconsistency with the `pixi run agg-<src>` task
+wrappers documented elsewhere (two valid invocation styles coexist), not a failure.
+Recorded so it isn't re-raised.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - Daymet: sources/daymet.md
       - SNODAS: sources/snodas.md
       - Margulis WUS-SR: sources/margulis_wus_sr.md
+      - UA SWE: sources/ua_swe.md
       - SSEBop: sources/ssebop.md
   - References:
       - TM 6-B10 crib sheet: references/tm6b10-summary.md
@@ -136,6 +137,11 @@ nav:
       - Known gaps resolved: references/known-gaps-resolved.md
       - Target period coverage: references/target-period-coverage.md
       - Lessons learned: references/lessons-learned.md
+  - Data release:
+      - Overview: data_release/README.md
+      - USGS data release process: data_release/usgs-process.md
+      - FGDC field map: data_release/fgdc-field-map.md
+      - sciencebasepy notes: data_release/sciencebasepy-notes.md
   - API reference:
       - Overview: api/index.md
       - Catalog: api/catalog.md

--- a/slurm/shared/agg_all.body.sh
+++ b/slurm/shared/agg_all.body.sh
@@ -4,7 +4,8 @@
 # PROJECT_DIR + REPO_DIR. Keeping the task array + dispatch here means the two
 # fabrics differ only in their wrapper's PROJECT_DIR default.
 #
-# Submits one SLURM array task per aggregation source (14 total). SSEBop is the
+# Submits one SLURM array task per aggregation source (15 total, indices 0–14).
+# SSEBop is the
 # remote-STAC aggregator and has its own script (slurm/shared/agg_ssebop.slurm).
 # Daymet has its own script too (slurm/shared/agg_daymet.slurm) because it
 # requires a --region argument plus an operator-staged zarr root.

--- a/src/nhf_spatial_targets/init_run.py
+++ b/src/nhf_spatial_targets/init_run.py
@@ -211,9 +211,13 @@ _CREDENTIALS_TEMPLATE = {
         "password": "",
     },
     "cds": {
-        "_comment": "Copernicus CDS API — https://cds.climate.copernicus.eu",
+        "_comment": (
+            "Copernicus CDS API — paste the Personal Access Token shown on "
+            "https://cds.climate.copernicus.eu/profile (a single token; the "
+            "current CDS endpoint no longer uses the legacy '<uid>:<key>' form)"
+        ),
         "url": "https://cds.climate.copernicus.eu/api",
-        "key": "<uid>:<key>",
+        "key": "<personal-access-token>",
     },
 }
 


### PR DESCRIPTION
Closes #312.

## What

Adds a full **public-API & operator-documentation evaluation** (`docs/reviews/2026-06-10-public-api-evaluation.md`) aimed at a successor maintainer, and closes the six **Tier-1 "fix-now"** items it surfaced — places where a documented recipe was wrong or actively misleading.

## The six fixes

1. **`CLAUDE.md`** documented the removed `reconcile-manifest` command → now points to `rebuild-manifest` (which subsumed it in #279).
2. **`init_run.py`** CDS credential template used the stale `<uid>:<key>` form against the single-PAT endpoint → now a single Personal Access Token with a self-documenting comment.
3. **`docs/index.md`** SCA/SWE source rows were pre-#237 stale (single-source SCA, missing UA SWE); the README implementation-status SCA/SWE rows are refreshed to match.
4. **`mkdocs.yml`** nav un-orphans `docs/sources/ua_swe.md` and the four `docs/data_release/*` pages (both were unreachable and would trip the documented `--strict` build).
5. **`README.md`** HPC section gains an explicit `--account=impd` callout — mandatory on caldera, where the `default` account is rejected with `AssocMaxSubmitJobLimit`.
6. **`README.md`** Quick-Start adds `fetch-ua-swe` (a default source in two targets, previously omitted); the "14"→"15" agg/fetch array-size prose is corrected (verified 15 tasks, indices 0–14) in the README and `slurm/shared/agg_all.body.sh`.

## Root cause (see the evaluation doc §1)

All six share one cause: **load-bearing operator knowledge lived in `CLAUDE.md` / `MEMORY` / committed SLURM scripts, not in the artifact the operator edits or the page they read.** The fixes move each fact to the operator-facing surface.

## Not in this PR

The evaluation's **roadmap** items (operator catch-up guide, `slurm/project_gfv2/README.md`, `config/pipeline.yml` reconciliation, API-reference coverage) and **CLI-grammar** items (`-d` alias on fetch/agg, `--scope source`→`sources`, the maintenance-verb sub-app question) are filed as follow-up issues — they need design decisions or net-new material, not a doc-sync edit.

## Verification

- `pixi run -e dev fmt` + `lint` pass; pre-commit hooks pass.
- The `init_run.py` change touches `_CREDENTIALS_TEMPLATE`; no test asserts the literal key value (`test_credentials.py` uses its own fixtures and `materialize_cdsapirc` writes any string verbatim), so no test change is required.
- One earlier "broken recipe" claim (`pixi run nhf-targets agg …`) was **refuted** on verification and recorded as such in the doc appendix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)