### PR TITLE
docs(#314): operator catch-up guide + expose maintenance verbs as pixi tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,14 @@ pixi run nhf-targets agg all          --project-dir /data/nhf-runs/my-run
 pixi run catalog-sources
 pixi run catalog-variables
 
+# Existing-project catch-up / maintenance (see docs/maintenance.md).
+# upgrade-* are report-only; rebuild-manifest / rechunk regenerate derived
+# artifacts. Re-run validate after any config.yml edit (publish gate is fatal).
+pixi run upgrade-config   -- --project-dir /data/nhf-runs/my-run
+pixi run upgrade-manifest -- --project-dir /data/nhf-runs/my-run
+pixi run rebuild-manifest -- --project-dir /data/nhf-runs/my-run
+pixi run rechunk          -- --project-dir /data/nhf-runs/my-run --dry-run
+
 # Development (requires dev environment: pixi install -e dev)
 pixi run -e dev test          # pytest (excludes integration tests)
 pixi run -e dev test-integration  # integration tests (requires credentials/network)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ The fabric file must contain a polygon geometry column and a unique integer HRU 
 | 6 | `nhf-targets agg <source> --project-dir <dir>` | Aggregates source data to HRU fabric. SSEBop and Daymet take an explicit `--period` (remote STAC / multi-year zarr); others infer the period from available years on disk. |
 | 7 | `nhf-targets run --project-dir <dir>` | Builds all six calibration targets (runoff, AET, recharge, soil moisture, SCA, SWE) from aggregated data. Pass `--target <key>` to build a single target. |
 
+**Maintaining an existing project.** When a `git pull` brings a new config key, a new
+source, a new manifest field, or a storage-layout change, you bring an existing project
+up to date with the report-only `upgrade-config` / `upgrade-manifest` commands and the
+regenerating `rebuild-manifest` / `rechunk` / `validate` commands — never by re-`init`ing.
+The catch-up sequences and the one ordering rule that bites (re-run `validate` after any
+`config.yml` edit, or the publish gate fails) are documented in
+[docs/maintenance.md](docs/maintenance.md).
+
 **Key paths:**
 
 - `<project>/config.yml` — project configuration (fabric, datastore, daymet_root, targets, dir_mode)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,6 +89,7 @@ pixi run run-swe    -- --project-dir /data/my-targets
 
 ## Where to go next
 
+- [Maintaining an existing project](maintenance.md) — catching a project up after a pull adds a config key / source / manifest field, and the `validate`-after-config-edit rule
 - [Architecture · Transformation pipeline](architecture/transformation-pipeline.md) — pre/post-aggregation policy, `mean` vs `masked_mean`, canonical row order
 - [Architecture · Python patterns](architecture/python-patterns.md) — `from __future__ import annotations`, atomic writes, fingerprint caches, why every module looks the way it does
 - [Sources](sources/index.md) — per-source operator notes for every gridded dataset

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,150 @@
+# Maintaining an existing project
+
+A project directory (`config.yml`, `fabric.json`, `manifest.json`, the aggregated
+and target NetCDFs) is a long-lived audit trail — you never delete it and you never
+re-`init` it. But the pipeline keeps evolving: a `git pull` can bring a new config
+key, a new source dataset, a new manifest field, or a storage-layout change. This
+page is the **operator's** guide to bringing an existing project up to date without
+losing hand-authored intent or already-fetched data.
+
+> It is the mirror image of the **developer** checklists in `CLAUDE.md`
+> ("Config schema additions", "When you add a source / variable / target / stage").
+> Those tell the person *adding* an element what to change in the codebase; this tells
+> the person *running* a project how to absorb that change afterward.
+
+## The durability split (why catch-up is safe)
+
+Project artifacts fall into two kinds with opposite rules. Catch-up only ever
+regenerates the **derived** kind; it never touches your **intent**.
+
+| Kind | Artifacts | Catch-up rule |
+|---|---|---|
+| **Intent** (hand-authored) | `config.yml`, `catalog/` | Edited only by *you*, by hand. The report-only commands below tell you what to paste; they never write to these files. |
+| **Derived** (a projection) | `manifest.json`, `config.effective.yml`, `fabric.json` | Regenerated from disk + catalog + intent. Never hand-edited. `validate` and `rebuild-manifest` own these. |
+
+## The maintenance commands
+
+Five commands, plus `validate`. The verbs split into **report-only** (safe to run any
+time; they only print) and **regenerating** (they rewrite a *derived* artifact, never
+your intent):
+
+| Command | Kind | Reads | Writes | Use when |
+|---|---|---|---|---|
+| `upgrade-config` | report-only | `config.yml`, defaults, catalog | nothing (prints stubs) | after a pull that may add optional config keys / targets / sources |
+| `upgrade-manifest` | report-only | `manifest.json` | nothing (prints status) | to check whether the manifest schema is behind |
+| `validate` | regenerates | `config.yml`, fabric, catalog | `fabric.json`, `config.effective.yml`, `manifest.json` | after **any** `config.yml` edit, and before any release |
+| `rebuild-manifest` | regenerates | datastore × catalog, `data/aggregated/`, `targets/`, `fabric.json` | `manifest.json` | after fetching/aggregating new data, or to normalize a behind manifest |
+| `rechunk` | regenerates | `data/aggregated/`, `targets/` | rewrites those NCs in place | one-time backfill of NetCDFs built before the chunked-encoding policy (#165) |
+
+All five accept `--project-dir`/`-d`. The report-only pair **exit non-zero on drift**
+(0 = in sync), so you can wire them into a scripted heartbeat. `rebuild-manifest` and
+`rechunk` accept `--dry-run` to preview without writing.
+
+```bash
+pixi run upgrade-config    -- --project-dir /data/my-targets
+pixi run upgrade-manifest  -- --project-dir /data/my-targets
+pixi run rebuild-manifest  -- --project-dir /data/my-targets
+pixi run rechunk           -- --project-dir /data/my-targets --dry-run
+```
+
+> **Naming caveat.** `upgrade-config` and `upgrade-manifest` only *report* — they do
+> not upgrade anything. The actuator for the manifest is `rebuild-manifest`; the
+> actuator for config is `validate` (there is no `rebuild-config`). Reconciling the
+> verb names with this behavior is tracked in
+> [issue #319](https://github.com/rmcd-mscb/nhf-spatial-targets/issues/319).
+
+## The one ordering rule that bites
+
+After you edit `config.yml` — including pasting a stub from `upgrade-config` — you
+**must** re-run `validate` before you publish:
+
+```bash
+# edit config.yml ...
+pixi run validate -- --project-dir /data/my-targets
+```
+
+`validate` regenerates `config.effective.yml`, a hash-stamped projection of your
+`config.yml`. `release publish` has an **unconditionally fatal** preflight gate
+(`_preflight_effective_config_current`, no override flag) that refuses to publish if
+`config.effective.yml`'s recorded hash no longer matches the current `config.yml`
+bytes. If you edit config and forget to re-validate, the failure surfaces only later,
+at publish time, as a staleness error. Re-validating immediately after every config
+edit keeps you clear of it.
+
+## The three catch-up sequences
+
+### (a) A new config key landed
+
+A developer added an optional key to the init template and registered it in
+`upgrade_config.OPTIONAL_CONFIG_FEATURES`. Existing projects don't have it.
+
+```bash
+pixi run upgrade-config -- --project-dir /data/my-targets   # prints the commented stub to paste
+# paste the printed block into config.yml by hand
+pixi run validate -- --project-dir /data/my-targets         # regenerates config.effective.yml
+```
+
+`upgrade-config` also prints two informational tables when relevant: **targets in the
+defaults schema absent from your config** and **catalog sources available but not yet
+in your `targets.*.sources[]`** (the latter only if you pin explicit source lists).
+Neither affects the exit code — they are hints, not drift.
+
+### (b) A new source dataset landed
+
+A developer added a source to `catalog/sources.yml` plus its `fetch/` and `aggregate/`
+modules. To fold it into an existing project's targets:
+
+```bash
+pixi run upgrade-config -- --project-dir /data/my-targets   # "available catalog sources" hint
+# if you pin sources: add the new key to the relevant target's sources[] in config.yml, then:
+pixi run validate -- --project-dir /data/my-targets         # re-stamp config.effective.yml
+pixi run fetch-<src> -- --project-dir /data/my-targets      # download to the shared datastore
+pixi run agg-<src>   -- --project-dir /data/my-targets      # aggregate to this fabric
+pixi run rebuild-manifest -- --project-dir /data/my-targets # the new aggregated dir enters the projection
+pixi run run-<target> -- --project-dir /data/my-targets     # rebuild the affected target(s)
+```
+
+If your project uses the *default* source set for a target (no pinned `sources[]`),
+the new source is picked up automatically — skip the config edit and go straight to
+`fetch` → `agg` → `rebuild-manifest` → `run`.
+
+### (c) A new manifest field landed
+
+A developer bumped `CURRENT_MANIFEST_SCHEMA_VERSION` (the manifest's top-level *shape*
+changed).
+
+```bash
+pixi run upgrade-manifest  -- --project-dir /data/my-targets  # reports "schema vN; current is M"
+pixi run rebuild-manifest  -- --project-dir /data/my-targets  # re-stamps to the current schema
+```
+
+`rebuild-manifest` is a deterministic projection of what is on disk: it regenerates
+`sources` and `steps`, and **read-merges** identity fields (`created_utc`, the fabric
+authorship block, any `release` config) from the existing manifest rather than
+re-minting them. Same disk + catalog + code → byte-identical manifest.
+
+## One-time: backfill old NetCDF encoding
+
+Projects whose aggregated/target NetCDFs were built before the chunked-compressed
+encoding policy (#165) can reclaim disk and gain consistent chunking with a one-time,
+idempotent, value-preserving rewrite:
+
+```bash
+pixi run rechunk -- --project-dir /data/my-targets --dry-run   # preview: counts + candidate GB
+pixi run rechunk -- --project-dir /data/my-targets             # rewrite in place
+```
+
+`rechunk` leaves the shared datastore's consolidated NCs and the daymet/ssebop
+aggregated outputs untouched (intentionally unchunked, per #165). Restrict scope with
+`--layer aggregated|target` or `--source <key>`. See
+[Architecture · NetCDF encoding policy](architecture/nc-encoding-policy.md) for the
+per-layer rationale.
+
+## New project against an existing datastore
+
+Pointing a brand-new fabric project at a datastore that another project already
+populated is the same gap-fill: after `init` → edit `config.yml` → `validate`, the raw
+downloads are already present, so you skip `fetch`, run `agg-*` (or `agg-all`) to build
+this fabric's aggregated NCs, then `rebuild-manifest` to project them into
+`manifest.json`. (`rebuild-manifest` subsumed the former `reconcile-manifest`, removed
+in #279; see [Architecture · Reconcile manifest](architecture/reconcile-manifest.md).)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - Home: index.md
   - Getting started:
       - Quick start: getting-started.md
+      - Maintaining an existing project: maintenance.md
   - Architecture:
       - Transformation pipeline: architecture/transformation-pipeline.md
       - NetCDF encoding policy: architecture/nc-encoding-policy.md

--- a/pixi.toml
+++ b/pixi.toml
@@ -169,6 +169,16 @@ run-som    = { cmd = "nhf-targets run --target soil_moisture" }
 run-sca    = { cmd = "nhf-targets run --target snow_covered_area" }
 run-swe    = { cmd = "nhf-targets run --target snow_water_equivalent" }
 
+# Existing-project catch-up / maintenance — pass --project-dir as extra arg.
+# See docs/maintenance.md for the catch-up sequences (new config key / source /
+# manifest field) and the validate-after-config-edit ordering rule.
+# upgrade-* are report-only (exit non-zero on drift); rebuild-manifest/rechunk
+# regenerate derived artifacts (both accept --dry-run).
+upgrade-config   = { cmd = "nhf-targets upgrade-config",   description = "Report optional-config features missing from a project's config.yml (report-only)" }
+upgrade-manifest = { cmd = "nhf-targets upgrade-manifest", description = "Report whether manifest.json predates the current schema (report-only)" }
+rebuild-manifest = { cmd = "nhf-targets rebuild-manifest", description = "Regenerate manifest.json as a deterministic projection of on-disk artifacts" }
+rechunk          = { cmd = "nhf-targets rechunk",          description = "Backfill aggregated/target NCs to the chunked+compressed layout (#165)" }
+
 # Fetch source data
 fetch-era5-land = { cmd = "nhf-targets fetch era5-land", description = "Download ERA5-Land data into a project datastore" }
 fetch-gldas = { cmd = "nhf-targets fetch gldas", description = "Download GLDAS-2 runoff data into a project datastore" }


### PR DESCRIPTION
Closes #314. Follow-up from the public-API evaluation ([docs/reviews/2026-06-10-public-api-evaluation.md](docs/reviews/2026-06-10-public-api-evaluation.md), Tier-3 #14/#15).

## Problem

The five maintenance verbs — `upgrade-config`, `upgrade-manifest`, `rebuild-manifest`, `rechunk`, and the `validate`-regenerates path — existed only as bare `nhf-targets` subcommands: **no pixi wrapper, no `--help` grouping, no operator-facing doc.** A successor catching an existing project up after a new element lands could only discover them by reading `cli/run.py`. The `CLAUDE.md` checklists cover the *developer adding* the element, not the *operator absorbing* it.

## What this PR does

- **`docs/maintenance.md`** — an operator-facing catch-up guide, the mirror image of the developer checklists. It covers:
  - the **intent vs derived** durability split (catch-up only ever regenerates derived artifacts);
  - a **report-only vs regenerating** command table (what each reads / writes / when to use it);
  - the **three catch-up sequences** — new config key, new source, new manifest field — as copy-pasteable command blocks;
  - the **one ordering rule that bites**: re-run `validate` after *any* `config.yml` edit, because `release publish`'s `_preflight_effective_config_current` gate is **unconditionally fatal** (no override) on a stale `config.effective.yml`;
  - the one-time `rechunk` backfill and the new-project-against-existing-datastore gap-fill.
- **`pixi.toml`** — adds `upgrade-config` / `upgrade-manifest` / `rebuild-manifest` / `rechunk` wrappers in a dedicated maintenance block (every other operator command already had one).
- **Wiring** — the guide is linked from the mkdocs nav, getting-started "Where to go next", the README workflow section, and the CLAUDE.md command list.

## Notes / deferrals

- The **verb-naming** problem (`upgrade-*` are report-only; there is no `rebuild-config`) is called out in the guide with a pointer to #319 (CLI-grammar decisions), where the `manifest` sub-app / rename question lives. This PR exposes and documents the verbs as-is; it does not rename them.
- No Python source changed → no test impact. The new pixi tasks map 1:1 to already-registered CLI commands (verified) and `pixi.toml` parses.

## Verification

- `pixi.toml` parses; the four new tasks resolve to registered CLI commands (`cli/run.py` `register`).
- `docs/maintenance.md` internal links (`architecture/nc-encoding-policy.md`, `architecture/reconcile-manifest.md`) resolve; the page is in the mkdocs nav (no orphan, `--strict`-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)