### PR TITLE
fix(#336): group-readable pipeline outputs (mkstemp 0600 → umask)

### DIFF
--- a/docs/architecture/nc-encoding-policy.md
+++ b/docs/architecture/nc-encoding-policy.md
@@ -113,10 +113,43 @@ zlib decompression of the chunk offsets the chunk-locality gain for the
 single-HRU pattern. Disk pressure on the shared filesystem was the motivating
 concern, and that is where the policy pays off.
 
+## Output file permissions (shared-filesystem readability)
+
+Every atomic writer creates its tempfile with `tempfile.mkstemp`, which
+hardcodes mode **0600**, and the netCDF4/HDF5 backend truncates that tempfile
+*in place* rather than recreating it — so the published NC inherits 0600
+**regardless of the process umask**. On the shared HPC filesystem that made
+outputs unreadable to the `impd` group. Setting `umask` alone does **not** fix
+this: mkstemp ignores umask.
+
+The fix is two layers:
+
+- `io_nc.apply_umask_mode(path)` chmods the tempfile to `0o666 & ~umask` before
+  the atomic rename. Every `mkstemp`-based atomic writer calls it:
+  `atomic_to_netcdf` (aggregated + target NCs), `fetch/consolidate.py`
+  (datastore consolidated NCs), the per-source and canonical manifest writers
+  (`release/lineage.py:atomic_write_manifest`, the `fetch/*` and
+  `aggregate/_driver.py` manifest writes), the release registry
+  (`release/registry.py`), and the gdptools weight-cache CSV writers
+  (`aggregate/_driver.py`, `aggregate/ssebop.py`). The plain-path atomic writers
+  (`era5_land` NC, `snodas` NC, `ua_swe` NC, `gldas`, `pangaea`, `reitz2017`,
+  `rechunk`, `validate` `fabric.json`) create a *new* file on write, so they
+  already honor umask and need no chmod. Credential files
+  (`credentials.py`) and `config.effective.yml` set their mode explicitly and
+  are intentionally excluded.
+- The CLI launcher sets `os.umask(0o002)` in-process, and the SLURM scripts set
+  `umask 002`. SLURM does not inherit the login-shell umask, so the in-process
+  umask is what makes batch runs land at **664**. Credential writes are
+  unaffected — they `chmod 0600` explicitly.
+
+Net result: pipeline NCs land as `-rw-rw-r--` (664) under the default umask.
+chmod failures propagate — a silently owner-only output is worse than a loud
+failure.
+
 ## Cross-references
 
 - [`io_nc.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/io_nc.py) — `build_encoding` /
-  `atomic_to_netcdf` (the single policy home).
+  `atomic_to_netcdf` / `apply_umask_mode` (the single policy home).
 - [`rechunk.py`](https://github.com/rmcd-mscb/nhf-spatial-targets/blob/main/src/nhf_spatial_targets/rechunk.py) — the backfill CLI.
 - [transformation-pipeline.md](transformation-pipeline.md) — *where* transforms
   live (this doc is *how* NCs are encoded); canonical `id_col`-ascending row

--- a/docs/architecture/nc-encoding-policy.md
+++ b/docs/architecture/nc-encoding-policy.md
@@ -115,12 +115,12 @@ concern, and that is where the policy pays off.
 
 ## Output file permissions (shared-filesystem readability)
 
-Every atomic writer creates its tempfile with `tempfile.mkstemp`, which
-hardcodes mode **0600**, and the netCDF4/HDF5 backend truncates that tempfile
-*in place* rather than recreating it — so the published NC inherits 0600
-**regardless of the process umask**. On the shared HPC filesystem that made
-outputs unreadable to the `impd` group. Setting `umask` alone does **not** fix
-this: mkstemp ignores umask.
+The **`mkstemp`-based** atomic writers create their tempfile with
+`tempfile.mkstemp`, which hardcodes mode **0600**, and the netCDF4/HDF5 backend
+truncates that tempfile *in place* rather than recreating it — so the published
+NC inherits 0600 **regardless of the process umask**. On the shared HPC
+filesystem that made outputs unreadable to the `impd` group. Setting `umask`
+alone does **not** fix this: mkstemp ignores umask.
 
 The fix is two layers:
 
@@ -131,12 +131,17 @@ The fix is two layers:
   (`release/lineage.py:atomic_write_manifest`, the `fetch/*` and
   `aggregate/_driver.py` manifest writes), the release registry
   (`release/registry.py`), and the gdptools weight-cache CSV writers
-  (`aggregate/_driver.py`, `aggregate/ssebop.py`). The plain-path atomic writers
-  (`era5_land` NC, `snodas` NC, `ua_swe` NC, `gldas`, `pangaea`, `reitz2017`,
-  `rechunk`, `validate` `fabric.json`) create a *new* file on write, so they
-  already honor umask and need no chmod. Credential files
-  (`credentials.py`) and `config.effective.yml` set their mode explicitly and
-  are intentionally excluded.
+  (`aggregate/_driver.py`, `aggregate/ssebop.py`). The **plain-path** writers —
+  the rule is *any writer that passes a not-yet-existing `.tmp`/output path to
+  `to_netcdf` / `write_text` rather than an `mkstemp` fd* (today: `era5_land`,
+  `snodas`, `ua_swe` NCs, `gldas`, `pangaea`, `reitz2017`, `rechunk`, and
+  `validate`'s `fabric.json` `write_text`) — create a *new* file on write, so
+  the kernel applies `0o666 & ~umask` at creation and they need no chmod. (Note
+  `fabric.json` is a plain `write_text`, not tempfile+rename, so its mode is
+  only umask-correct on *first* creation; an existing file is truncated in
+  place, preserving its mode.) Credential files (`credentials.py`) and
+  `config.effective.yml` set their mode explicitly and are intentionally
+  excluded.
 - The CLI launcher sets `os.umask(0o002)` in-process, and the SLURM scripts set
   `umask 002`. SLURM does not inherit the login-shell umask, so the in-process
   umask is what makes batch runs land at **664**. Credential writes are

--- a/slurm/project_gfv2/agg_all_gfv2.slurm
+++ b/slurm/project_gfv2/agg_all_gfv2.slurm
@@ -26,6 +26,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 # Resolve the repo from the submit cwd (sbatch spool-copies the script, so
 # $BASH_SOURCE is not in the repo — issue #174). Override REPO_DIR to run a

--- a/slurm/project_gfv2/rechunk_gfv2.slurm
+++ b/slurm/project_gfv2/rechunk_gfv2.slurm
@@ -30,6 +30,12 @@
 #   grep -h "Rechunked\|failed" logs/rechunk_*_<jobid>.out logs/rechunk_*_<jobid>.err
 
 set -euo pipefail
+
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
 export PYTHONUNBUFFERED=1
 
 # REPO_DIR defaults to the repo you ran `sbatch` from. sbatch copies the script

--- a/slurm/project_gfv2/rechunk_gfv2_targets.slurm
+++ b/slurm/project_gfv2/rechunk_gfv2_targets.slurm
@@ -30,6 +30,12 @@
 #   pixi run nhf-targets maintenance rechunk --project-dir <gfv2> --layer target --dry-run
 
 set -euo pipefail
+
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
 export PYTHONUNBUFFERED=1
 
 # REPO_DIR defaults to the repo you ran `sbatch` from. sbatch copies the script

--- a/slurm/project_gfv2/render_gfv2.slurm
+++ b/slurm/project_gfv2/render_gfv2.slurm
@@ -25,6 +25,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {

--- a/slurm/project_gfv2/run_gfv2.slurm
+++ b/slurm/project_gfv2/run_gfv2.slurm
@@ -21,6 +21,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-spatial-targets}"
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {

--- a/slurm/project_or/agg_all_or.slurm
+++ b/slurm/project_or/agg_all_or.slurm
@@ -30,6 +30,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets}"
 # Resolve the repo from the submit cwd (sbatch spool-copies the script — #174).
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"

--- a/slurm/project_or/render_or.slurm
+++ b/slurm/project_or/render_or.slurm
@@ -30,6 +30,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets}"
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {

--- a/slurm/project_or/run_or.slurm
+++ b/slurm/project_or/run_or.slurm
@@ -30,6 +30,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 PROJECT_DIR="${PROJECT_DIR:-/caldera/hovenweep/projects/usgs/water/impd/nhgf/or-spatial-targets}"
 REPO_DIR="${REPO_DIR:-$(git -C "${SLURM_SUBMIT_DIR:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "$REPO_DIR" ] || {

--- a/slurm/shared/agg_daymet.slurm
+++ b/slurm/shared/agg_daymet.slurm
@@ -41,6 +41,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/agg_snodas.slurm
+++ b/slurm/shared/agg_snodas.slurm
@@ -62,6 +62,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so SLURM logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 export PYTHONUNBUFFERED=1

--- a/slurm/shared/agg_ssebop.slurm
+++ b/slurm/shared/agg_ssebop.slurm
@@ -32,6 +32,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/agg_ua_swe.slurm
+++ b/slurm/shared/agg_ua_swe.slurm
@@ -73,6 +73,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so SLURM logs update in real time.
 export PYTHONUNBUFFERED=1
 

--- a/slurm/shared/fetch_all.slurm
+++ b/slurm/shared/fetch_all.slurm
@@ -51,6 +51,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/fetch_era5_land.slurm
+++ b/slurm/shared/fetch_era5_land.slurm
@@ -53,6 +53,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/fetch_margulis_wus_sr.slurm
+++ b/slurm/shared/fetch_margulis_wus_sr.slurm
@@ -41,6 +41,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/fetch_snodas.slurm
+++ b/slurm/shared/fetch_snodas.slurm
@@ -49,6 +49,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/fetch_ua_swe.slurm
+++ b/slurm/shared/fetch_ua_swe.slurm
@@ -55,6 +55,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs update in real time.
 export PYTHONUNBUFFERED=1
 

--- a/slurm/shared/inspect_aggregated.slurm
+++ b/slurm/shared/inspect_aggregated.slurm
@@ -47,6 +47,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/slurm/shared/inspect_consolidated.slurm
+++ b/slurm/shared/inspect_consolidated.slurm
@@ -52,6 +52,12 @@
 
 set -euo pipefail
 
+# Group-writable output on the shared HPC filesystem — SLURM does not
+# inherit the login-shell umask. Belt-and-suspenders with os.umask(0o002)
+# in the CLI (see io_nc.apply_umask_mode for why umask alone is not enough
+# for the mkstemp-based atomic NetCDF writers).
+umask 002
+
 # Flush Python stdout per-line so slurm logs (--output=...) update in
 # real time instead of dumping batches when the 8 KB block buffer fills.
 # Slow workloads can otherwise look frozen for tens of minutes.

--- a/src/nhf_spatial_targets/aggregate/_driver.py
+++ b/src/nhf_spatial_targets/aggregate/_driver.py
@@ -189,6 +189,9 @@ def update_manifest(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(manifest_path)
         except Exception:
             Path(tmp_path).unlink(missing_ok=True)
@@ -938,6 +941,9 @@ def compute_or_load_weights(
     try:
         with os.fdopen(tmp_fd, "w") as f:
             weights.to_csv(f, index=False)
+        from nhf_spatial_targets.io_nc import apply_umask_mode
+
+        apply_umask_mode(tmp_path)
         Path(tmp_path).replace(wp)
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/aggregate/ssebop.py
+++ b/src/nhf_spatial_targets/aggregate/ssebop.py
@@ -123,6 +123,9 @@ def _process_batch(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 weights.to_csv(f, index=False)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(wp)
         except Exception:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/cli/__init__.py
+++ b/src/nhf_spatial_targets/cli/__init__.py
@@ -22,6 +22,7 @@ intercepts continue to work after the split.
 
 from __future__ import annotations
 
+import os
 from importlib.metadata import version as _pkg_version
 from typing import Annotated
 
@@ -65,6 +66,13 @@ def launcher(
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = False,
 ):
     """Global options for nhf-targets."""
+    # Group-writable default so pipeline outputs (NetCDFs, manifests) land
+    # readable to the impd group on the shared HPC filesystem. SLURM does not
+    # inherit the login-shell umask, so this must be set in-process rather than
+    # relying on the operator's shell. Credential writes chmod 0600 explicitly,
+    # so this does not loosen them. See io_nc.apply_umask_mode for why the
+    # umask alone is insufficient for the mkstemp-based atomic writers.
+    os.umask(0o002)
     setup_logging(verbose)
     app(tokens)  # dispatch remaining tokens to the root app
 

--- a/src/nhf_spatial_targets/fetch/consolidate.py
+++ b/src/nhf_spatial_targets/fetch/consolidate.py
@@ -150,6 +150,9 @@ def _write_netcdf(
             kwargs["encoding"] = encoding
         with ProgressBar():
             ds.to_netcdf(tmp_path, **kwargs)
+        from nhf_spatial_targets.io_nc import apply_umask_mode
+
+        apply_umask_mode(tmp_path)
         tmp_path.replace(out_path)
     except BaseException as exc:
         tmp_path.unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/fetch/daymet.py
+++ b/src/nhf_spatial_targets/fetch/daymet.py
@@ -508,6 +508,9 @@ def _update_manifest(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(manifest_path)
         except BaseException:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/fetch/era5_land.py
+++ b/src/nhf_spatial_targets/fetch/era5_land.py
@@ -932,6 +932,9 @@ def _update_manifest(
         try:
             with os.fdopen(fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp)
             Path(tmp).replace(manifest_path)
         except BaseException:
             Path(tmp).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
+++ b/src/nhf_spatial_targets/fetch/margulis_wus_sr.py
@@ -775,6 +775,9 @@ def _update_manifest(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(manifest_path)
         except BaseException:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/fetch/snodas.py
+++ b/src/nhf_spatial_targets/fetch/snodas.py
@@ -1334,6 +1334,9 @@ def _update_manifest(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(manifest_path)
         except BaseException:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/fetch/ua_swe.py
+++ b/src/nhf_spatial_targets/fetch/ua_swe.py
@@ -742,6 +742,9 @@ def _update_manifest(
         try:
             with os.fdopen(tmp_fd, "w") as f:
                 json.dump(manifest, f, indent=2)
+            from nhf_spatial_targets.io_nc import apply_umask_mode
+
+            apply_umask_mode(tmp_path)
             Path(tmp_path).replace(manifest_path)
         except BaseException:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -268,10 +268,13 @@ def apply_umask_mode(path: Path | str) -> None:
     664) instead of the mkstemp default of 600.
 
     umask has no read-only accessor, so it is read via the set-and-restore
-    idiom. This runs on the writer's main thread after ``to_netcdf`` returns, so
-    the transient ``umask(0)`` window races nothing. chmod failures are left to
-    propagate — a silently owner-only output on a shared filesystem is worse
-    than a loud failure.
+    idiom. ``os.umask`` is *process*-global, not thread-local, so the transient
+    ``umask(0)`` window is only race-free because every caller invokes this
+    serially on the main thread after its write completes — keep it that way. A
+    future writer that calls this from a worker thread while another thread is
+    creating a file could see the ``umask(0)`` window and emit a world-writable
+    file. chmod failures are left to propagate — a silently owner-only output on
+    a shared filesystem is worse than a loud failure.
     """
     current = os.umask(0)
     os.umask(current)

--- a/src/nhf_spatial_targets/io_nc.py
+++ b/src/nhf_spatial_targets/io_nc.py
@@ -257,6 +257,27 @@ def build_encoding(
     return encoding
 
 
+def apply_umask_mode(path: Path | str) -> None:
+    """Reset *path*'s permissions to ``0o666 & ~umask``.
+
+    ``tempfile.mkstemp`` hardcodes mode 0600, and the netCDF4/HDF5 backend
+    truncates the tempfile *in place* rather than recreating it, so a NetCDF
+    written into an mkstemp tempfile keeps owner-only perms regardless of the
+    process umask. Call this on the tempfile before the atomic rename so the
+    published file is group/world-readable per the process umask (umask 002 ->
+    664) instead of the mkstemp default of 600.
+
+    umask has no read-only accessor, so it is read via the set-and-restore
+    idiom. This runs on the writer's main thread after ``to_netcdf`` returns, so
+    the transient ``umask(0)`` window races nothing. chmod failures are left to
+    propagate — a silently owner-only output on a shared filesystem is worse
+    than a loud failure.
+    """
+    current = os.umask(0)
+    os.umask(current)
+    os.chmod(path, 0o666 & ~current)
+
+
 def atomic_to_netcdf(
     ds: xr.Dataset,
     path: Path | str,
@@ -267,7 +288,10 @@ def atomic_to_netcdf(
     """Write *ds* to *path* atomically: tempfile in the same dir, then rename.
 
     A sibling tempfile keeps the rename on the same filesystem (atomic). On any
-    exception the tempfile is removed so no partial NetCDF is left behind.
+    exception the tempfile is removed so no partial NetCDF is left behind. The
+    tempfile's mkstemp-default 0600 mode is relaxed to honor the process umask
+    (see :func:`apply_umask_mode`) before the rename, so the published NetCDF is
+    group-readable on shared filesystems.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -276,6 +300,7 @@ def atomic_to_netcdf(
     tmp_path = Path(tmp_name)
     try:
         ds.to_netcdf(tmp_path, format=format, encoding=encoding)
+        apply_umask_mode(tmp_path)
         tmp_path.replace(path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/release/lineage.py
+++ b/src/nhf_spatial_targets/release/lineage.py
@@ -279,6 +279,9 @@ def atomic_write_manifest(manifest_path: Path, manifest: _Manifest) -> None:
     try:
         with os.fdopen(tmp_fd, "w") as f:
             json.dump(manifest, f, indent=2)
+        from nhf_spatial_targets.io_nc import apply_umask_mode
+
+        apply_umask_mode(tmp_path)
         Path(tmp_path).replace(manifest_path)
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)

--- a/src/nhf_spatial_targets/release/registry.py
+++ b/src/nhf_spatial_targets/release/registry.py
@@ -170,6 +170,9 @@ def _atomic_dump(path: Path, data) -> None:
     try:
         with os.fdopen(tmp_fd, "w") as f:
             f.write(buf.getvalue())
+        from nhf_spatial_targets.io_nc import apply_umask_mode
+
+        apply_umask_mode(tmp_path)
         Path(tmp_path).replace(path)
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,24 @@ import yaml
 from nhf_spatial_targets.workspace import Project
 
 
+@pytest.fixture(autouse=True)
+def _restore_umask():
+    """Snapshot and restore the process umask around every test.
+
+    ``os.umask`` is process-global. The CLI launcher sets ``os.umask(0o002)``
+    (intended, permanent in production) and several tests set their own umask to
+    probe file modes — either would otherwise leak the mutated umask into
+    unrelated later tests, making permission assertions order-dependent. This
+    autouse fixture contains that blast radius.
+    """
+    original = os.umask(0o022)
+    try:
+        os.umask(original)
+        yield
+    finally:
+        os.umask(original)
+
+
 @pytest.fixture()
 def no_system_cred_checks():
     """Suppress ~/.cdsapirc and ~/.netrc existence checks (for validate_workspace tests)."""

--- a/tests/test_io_nc.py
+++ b/tests/test_io_nc.py
@@ -326,3 +326,39 @@ def test_chunk_aligned_per_hru_read_budget(tmp_path: Path):
         scattered = rng.choice(n_hru, size=100, replace=False)
         for h in scattered:
             np.testing.assert_array_equal(v[:, int(h)], data[:, int(h)])
+
+
+# --- output permissions (shared-filesystem group readability) -----------
+
+
+def test_atomic_to_netcdf_honors_umask_not_mkstemp_0600(tmp_path):
+    """Published NC honors the process umask, not mkstemp's hardcoded 0600.
+
+    Regression for owner-only (-rw-------) aggregated/target NCs on the shared
+    HPC filesystem: ``tempfile.mkstemp`` creates the tempfile at 0600 and the
+    netCDF4/HDF5 backend truncates it in place, so without an explicit chmod the
+    final file stays owner-only regardless of umask. ``apply_umask_mode`` must
+    relax it to ``0o666 & ~umask``.
+    """
+    import os
+    import stat
+
+    from nhf_spatial_targets.io_nc import atomic_to_netcdf
+
+    ds = xr.Dataset({"x": ("t", np.arange(3.0))})
+    old = os.umask(0o002)
+    try:
+        out = tmp_path / "grouped.nc"
+        atomic_to_netcdf(ds, out)
+        mode = stat.S_IMODE(out.stat().st_mode)
+        assert mode == 0o664, oct(mode)
+        # And under a restrictive umask the group bit is still what umask allows
+        # (0640), never the mkstemp 0600 the bug produced.
+        os.umask(0o027)
+        out2 = tmp_path / "grouped2.nc"
+        atomic_to_netcdf(ds, out2)
+        mode2 = stat.S_IMODE(out2.stat().st_mode)
+        assert mode2 == 0o640, oct(mode2)
+        assert mode2 & stat.S_IRGRP, "output must be group-readable"
+    finally:
+        os.umask(old)

--- a/tests/test_io_nc.py
+++ b/tests/test_io_nc.py
@@ -362,3 +362,36 @@ def test_atomic_to_netcdf_honors_umask_not_mkstemp_0600(tmp_path):
         assert mode2 & stat.S_IRGRP, "output must be group-readable"
     finally:
         os.umask(old)
+
+
+def test_apply_umask_mode_mask_arithmetic(tmp_path):
+    """apply_umask_mode sets 0o666 & ~umask, not a hardcoded mode."""
+    import os
+    import stat
+
+    from nhf_spatial_targets.io_nc import apply_umask_mode
+
+    cases = {0o002: 0o664, 0o027: 0o640, 0o000: 0o666}
+    for umask, expected in cases.items():
+        old = os.umask(umask)
+        try:
+            f = tmp_path / f"m_{umask:04o}"
+            f.write_text("x")
+            os.chmod(f, 0o600)  # simulate the mkstemp default
+            apply_umask_mode(f)
+            got = stat.S_IMODE(f.stat().st_mode)
+            assert got == expected, f"umask {umask:04o}: {got:04o} != {expected:04o}"
+        finally:
+            os.umask(old)
+
+
+def test_apply_umask_mode_raises_on_missing_path(tmp_path):
+    """The loud-failure contract: a chmod that fails propagates, never silent.
+
+    Regression guard for the design promise that a failed permission relax is
+    surfaced (not swallowed) so an owner-only output can't ship unnoticed.
+    """
+    from nhf_spatial_targets.io_nc import apply_umask_mode
+
+    with pytest.raises(FileNotFoundError):
+        apply_umask_mode(tmp_path / "does_not_exist.nc")

--- a/tests/test_release_lineage.py
+++ b/tests/test_release_lineage.py
@@ -47,6 +47,27 @@ def sample_output(tmp_path: Path) -> Path:
     return p
 
 
+def test_atomic_write_manifest_is_group_readable(manifest_path: Path) -> None:
+    """manifest.json lands group-readable (0o666 & ~umask), not mkstemp's 0600.
+
+    The manifest writer creates its tempfile with mkstemp (mode 0600); without
+    apply_umask_mode the published manifest would be owner-only on the shared
+    filesystem. Guards that the non-NC write path actually calls the helper.
+    """
+    import os
+    import stat
+
+    from nhf_spatial_targets.release.lineage import atomic_write_manifest
+
+    old = os.umask(0o002)
+    try:
+        atomic_write_manifest(manifest_path, {"sources": {}, "steps": []})
+        mode = stat.S_IMODE(manifest_path.stat().st_mode)
+        assert mode == 0o664, oct(mode)
+    finally:
+        os.umask(old)
+
+
 # ---------------------------------------------------------------------------
 # File-entry shape
 # ---------------------------------------------------------------------------

--- a/tests/test_release_registry.py
+++ b/tests/test_release_registry.py
@@ -196,6 +196,32 @@ def test_put_source_round_trips(reg_path: Path) -> None:
     }
 
 
+def test_put_source_output_is_group_readable(reg_path: Path) -> None:
+    """The registry .yml lands group-readable (0o666 & ~umask), not 0600.
+
+    _atomic_dump writes via mkstemp (mode 0600); guards that the registry write
+    path calls apply_umask_mode so the shared release registry is group-readable.
+    """
+    import os
+    import stat
+
+    old = os.umask(0o002)
+    try:
+        registry.put_source(
+            "era5_land",
+            sb_id="s",
+            uploaded_utc="2026-05-28T01:00:00+00:00",
+            file_count=1,
+            total_bytes=1,
+            manifest_sha256="ab",
+            path=reg_path,
+        )
+        mode = stat.S_IMODE(reg_path.stat().st_mode)
+        assert mode == 0o664, oct(mode)
+    finally:
+        os.umask(old)
+
+
 def test_put_source_preserves_sibling_sources(reg_path: Path) -> None:
     """Writing one source must not drop a previously-written sibling (#97)."""
     registry.put_source(


### PR DESCRIPTION
Closes #336

## Problem

Pipeline artifacts (aggregated/target NetCDFs, datastore consolidated NCs, manifests, weight caches) landed on the shared HPC filesystem as `-rw-------` (0600), unreadable to the `impd` group and guests. Desired: `-rw-rw-r--` (664).

## Root cause (not umask)

Every atomic writer creates its tempfile with `tempfile.mkstemp`, which hardcodes mode **0600**, and the netCDF4/HDF5 backend truncates that tempfile **in place** rather than recreating it — so the published file inherits 0600 **regardless of the process umask**. Reproduced under both umask 077 and 002: both yield 0600. Setting `umask` alone cannot fix the mkstemp sites.

Plain-path writers (e.g. `era5_land`) create a *new* file on write and correctly honored umask — which is exactly why they were unaffected on disk, confirming the mechanism.

## Fix (two layers)

1. **`io_nc.apply_umask_mode(path)`** chmods the mkstemp tempfile to `0o666 & ~umask` before the atomic rename. Wired into every mkstemp writer:
   - `atomic_to_netcdf` — aggregated + target NCs
   - `fetch/consolidate.py` — datastore consolidated NCs
   - `release/lineage.py:atomic_write_manifest` — canonical `manifest.json`
   - `aggregate/_driver.py` (per-source manifest + weight CSV), `aggregate/ssebop.py` (weight CSV)
   - `fetch/{daymet,snodas,margulis_wus_sr,ua_swe,era5_land}.py` — per-source manifests
   - `release/registry.py` — release registry `.yml`
2. **`os.umask(0o002)`** in the CLI launcher (runs for every subcommand; **survives SLURM**, which does not inherit the login-shell umask) + **`umask 002`** in all 19 SLURM scripts (belt for non-Python steps).

**Intentionally excluded:** credential files (`credentials.py`, chmod 0600 explicitly), `config.effective.yml` (ends 0444 = world-readable), and the plain-path writers (`fabric.json`, `era5_land`/`snodas`/`ua_swe` NCs, `gldas`, `pangaea`, `reitz2017`, `rechunk`) which already honor umask.

## Testing

- New regression test in `tests/test_io_nc.py`: asserts 664 under umask 002 and 640 under umask 027 (fails on the old mkstemp-0600 behavior).
- Smoke-tested `atomic_write_manifest` → 664 under umask 002.
- `pixi run -e dev fmt` + `lint` clean.

## Docs

- `docs/architecture/nc-encoding-policy.md` gains an "Output file permissions" section.

## Operator note (not in this diff)

Existing 0600 artifacts on disk were backfilled to 664 out-of-band (OR project, gfv2, datastore — NCs, manifests, weight CSVs); `.credentials.yml` files tightened to 600. New runs need no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)