### PR TITLE
fix(#332): recognize representative_points in validate's unknown-key linter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,15 @@ duplicate kept drifting out of step with the template.
 `maintenance check-config` is **report-only** — it never mutates an operator's
 `config.yml`; it prints what's missing and the literal block to paste.
 
+**Also register the key with `validate`'s unknown-key linter.** `validate`
+warns on any top-level key absent from `defaults.py:DEFAULTS` (typo guard). A
+new key that belongs in the core schema goes in `DEFAULTS` with its default.
+A **notebook-facing / free-form key** (one consumed outside the core pipeline,
+with a free-form sub-structure — e.g. `representative_points`) instead goes in
+`defaults.py:_OPAQUE_TOPLEVEL_KEYS`, so the linter recognises it without
+descending into its arbitrary sub-keys. Skipping this makes `validate` emit a
+misleading "unknown config key (typo?)" warning for a blessed key.
+
 ## Manifest & config durability
 
 Project artifacts split into two kinds with opposite durability rules. Never

--- a/src/nhf_spatial_targets/defaults.py
+++ b/src/nhf_spatial_targets/defaults.py
@@ -17,6 +17,18 @@ from __future__ import annotations
 import copy
 from collections.abc import Iterator
 
+#: Top-level config keys that are *known* but intentionally not part of the
+#: core pipeline :data:`DEFAULTS` schema, and whose sub-structure is free-form
+#: (so it must not be introspected for unknown-key warnings). Currently just
+#: ``representative_points`` — a notebook-facing key (consumed by
+#: ``notebooks/_helpers.load_representative_points``, shipped as a stub by
+#: ``init_run._CONFIG_TEMPLATE`` and discoverable via
+#: ``upgrade_config.OPTIONAL_CONFIG_FEATURES``). Its value is
+#: ``{<target>: {<label>: [lon, lat], ...}, ...}`` with free-form target names
+#: and label strings, so ``find_unknown_keys`` recognises the top-level key but
+#: does not descend into it.
+_OPAQUE_TOPLEVEL_KEYS: frozenset[str] = frozenset({"representative_points"})
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -210,7 +222,10 @@ def find_unknown_keys(user: dict | None) -> list[str]:
     """Return dotted paths for user-set keys not present in :data:`DEFAULTS`.
 
     Catches typos like ``runoff.nn_fil``. Lists are leaves (their items are
-    not introspected). Top-level keys not in DEFAULTS are reported as-is.
+    not introspected). Top-level keys not in DEFAULTS are reported as-is,
+    except the free-form notebook-facing keys in
+    :data:`_OPAQUE_TOPLEVEL_KEYS` (e.g. ``representative_points``), which are
+    recognised and left un-introspected.
     """
     user = user or {}
     return list(_walk_unknown(DEFAULTS, user, prefix=()))
@@ -275,6 +290,11 @@ def _walk_unknown(defaults: dict, user: dict, prefix: tuple[str, ...]) -> Iterat
         return
     for k, uv in user.items():
         path = (*prefix, k)
+        # A known free-form top-level key (e.g. representative_points): not in
+        # DEFAULTS, but recognised so it isn't flagged as a typo, and not
+        # descended into because its sub-keys are intentionally free-form.
+        if not prefix and k in _OPAQUE_TOPLEVEL_KEYS:
+            continue
         if k not in defaults:
             yield ".".join(path)
             continue

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -115,6 +115,31 @@ def test_find_unknown_keys_returns_typos():
     assert "targets.runoff.nn_fil" in unknown
 
 
+def test_find_unknown_keys_allows_representative_points():
+    """The notebook-facing representative_points key is recognised, and its
+    free-form sub-structure (target names + label strings) is not flagged."""
+    user = {
+        "datastore": "/data",
+        "fabric": {"path": "/p", "id_col": "nhm_id"},
+        "representative_points": {
+            "swe": {"Cascades": [-121.7, 45.4]},
+            "sca": {"Willamette HW": [-121.85, 44.10]},
+        },
+    }
+    unknown = find_unknown_keys(user)
+    assert not any(p.startswith("representative_points") for p in unknown)
+
+
+def test_find_unknown_keys_still_flags_real_typo_alongside_opaque_key():
+    """The opaque-key allowance does not suppress genuine typos elsewhere."""
+    user = {
+        "representative_points": {"swe": {"A": [-121.0, 45.0]}},
+        "targets": {"runoff": {"nn_fil": True}},  # typo
+    }
+    unknown = find_unknown_keys(user)
+    assert "targets.runoff.nn_fil" in unknown
+
+
 def test_missing_required_reports_paths():
     """Missing required keys return their dotted paths."""
     user = {"fabric": {"id_col": "nhm_id"}}  # no datastore, no fabric.path


### PR DESCRIPTION
Closes #332.

## Problem
`validate` warns `unknown config key: representative_points (typo?)` on every run for projects that set it — but it's a blessed key (init-template stub, `upgrade_config` discovery, consumed by the inspect notebooks via `_helpers.load_representative_points`). It was just never registered with the unknown-key linter, which checks against `defaults.DEFAULTS`.

## Fix
`representative_points` is notebook-facing and free-form (`{<target>: {<label>: [lon, lat]}}`), not core pipeline schema — adding it to `DEFAULTS` would need every target name enumerated or would make `find_unknown_keys` descend into arbitrary sub-keys. Instead it's registered in a new `defaults._OPAQUE_TOPLEVEL_KEYS` allowlist that the linter recognizes without introspecting.

Also documents the missing step in CLAUDE.md's "Config schema additions" checklist (the linter validates against `defaults.py`, which the old 3-point checklist omitted), so future notebook-facing keys don't reintroduce the warning.

## Tests
`tests/test_defaults.py`:
- `representative_points` (with free-form sub-structure) produces no unknown-key warning
- a genuine typo alongside it is still flagged
- a misspelled top-level key (not in the allowlist) is still flagged

## Verification
Re-ran `validate --project-dir ../or-spatial-targets`: the `representative_points` warning is gone, validate still succeeds (only the benign `release.authors` default note remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)