### PR TITLE
refactor(#319): unify CLI grammar; group maintenance verbs under a maintenance sub-app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,11 @@ pixi run catalog-sources
 pixi run catalog-variables
 
 # Existing-project catch-up / maintenance (see docs/maintenance.md).
-# upgrade-* are report-only; rebuild-manifest / rechunk regenerate derived
-# artifacts. Re-run validate after any config.yml edit (publish gate is fatal).
-pixi run upgrade-config   -- --project-dir /data/nhf-runs/my-run
-pixi run upgrade-manifest -- --project-dir /data/nhf-runs/my-run
+# All four live under the `nhf-targets maintenance` sub-app. check-* are
+# report-only; rebuild-manifest / rechunk regenerate derived artifacts.
+# Re-run validate after any config.yml edit (publish gate is fatal).
+pixi run check-config     -- --project-dir /data/nhf-runs/my-run
+pixi run check-manifest   -- --project-dir /data/nhf-runs/my-run
 pixi run rebuild-manifest -- --project-dir /data/nhf-runs/my-run
 pixi run rechunk          -- --project-dir /data/nhf-runs/my-run --dry-run
 
@@ -81,7 +82,8 @@ catalog/           # YAML data source registry and variable definitions
 src/nhf_spatial_targets/
   _logging.py      # Structured logging setup
   catalog.py       # Python API for catalog/ YAML files
-  cli.py           # Cyclopts CLI: nhf-targets init | materialize-credentials | validate | run | fetch | catalog
+  cli/             # Cyclopts CLI: init | materialize-credentials | validate | run
+                   #   + sub-apps: fetch | agg (alias: aggregate) | catalog | release | maintenance
   credentials.py   # materialize_cdsapirc / materialize_netrc_earthdata helpers
   defaults.py      # Default config schema and merge logic
   workspace.py     # Project path resolution, Project dataclass, make_dir()
@@ -122,9 +124,9 @@ duplicate kept drifting out of step with the template.
    line) appears in the rendered template.
 3. **`src/nhf_spatial_targets/upgrade_config.py:OPTIONAL_CONFIG_FEATURES`**
    — append an `OptionalConfigFeature` entry so existing-project operators
-   discover the addition via `nhf-targets upgrade-config -d <dir>`.
+   discover the addition via `nhf-targets maintenance check-config -d <dir>`.
 
-`upgrade-config` is **report-only** — it never mutates an operator's
+`maintenance check-config` is **report-only** — it never mutates an operator's
 `config.yml`; it prints what's missing and the literal block to paste.
 
 ## Manifest & config durability
@@ -134,13 +136,13 @@ blur them (issue #279).
 
 | Kind | Artifacts | Rule |
 |---|---|---|
-| **Intent** (hand-authored) | `config.yml`, `catalog/` | Never auto-clobbered by development. Non-destructively upgradable (report-only: `upgrade-config`, `upgrade-manifest`). **Validated against the catalog so dangling refs fail loudly** (`validate` rejects a `targets.*.sources[]` key absent from, or superseded in, `sources.yml`). |
+| **Intent** (hand-authored) | `config.yml`, `catalog/` | Never auto-clobbered by development. Non-destructively upgradable (report-only: `maintenance check-config`, `maintenance check-manifest`). **Validated against the catalog so dangling refs fail loudly** (`validate` rejects a `targets.*.sources[]` key absent from, or superseded in, `sources.yml`). |
 | **Derived** (a projection) | `manifest.json`, `config.effective.yml`, `fabric.json` | Regenerable as a pure projection. Version-stamped. **Staleness-gated at publish.** Never hand-edited. |
 
 The core invariant:
 
 > `manifest.json` = a deterministic projection of (on-disk artifacts × current
-> catalog × `fabric.json`). `rebuild-manifest` is authoritative; live capture
+> catalog × `fabric.json`). `maintenance rebuild-manifest` is authoritative; live capture
 > (during `agg`/`run`) is a fast path the projection can always reproduce.
 
 `config.effective.yml` is the same kind of artifact for config: a
@@ -216,7 +218,7 @@ Modeled on the three-point "Config schema additions" checklist above:
 - Mark superseded sources with `superseded_by:` key and `status: superseded`
 - Fabric-restricted sources (e.g. Margulis WUS-SR for Oregon) carry an optional `fabric_scope: {fabrics: [<token>], notes: ...}` block. Allowed fabric tokens are enumerated by `catalog.FABRIC_SCOPE_TOKENS` and validated by `catalog.validate_fabric_scope`; adding a new fabric means extending that set and the matching check in target builders. Raw downloads remain reusable across projects sharing a datastore — `fabric_scope` is enforced at the target-build stage, not at fetch time
 - **CF-1.6 compliance is required for every NetCDF the pipeline writes** — consolidated source NCs in `<datastore>/<source>/{daily,monthly}/`, aggregated NCs in `<project>/data/aggregated/`, and final target NCs in `<project>/targets/`. Use `fetch/consolidate.py:apply_cf_metadata` as the single entry point for setting `Conventions=CF-1.6`, variable `units` / `long_name` / `cell_methods` / `grid_mapping` from the catalog, coordinate `standard_name` / `units` / `axis`, and the WGS84 `crs` ancillary variable. Do not set these attrs by hand in source-specific code — read everything from `catalog/sources.yml` so a unit correction in the catalog flows through every NC on the next consolidate. Each fetch/consolidate module should have a test that asserts the output NC carries the required CF-1.6 attribute set.
-- **Never write a NetCDF with a bare `ds.to_netcdf(...)`.** Route every pipeline-written NC (aggregated, target) through `io_nc.build_encoding` + `io_nc.atomic_to_netcdf` so it gets the canonical chunking + zlib + pinned-time encoding. The full per-layer policy, the HDF5 partial-chunk rationale, and the `nhf-targets rechunk` backfill are in [docs/architecture/nc-encoding-policy.md](docs/architecture/nc-encoding-policy.md). `build_encoding(layer="consolidated", ...)` is a seam owned by issue #158 and currently raises; daymet/ssebop aggregated outputs are intentionally left unchunked.
+- **Never write a NetCDF with a bare `ds.to_netcdf(...)`.** Route every pipeline-written NC (aggregated, target) through `io_nc.build_encoding` + `io_nc.atomic_to_netcdf` so it gets the canonical chunking + zlib + pinned-time encoding. The full per-layer policy, the HDF5 partial-chunk rationale, and the `nhf-targets maintenance rechunk` backfill are in [docs/architecture/nc-encoding-policy.md](docs/architecture/nc-encoding-policy.md). `build_encoding(layer="consolidated", ...)` is a seam owned by issue #158 and currently raises; daymet/ssebop aggregated outputs are intentionally left unchunked.
 - **Canonical row order on every fabric-aligned artifact is `id_col` ascending**, enforced at emission (issue #93). Aggregator (`aggregate/_driver.py`, `aggregate/ssebop.py`) sorts `year_ds` by `id_col` immediately before `_atomic_write_netcdf`; target writers call `write_target_nc(..., sort_dim=project.id_col)`. `validate` records `id_col_sorted: bool` on `fabric.json` / `manifest.json` and warns when the source `.gpkg` is not monotonic (it does not fail — the aggregator canonicalizes anyway). `read_aggregated_source` keeps a defensive `.sortby(id_col)` for pre-#93 NCs already on disk. Downstream code may rely on positional alignment without runtime checks; full reasoning is in [docs/architecture/transformation-pipeline.md](docs/architecture/transformation-pipeline.md#canonical-row-order-on-emission).
 
 ## Aggregation Transformation Policy
@@ -331,7 +333,7 @@ The pipeline separates **projects** (fabric-specific) from the **datastore** (sh
 6. `nhf-targets agg ssebop --project-dir <project-dir>` aggregates remote data to fabric
 7. `nhf-targets run --project-dir <project-dir>` builds calibration targets
 
-- `nhf-targets rebuild-manifest --project-dir <dir>` regenerates `manifest.json`
+- `nhf-targets maintenance rebuild-manifest --project-dir <dir>` regenerates `manifest.json`
   as a deterministic projection of (on-disk artifacts × catalog × `fabric.json`).
   This subsumes the former `reconcile-manifest` (removed in #279); it also covers
   the gap-fill case of a new project pointed at an existing shared datastore. See

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ shows the multi-variant pattern (monthly + annual emit).
    and `OPTIONAL_CONFIG_FEATURES` in
    [`src/nhf_spatial_targets/upgrade_config.py`](src/nhf_spatial_targets/upgrade_config.py)
    so existing-project operators find the new keys via
-   `nhf-targets upgrade-config` (see `CLAUDE.md` §Config schema additions).
+   `nhf-targets maintenance check-config` (see `CLAUDE.md` §Config schema additions).
 10. **Inspect notebook** — copy
     [`notebooks/targets/inspect_target_swe.ipynb`](notebooks/targets/inspect_target_swe.ipynb)
     to `notebooks/targets/inspect_target_<target>.ipynb` and retarget the

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The fabric file must contain a polygon geometry column and a unique integer HRU 
 
 **Maintaining an existing project.** When a `git pull` brings a new config key, a new
 source, a new manifest field, or a storage-layout change, you bring an existing project
-up to date with the report-only `upgrade-config` / `upgrade-manifest` commands and the
+up to date with the report-only `check-config` / `check-manifest` commands and the
 regenerating `rebuild-manifest` / `rechunk` / `validate` commands — never by re-`init`ing.
 The catch-up sequences and the one ordering rule that bites (re-run `validate` after any
 `config.yml` edit, or the publish gate fails) are documented in
@@ -495,7 +495,7 @@ nhf-spatial-targets/
 │   ├── extract_geofabric.ipynb
 │   └── debug_mod16a2_agg.ipynb
 ├── src/nhf_spatial_targets/
-│   ├── cli.py               # nhf-targets CLI (cyclopts)
+│   ├── cli/                 # nhf-targets CLI (cyclopts; fetch/agg/catalog/release/maintenance sub-apps)
 │   ├── _logging.py          # structured logging setup
 │   ├── catalog.py           # catalog interface to YAML files
 │   ├── credentials.py       # ~/.cdsapirc and ~/.netrc materialisation

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -23,7 +23,7 @@ ScienceBase release (`CLAUDE.md` §Manifest & config durability).
 | `validate` | [Validate](validate.md) | Preflight checks; writes `fabric.json` + `config.effective.yml` (the config actuator) |
 | `rebuild_manifest` | [Rebuild manifest](rebuild-manifest.md) | `manifest.json` as a deterministic projection of (disk × catalog × `fabric.json`) |
 | `release.lineage` | [Lineage](lineage.md) | Shared manifest skeleton, step kinds, `mtime`-derived timestamps |
-| `upgrade_config` | [Upgrade config](upgrade-config.md) | Report-only optional-config drift; the paste-this block |
+| `upgrade_config` | [Upgrade config](upgrade-config.md) | Report-only optional-config drift (`maintenance check-config`); the paste-this block |
 | `rechunk` | [Rechunk](rechunk.md) | Idempotent backfill of NCs to the canonical chunk/compress layout |
 | `fetch.consolidate` | [Consolidate](consolidate.md) | `apply_cf_metadata` — the single CF-1.6 metadata entry point |
 | `release` | [Release package](release.md) | ScienceBase data-release subsystem (build → dry-run → publish) |

--- a/docs/api/rechunk.md
+++ b/docs/api/rechunk.md
@@ -3,7 +3,7 @@
 `nhf_spatial_targets.rechunk` backfills already-written aggregated and target
 NetCDFs to the canonical chunking + compression layout (the #165 policy in
 [`docs/architecture/nc-encoding-policy.md`](../architecture/nc-encoding-policy.md)).
-It is the actuator behind `nhf-targets rechunk`.
+It is the actuator behind `nhf-targets maintenance rechunk`.
 
 Every conversion is **idempotent** (already-canonical files are skipped),
 **atomic** (tmp file + rename), and **value-preserving** (each variable is

--- a/docs/api/upgrade-config.md
+++ b/docs/api/upgrade-config.md
@@ -1,7 +1,7 @@
 # Upgrade config
 
 `nhf_spatial_targets.upgrade_config` is the operator-facing drift report behind
-`nhf-targets upgrade-config`. Existing projects don't pick up new optional
+`nhf-targets maintenance check-config`. Existing projects don't pick up new optional
 config features added to the init template after they were created; this module
 lists what's missing and prints the literal commented block to paste.
 

--- a/docs/architecture/nc-encoding-policy.md
+++ b/docs/architecture/nc-encoding-policy.md
@@ -28,7 +28,7 @@ tells you to route through `io_nc` instead, and why.
 - **Pin time** to `units="days since 1970-01-01 00:00:00"`,
   `calendar="proleptic_gregorian"`, `dtype="float64"` on `time`/`time_bnds`,
   on every layer.
-- **Backfill existing files** with `nhf-targets rechunk` rather than
+- **Backfill existing files** with `nhf-targets maintenance rechunk` rather than
   re-aggregating.
 
 ## The principle
@@ -78,13 +78,13 @@ would force the compressor to re-inflate every on-disk chunk on every time
 slab — ~30× read amplification on a daily source. Full-time dask chunks read
 each on-disk chunk exactly once.
 
-## Migration: `nhf-targets rechunk`
+## Migration: `nhf-targets maintenance rechunk`
 
 The writers only chunk NCs they newly write. Projects built before this work
 hold contiguous, uncompressed NCs. Backfill them in place:
 
 ```bash
-nhf-targets rechunk --project-dir <dir> [--layer aggregated|target] [--source <key>] [--dry-run]
+nhf-targets maintenance rechunk --project-dir <dir> [--layer aggregated|target] [--source <key>] [--dry-run]
 ```
 
 It is **idempotent** (skips files already fully chunked), **atomic**

--- a/docs/architecture/python-patterns.md
+++ b/docs/architecture/python-patterns.md
@@ -9,8 +9,8 @@ If you are new to the repo and have Python experience but limited software-engin
 | Pattern | Where to look | Why it's there |
 |---|---|---|
 | `from __future__ import annotations` (every module) | top of any `.py` | Cheap, modern type-annotation syntax (`X \| Y`) without runtime cost |
-| `if TYPE_CHECKING:` import guards | [`cli.py:12-13`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli.py#L12-L13) | Heavy imports only at type-check time, never at runtime |
-| `Annotated[Type, Parameter(...)]` cyclopts wiring | every `@app.command` in [`cli.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli.py) | CLI help text lives next to the parameter; no separate argparse spec |
+| `if TYPE_CHECKING:` import guards | [`cli/run.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli/run.py) | Heavy imports only at type-check time, never at runtime |
+| `Annotated[Type, Parameter(...)]` cyclopts wiring | every command in the [`cli/`](https://github.com/rmcd-mscb/nhf-spatial-targets/tree/main/src/nhf_spatial_targets/cli) package | CLI help text lives next to the parameter; no separate argparse spec |
 | `@dataclass(frozen=True)` plugin adapters | [`aggregate/_adapter.py:SourceAdapter`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/aggregate/_adapter.py) | Declarative source plugins; immutable singletons safe to share |
 | Atomic file writes (tempfile + `os.replace`) | [`io_nc.py:atomic_to_netcdf`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/io_nc.py) | Crashed jobs never leave partial NetCDFs that look valid |
 | Manifest read-merge-write under `flock` | [`release/lineage.py:merge_source_and_append_step`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/release/lineage.py) | Concurrent SLURM array jobs can't clobber each other's manifest writes |
@@ -29,7 +29,7 @@ If you are new to the repo and have Python experience but limited software-engin
 
 ## 2. `if TYPE_CHECKING:` import guards
 
-**What:** Some imports live inside an `if TYPE_CHECKING:` block at the top of a module. Example from [`cli.py:12-13`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli.py#L12-L13):
+**What:** Some imports live inside an `if TYPE_CHECKING:` block at the top of a module. Example from [`cli/run.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli/run.py):
 
 ```python
 from typing import TYPE_CHECKING, Annotated
@@ -40,14 +40,14 @@ if TYPE_CHECKING:
 
 **Why:** `TYPE_CHECKING` is `False` at runtime and `True` only when a static type checker (mypy, pyright) is reading the file. So the import inside the guard runs at type-check time but never at runtime. Two reasons we use it:
 
-1. **Avoid circular imports.** `cli.py` references `Project` in annotations but `workspace.py` may transitively import something from `cli.py`. The guard keeps the type reference without creating a runtime cycle.
+1. **Avoid circular imports.** `cli/run.py` references `Project` in annotations but `workspace.py` may transitively import something from the `cli` package. The guard keeps the type reference without creating a runtime cycle.
 2. **Avoid heavy imports.** When a module only needs a class for annotations, not at runtime, the guard prevents loading geopandas / xarray / etc. just to declare a signature.
 
 **How to extend:** use the guard when an import is only needed for type annotations. Pair it with `from __future__ import annotations` (which makes the annotation a string at runtime, so the guarded import is never resolved at runtime). For runtime-needed imports, never use the guard.
 
 ## 3. `Annotated[Type, Parameter(...)]` cyclopts wiring
 
-**What:** Every CLI command in `cli.py` annotates its parameters with `Annotated[Type, Parameter(...)]` instead of using a separate argparse-style spec. Example:
+**What:** Every CLI command in the `cli/` package annotates its parameters with `Annotated[Type, Parameter(...)]` instead of using a separate argparse-style spec. Example:
 
 ```python
 workdir: Annotated[
@@ -58,7 +58,7 @@ workdir: Annotated[
 
 **Why:** cyclopts (our CLI framework) inspects the `Annotated` metadata to build the parser. The parameter's flag name, alias, and help string live **next to the type** rather than in a parallel declaration. The function signature is the single source of truth — no risk of the help text drifting away from the implementation.
 
-**How to extend:** when adding a new CLI command, use `Annotated[<concrete-type>, Parameter(name=..., help=...)] = <default>` for each parameter. Defaults live on the function signature (so type checkers see them); cyclopts reads `name` and `help` from the `Parameter` metadata. For parameters reused across commands (e.g. `--batch-size` on every `agg` subcommand), pull the `Parameter` into a module-level alias and reference it — see `_AGG_BATCH_SIZE_PARAM` in [`cli.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli.py).
+**How to extend:** when adding a new CLI command, use `Annotated[<concrete-type>, Parameter(name=..., help=...)] = <default>` for each parameter. Defaults live on the function signature (so type checkers see them); cyclopts reads `name` and `help` from the `Parameter` metadata. For parameters reused across commands (e.g. `--batch-size` on every `agg` subcommand), pull the `Parameter` into a module-level alias and reference it — see `_AGG_BATCH_SIZE_PARAM` and `_PROJECT_DIR_PARAM` in [`cli/_params.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/cli/_params.py).
 
 ## 4. `@dataclass(frozen=True)` plugin adapters
 

--- a/docs/architecture/reconcile-manifest.md
+++ b/docs/architecture/reconcile-manifest.md
@@ -1,7 +1,7 @@
 # reconcile-manifest (removed — superseded by `rebuild-manifest`)
 
 > **`nhf-targets reconcile-manifest` no longer exists.** It was removed in
-> issue #279 (PR-2) and replaced by `nhf-targets rebuild-manifest`.
+> issue #279 (PR-2) and replaced by `nhf-targets maintenance rebuild-manifest`.
 
 ## Why it was replaced
 
@@ -20,7 +20,7 @@ source uniformly, and it is byte-identical on re-run.
 ## What to run instead
 
 ```bash
-nhf-targets rebuild-manifest --project-dir <dir> [--compute-sha256] [--dry-run]
+nhf-targets maintenance rebuild-manifest --project-dir <dir> [--compute-sha256] [--dry-run]
 ```
 
 - **Sources** = the (datastore ∩ catalog) ∪ aggregated-dirs union. A dir whose

--- a/docs/data_release/walkthrough.md
+++ b/docs/data_release/walkthrough.md
@@ -59,17 +59,19 @@ nhf-targets release status -d $PROJ --scope all --token <sb-token>
 nhf-targets release publish -d $PROJ --scope fabric --confirm --token <sb-token>
 ```
 
-!!! warning "`publish` scope is singular (`--scope source`)"
-    `build` / `status` / `dry-run` take `--scope sources` (plural); `publish`
-    takes `--scope source` (singular) and needs `--source-key <key>` to name
-    the source. This asymmetry is tracked in #319.
+!!! note "Publishing a single source child"
+    Every subcommand spells the scope the same way (`--scope sources`); a
+    *confirmed* `publish --scope sources` additionally needs `--source <key>`
+    to name the one source child to publish (the singular `--scope source` /
+    `--source-key` spellings were removed in #319).
 
 ## The publish gate
 
 `publish` refuses to write when the on-disk `manifest.json` is incomplete or
 drifts from the [rebuild projection](../api/rebuild-manifest.md), or when
 `config.effective.yml` is stale relative to `config.yml` (you edited config
-without re-running `validate`). Regenerate with `nhf-targets rebuild-manifest`
-and `nhf-targets validate` rather than overriding. `--allow-incomplete-sources`
+without re-running `validate`). Regenerate with
+`nhf-targets maintenance rebuild-manifest` and `nhf-targets validate` rather
+than overriding. `--allow-incomplete-sources`
 is a deliberate, logged override for the source-completeness check only; the
 schema / fabric / steps checks stay fatal.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -20,7 +20,7 @@ regenerates the **derived** kind; it never touches your **intent**.
 | Kind | Artifacts | Catch-up rule |
 |---|---|---|
 | **Intent** (hand-authored) | `config.yml`, `catalog/` | Edited only by *you*, by hand. The report-only commands below tell you what to paste; they never write to these files. |
-| **Derived** (a projection) | `manifest.json`, `config.effective.yml`, `fabric.json` | Regenerated from disk + catalog + intent. Never hand-edited. `validate` and `rebuild-manifest` own these. |
+| **Derived** (a projection) | `manifest.json`, `config.effective.yml`, `fabric.json` | Regenerated from disk + catalog + intent. Never hand-edited. `validate` and `maintenance rebuild-manifest` own these. |
 
 ## The maintenance commands
 
@@ -30,32 +30,34 @@ your intent):
 
 | Command | Kind | Reads | Writes | Use when |
 |---|---|---|---|---|
-| `upgrade-config` | report-only | `config.yml`, defaults, catalog | nothing (prints stubs) | after a pull that may add optional config keys / targets / sources |
-| `upgrade-manifest` | report-only | `manifest.json` | nothing (prints status) | to check whether the manifest schema is behind |
+| `maintenance check-config` | report-only | `config.yml`, defaults, catalog | nothing (prints stubs) | after a pull that may add optional config keys / targets / sources |
+| `maintenance check-manifest` | report-only | `manifest.json` | nothing (prints status) | to check whether the manifest schema is behind |
 | `validate` | regenerates | `config.yml`, fabric, catalog | `fabric.json`, `config.effective.yml`, `manifest.json` | after **any** `config.yml` edit, and before any release |
-| `rebuild-manifest` | regenerates | datastore × catalog, `data/aggregated/`, `targets/`, `fabric.json` | `manifest.json` | after fetching/aggregating new data, or to normalize a behind manifest |
-| `rechunk` | regenerates | `data/aggregated/`, `targets/` | rewrites those NCs in place | one-time backfill of NetCDFs built before the chunked-encoding policy (#165) |
+| `maintenance rebuild-manifest` | regenerates | datastore × catalog, `data/aggregated/`, `targets/`, `fabric.json` | `manifest.json` | after fetching/aggregating new data, or to normalize a behind manifest |
+| `maintenance rechunk` | regenerates | `data/aggregated/`, `targets/` | rewrites those NCs in place | one-time backfill of NetCDFs built before the chunked-encoding policy (#165) |
 
-All five accept `--project-dir`/`-d`. The report-only pair **exit non-zero on drift**
-(0 = in sync), so you can wire them into a scripted heartbeat. `rebuild-manifest` and
-`rechunk` accept `--dry-run` to preview without writing.
+All five accept `--project-dir`/`-d`. The report-only `check-*` pair **exit non-zero
+on drift** (0 = in sync), so you can wire them into a scripted heartbeat.
+`rebuild-manifest` and `rechunk` accept `--dry-run` to preview without writing.
 
 ```bash
-pixi run upgrade-config    -- --project-dir /data/my-targets
-pixi run upgrade-manifest  -- --project-dir /data/my-targets
-pixi run rebuild-manifest  -- --project-dir /data/my-targets
-pixi run rechunk           -- --project-dir /data/my-targets --dry-run
+pixi run check-config     -- --project-dir /data/my-targets
+pixi run check-manifest   -- --project-dir /data/my-targets
+pixi run rebuild-manifest -- --project-dir /data/my-targets
+pixi run rechunk          -- --project-dir /data/my-targets --dry-run
 ```
 
-> **Naming caveat.** `upgrade-config` and `upgrade-manifest` only *report* — they do
-> not upgrade anything. The actuator for the manifest is `rebuild-manifest`; the
-> actuator for config is `validate` (there is no `rebuild-config`). Reconciling the
-> verb names with this behavior is tracked in
-> [issue #319](https://github.com/rmcd-mscb/nhf-spatial-targets/issues/319).
+> **Verb grammar.** The `check-*` commands only *report* — they never write. The
+> actuator for the manifest is `maintenance rebuild-manifest`; the actuator for
+> config is `validate` (there is no `rebuild-config`). The grouping and `check-*`
+> naming landed with
+> [issue #319](https://github.com/rmcd-mscb/nhf-spatial-targets/issues/319),
+> which renamed the former flat `upgrade-config` / `upgrade-manifest` /
+> `rebuild-manifest` / `rechunk` root commands.
 
 ## The one ordering rule that bites
 
-After you edit `config.yml` — including pasting a stub from `upgrade-config` — you
+After you edit `config.yml` — including pasting a stub from `check-config` — you
 **must** re-run `validate` before you publish:
 
 ```bash
@@ -79,12 +81,12 @@ A developer added an optional key to the init template and registered it in
 `upgrade_config.OPTIONAL_CONFIG_FEATURES`. Existing projects don't have it.
 
 ```bash
-pixi run upgrade-config -- --project-dir /data/my-targets   # prints the commented stub to paste
+pixi run check-config -- --project-dir /data/my-targets     # prints the commented stub to paste
 # paste the printed block into config.yml by hand
 pixi run validate -- --project-dir /data/my-targets         # regenerates config.effective.yml
 ```
 
-`upgrade-config` also prints two informational tables when relevant: **targets in the
+`check-config` also prints two informational tables when relevant: **targets in the
 defaults schema absent from your config** and **catalog sources available but not yet
 in your `targets.*.sources[]`** (the latter only if you pin explicit source lists).
 Neither affects the exit code — they are hints, not drift.
@@ -95,7 +97,7 @@ A developer added a source to `catalog/sources.yml` plus its `fetch/` and `aggre
 modules. To fold it into an existing project's targets:
 
 ```bash
-pixi run upgrade-config -- --project-dir /data/my-targets   # "available catalog sources" hint
+pixi run check-config -- --project-dir /data/my-targets     # "available catalog sources" hint
 # if you pin sources: add the new key to the relevant target's sources[] in config.yml, then:
 pixi run validate -- --project-dir /data/my-targets         # re-stamp config.effective.yml
 pixi run fetch-<src> -- --project-dir /data/my-targets      # download to the shared datastore
@@ -114,7 +116,7 @@ A developer bumped `CURRENT_MANIFEST_SCHEMA_VERSION` (the manifest's top-level *
 changed).
 
 ```bash
-pixi run upgrade-manifest  -- --project-dir /data/my-targets  # reports "schema vN; current is M"
+pixi run check-manifest    -- --project-dir /data/my-targets  # reports "schema vN; current is M"
 pixi run rebuild-manifest  -- --project-dir /data/my-targets  # re-stamps to the current schema
 ```
 

--- a/docs/superpowers/specs/2026-06-10-cli-grammar-design.md
+++ b/docs/superpowers/specs/2026-06-10-cli-grammar-design.md
@@ -1,0 +1,115 @@
+# CLI Grammar Consistency & Maintenance Sub-App — Design (issue #319)
+
+**Date:** 2026-06-10
+**Issue:** #319 — CLI grammar consistency (`-d` alias, `--scope source/sources`,
+source naming) + maintenance-verb structure
+**Source review:** `docs/reviews/2026-06-10-public-api-evaluation.md` Tier-2
+#6/#7/#8 + §3 road-not-taken.
+
+## Decisions (operator-confirmed)
+
+1. **Maintenance sub-app with `check-*` rename.** The four flat maintenance
+   verbs move under a new `nhf-targets maintenance` sub-app, and the two
+   report-only verbs are renamed so verb mood tracks behavior:
+
+   | Old (root) | New | Behavior |
+   |---|---|---|
+   | `upgrade-config` | `maintenance check-config` | report-only |
+   | `upgrade-manifest` | `maintenance check-manifest` | report-only |
+   | `rebuild-manifest` | `maintenance rebuild-manifest` | mutates `manifest.json` |
+   | `rechunk` | `maintenance rechunk` | mutates NCs in place |
+
+2. **Hard break — no deprecated aliases.** The old root spellings are removed
+   outright. Every committed reference (pixi tasks, SLURM scripts, docs,
+   CLAUDE.md, in-code messages) is updated in the same PR. Historical records
+   (`docs/superpowers/{specs,plans}`, `docs/reviews`) are point-in-time
+   documents and are NOT edited.
+
+3. **`release publish --scope sources` (rename only, same behavior).** The
+   publish scope value `source` becomes `sources`, matching
+   `build`/`status`/`dry-run`. Publishing a single source child still requires
+   the source-key flag; no publish-all-sources behavior is added.
+
+4. **`--source` is the canonical source-key flag.** `rechunk --source` is
+   already correct; `release publish --source-key` becomes `--source` (hard
+   break). The Python API keyword `source_key=` is internal and unchanged.
+
+## Additional in-scope items (from the issue checklist)
+
+- **`-d` alias on every `fetch` and `agg` command.** A shared
+  `_PROJECT_DIR_PARAM` (`name=["--project-dir", "-d"]`) moves into
+  `cli/_params.py`; `fetch.py`, `agg.py`, `release.py`, and the new
+  `maintenance.py` all use it (release already had its own copy — consolidated).
+- **`aggregate` alias for the `agg` sub-app** (additive; `agg` remains primary).
+- **`run --target` accepts the short nicknames** used by the pixi task names:
+  `rch` → `recharge`, `som` → `soil_moisture`, `sca` → `snow_covered_area`,
+  `swe` → `snow_water_equivalent` (long keys keep working; help text lists the
+  accepted vocabulary).
+- **App tagline** says `nhf-targets` (matching the binary) instead of
+  `nhf-spatial-targets`.
+
+## Out of scope
+
+- Renaming the Python implementation modules (`upgrade_config.py`,
+  `upgrade_manifest.py`) or their public functions — internal API, not CLI
+  grammar. The `docs/api/` pages keep their module focus; only the CLI
+  invocations shown in them change.
+- Publish-all-sources semantics for `release publish --scope sources`
+  (deliberately rejected to keep this PR behavior-neutral).
+- The `fetch` vs `agg` `--worker-index`/`-w` alias divergence (review Tier-4,
+  not in the issue checklist).
+
+## Architecture
+
+New module `src/nhf_spatial_targets/cli/maintenance.py`:
+
+- `maintenance_app = App(name="maintenance", help=...)` registered on the root
+  app in `cli/__init__.py`.
+- The four command bodies move verbatim from `cli/run.py` (no behavior
+  change beyond names): `check_config_cmd`, `check_manifest_cmd`,
+  `rebuild_manifest_cmd`, `rechunk`.
+- `cli/__init__.py` re-exports keep working for tests
+  (`rechunk`, `rebuild_manifest_cmd`, `check_config_cmd`, `check_manifest_cmd`).
+
+`cli/run.py` keeps `init`, `materialize-credentials`, `validate`, `run` and
+gains a `_TARGET_NICKNAMES` mapping applied before dispatch.
+
+`cli/release.py`: `--scope` literal sets become `{fabric, sources, umbrella}`
+for publish; `_PUBLISH_PREVIEW_SCOPE` keys updated; `--source-key` parameter
+renamed to `--source` (function kwarg `source_key` retained internally);
+error/help text updated. Domain-level `PublishResult.scope` literals
+(`"source"` etc.) are untouched.
+
+In-code operator messages that print old spellings are updated:
+`upgrade_manifest.py` ("run 'nhf-targets maintenance rebuild-manifest …'"),
+plus any `rebuild-manifest`/`rechunk` invocation strings in
+`release/publish.py`, `release/payload.py`, `rebuild_manifest.py`,
+`targets/_intermediates.py`, `fetch/margulis_wus_sr.py` (prose mentions of
+chunking stay).
+
+## Surface updates (hard-break sweep)
+
+- **pixi.toml:** tasks `upgrade-config` → `check-config`, `upgrade-manifest` →
+  `check-manifest`; all four cmds become `nhf-targets maintenance …`;
+  comment block updated.
+- **SLURM:** `slurm/project_gfv2/rechunk_gfv2*.slurm` and
+  `slurm/project_gfv2/README.md` use `nhf-targets maintenance rechunk`.
+- **Docs:** CLAUDE.md (commands, config-schema checklist, manifest section),
+  README.md, CONTRIBUTING.md, docs/maintenance.md, docs/api/{index,
+  rebuild-manifest, upgrade-config, rechunk, lineage}.md,
+  docs/architecture/{reconcile-manifest, nc-encoding-policy,
+  transformation-pipeline}.md, docs/data_release/{usgs-process,
+  walkthrough}.md, mkdocs.yml nav labels if they name commands.
+
+## Testing
+
+- Move/rename CLI-level tests: `test_upgrade_config.py` /
+  `test_upgrade_manifest.py` import from `cli.maintenance`;
+  `test_rechunk.py` re-export path unchanged.
+- `test_release_cli.py`: `--scope sources`, `--source`.
+- New coverage in `test_cli.py` / `test_cli_agg.py`:
+  - `maintenance <verb>` dispatches (all four),
+  - old root spellings now fail (hard-break guard),
+  - `-d` works on a representative `fetch` and `agg` command,
+  - `run --target rch` maps to `recharge`; unknown nickname still errors,
+  - `aggregate` aliases `agg`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -172,12 +172,12 @@ run-swe    = { cmd = "nhf-targets run --target snow_water_equivalent" }
 # Existing-project catch-up / maintenance — pass --project-dir as extra arg.
 # See docs/maintenance.md for the catch-up sequences (new config key / source /
 # manifest field) and the validate-after-config-edit ordering rule.
-# upgrade-* are report-only (exit non-zero on drift); rebuild-manifest/rechunk
+# check-* are report-only (exit non-zero on drift); rebuild-manifest/rechunk
 # regenerate derived artifacts (both accept --dry-run).
-upgrade-config   = { cmd = "nhf-targets upgrade-config",   description = "Report optional-config features missing from a project's config.yml (report-only)" }
-upgrade-manifest = { cmd = "nhf-targets upgrade-manifest", description = "Report whether manifest.json predates the current schema (report-only)" }
-rebuild-manifest = { cmd = "nhf-targets rebuild-manifest", description = "Regenerate manifest.json as a deterministic projection of on-disk artifacts" }
-rechunk          = { cmd = "nhf-targets rechunk",          description = "Backfill aggregated/target NCs to the chunked+compressed layout (#165)" }
+check-config     = { cmd = "nhf-targets maintenance check-config",     description = "Report optional-config features missing from a project's config.yml (report-only)" }
+check-manifest   = { cmd = "nhf-targets maintenance check-manifest",   description = "Report whether manifest.json predates the current schema (report-only)" }
+rebuild-manifest = { cmd = "nhf-targets maintenance rebuild-manifest", description = "Regenerate manifest.json as a deterministic projection of on-disk artifacts" }
+rechunk          = { cmd = "nhf-targets maintenance rechunk",          description = "Backfill aggregated/target NCs to the chunked+compressed layout (#165)" }
 
 # Fetch source data
 fetch-era5-land = { cmd = "nhf-targets fetch era5-land", description = "Download ERA5-Land data into a project datastore" }

--- a/slurm/project_gfv2/README.md
+++ b/slurm/project_gfv2/README.md
@@ -58,7 +58,7 @@ sbatch --array=11 slurm/project_gfv2/rechunk_gfv2.slurm    # one source (snodas)
 
 # Target NCs — single job; --mem=160G headroom for the ~11 GB (decompressed
 # ~55 GB) SWE targets. Preview first on the login node:
-pixi run nhf-targets rechunk --project-dir $GFV2 --layer target --dry-run
+pixi run nhf-targets maintenance rechunk --project-dir $GFV2 --layer target --dry-run
 sbatch slurm/project_gfv2/rechunk_gfv2_targets.slurm
 ```
 

--- a/slurm/project_gfv2/rechunk_gfv2.slurm
+++ b/slurm/project_gfv2/rechunk_gfv2.slurm
@@ -78,7 +78,7 @@ echo "=== Repo:    $REPO_DIR ($(git -C "$REPO_DIR" branch --show-current 2>/dev/
 echo "=== Project: $PROJECT_DIR ==="
 echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
 
-pixi run nhf-targets rechunk \
+pixi run nhf-targets maintenance rechunk \
     --project-dir "$PROJECT_DIR" \
     --layer aggregated \
     --source "$SRC"

--- a/slurm/project_gfv2/rechunk_gfv2_targets.slurm
+++ b/slurm/project_gfv2/rechunk_gfv2_targets.slurm
@@ -27,7 +27,7 @@
 #   mkdir -p logs
 #   sbatch rechunk_gfv2_targets.slurm
 #   # preview (no writes; fine on the login node):
-#   pixi run nhf-targets rechunk --project-dir <gfv2> --layer target --dry-run
+#   pixi run nhf-targets maintenance rechunk --project-dir <gfv2> --layer target --dry-run
 
 set -euo pipefail
 export PYTHONUNBUFFERED=1
@@ -53,6 +53,6 @@ echo "=== rechunk targets: $PROJECT_DIR ==="
 echo "=== Repo:    $REPO_DIR ($(git -C "$REPO_DIR" branch --show-current 2>/dev/null)) ==="
 echo "=== Start:   $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(hostname) ==="
 
-pixi run nhf-targets rechunk --project-dir "$PROJECT_DIR" --layer target
+pixi run nhf-targets maintenance rechunk --project-dir "$PROJECT_DIR" --layer target
 
 echo "=== Done:    $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="

--- a/src/nhf_spatial_targets/cli/__init__.py
+++ b/src/nhf_spatial_targets/cli/__init__.py
@@ -2,13 +2,15 @@
 
 The CLI is split across per-stage submodules:
 
-- ``cli.fetch``    — ``fetch`` sub-app (downloads to the datastore)
-- ``cli.agg``      — ``agg`` sub-app (HRU aggregation)
-- ``cli.catalog``  — ``catalog`` sub-app (registry inspection)
-- ``cli.run``      — root-level commands (init / validate / run / rechunk
-  / rebuild-manifest / upgrade-config / materialize-credentials)
-- ``cli._params``  — shared ``Annotated[..., Parameter(...)]`` aliases for
-  the agg sub-app
+- ``cli.fetch``       — ``fetch`` sub-app (downloads to the datastore)
+- ``cli.agg``         — ``agg`` sub-app (HRU aggregation; ``aggregate`` alias)
+- ``cli.catalog``     — ``catalog`` sub-app (registry inspection)
+- ``cli.release``     — ``release`` sub-app (ScienceBase data release)
+- ``cli.maintenance`` — ``maintenance`` sub-app (check-config /
+  check-manifest / rebuild-manifest / rechunk)
+- ``cli.run``         — root-level commands (init / validate / run /
+  materialize-credentials)
+- ``cli._params``     — shared ``Annotated[..., Parameter(...)]`` aliases
 
 The package re-exports ``app`` (the root cyclopts ``App``), ``main``
 (``app.meta``, the ``pyproject.toml`` script entry), ``_dispatch``,
@@ -52,7 +54,7 @@ from nhf_spatial_targets.aggregate.watergap22d import aggregate_watergap22d
 
 app = App(
     name="nhf-targets",
-    help="nhf-spatial-targets: build NHM calibration target datasets.",
+    help="nhf-targets: build NHM calibration target datasets.",
     version=_pkg_version("nhf-spatial-targets"),
 )
 
@@ -72,17 +74,20 @@ def launcher(
 from nhf_spatial_targets.cli.agg import agg_app  # noqa: E402
 from nhf_spatial_targets.cli.catalog import catalog_app  # noqa: E402
 from nhf_spatial_targets.cli.fetch import fetch_app  # noqa: E402
+from nhf_spatial_targets.cli.maintenance import (  # noqa: E402
+    check_config_cmd,
+    check_manifest_cmd,
+    maintenance_app,
+    rebuild_manifest_cmd,
+    rechunk,
+)
 from nhf_spatial_targets.cli.release import release_app  # noqa: E402
 from nhf_spatial_targets.cli.run import (  # noqa: E402
     _dispatch,
     init,
     materialize_credentials_cmd,
-    rebuild_manifest_cmd,
-    rechunk,
     register as _register_run_commands,
     run,
-    upgrade_config_cmd,
-    upgrade_manifest_cmd,
     validate,
 )
 
@@ -90,6 +95,7 @@ app.command(fetch_app)
 app.command(agg_app)
 app.command(catalog_app)
 app.command(release_app)
+app.command(maintenance_app)
 _register_run_commands(app)
 
 
@@ -103,14 +109,14 @@ __all__ = [
     "main",
     "setup_logging",
     "_dispatch",
-    # root-level command callables (kept importable for tests)
+    # command callables (kept importable for tests)
     "init",
     "validate",
     "run",
     "rechunk",
     "rebuild_manifest_cmd",
-    "upgrade_config_cmd",
-    "upgrade_manifest_cmd",
+    "check_config_cmd",
+    "check_manifest_cmd",
     "materialize_credentials_cmd",
     # aggregate callables (test-patch targets)
     "aggregate_daymet",

--- a/src/nhf_spatial_targets/cli/__init__.py
+++ b/src/nhf_spatial_targets/cli/__init__.py
@@ -10,7 +10,7 @@ The CLI is split across per-stage submodules:
   check-manifest / rebuild-manifest / rechunk)
 - ``cli.run``         — root-level commands (init / validate / run /
   materialize-credentials)
-- ``cli._params``     — shared ``Annotated[..., Parameter(...)]`` aliases
+- ``cli._params``     — shared ``Parameter`` aliases (used inside ``Annotated``)
 
 The package re-exports ``app`` (the root cyclopts ``App``), ``main``
 (``app.meta``, the ``pyproject.toml`` script entry), ``_dispatch``,

--- a/src/nhf_spatial_targets/cli/_params.py
+++ b/src/nhf_spatial_targets/cli/_params.py
@@ -1,4 +1,4 @@
-"""Shared cyclopts Parameter aliases for the CLI sub-app commands.
+"""Shared cyclopts Parameter aliases for CLI commands (root app and sub-apps).
 
 Each command annotates its matching parameter as
 ``Annotated[<type>, _*_PARAM] = <default>``. Cyclopts reads name +

--- a/src/nhf_spatial_targets/cli/_params.py
+++ b/src/nhf_spatial_targets/cli/_params.py
@@ -1,7 +1,7 @@
-"""Shared cyclopts Parameter aliases for the agg sub-app commands.
+"""Shared cyclopts Parameter aliases for the CLI sub-app commands.
 
-Each ``agg`` command annotates its matching parameter as
-``Annotated[<type>, _AGG_*_PARAM] = <default>``. Cyclopts reads name +
+Each command annotates its matching parameter as
+``Annotated[<type>, _*_PARAM] = <default>``. Cyclopts reads name +
 help from the Parameter; the default lives on the function signature so
 the type checker still sees a concrete default (a single source of
 truth for both behavior + docs).
@@ -10,6 +10,14 @@ truth for both behavior + docs).
 from __future__ import annotations
 
 from cyclopts import Parameter
+
+# Every project-scoped command across every sub-surface (root, fetch, agg,
+# release, maintenance) spells the project directory the same way, with the
+# same -d short alias (issue #319).
+_PROJECT_DIR_PARAM = Parameter(
+    name=["--project-dir", "-d"],
+    help="Project created by 'nhf-targets init'.",
+)
 
 _AGG_BATCH_SIZE_PARAM = Parameter(
     name="--batch-size",

--- a/src/nhf_spatial_targets/cli/agg.py
+++ b/src/nhf_spatial_targets/cli/agg.py
@@ -21,13 +21,19 @@ from cyclopts import App, Parameter
 
 from nhf_spatial_targets.cli._params import (
     _AGG_BATCH_SIZE_PARAM,
+    _PROJECT_DIR_PARAM,
     _AGG_N_WORKERS_PARAM,
     _AGG_WORKER_INDEX_PARAM,
 )
 
 _logger = logging.getLogger(__name__)
 
-agg_app = App(name="agg", help="Aggregate source datasets to HRU fabric polygons.")
+# "aggregate" is an accepted spelling of the abbreviated sub-app name
+# (issue #319); "agg" stays primary in docs and pixi tasks.
+agg_app = App(
+    name=["agg", "aggregate"],
+    help="Aggregate source datasets to HRU fabric polygons.",
+)
 
 
 def _resolve_agg_fn(name: str) -> Callable[..., object]:
@@ -145,13 +151,7 @@ def _run_tier_agg(
 
 @agg_app.command(name="ssebop")
 def agg_ssebop_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -218,13 +218,7 @@ def agg_ssebop_cmd(
 
 @agg_app.command(name="daymet")
 def agg_daymet_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -304,7 +298,7 @@ def agg_daymet_cmd(
 
 @agg_app.command(name="era5-land")
 def agg_era5_land_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -322,7 +316,7 @@ def agg_era5_land_cmd(
 
 @agg_app.command(name="gldas")
 def agg_gldas_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -340,7 +334,7 @@ def agg_gldas_cmd(
 
 @agg_app.command(name="merra2")
 def agg_merra2_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -358,7 +352,7 @@ def agg_merra2_cmd(
 
 @agg_app.command(name="ncep-ncar")
 def agg_ncep_ncar_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -376,7 +370,7 @@ def agg_ncep_ncar_cmd(
 
 @agg_app.command(name="nldas-mosaic")
 def agg_nldas_mosaic_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -394,7 +388,7 @@ def agg_nldas_mosaic_cmd(
 
 @agg_app.command(name="nldas-noah")
 def agg_nldas_noah_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -412,7 +406,7 @@ def agg_nldas_noah_cmd(
 
 @agg_app.command(name="watergap22d")
 def agg_watergap22d_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -430,7 +424,7 @@ def agg_watergap22d_cmd(
 
 @agg_app.command(name="reitz2017")
 def agg_reitz2017_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -448,7 +442,7 @@ def agg_reitz2017_cmd(
 
 @agg_app.command(name="mod16a2")
 def agg_mod16a2_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -466,7 +460,7 @@ def agg_mod16a2_cmd(
 
 @agg_app.command(name="mod10c1")
 def agg_mod10c1_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -484,7 +478,7 @@ def agg_mod10c1_cmd(
 
 @agg_app.command(name="snodas")
 def agg_snodas_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -515,7 +509,7 @@ def agg_snodas_cmd(
 
 @agg_app.command(name="ua-swe")
 def agg_ua_swe_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -546,7 +540,7 @@ def agg_ua_swe_cmd(
 
 @agg_app.command(name="era5-land-sd")
 def agg_era5_land_sd_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -570,7 +564,7 @@ def agg_era5_land_sd_cmd(
 
 @agg_app.command(name="margulis-wus-sr")
 def agg_margulis_wus_sr_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -601,7 +595,7 @@ def agg_margulis_wus_sr_cmd(
 
 @agg_app.command(name="mwbm-climgrid")
 def agg_mwbm_climgrid_cmd(
-    workdir: Annotated[Path, Parameter(name=["--project-dir"])],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,
@@ -633,12 +627,7 @@ def agg_mwbm_climgrid_cmd(
 
 @agg_app.command(name="all")
 def agg_all_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"], help="Project created by 'nhf-targets init'."
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     batch_size: Annotated[int | None, _AGG_BATCH_SIZE_PARAM] = None,
     worker_index: Annotated[int, _AGG_WORKER_INDEX_PARAM] = 0,
     n_workers: Annotated[int, _AGG_N_WORKERS_PARAM] = 1,

--- a/src/nhf_spatial_targets/cli/fetch.py
+++ b/src/nhf_spatial_targets/cli/fetch.py
@@ -9,6 +9,8 @@ from typing import Annotated
 
 from cyclopts import App, Parameter
 
+from nhf_spatial_targets.cli._params import _PROJECT_DIR_PARAM
+
 _logger = logging.getLogger(__name__)
 
 # Exit code for a run that completed but produced incomplete data — some
@@ -74,13 +76,7 @@ def _emit_fetch_banner(console, display_name: str, summary: object) -> bool:
 
 @fetch_app.command(name="all")
 def fetch_all_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -213,13 +209,7 @@ def fetch_all_cmd(
 
 @fetch_app.command(name="merra2")
 def fetch_merra2_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -262,13 +252,7 @@ def fetch_merra2_cmd(
 
 @fetch_app.command(name="nldas-mosaic")
 def fetch_nldas_mosaic_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -307,13 +291,7 @@ def fetch_nldas_mosaic_cmd(
 
 @fetch_app.command(name="nldas-noah")
 def fetch_nldas_noah_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -352,13 +330,7 @@ def fetch_nldas_noah_cmd(
 
 @fetch_app.command(name="ncep-ncar")
 def fetch_ncep_ncar_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -397,13 +369,7 @@ def fetch_ncep_ncar_cmd(
 
 @fetch_app.command(name="mod16a2")
 def fetch_mod16a2_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -460,13 +426,7 @@ def fetch_mod16a2_cmd(
 
 @fetch_app.command(name="mod10c1")
 def fetch_mod10c1_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -521,13 +481,7 @@ def fetch_mod10c1_cmd(
 
 @fetch_app.command(name="watergap22d")
 def fetch_watergap22d_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -566,13 +520,7 @@ def fetch_watergap22d_cmd(
 
 @fetch_app.command(name="era5-land")
 def fetch_era5_land_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -643,13 +591,7 @@ def fetch_era5_land_cmd(
 
 @fetch_app.command(name="gldas")
 def fetch_gldas_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -688,13 +630,7 @@ def fetch_gldas_cmd(
 
 @fetch_app.command(name="reitz2017")
 def fetch_reitz2017_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -733,13 +669,7 @@ def fetch_reitz2017_cmd(
 
 @fetch_app.command(name="mwbm-climgrid")
 def fetch_mwbm_climgrid_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -792,13 +722,7 @@ def fetch_mwbm_climgrid_cmd(
 
 @fetch_app.command(name="daymet")
 def fetch_daymet_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -865,13 +789,7 @@ def fetch_daymet_cmd(
 
 @fetch_app.command(name="snodas")
 def fetch_snodas_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -941,13 +859,7 @@ def fetch_snodas_cmd(
 
 @fetch_app.command(name="margulis-wus-sr")
 def fetch_margulis_wus_sr_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),
@@ -991,13 +903,7 @@ def fetch_margulis_wus_sr_cmd(
 
 @fetch_app.command(name="ua-swe")
 def fetch_ua_swe_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     period: Annotated[
         str,
         Parameter(name=["--period", "-p"], help="Temporal range as 'YYYY/YYYY'."),

--- a/src/nhf_spatial_targets/cli/maintenance.py
+++ b/src/nhf_spatial_targets/cli/maintenance.py
@@ -1,0 +1,342 @@
+"""``nhf-targets maintenance`` sub-app: existing-project catch-up commands.
+
+Groups the maintenance verbs so report-vs-mutate is legible from the
+grammar (issue #319):
+
+- ``check-config`` / ``check-manifest`` are **report-only** — they never
+  mutate the operator's intent artifacts; they print what's missing or
+  behind and exit non-zero on drift so scripted heartbeats can detect it.
+- ``rebuild-manifest`` / ``rechunk`` **mutate derived artifacts** —
+  ``manifest.json`` is regenerated as a deterministic projection; NCs are
+  rewritten in place to the canonical encoding. Both accept ``--dry-run``.
+
+The config actuator remains ``nhf-targets validate`` (it regenerates
+``config.effective.yml``); see docs/maintenance.md for the catch-up
+sequences.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from cyclopts import App, Parameter
+
+from nhf_spatial_targets.cli._params import _PROJECT_DIR_PARAM
+
+_logger = logging.getLogger(__name__)
+
+maintenance_app = App(
+    name="maintenance",
+    help=(
+        "Catch up an existing project: check-* report drift (read-only); "
+        "rebuild-manifest / rechunk regenerate derived artifacts."
+    ),
+)
+
+
+@maintenance_app.command(name="rechunk")
+def rechunk(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    layer: Annotated[
+        str | None,
+        Parameter(
+            name=["--layer"],
+            help="Restrict to 'aggregated' or 'target' (default: both).",
+        ),
+    ] = None,
+    source: Annotated[
+        str | None,
+        Parameter(
+            name=["--source"],
+            help="Restrict the aggregated layer to one source key.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        Parameter(
+            name=["--dry-run"],
+            help="Report what would be rechunked without writing.",
+        ),
+    ] = False,
+):
+    """Backfill existing aggregated/target NCs to the chunked+compressed layout.
+
+    Rewrites contiguous/uncompressed NetCDFs (built before #165) in place to the
+    canonical io_nc layout: value-preserving, atomic, and idempotent. Does not
+    touch the shared datastore's consolidated NCs, nor the daymet/ssebop
+    aggregated outputs (left as-is by #165 ST3).
+    """
+    from nhf_spatial_targets.rechunk import rechunk_project
+    from nhf_spatial_targets.workspace import load as load_project
+
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+    if not (workdir / "fabric.json").exists():
+        print(
+            f"Error: fabric.json not found in {workdir}. "
+            "Run 'nhf-targets validate' first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if layer is not None and layer not in ("aggregated", "target"):
+        print(
+            f"Error: invalid --layer {layer!r}; expected 'aggregated' or 'target'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    try:
+        project = load_project(workdir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # A mistyped --source would otherwise be a silent no-op; fail loudly.
+    if source is not None and not (project.aggregated_dir() / source).is_dir():
+        print(
+            f"Error: no aggregated source directory '{source}' under "
+            f"{project.aggregated_dir()}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    results = rechunk_project(project, layer=layer, source=source, dry_run=dry_run)
+
+    rechunked = [r for r in results if r["status"] == "rechunked"]
+    skipped = [r for r in results if r["status"].startswith("skipped")]
+    planned = [r for r in results if r["status"] == "would-rechunk"]
+    failed = [r for r in results if r["status"] == "failed"]
+    total_before = sum(r["size_before"] for r in results)
+    total_after = sum(r["size_after"] for r in results if r["size_after"] is not None)
+
+    if dry_run:
+        print(
+            f"[dry-run] {len(planned)} file(s) would be rechunked, "
+            f"{len(skipped)} skipped "
+            f"({total_before / 1e9:.2f} GB candidate)."
+        )
+    else:
+        saved = total_before - total_after if rechunked else 0
+        reclaimed_from = sum(r["size_before"] for r in rechunked)
+        pct = 100.0 * saved / reclaimed_from if reclaimed_from else 0.0
+        print(
+            f"Rechunked {len(rechunked)} file(s), skipped {len(skipped)}. "
+            f"Reclaimed {saved / 1e9:.2f} GB "
+            f"({pct:.0f}% of the rewritten files)."
+        )
+
+    if failed:
+        print(f"Error: {len(failed)} file(s) failed to rechunk:", file=sys.stderr)
+        for r in failed:
+            print(f"  {r['path'].name}: {r.get('error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+@maintenance_app.command(name="rebuild-manifest")
+def rebuild_manifest_cmd(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+    compute_sha256: Annotated[
+        bool,
+        Parameter(
+            name=["--compute-sha256"],
+            help="Fingerprint every file (slow; multi-GB NCs). Default: off.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        Parameter(name=["--dry-run"], help="Report the projection; write nothing."),
+    ] = False,
+):
+    """Regenerate manifest.json as a deterministic projection of on-disk artifacts.
+
+    The one authoritative provenance command: manifest.json = f(datastore x
+    catalog, data/aggregated/, targets/, fabric.json). Sources are the
+    (datastore n catalog) U aggregated-dirs union; steps are synthesized
+    deterministically. Identity fields (created_utc, fabric authorship, any
+    release block) are read-merged, never re-minted; the result is
+    byte-identical on re-run. Subsumes the former 'reconcile-manifest'.
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    from nhf_spatial_targets import workspace
+    from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
+
+    console = Console()
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        project = workspace.load(workdir)
+        manifest = rebuild_manifest(
+            project, compute_sha256=compute_sha256, dry_run=dry_run
+        )
+    except (FileNotFoundError, ValueError, KeyError, OSError) as e:
+        print(f"rebuild-manifest failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    sources = manifest["sources"]
+    derived = sum(1 for s in sources.values() if s.get("derived_variant"))
+    title = (
+        "rebuild-manifest (dry run — no changes written)"
+        if dry_run
+        else "rebuild-manifest"
+    )
+    table = Table(title=title)
+    table.add_column("metric", style="bold")
+    table.add_column("count", justify="right")
+    table.add_row("sources", str(len(sources)))
+    table.add_row("  of which derived variants", str(derived))
+    table.add_row("steps", str(len(manifest["steps"])))
+    console.print(table)
+
+    verb = "would write" if dry_run else "wrote"
+    console.print(
+        f"[bold green]{verb} manifest.json with {len(sources)} source(s) "
+        f"and {len(manifest['steps'])} step(s).[/bold green]"
+    )
+
+
+@maintenance_app.command(name="check-config")
+def check_config_cmd(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+):
+    """Report optional-config features missing from the project's config.yml.
+
+    Existing projects don't pick up new optional features (e.g. fabric.token,
+    representative_points) added to the init template, because they were
+    created before those features existed. This command compares the project's
+    config.yml against the registry in upgrade_config.OPTIONAL_CONFIG_FEATURES
+    and prints the literal commented block to paste for each missing feature.
+
+    Report-only: never mutates the operator's config.yml. Exits 0 if in sync,
+    1 on drift (so scripted heartbeats can detect it).
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    from nhf_spatial_targets.upgrade_config import (
+        check_available_sources,
+        check_drift,
+        check_missing_targets,
+    )
+
+    console = Console()
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        missing = check_drift(workdir)
+        missing_targets = check_missing_targets(workdir)
+        available = check_available_sources(workdir)
+    except FileNotFoundError as e:
+        print(f"check-config failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        # check_missing_targets / check_available_sources parse config.yml
+        # (check_drift was text-only). A malformed config must fail with an
+        # actionable message, not a raw traceback -- this command exists to
+        # help the operator fix config drift.
+        print(f"check-config failed to parse config.yml: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # --- Optional-feature stubs (the only signal that drives the exit code) ---
+    if not missing:
+        console.print(
+            "[bold green]Project config is in sync with the latest "
+            "optional-feature stubs in the init template.[/bold green]"
+        )
+    else:
+        table = Table(title="Optional features missing from this project's config.yml")
+        table.add_column("feature", style="bold")
+        table.add_column("added")
+        table.add_column("why")
+        for feat in missing:
+            table.add_row(feat.name, feat.added, feat.why)
+        console.print(table)
+
+        console.print(
+            "\nPaste each block below into config.yml (or see "
+            "src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE for context). "
+            "This command never edits your file.\n"
+        )
+        for feat in missing:
+            console.print(f"[bold]# --- {feat.name} ---[/bold]")
+            console.print(feat.block)
+
+    # --- Whole-target additions (report-only hint; issue #279, PR-5) ---
+    if missing_targets:
+        ttable = Table(
+            title="Targets in the defaults schema absent from your config.yml"
+        )
+        ttable.add_column("target", style="bold")
+        ttable.add_column("note")
+        for tname in missing_targets:
+            ttable.add_row(
+                tname,
+                "in defaults; add a targets: entry to build it on this fabric",
+            )
+        console.print(ttable)
+
+    # --- Newly-available catalog sources (report-only hint; issue #279, PR-5) ---
+    if available:
+        stable = Table(title="Catalog sources available but not in targets.*.sources[]")
+        stable.add_column("target", style="bold")
+        stable.add_column("available source(s)")
+        for tname, srcs in available.items():
+            stable.add_row(tname, ", ".join(srcs))
+        console.print(stable)
+
+    # Exit code stays driven solely by optional-feature drift, preserving the
+    # report-only contract; the whole-target and new-source tables above are
+    # informational hints and never, on their own, fail the command.
+    if missing:
+        sys.exit(1)
+
+
+@maintenance_app.command(name="check-manifest")
+def check_manifest_cmd(
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
+):
+    """Report whether manifest.json predates the current manifest schema.
+
+    Report-only: never mutates the manifest. Exits 0 if current, 1 if behind
+    (so scripted heartbeats detect drift). To normalize a behind manifest, run
+    'nhf-targets maintenance rebuild-manifest -d <dir>'.
+    """
+    from rich.console import Console
+
+    from nhf_spatial_targets.release.lineage import CURRENT_MANIFEST_SCHEMA_VERSION
+    from nhf_spatial_targets.upgrade_manifest import check_manifest_schema
+
+    console = Console()
+    if not workdir.exists():
+        print(f"Error: Project not found: {workdir}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        behind = check_manifest_schema(workdir)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"check-manifest failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if behind is None:
+        console.print(
+            "[bold green]manifest.json is at the current schema version "
+            f"({CURRENT_MANIFEST_SCHEMA_VERSION}).[/bold green]"
+        )
+        return
+
+    console.print(
+        f"[bold yellow]manifest.json is schema version {behind}; current is "
+        f"{CURRENT_MANIFEST_SCHEMA_VERSION}.[/bold yellow]\n\n"
+        "Run 'nhf-targets maintenance rebuild-manifest -d <dir>' to regenerate "
+        "it as a complete, version-stamped projection of the on-disk artifacts. "
+        "This command never edits your manifest."
+    )
+    sys.exit(1)

--- a/src/nhf_spatial_targets/cli/release.py
+++ b/src/nhf_spatial_targets/cli/release.py
@@ -37,6 +37,8 @@ from typing import TYPE_CHECKING, Annotated, Literal, NoReturn
 
 from cyclopts import App, Parameter
 
+from nhf_spatial_targets.cli._params import _PROJECT_DIR_PARAM
+
 from nhf_spatial_targets.release.build import build_all
 from nhf_spatial_targets.release.checksums import compute_checksums
 from nhf_spatial_targets.release.config import scaffold_release_yml
@@ -60,12 +62,8 @@ release_app = App(
     help="Build, validate, and publish the ScienceBase data release.",
 )
 
-# --project-dir is shared by every subcommand except auth-test (which needs only
-# credentials). The default lives on each signature so the type checker sees it.
-_PROJECT_DIR_PARAM = Parameter(
-    name=["--project-dir", "-d"],
-    help="Project created by 'nhf-targets init'.",
-)
+# --project-dir (shared with every other sub-app via cli._params) is taken by
+# every subcommand except auth-test (which needs only credentials).
 _TOKEN_PARAM = Parameter(
     name=["--token"],
     help=(
@@ -79,13 +77,14 @@ _ENV_PARAM = Parameter(
 )
 
 # A publish --scope maps to the dry_run build scope used for its no-confirm
-# preview. dry_run has no single-source or umbrella-only scope, so a 'source'
-# preview shows every source child and an 'umbrella' preview shows everything
-# (the umbrella's metadata unions its children, so 'all' is the faithful
-# preview). --confirm then publishes only the requested scope.
+# preview. dry_run has no single-source or umbrella-only scope, so a 'sources'
+# preview shows every source child (even though a confirmed publish targets the
+# one named by --source) and an 'umbrella' preview shows everything (the
+# umbrella's metadata unions its children, so 'all' is the faithful preview).
+# --confirm then publishes only the requested scope.
 _PUBLISH_PREVIEW_SCOPE: dict[str, Literal["fabric", "sources", "all"]] = {
     "fabric": "fabric",
-    "source": "sources",
+    "sources": "sources",
     "umbrella": "all",
 }
 
@@ -403,14 +402,14 @@ def status(
 def publish(
     workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     scope: Annotated[
-        Literal["umbrella", "source", "fabric"],
+        Literal["umbrella", "sources", "fabric"],
         Parameter(name=["--scope"], help="What to publish (default: fabric)."),
     ] = "fabric",
     source_key: Annotated[
         str | None,
         Parameter(
-            name=["--source-key"],
-            help="Source key to publish; required with --scope source --confirm.",
+            name=["--source"],
+            help="Source key to publish; required with --scope sources --confirm.",
         ),
     ] = None,
     confirm: Annotated[
@@ -449,7 +448,7 @@ def publish(
                 "Override the manifest completeness gate: publish even if the "
                 "manifest under-reports sources or drifts from the projection "
                 "(logged warning). Schema/fabric/steps checks stay fatal. "
-                "Prefer 'nhf-targets rebuild-manifest' instead."
+                "Prefer 'nhf-targets maintenance rebuild-manifest' instead."
             ),
         ),
     ] = False,
@@ -479,9 +478,7 @@ def publish(
         _run_client_op(
             "dry-run", dry_run, project, client, scope=_PUBLISH_PREVIEW_SCOPE[scope]
         )
-        target = (
-            scope if scope != "source" else f"source/{source_key or '<source-key>'}"
-        )
+        target = scope if scope != "sources" else f"sources/{source_key or '<source>'}"
         from rich.console import Console
 
         Console().print(
@@ -490,8 +487,8 @@ def publish(
         return
 
     # --- confirmed publish ---
-    if scope == "source" and not source_key:
-        _fail("--scope source --confirm requires --source-key.", 2)
+    if scope == "sources" and not source_key:
+        _fail("--scope sources --confirm requires --source.", 2)
     if (scope == "umbrella" or create_umbrella) and not parent_id:
         _fail(
             "publishing the umbrella requires --parent-id (the ScienceBase "
@@ -523,7 +520,7 @@ def publish(
                     allow_incomplete_sources=allow_incomplete_sources,
                 )
             )
-        elif scope == "source":
+        elif scope == "sources":
             results.append(
                 publish_source_child(
                     project,

--- a/src/nhf_spatial_targets/cli/run.py
+++ b/src/nhf_spatial_targets/cli/run.py
@@ -78,6 +78,7 @@ def run(
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    requested = target
     if target is not None:
         target = _TARGET_NICKNAMES.get(target, target)
 
@@ -94,7 +95,8 @@ def run(
 
     for name in to_run:
         if name not in targets_cfg:
-            print(f"Error: Unknown target: {name}", file=sys.stderr)
+            # Report the token the user typed, not the nickname expansion.
+            print(f"Error: Unknown target: {requested or name}", file=sys.stderr)
             sys.exit(1)
         print(f"Building target: {name}")
         try:

--- a/src/nhf_spatial_targets/cli/run.py
+++ b/src/nhf_spatial_targets/cli/run.py
@@ -1,9 +1,9 @@
 """Root-level ``nhf-targets`` commands.
 
-Contains: ``init``, ``materialize-credentials``, ``validate``, ``run``,
-``rechunk``, ``rebuild-manifest``, and ``upgrade-config``. These attach
-to the root ``app`` defined in :mod:`nhf_spatial_targets.cli` rather
-than to one of the per-stage sub-apps (``fetch``, ``agg``, ``catalog``).
+Contains: ``init``, ``materialize-credentials``, ``validate``, and ``run``.
+These attach to the root ``app`` defined in :mod:`nhf_spatial_targets.cli`
+rather than to one of the per-stage sub-apps (``fetch``, ``agg``,
+``catalog``, ``release``, ``maintenance``).
 """
 
 from __future__ import annotations
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Annotated
 import yaml
 from cyclopts import Parameter
 
+from nhf_spatial_targets.cli._params import _PROJECT_DIR_PARAM
+
 if TYPE_CHECKING:
     from cyclopts import App
 
@@ -23,32 +25,36 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# Short nicknames accepted by ``run --target`` in addition to the long
+# config keys, matching the ``pixi run run-<nick>`` task names (issue #319).
+_TARGET_NICKNAMES = {
+    "rch": "recharge",
+    "som": "soil_moisture",
+    "sca": "snow_covered_area",
+    "swe": "snow_water_equivalent",
+}
+
 
 def register(app: "App") -> None:
     """Register the root-level commands on ``app``."""
     app.command(run)
-    app.command(rechunk)
-    app.command(rebuild_manifest_cmd, name="rebuild-manifest")
-    app.command(upgrade_config_cmd, name="upgrade-config")
-    app.command(upgrade_manifest_cmd, name="upgrade-manifest")
     app.command(init)
     app.command(materialize_credentials_cmd, name="materialize-credentials")
     app.command(validate)
 
 
 def run(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir", "-d"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
+    workdir: Annotated[Path, _PROJECT_DIR_PARAM],
     target: Annotated[
         str | None,
         Parameter(
             name=["--target", "-t"],
-            help="Run a single target (default: all enabled).",
+            help=(
+                "Run a single target (default: all enabled). Accepts the "
+                "config keys runoff / aet / recharge / soil_moisture / "
+                "snow_covered_area / snow_water_equivalent or the short "
+                "nicknames rch / som / sca / swe."
+            ),
         ),
     ] = None,
 ):
@@ -71,6 +77,9 @@ def run(
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
+
+    if target is not None:
+        target = _TARGET_NICKNAMES.get(target, target)
 
     targets_cfg = project.config.get("targets", {})
     to_run = (
@@ -126,330 +135,6 @@ def _dispatch(
         print(f"Error: No builder registered for target: {name}", file=sys.stderr)
         sys.exit(1)
     builders[name](project)
-
-
-def rechunk(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir", "-d"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
-    layer: Annotated[
-        str | None,
-        Parameter(
-            name=["--layer"],
-            help="Restrict to 'aggregated' or 'target' (default: both).",
-        ),
-    ] = None,
-    source: Annotated[
-        str | None,
-        Parameter(
-            name=["--source"],
-            help="Restrict the aggregated layer to one source key.",
-        ),
-    ] = None,
-    dry_run: Annotated[
-        bool,
-        Parameter(
-            name=["--dry-run"],
-            help="Report what would be rechunked without writing.",
-        ),
-    ] = False,
-):
-    """Backfill existing aggregated/target NCs to the chunked+compressed layout.
-
-    Rewrites contiguous/uncompressed NetCDFs (built before #165) in place to the
-    canonical io_nc layout: value-preserving, atomic, and idempotent. Does not
-    touch the shared datastore's consolidated NCs, nor the daymet/ssebop
-    aggregated outputs (left as-is by #165 ST3).
-    """
-    from nhf_spatial_targets.rechunk import rechunk_project
-    from nhf_spatial_targets.workspace import load as load_project
-
-    if not workdir.exists():
-        print(f"Error: Project not found: {workdir}", file=sys.stderr)
-        sys.exit(2)
-    if not (workdir / "fabric.json").exists():
-        print(
-            f"Error: fabric.json not found in {workdir}. "
-            "Run 'nhf-targets validate' first.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    if layer is not None and layer not in ("aggregated", "target"):
-        print(
-            f"Error: invalid --layer {layer!r}; expected 'aggregated' or 'target'.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-
-    try:
-        project = load_project(workdir)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-    # A mistyped --source would otherwise be a silent no-op; fail loudly.
-    if source is not None and not (project.aggregated_dir() / source).is_dir():
-        print(
-            f"Error: no aggregated source directory '{source}' under "
-            f"{project.aggregated_dir()}.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-
-    results = rechunk_project(project, layer=layer, source=source, dry_run=dry_run)
-
-    rechunked = [r for r in results if r["status"] == "rechunked"]
-    skipped = [r for r in results if r["status"].startswith("skipped")]
-    planned = [r for r in results if r["status"] == "would-rechunk"]
-    failed = [r for r in results if r["status"] == "failed"]
-    total_before = sum(r["size_before"] for r in results)
-    total_after = sum(r["size_after"] for r in results if r["size_after"] is not None)
-
-    if dry_run:
-        print(
-            f"[dry-run] {len(planned)} file(s) would be rechunked, "
-            f"{len(skipped)} skipped "
-            f"({total_before / 1e9:.2f} GB candidate)."
-        )
-    else:
-        saved = total_before - total_after if rechunked else 0
-        reclaimed_from = sum(r["size_before"] for r in rechunked)
-        pct = 100.0 * saved / reclaimed_from if reclaimed_from else 0.0
-        print(
-            f"Rechunked {len(rechunked)} file(s), skipped {len(skipped)}. "
-            f"Reclaimed {saved / 1e9:.2f} GB "
-            f"({pct:.0f}% of the rewritten files)."
-        )
-
-    if failed:
-        print(f"Error: {len(failed)} file(s) failed to rechunk:", file=sys.stderr)
-        for r in failed:
-            print(f"  {r['path'].name}: {r.get('error')}", file=sys.stderr)
-        sys.exit(1)
-
-
-def rebuild_manifest_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir", "-d"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
-    compute_sha256: Annotated[
-        bool,
-        Parameter(
-            name=["--compute-sha256"],
-            help="Fingerprint every file (slow; multi-GB NCs). Default: off.",
-        ),
-    ] = False,
-    dry_run: Annotated[
-        bool,
-        Parameter(name=["--dry-run"], help="Report the projection; write nothing."),
-    ] = False,
-):
-    """Regenerate manifest.json as a deterministic projection of on-disk artifacts.
-
-    The one authoritative provenance command: manifest.json = f(datastore x
-    catalog, data/aggregated/, targets/, fabric.json). Sources are the
-    (datastore n catalog) U aggregated-dirs union; steps are synthesized
-    deterministically. Identity fields (created_utc, fabric authorship, any
-    release block) are read-merged, never re-minted; the result is
-    byte-identical on re-run. Subsumes the former 'reconcile-manifest'.
-    """
-    from rich.console import Console
-    from rich.table import Table
-
-    from nhf_spatial_targets import workspace
-    from nhf_spatial_targets.rebuild_manifest import rebuild_manifest
-
-    console = Console()
-    if not workdir.exists():
-        print(f"Error: Project not found: {workdir}", file=sys.stderr)
-        sys.exit(2)
-
-    try:
-        project = workspace.load(workdir)
-        manifest = rebuild_manifest(
-            project, compute_sha256=compute_sha256, dry_run=dry_run
-        )
-    except (FileNotFoundError, ValueError, KeyError, OSError) as e:
-        print(f"rebuild-manifest failed: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    sources = manifest["sources"]
-    derived = sum(1 for s in sources.values() if s.get("derived_variant"))
-    title = (
-        "rebuild-manifest (dry run — no changes written)"
-        if dry_run
-        else "rebuild-manifest"
-    )
-    table = Table(title=title)
-    table.add_column("metric", style="bold")
-    table.add_column("count", justify="right")
-    table.add_row("sources", str(len(sources)))
-    table.add_row("  of which derived variants", str(derived))
-    table.add_row("steps", str(len(manifest["steps"])))
-    console.print(table)
-
-    verb = "would write" if dry_run else "wrote"
-    console.print(
-        f"[bold green]{verb} manifest.json with {len(sources)} source(s) "
-        f"and {len(manifest['steps'])} step(s).[/bold green]"
-    )
-
-
-def upgrade_config_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir", "-d"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
-):
-    """Report optional-config features missing from the project's config.yml.
-
-    Existing projects don't pick up new optional features (e.g. fabric.token,
-    representative_points) added to the init template, because they were
-    created before those features existed. This command compares the project's
-    config.yml against the registry in upgrade_config.OPTIONAL_CONFIG_FEATURES
-    and prints the literal commented block to paste for each missing feature.
-
-    Report-only: never mutates the operator's config.yml. Exits 0 if in sync,
-    1 on drift (so scripted heartbeats can detect it).
-    """
-    from rich.console import Console
-    from rich.table import Table
-
-    from nhf_spatial_targets.upgrade_config import (
-        check_available_sources,
-        check_drift,
-        check_missing_targets,
-    )
-
-    console = Console()
-    if not workdir.exists():
-        print(f"Error: Project not found: {workdir}", file=sys.stderr)
-        sys.exit(2)
-    try:
-        missing = check_drift(workdir)
-        missing_targets = check_missing_targets(workdir)
-        available = check_available_sources(workdir)
-    except FileNotFoundError as e:
-        print(f"upgrade-config failed: {e}", file=sys.stderr)
-        sys.exit(1)
-    except yaml.YAMLError as e:
-        # check_missing_targets / check_available_sources parse config.yml
-        # (check_drift was text-only). A malformed config must fail with an
-        # actionable message, not a raw traceback -- this command exists to
-        # help the operator fix config drift.
-        print(f"upgrade-config failed to parse config.yml: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # --- Optional-feature stubs (the only signal that drives the exit code) ---
-    if not missing:
-        console.print(
-            "[bold green]Project config is in sync with the latest "
-            "optional-feature stubs in the init template.[/bold green]"
-        )
-    else:
-        table = Table(title="Optional features missing from this project's config.yml")
-        table.add_column("feature", style="bold")
-        table.add_column("added")
-        table.add_column("why")
-        for feat in missing:
-            table.add_row(feat.name, feat.added, feat.why)
-        console.print(table)
-
-        console.print(
-            "\nPaste each block below into config.yml (or see "
-            "src/nhf_spatial_targets/init_run.py:_CONFIG_TEMPLATE for context). "
-            "This command never edits your file.\n"
-        )
-        for feat in missing:
-            console.print(f"[bold]# --- {feat.name} ---[/bold]")
-            console.print(feat.block)
-
-    # --- Whole-target additions (report-only hint; issue #279, PR-5) ---
-    if missing_targets:
-        ttable = Table(
-            title="Targets in the defaults schema absent from your config.yml"
-        )
-        ttable.add_column("target", style="bold")
-        ttable.add_column("note")
-        for tname in missing_targets:
-            ttable.add_row(
-                tname,
-                "in defaults; add a targets: entry to build it on this fabric",
-            )
-        console.print(ttable)
-
-    # --- Newly-available catalog sources (report-only hint; issue #279, PR-5) ---
-    if available:
-        stable = Table(title="Catalog sources available but not in targets.*.sources[]")
-        stable.add_column("target", style="bold")
-        stable.add_column("available source(s)")
-        for tname, srcs in available.items():
-            stable.add_row(tname, ", ".join(srcs))
-        console.print(stable)
-
-    # Exit code stays driven solely by optional-feature drift, preserving the
-    # report-only contract; the whole-target and new-source tables above are
-    # informational hints and never, on their own, fail the command.
-    if missing:
-        sys.exit(1)
-
-
-def upgrade_manifest_cmd(
-    workdir: Annotated[
-        Path,
-        Parameter(
-            name=["--project-dir", "-d"],
-            help="Project created by 'nhf-targets init'.",
-        ),
-    ],
-):
-    """Report whether manifest.json predates the current manifest schema.
-
-    Report-only: never mutates the manifest. Exits 0 if current, 1 if behind
-    (so scripted heartbeats detect drift). To normalize a behind manifest, run
-    'nhf-targets rebuild-manifest -d <dir>'.
-    """
-    from rich.console import Console
-
-    from nhf_spatial_targets.release.lineage import CURRENT_MANIFEST_SCHEMA_VERSION
-    from nhf_spatial_targets.upgrade_manifest import check_manifest_schema
-
-    console = Console()
-    if not workdir.exists():
-        print(f"Error: Project not found: {workdir}", file=sys.stderr)
-        sys.exit(2)
-    try:
-        behind = check_manifest_schema(workdir)
-    except (FileNotFoundError, ValueError) as e:
-        print(f"upgrade-manifest failed: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    if behind is None:
-        console.print(
-            "[bold green]manifest.json is at the current schema version "
-            f"({CURRENT_MANIFEST_SCHEMA_VERSION}).[/bold green]"
-        )
-        return
-
-    console.print(
-        f"[bold yellow]manifest.json is schema version {behind}; current is "
-        f"{CURRENT_MANIFEST_SCHEMA_VERSION}.[/bold yellow]\n\n"
-        "Run 'nhf-targets rebuild-manifest -d <dir>' to regenerate it as a "
-        "complete, version-stamped projection of the on-disk artifacts. "
-        "This command never edits your manifest."
-    )
-    sys.exit(1)
 
 
 def init(

--- a/src/nhf_spatial_targets/release/payload.py
+++ b/src/nhf_spatial_targets/release/payload.py
@@ -213,7 +213,7 @@ def stage_fabric_child(project: Project, *, copy: bool = False) -> FabricChildPl
         raise ReleaseError(
             f"Cannot stage fabric child: manifest.json missing at "
             f"{plan.manifest_src}. Run 'nhf-targets validate' then "
-            f"'nhf-targets rebuild-manifest' for this project before publishing."
+            f"'nhf-targets maintenance rebuild-manifest' for this project before publishing."
         )
     _copy_file(plan.manifest_src, plan.stage_dir / "manifest.json")
 

--- a/src/nhf_spatial_targets/release/publish.py
+++ b/src/nhf_spatial_targets/release/publish.py
@@ -354,7 +354,7 @@ def _preflight_provenance_complete(
     projection of the on-disk artifacts, reads the on-disk manifest, and
     refuses to publish unless they agree. Publish stays a pure read-local /
     write-remote operation: this gate never writes the manifest -- regenerating
-    it is the operator's explicit ``nhf-targets rebuild-manifest`` action, which
+    it is the operator's explicit ``nhf-targets maintenance rebuild-manifest`` action, which
     is what keeps publish idempotent.
 
     Always-fatal (a manifest this broken cannot be published at all):
@@ -386,7 +386,7 @@ def _preflight_provenance_complete(
     on_disk = read_manifest(project.manifest_path)
 
     rebuild_hint = (
-        f"run 'nhf-targets rebuild-manifest -d {project.workdir}' to regenerate "
+        f"run 'nhf-targets maintenance rebuild-manifest -d {project.workdir}' to regenerate "
         f"manifest.json as a complete projection of the on-disk artifacts, then "
         f"re-publish"
     )

--- a/src/nhf_spatial_targets/upgrade_config.py
+++ b/src/nhf_spatial_targets/upgrade_config.py
@@ -4,7 +4,7 @@ init template.
 Existing projects don't pick up new optional features (e.g. ``fabric.token``,
 ``representative_points``) added to the init template, because they were
 created before those features existed. This module is the operator-facing
-discovery path: ``nhf-targets upgrade-config -d <dir>`` lists what's missing,
+discovery path: ``nhf-targets maintenance check-config -d <dir>`` lists what's missing,
 with the literal commented block to paste.
 
 **Report-only.** This module never mutates the operator's config.yml.
@@ -44,7 +44,7 @@ class OptionalConfigFeature:
         ``(?m)^\\s*#?\\s*<key>\\s*:``.
     block
         The literal commented stub from ``_CONFIG_TEMPLATE`` — what the
-        operator sees in the ``--upgrade-config`` paste output. Kept in
+        operator sees in the ``check-config`` paste output. Kept in
         sync with the init template by the CLAUDE.md discipline.
     added
         Provenance shown in the report table (``"2026-05-23 (#193)"``).
@@ -206,7 +206,7 @@ def check_drift(project_dir: Path) -> list[OptionalConfigFeature]:
 # Whole-target + new-source hints (issue #279, PR-5)
 # ---------------------------------------------------------------------------
 #
-# Beyond the enumerated optional params above, upgrade-config also surfaces two
+# Beyond the enumerated optional params above, check-config also surfaces two
 # coarser-grained drifts, both report-only:
 #   - a whole target in the defaults schema that the operator's config omits;
 #   - a catalog source eligible for a target (per variables.yml) that the

--- a/src/nhf_spatial_targets/upgrade_manifest.py
+++ b/src/nhf_spatial_targets/upgrade_manifest.py
@@ -4,8 +4,8 @@ Mirrors :mod:`nhf_spatial_targets.upgrade_config`: a report-only operator
 discovery path. ``nhf-targets maintenance check-manifest -d <dir>`` detects a manifest
 whose ``manifest_schema_version`` is behind
 :data:`~nhf_spatial_targets.release.lineage.CURRENT_MANIFEST_SCHEMA_VERSION`
-and points the operator at the forthcoming ``rebuild-manifest`` command (issue
-#279, lands in a later PR) that will normalize it. **Never mutates.**
+and points the operator at ``nhf-targets maintenance rebuild-manifest`` to
+normalize it. **Never mutates.**
 """
 
 from __future__ import annotations

--- a/src/nhf_spatial_targets/upgrade_manifest.py
+++ b/src/nhf_spatial_targets/upgrade_manifest.py
@@ -1,7 +1,7 @@
 """Report whether a project's manifest.json predates the current schema.
 
 Mirrors :mod:`nhf_spatial_targets.upgrade_config`: a report-only operator
-discovery path. ``nhf-targets upgrade-manifest -d <dir>`` detects a manifest
+discovery path. ``nhf-targets maintenance check-manifest -d <dir>`` detects a manifest
 whose ``manifest_schema_version`` is behind
 :data:`~nhf_spatial_targets.release.lineage.CURRENT_MANIFEST_SCHEMA_VERSION`
 and points the operator at the forthcoming ``rebuild-manifest`` command (issue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -979,3 +979,85 @@ def test_run_runoff_smoke(tmp_path):
     project = load(workdir)
     _dispatch("runoff", project)
     assert (workdir / "targets" / "runoff_targets.nc").exists()
+
+
+# ---- CLI grammar (issue #319) ----------------------------------------------
+
+
+def test_run_target_nickname_maps_to_long_key(tmp_path):
+    """--target accepts the pixi-task nicknames (rch/som/sca/swe)."""
+    workdir = _make_minimal_project(
+        tmp_path,
+        "targets:\n  recharge:\n    enabled: true\n    period: 2000-01-01/2000-12-31\n",
+    )
+
+    with patch("nhf_spatial_targets.cli._dispatch") as mock_dispatch:
+        _run("run", "--project-dir", str(workdir), "--target", "rch")
+
+    mock_dispatch.assert_called_once()
+    assert mock_dispatch.call_args[0][0] == "recharge"
+
+
+def test_run_unknown_nickname_still_errors(tmp_path):
+    """A token that is neither a config key nor a nickname exits 1."""
+    workdir = _make_minimal_project(
+        tmp_path,
+        "targets:\n  runoff:\n    enabled: true\n    period: 2000-01-01/2000-12-31\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _run("run", "--project-dir", str(workdir), "--target", "bogus")
+    assert exc.value.code == 1
+
+
+def test_project_dir_short_alias_on_fetch(tmp_path):
+    """fetch commands accept -d as an alias for --project-dir."""
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+
+    with patch(
+        "nhf_spatial_targets.fetch.merra2.fetch_merra2",
+        return_value={"source_key": "merra2"},
+    ) as mock_fetch:
+        _run("fetch", "merra2", "-d", str(workdir), "-p", "2010/2010")
+
+    mock_fetch.assert_called_once_with(workdir=workdir, period="2010/2010")
+
+
+def test_project_dir_short_alias_on_agg(tmp_path):
+    """agg commands accept -d as an alias for --project-dir."""
+    with patch("nhf_spatial_targets.cli.aggregate_gldas") as mock_agg:
+        import json as json_mod
+
+        workdir = _make_minimal_project(tmp_path)
+        (workdir / "fabric.json").write_text(json_mod.dumps({"id_col": "nhm_id"}))
+        _run("agg", "gldas", "-d", str(workdir))
+
+    mock_agg.assert_called_once()
+
+
+def test_aggregate_is_an_alias_for_agg(tmp_path):
+    """The spelled-out sub-app name dispatches identically to 'agg'."""
+    with patch("nhf_spatial_targets.cli.aggregate_gldas") as mock_agg:
+        workdir = _make_minimal_project(tmp_path)
+        _run("aggregate", "gldas", "-d", str(workdir))
+
+    mock_agg.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "verb", ["upgrade-config", "upgrade-manifest", "rebuild-manifest", "rechunk"]
+)
+def test_old_flat_maintenance_verbs_are_removed(verb, tmp_path):
+    """The pre-#319 root spellings are a hard break: unknown commands."""
+    from cyclopts.exceptions import UnknownCommandError
+
+    with pytest.raises(UnknownCommandError):
+        app([verb, "--project-dir", str(tmp_path)], exit_on_error=False)
+
+
+def test_maintenance_subapp_hosts_all_four_verbs():
+    from nhf_spatial_targets.cli.maintenance import maintenance_app
+
+    for verb in ("check-config", "check-manifest", "rebuild-manifest", "rechunk"):
+        assert verb in maintenance_app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -998,8 +998,9 @@ def test_run_target_nickname_maps_to_long_key(tmp_path):
     assert mock_dispatch.call_args[0][0] == "recharge"
 
 
-def test_run_unknown_nickname_still_errors(tmp_path):
-    """A token that is neither a config key nor a nickname exits 1."""
+def test_run_unknown_nickname_still_errors(tmp_path, capsys):
+    """A token that is neither a config key nor a nickname exits 1, and the
+    error echoes the token the user typed (not a nickname expansion)."""
     workdir = _make_minimal_project(
         tmp_path,
         "targets:\n  runoff:\n    enabled: true\n    period: 2000-01-01/2000-12-31\n",
@@ -1008,6 +1009,7 @@ def test_run_unknown_nickname_still_errors(tmp_path):
     with pytest.raises(SystemExit) as exc:
         _run("run", "--project-dir", str(workdir), "--target", "bogus")
     assert exc.value.code == 1
+    assert "Unknown target: bogus" in capsys.readouterr().err
 
 
 def test_project_dir_short_alias_on_fetch(tmp_path):
@@ -1061,3 +1063,48 @@ def test_maintenance_subapp_hosts_all_four_verbs():
 
     for verb in ("check-config", "check-manifest", "rebuild-manifest", "rechunk"):
         assert verb in maintenance_app
+
+
+@pytest.mark.parametrize("verb", ["check-manifest", "rebuild-manifest", "rechunk"])
+def test_maintenance_verbs_parse_through_the_app(verb, tmp_path):
+    """Each verb's cyclopts signature binds -d; a missing project exits 2.
+
+    check-config gets full token-level coverage in test_upgrade_config.py;
+    these smokes pin the parse path of the other three (a broken Parameter
+    annotation would otherwise only surface at runtime).
+    """
+    missing = tmp_path / "no-such-project"
+    with pytest.raises(SystemExit) as exc:
+        app(["maintenance", verb, "-d", str(missing)], exit_on_error=False)
+    assert exc.value.code == 2
+
+
+def test_release_publish_old_scope_spelling_rejected(tmp_path):
+    """--scope source (singular, pre-#319) is no longer a valid choice."""
+    from cyclopts.exceptions import CoercionError
+
+    with pytest.raises(CoercionError):
+        app(
+            ["release", "publish", "-d", str(tmp_path), "--scope", "source"],
+            exit_on_error=False,
+        )
+
+
+def test_release_publish_old_source_key_flag_rejected(tmp_path):
+    """--source-key (pre-#319) is no longer a recognized option."""
+    from cyclopts.exceptions import UnknownOptionError
+
+    with pytest.raises(UnknownOptionError):
+        app(
+            [
+                "release",
+                "publish",
+                "-d",
+                str(tmp_path),
+                "--scope",
+                "sources",
+                "--source-key",
+                "era5_land",
+            ],
+            exit_on_error=False,
+        )

--- a/tests/test_rebuild_manifest.py
+++ b/tests/test_rebuild_manifest.py
@@ -388,7 +388,7 @@ def test_frozen_clock_guard_rebuild_dry_run(tmp_path, monkeypatch):
 
 
 def test_rebuild_manifest_cmd_dry_run_writes_nothing(tmp_path):
-    from nhf_spatial_targets.cli.run import rebuild_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import rebuild_manifest_cmd
 
     project = _make_project(tmp_path, aggregated_dirs={"merra2": ["merra2_agg.nc"]})
     rebuild_manifest_cmd(project.workdir, dry_run=True)
@@ -396,7 +396,7 @@ def test_rebuild_manifest_cmd_dry_run_writes_nothing(tmp_path):
 
 
 def test_rebuild_manifest_cmd_writes(tmp_path):
-    from nhf_spatial_targets.cli.run import rebuild_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import rebuild_manifest_cmd
 
     project = _make_project(tmp_path, aggregated_dirs={"merra2": ["merra2_agg.nc"]})
     rebuild_manifest_cmd(project.workdir)
@@ -412,9 +412,11 @@ def test_reconcile_manifest_is_removed():
         importlib.import_module("nhf_spatial_targets.reconcile")
 
     from nhf_spatial_targets.cli import app
+    from nhf_spatial_targets.cli.maintenance import maintenance_app
 
     assert "reconcile-manifest" not in app  # command de-registered
-    assert "rebuild-manifest" in app  # replacement registered
+    assert "reconcile-manifest" not in maintenance_app
+    assert "rebuild-manifest" in maintenance_app  # replacement registered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_cli.py
+++ b/tests/test_release_cli.py
@@ -273,7 +273,7 @@ def test_publish_allow_incomplete_sources_threads_to_publisher(tmp_path, monkeyp
     assert pub.call_args.kwargs["allow_incomplete_sources"] is True
 
 
-def test_publish_source_confirm_requires_source_key(tmp_path, monkeypatch):
+def test_publish_sources_confirm_requires_source(tmp_path, monkeypatch):
     project = build_release_project(tmp_path)
     _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
     monkeypatch.setattr(rel, "publish_source_child", MagicMock())
@@ -285,7 +285,7 @@ def test_publish_source_confirm_requires_source_key(tmp_path, monkeypatch):
         "-d",
         str(project.workdir),
         "--scope",
-        "source",
+        "sources",
         "--confirm",
     )
 
@@ -302,15 +302,15 @@ def test_publish_source_confirm_dispatches_with_key(tmp_path, monkeypatch):
         "-d",
         str(project.workdir),
         "--scope",
-        "source",
-        "--source-key",
+        "sources",
+        "--source",
         "era5_land",
         "--confirm",
     )
 
     pub.assert_called_once()
     assert pub.call_args.args[2] == "era5_land"
-    assert (project.release_dir / "last_publish_source_era5_land.log").is_file()
+    assert (project.release_dir / "last_publish_sources_era5_land.log").is_file()
 
 
 def test_publish_umbrella_confirm_requires_parent_id(tmp_path, monkeypatch):
@@ -393,14 +393,14 @@ def test_publish_create_umbrella_composes_umbrella_then_child(tmp_path, monkeypa
 
 @pytest.mark.parametrize(
     "publish_scope,preview_scope",
-    [("source", "sources"), ("umbrella", "all"), ("fabric", "fabric")],
+    [("sources", "sources"), ("umbrella", "all"), ("fabric", "fabric")],
 )
 def test_publish_without_confirm_previews_mapped_scope(
     tmp_path, monkeypatch, publish_scope, preview_scope
 ):
     """The publish-scope -> dry-run-scope preview mapping (_PUBLISH_PREVIEW_SCOPE):
     a no-confirm publish runs dry_run with the mapped build scope, never the raw
-    publish scope (umbrella/source are not valid dry_run scopes)."""
+    publish scope (umbrella is not a valid dry_run scope)."""
     project = build_release_project(tmp_path)
     _patch_seams(monkeypatch, project, make_sb_client(FakeSbSession()))
     recorder = MagicMock()

--- a/tests/test_upgrade_config.py
+++ b/tests/test_upgrade_config.py
@@ -1,4 +1,4 @@
-"""Tests for nhf-targets upgrade-config (#193 follow-up).
+"""Tests for nhf-targets maintenance check-config (#193 follow-up).
 
 Detection is the contract: a feature is in sync if its `detect` regex matches
 the project's config.yml text in any form — live value, the commented stub
@@ -129,7 +129,7 @@ def test_cli_exits_one_on_drift(tmp_path, capsys):
 
     _write_minimal_config(tmp_path)
     with pytest.raises(SystemExit) as exc:
-        app(["upgrade-config", "--project-dir", str(tmp_path)])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path)])
     assert exc.value.code == 1
     out = capsys.readouterr().out
     # The missing feature names appear in stdout so the operator can act.
@@ -154,7 +154,7 @@ def test_cli_exits_zero_when_in_sync(tmp_path, capsys):
     )
     # Cyclopts wraps even successful returns in SystemExit(0).
     with pytest.raises(SystemExit) as exc:
-        app(["upgrade-config", "--project-dir", str(tmp_path)])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path)])
     assert exc.value.code in (None, 0)
     out = capsys.readouterr().out
     assert "in sync" in out.lower()
@@ -164,7 +164,7 @@ def test_cli_exits_two_when_project_missing(tmp_path, capsys):
     from nhf_spatial_targets.cli import app
 
     with pytest.raises(SystemExit) as exc:
-        app(["upgrade-config", "--project-dir", str(tmp_path / "no-such")])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path / "no-such")])
     assert exc.value.code == 2
     err = capsys.readouterr().err
     assert "not found" in err.lower()
@@ -172,7 +172,7 @@ def test_cli_exits_two_when_project_missing(tmp_path, capsys):
 
 # --- whole-target + new-source hints (issue #279, PR-5) ----------------------
 #
-# upgrade-config is extended beyond the enumerated optional params to surface
+# check-config is extended beyond the enumerated optional params to surface
 # (a) whole targets present in the defaults schema but absent from the
 # operator's config.yml, and (b) catalog sources eligible for a target (per
 # variables.yml) but not pinned in the operator's targets.<t>.sources[]. Both
@@ -274,14 +274,14 @@ def test_target_to_variable_mapping_is_consistent():
 
 
 def test_cli_never_mutates_config(tmp_path):
-    """upgrade-config (with the new hints) is report-only: config.yml is
+    """check-config (with the new hints) is report-only: config.yml is
     byte-identical before and after the command runs."""
     from nhf_spatial_targets.cli import app
 
     cfg = _config_with_targets(tmp_path)
     before = cfg.read_bytes()
     with pytest.raises(SystemExit):
-        app(["upgrade-config", "--project-dir", str(tmp_path)])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path)])
     assert cfg.read_bytes() == before
 
 
@@ -292,10 +292,10 @@ def test_cli_exits_one_when_config_missing_in_existing_dir(tmp_path, capsys):
 
     tmp_path.mkdir(parents=True, exist_ok=True)  # dir exists; config.yml absent
     with pytest.raises(SystemExit) as exc:
-        app(["upgrade-config", "--project-dir", str(tmp_path)])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path)])
     assert exc.value.code == 1
     err = capsys.readouterr().err
-    assert "upgrade-config failed" in err
+    assert "check-config failed" in err
 
 
 def test_cli_exits_one_on_malformed_config(tmp_path, capsys):
@@ -308,7 +308,7 @@ def test_cli_exits_one_on_malformed_config(tmp_path, capsys):
     # Unclosed bracket -> yaml.ParserError (a yaml.YAMLError subclass).
     (tmp_path / "config.yml").write_text("targets: [unclosed\n")
     with pytest.raises(SystemExit) as exc:
-        app(["upgrade-config", "--project-dir", str(tmp_path)])
+        app(["maintenance", "check-config", "--project-dir", str(tmp_path)])
     assert exc.value.code == 1
     err = capsys.readouterr().err
     assert "parse config.yml" in err

--- a/tests/test_upgrade_manifest.py
+++ b/tests/test_upgrade_manifest.py
@@ -83,16 +83,16 @@ def test_check_never_mutates(tmp_path):
 
 
 def test_cli_exits_1_on_drift(tmp_path):
-    from nhf_spatial_targets.cli.run import upgrade_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import check_manifest_cmd
 
     (tmp_path / "manifest.json").write_text(json.dumps({"sources": {}, "steps": []}))
     with pytest.raises(SystemExit) as e:
-        upgrade_manifest_cmd(tmp_path)
+        check_manifest_cmd(tmp_path)
     assert e.value.code == 1
 
 
 def test_cli_exits_0_in_sync(tmp_path):
-    from nhf_spatial_targets.cli.run import upgrade_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import check_manifest_cmd
     from nhf_spatial_targets.release.lineage import CURRENT_MANIFEST_SCHEMA_VERSION
 
     (tmp_path / "manifest.json").write_text(
@@ -105,22 +105,22 @@ def test_cli_exits_0_in_sync(tmp_path):
         )
     )
     # No SystemExit on the in-sync path (returns normally / exit 0).
-    upgrade_manifest_cmd(tmp_path)
+    check_manifest_cmd(tmp_path)
 
 
 def test_cli_exits_2_on_missing_project_dir(tmp_path):
-    from nhf_spatial_targets.cli.run import upgrade_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import check_manifest_cmd
 
     missing = tmp_path / "does-not-exist"
     with pytest.raises(SystemExit) as e:
-        upgrade_manifest_cmd(missing)
+        check_manifest_cmd(missing)
     assert e.value.code == 2
 
 
 def test_cli_exits_1_on_corrupt_manifest(tmp_path):
-    from nhf_spatial_targets.cli.run import upgrade_manifest_cmd
+    from nhf_spatial_targets.cli.maintenance import check_manifest_cmd
 
     (tmp_path / "manifest.json").write_text("{not valid json")
     with pytest.raises(SystemExit) as e:
-        upgrade_manifest_cmd(tmp_path)
+        check_manifest_cmd(tmp_path)
     assert e.value.code == 1


### PR DESCRIPTION
Closes #319.

Implements the CLI-grammar decisions from the public-API evaluation
(`docs/reviews/2026-06-10-public-api-evaluation.md`, Tier-2 #6/#7/#8 + §3
road-not-taken). Design spec: `docs/superpowers/specs/2026-06-10-cli-grammar-design.md`.

## Decisions (operator-confirmed)

| Question | Call |
|---|---|
| Maintenance verb structure | `maintenance` sub-app + `check-*` rename |
| Deprecation policy | **Hard break** — no aliases; every committed reference updated in this PR |
| `publish --scope source` | Rename to `sources`, behavior unchanged |
| Source-key flag | `--source` canonical everywhere |

## The new grammar

```
nhf-targets maintenance check-config     -d <dir>            # was: upgrade-config (report-only)
nhf-targets maintenance check-manifest   -d <dir>            # was: upgrade-manifest (report-only)
nhf-targets maintenance rebuild-manifest -d <dir> [--dry-run]
nhf-targets maintenance rechunk          -d <dir> [--source <key>] [--dry-run]

nhf-targets fetch <src> -d <dir> ...      # -d now works on every fetch/agg command
nhf-targets agg <src>   -d <dir> ...      # 'aggregate' accepted as an alias of 'agg'
nhf-targets run -d <dir> -t rch           # short nicknames rch/som/sca/swe accepted

nhf-targets release publish --scope sources --source <key> --confirm
#                          (was: --scope source --source-key <key>)
```

## Hard-break sweep (same PR)

- **pixi tasks:** `upgrade-config`/`upgrade-manifest` → `check-config`/`check-manifest`;
  `rebuild-manifest`/`rechunk` keep their task names but dispatch through the sub-app.
- **SLURM:** `slurm/project_gfv2/rechunk_*.slurm` + README.
- **Docs:** CLAUDE.md, README, CONTRIBUTING, `docs/maintenance.md` (naming-caveat box
  replaced — #319 resolves it), api/architecture/data-release pages. Historical
  `docs/superpowers/{specs,plans}` and `docs/reviews` left as point-in-time records.
- **In-code messages** that print commands (`upgrade_manifest`, `release/publish`,
  `release/payload`) updated.

Out of scope (per spec): renaming the `upgrade_config.py`/`upgrade_manifest.py` Python
modules (internal API), and publish-all-sources semantics for `--scope sources`.

## Testing

- `pixi run -e dev test`: **1765 passed**; fmt + lint clean; `mkdocs build --strict` green.
- New coverage: maintenance sub-app hosts all four verbs; old root spellings raise
  `UnknownCommandError`; `-d` on fetch/agg; `aggregate` alias; `run --target rch`
  nickname mapping; publish `--scope sources` / `--source` dispatch and guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)